### PR TITLE
feat: proposal workspace v1 UI flow (draft/list/detail/submit)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+- 
+
+## Change type
+
+- [ ] Feature
+- [ ] Fix
+- [ ] Refactor
+- [ ] Tooling/CI
+- [ ] Docs only
+
+## Validation
+
+- [ ] `make check` passes locally
+- [ ] Additional relevant checks executed (if needed)
+
+## Documentation checklist (required)
+
+- [ ] `README.md` updated if behavior/commands/contracts changed
+- [ ] `docs/rfcs/README.md` updated if RFC status changed
+- [ ] New/updated RFC added for architecture or contract changes
+- [ ] `docs/documentation` updated for operational/tooling/architecture impact
+- [ ] No required documentation change (reason provided below)
+
+## Docs impact / reason if N/A
+
+- 
+
+## Testing notes
+
+- 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+## Working model
+
+This repository follows a docs-with-code rule: every implementation change must include the required documentation updates in the same pull request.
+
+## Documentation requirements by change type
+
+- UI flow, route, or UX behavior changes:
+  - Update `README.md` route/feature notes.
+  - Update or add integration tests.
+  - If behavior is material, add/update an RFC in `docs/rfcs` and update `docs/rfcs/README.md`.
+- Architecture or BFF contract mapping changes:
+  - Add/update an RFC in `docs/rfcs`.
+  - Update architecture docs under `docs/documentation`.
+- Tooling/CI/quality gate changes:
+  - Update docs under `docs/documentation` and relevant runbooks.
+- Operations/startup/environment changes:
+  - Update run commands and environment variable documentation in `README.md`.
+
+## Definition of done
+
+- Tests added/updated for the behavior change.
+- `make check` passes locally.
+- Required docs are updated in the same PR.
+- PR template checklist is fully completed.
+
+## Branch + PR policy
+
+- Target branch: `main` via pull request only.
+- Required status checks must pass.
+- Linear history is enforced.
+- Auto-merge is enabled for CI-passing PRs.
+
+## RFC flow
+
+- Use one RFC per focused architectural change.
+- Keep RFC status current in `docs/rfcs/README.md`.
+- When implemented, mark status as `IMPLEMENTED` and link the PR.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Unified UI for advisor workflows, currently scoped to DPM proposal simulation.
 
+## Contribution Standards
+
+- Contribution process: `CONTRIBUTING.md`
+- Docs-with-code standard: `docs/documentation/implementation-documentation-standard.md`
+- PR checklist template: `.github/pull_request_template.md`
+
 ## Standard Frontend Stack
 
 - Next.js (App Router)
@@ -23,3 +29,9 @@ npm run dev
 Open `http://localhost:3000/proposals/simulate`.
 
 Set `BFF_BASE_URL` to point to `advisor-experience-api`.
+
+## Current Routes
+
+- `/proposals/simulate` - simulate and save draft proposal
+- `/proposals` - proposal workspace list
+- `/proposals/[proposalId]` - proposal detail and submit-for-review action

--- a/docs/documentation/implementation-documentation-standard.md
+++ b/docs/documentation/implementation-documentation-standard.md
@@ -1,0 +1,22 @@
+# Implementation + Documentation Standard
+
+## Objective
+
+Keep implementation and documentation synchronized so every merged PR is executable, testable, and understandable without tribal knowledge.
+
+## Required updates per PR
+
+- Code change: add/update tests.
+- Contract/behavior change: update `README.md` and relevant UI/BFF flow docs.
+- Architecture change: add/update RFC under `docs/rfcs` and index entry in `docs/rfcs/README.md`.
+- Tooling/CI change: document new commands and pipeline behavior under `docs/documentation`.
+
+## Minimum evidence before merge
+
+- `make check` succeeds locally.
+- PR template documentation checklist completed.
+- RFC status updated (`PROPOSED`, `IMPLEMENTING`, `IMPLEMENTED`, `SUPERSEDED`) when applicable.
+
+## Practical rule
+
+If a new engineer cannot run and understand the change from repo docs alone, documentation is incomplete.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -2,4 +2,5 @@
 
 | RFC | Title | Status | File |
 | --- | --- | --- | --- |
-| RFC-0001 | DPM-First Proposal Simulation Screen | IMPLEMENTING | `docs/rfcs/RFC-0001-dpm-first-proposal-simulation-screen.md` |
+| RFC-0001 | DPM-First Proposal Simulation Screen | IMPLEMENTED | `docs/rfcs/RFC-0001-dpm-first-proposal-simulation-screen.md` |
+| RFC-0002 | UI Proposal Workspace v1 (Draft/List/Detail/Submit) | IMPLEMENTED | `docs/rfcs/RFC-0002-ui-proposal-workspace-v1.md` |

--- a/docs/rfcs/RFC-0001-dpm-first-proposal-simulation-screen.md
+++ b/docs/rfcs/RFC-0001-dpm-first-proposal-simulation-screen.md
@@ -1,6 +1,6 @@
 # RFC-0001: DPM-First Proposal Simulation Screen
 
-- Status: IMPLEMENTING
+- Status: IMPLEMENTED
 - Date: 2026-02-22
 
 ## Goal

--- a/docs/rfcs/RFC-0002-ui-proposal-workspace-v1.md
+++ b/docs/rfcs/RFC-0002-ui-proposal-workspace-v1.md
@@ -1,0 +1,36 @@
+# RFC-0002: UI Proposal Workspace v1 (Draft/List/Detail/Submit)
+
+- Status: IMPLEMENTED
+- Date: 2026-02-22
+- Depends on: RFC-0001
+
+## Goal
+
+Deliver a visible end-to-end advisor proposal flow on top of BFF + DPM: create draft, list proposals, inspect detail, and submit draft for first review.
+
+## Decision
+
+UI routes:
+
+- `/proposals/simulate` supports simulation and "Save Draft"
+- `/proposals` lists proposals from BFF
+- `/proposals/[proposalId]` shows detail and enables submit-for-review from `DRAFT`
+
+BFF contract usage:
+
+- simulate: `POST /api/v1/proposals/simulate`
+- create: `POST /api/v1/proposals`
+- list: `GET /api/v1/proposals`
+- detail: `GET /api/v1/proposals/{proposal_id}`
+- submit: `POST /api/v1/proposals/{proposal_id}/submit`
+
+## Out of Scope
+
+- Full approval chain UX (risk/compliance/client consent execution stages).
+- Multi-service portfolio/performance widgets.
+
+## Acceptance Criteria
+
+- Integration tests cover list and detail submit interactions.
+- Existing simulate test remains green.
+- `make check` passes (lint/typecheck/test/build).

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,16 @@
+import Link from "next/link";
+
 export default function Home() {
   return (
     <main>
       <h1>Advisor Workbench</h1>
       <ul>
-        <li>Proposal simulation: /proposals/simulate</li>
+        <li>
+          <Link href="/proposals">Proposal workspace</Link>
+        </li>
+        <li>
+          <Link href="/proposals/simulate">Proposal simulation</Link>
+        </li>
         <li>Legacy workbench stub: /workbench/PF_1001</li>
       </ul>
     </main>

--- a/src/app/proposals/[proposalId]/page.tsx
+++ b/src/app/proposals/[proposalId]/page.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+import ProposalDetailView from "@/features/proposals/components/proposal-detail-view";
+
+type Props = {
+  params: Promise<{
+    proposalId: string;
+  }>;
+};
+
+export default async function ProposalDetailPage({ params }: Props) {
+  const { proposalId } = await params;
+  return (
+    <main style={{ padding: "1rem", maxWidth: "960px", margin: "0 auto" }}>
+      <p>
+        <Link href="/proposals">Back to Proposal Workspace</Link>
+      </p>
+      <ProposalDetailView proposalId={proposalId} />
+    </main>
+  );
+}

--- a/src/app/proposals/page.tsx
+++ b/src/app/proposals/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+import ProposalListView from "@/features/proposals/components/proposal-list-view";
+
+export default function ProposalsPage() {
+  return (
+    <main style={{ padding: "1rem", maxWidth: "960px", margin: "0 auto" }}>
+      <h1>Advisory Proposals</h1>
+      <p>
+        <Link href="/proposals/simulate">Create Proposal Draft</Link>
+      </p>
+      <ProposalListView />
+    </main>
+  );
+}

--- a/src/app/proposals/simulate/page.tsx
+++ b/src/app/proposals/simulate/page.tsx
@@ -1,10 +1,15 @@
+import Link from "next/link";
+
 import ProposalSimulateForm from "@/features/proposals/components/proposal-simulate-form";
 
 export default function ProposalSimulatePage() {
   return (
-    <main>
+    <main style={{ padding: "1rem", maxWidth: "960px", margin: "0 auto" }}>
       <h1>Advisory Proposals</h1>
       <p>Run DPM proposal simulation via BFF.</p>
+      <p>
+        <Link href="/proposals">Go to Proposal Workspace</Link>
+      </p>
       <ProposalSimulateForm />
     </main>
   );

--- a/src/features/proposals/api.ts
+++ b/src/features/proposals/api.ts
@@ -1,4 +1,12 @@
-import { ProposalSimulateRequest, ProposalSimulateResponse } from "./types";
+import {
+  ProposalCreateRequest,
+  ProposalDetailData,
+  ProposalEnvelopeResponse,
+  ProposalListData,
+  ProposalSimulateRequest,
+  ProposalSimulateResponse,
+  ProposalSubmitRequest,
+} from "./types";
 
 const BFF_BASE_URL = process.env.BFF_BASE_URL ?? "http://localhost:8100";
 
@@ -21,4 +29,68 @@ export async function simulateProposal(
   }
 
   return (await response.json()) as ProposalSimulateResponse;
+}
+
+export async function createProposal(
+  payload: ProposalCreateRequest,
+  idempotencyKey: string
+): Promise<ProposalEnvelopeResponse> {
+  return await postJson("/api/v1/proposals", payload, idempotencyKey);
+}
+
+export async function listProposals(state?: string): Promise<ProposalListData> {
+  const query = state ? `?state=${encodeURIComponent(state)}` : "";
+  const response = await fetch(`${BFF_BASE_URL}/api/v1/proposals${query}`);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Proposal list failed (${response.status}): ${body}`);
+  }
+  const envelope = (await response.json()) as ProposalEnvelopeResponse;
+  return envelope.data as unknown as ProposalListData;
+}
+
+export async function getProposal(
+  proposalId: string,
+  includeEvidence = false
+): Promise<ProposalDetailData> {
+  const query = `?include_evidence=${includeEvidence ? "true" : "false"}`;
+  const response = await fetch(
+    `${BFF_BASE_URL}/api/v1/proposals/${proposalId}${query}`
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Proposal detail failed (${response.status}): ${body}`);
+  }
+  const envelope = (await response.json()) as ProposalEnvelopeResponse;
+  return envelope.data as unknown as ProposalDetailData;
+}
+
+export async function submitProposal(
+  proposalId: string,
+  payload: ProposalSubmitRequest
+): Promise<ProposalEnvelopeResponse> {
+  return await postJson(`/api/v1/proposals/${proposalId}/submit`, payload);
+}
+
+async function postJson(
+  path: string,
+  payload: Record<string, unknown>,
+  idempotencyKey?: string
+): Promise<ProposalEnvelopeResponse> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (idempotencyKey) {
+    headers["Idempotency-Key"] = idempotencyKey;
+  }
+  const response = await fetch(`${BFF_BASE_URL}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Proposal request failed (${response.status}): ${body}`);
+  }
+  return (await response.json()) as ProposalEnvelopeResponse;
 }

--- a/src/features/proposals/components/proposal-detail-view.tsx
+++ b/src/features/proposals/components/proposal-detail-view.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getProposal, submitProposal } from "../api";
+import { ProposalDetailData } from "../types";
+
+type Props = {
+  proposalId: string;
+};
+
+export default function ProposalDetailView({ proposalId }: Props) {
+  const [data, setData] = useState<ProposalDetailData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const detail = await getProposal(proposalId, false);
+        if (!cancelled) {
+          setData(detail);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : "Unknown error";
+          setError(message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [proposalId]);
+
+  async function onSubmitForReview() {
+    if (!data?.proposal?.current_state) {
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await submitProposal(proposalId, {
+        actor_id: "advisor_1",
+        expected_state: data.proposal.current_state,
+        review_type: "RISK",
+        reason: { source: "ui" },
+      });
+      const refreshed = await getProposal(proposalId, false);
+      setData(refreshed);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return <p>Loading proposal...</p>;
+  }
+
+  if (error) {
+    return <p style={{ color: "crimson" }}>Error: {error}</p>;
+  }
+
+  if (!data?.proposal) {
+    return <p>Proposal not found.</p>;
+  }
+
+  return (
+    <section>
+      <h2>Proposal {data.proposal.proposal_id}</h2>
+      <p>State: {data.proposal.current_state}</p>
+      <p>Portfolio: {data.proposal.portfolio_id ?? "N/A"}</p>
+      <p>Current version: {String(data.proposal.current_version_no ?? "N/A")}</p>
+      <button
+        type="button"
+        onClick={onSubmitForReview}
+        disabled={submitting || data.proposal.current_state !== "DRAFT"}
+      >
+        {submitting ? "Submitting..." : "Submit For Review"}
+      </button>
+      <details style={{ marginTop: "0.75rem" }}>
+        <summary>Raw proposal detail</summary>
+        <pre>{JSON.stringify(data, null, 2)}</pre>
+      </details>
+    </section>
+  );
+}

--- a/src/features/proposals/components/proposal-list-view.tsx
+++ b/src/features/proposals/components/proposal-list-view.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { listProposals } from "../api";
+import { ProposalSummary } from "../types";
+
+export default function ProposalListView() {
+  const [items, setItems] = useState<ProposalSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const data = await listProposals();
+        if (!cancelled) {
+          setItems(data.items ?? []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : "Unknown error";
+          setError(message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return <p>Loading proposals...</p>;
+  }
+
+  if (error) {
+    return <p style={{ color: "crimson" }}>Error: {error}</p>;
+  }
+
+  return (
+    <section>
+      <h2>Proposal Workspace</h2>
+      {items.length === 0 ? <p>No proposals found.</p> : null}
+      <ul>
+        {items.map((item) => (
+          <li key={item.proposal_id}>
+            <Link href={`/proposals/${item.proposal_id}`}>{item.proposal_id}</Link>
+            {" "}- state: {item.current_state}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/features/proposals/components/proposal-simulate-form.tsx
+++ b/src/features/proposals/components/proposal-simulate-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 
-import { simulateProposal } from "../api";
+import { createProposal, simulateProposal } from "../api";
 import { ProposalSimulateResponse } from "../types";
 
 const DEFAULT_PAYLOAD = {
@@ -42,13 +43,18 @@ export default function ProposalSimulateForm() {
     return `ui-${Date.now()}`;
   });
   const [loading, setLoading] = useState(false);
+  const [savingDraft, setSavingDraft] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<ProposalSimulateResponse | null>(null);
+  const [savedProposalId, setSavedProposalId] = useState<string | null>(null);
+  const [createdBy, setCreatedBy] = useState("advisor_1");
+  const [proposalTitle, setProposalTitle] = useState("DPM proposal draft");
 
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
     setResult(null);
+    setSavedProposalId(null);
     setLoading(true);
     try {
       const payload = JSON.parse(payloadText) as { body: Record<string, unknown> };
@@ -59,6 +65,33 @@ export default function ProposalSimulateForm() {
       setError(message);
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function onSaveDraft() {
+    setError(null);
+    setSavingDraft(true);
+    try {
+      const payload = JSON.parse(payloadText) as { body: Record<string, unknown> };
+      const createResponse = await createProposal(
+        {
+          body: {
+            created_by: createdBy,
+            simulate_request: payload.body,
+            metadata: {
+              title: proposalTitle,
+            },
+          },
+        },
+        `${idempotencyKey}-create`
+      );
+      const proposal = (createResponse.data.proposal as { proposal_id?: string } | undefined) ?? {};
+      setSavedProposalId(proposal.proposal_id ?? null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setError(message);
+    } finally {
+      setSavingDraft(false);
     }
   }
 
@@ -73,6 +106,20 @@ export default function ProposalSimulateForm() {
           onChange={(e) => setIdempotencyKey(e.target.value)}
           style={{ display: "block", width: "100%", marginBottom: "0.75rem" }}
         />
+        <label htmlFor="created-by">Created By</label>
+        <input
+          id="created-by"
+          value={createdBy}
+          onChange={(e) => setCreatedBy(e.target.value)}
+          style={{ display: "block", width: "100%", marginBottom: "0.75rem" }}
+        />
+        <label htmlFor="proposal-title">Proposal Title</label>
+        <input
+          id="proposal-title"
+          value={proposalTitle}
+          onChange={(e) => setProposalTitle(e.target.value)}
+          style={{ display: "block", width: "100%", marginBottom: "0.75rem" }}
+        />
 
         <label htmlFor="payload">Request Payload</label>
         <textarea
@@ -83,8 +130,16 @@ export default function ProposalSimulateForm() {
           style={{ display: "block", width: "100%", fontFamily: "monospace" }}
         />
 
-        <button type="submit" disabled={loading} style={{ marginTop: "0.75rem" }}>
+        <button type="submit" disabled={loading} style={{ marginTop: "0.75rem", marginRight: "0.5rem" }}>
           {loading ? "Simulating..." : "Simulate Proposal"}
+        </button>
+        <button
+          type="button"
+          onClick={onSaveDraft}
+          disabled={savingDraft}
+          style={{ marginTop: "0.75rem" }}
+        >
+          {savingDraft ? "Saving Draft..." : "Save Draft"}
         </button>
       </form>
 
@@ -103,6 +158,18 @@ export default function ProposalSimulateForm() {
           </details>
         </div>
       ) : null}
+
+      {savedProposalId ? (
+        <div style={{ marginTop: "0.75rem" }}>
+          <p>Draft saved as Proposal ID: {savedProposalId}</p>
+          <p>
+            <Link href={`/proposals/${savedProposalId}`}>Open Proposal Details</Link>
+          </p>
+        </div>
+      ) : null}
+      <p style={{ marginTop: "0.75rem" }}>
+        <Link href="/proposals">View Proposal Workspace</Link>
+      </p>
     </section>
   );
 }

--- a/src/features/proposals/types.ts
+++ b/src/features/proposals/types.ts
@@ -11,3 +11,54 @@ export type ProposalSimulateResponse = {
     [key: string]: unknown;
   };
 };
+
+export type ProposalCreateRequest = {
+  body: {
+    created_by: string;
+    simulate_request: Record<string, unknown>;
+    metadata?: {
+      title?: string;
+      advisor_notes?: string;
+      jurisdiction?: string;
+      mandate_id?: string;
+    };
+  };
+};
+
+export type ProposalEnvelopeResponse = {
+  correlation_id: string;
+  contract_version: string;
+  data: Record<string, unknown>;
+};
+
+export type ProposalSummary = {
+  proposal_id: string;
+  portfolio_id?: string;
+  current_state: string;
+  current_version_no?: number;
+  title?: string | null;
+  created_by?: string;
+  created_at?: string;
+};
+
+export type ProposalListData = {
+  items: ProposalSummary[];
+  next_cursor?: string | null;
+};
+
+export type ProposalDetailData = {
+  proposal: ProposalSummary;
+  current_version?: {
+    version_no?: number;
+    status_at_creation?: string;
+  };
+  [key: string]: unknown;
+};
+
+export type ProposalSubmitRequest = {
+  actor_id: string;
+  expected_state: string;
+  review_type: "RISK" | "COMPLIANCE";
+  reason?: Record<string, unknown>;
+  related_version_no?: number;
+};

--- a/tests/integration/proposal-detail-view.test.tsx
+++ b/tests/integration/proposal-detail-view.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+import ProposalDetailView from "../../src/features/proposals/components/proposal-detail-view";
+
+const { getProposalMock, submitProposalMock } = vi.hoisted(() => ({
+  getProposalMock: vi.fn(async () => ({
+    proposal: {
+      proposal_id: "pp_1",
+      current_state: "DRAFT",
+      portfolio_id: "pf_1",
+      current_version_no: 1,
+    },
+  })),
+  submitProposalMock: vi.fn(async () => ({
+    data: { proposal_id: "pp_1", current_state: "RISK_REVIEW" },
+  })),
+}));
+
+vi.mock("../../src/features/proposals/api", () => ({
+  getProposal: getProposalMock,
+  submitProposal: submitProposalMock,
+}));
+
+describe("ProposalDetailView", () => {
+  it("submits proposal for review from draft", async () => {
+    render(<ProposalDetailView proposalId="pp_1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("State: DRAFT")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit For Review" }));
+
+    await waitFor(() => {
+      expect(submitProposalMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/integration/proposal-list-view.test.tsx
+++ b/tests/integration/proposal-list-view.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+import ProposalListView from "../../src/features/proposals/components/proposal-list-view";
+
+vi.mock("../../src/features/proposals/api", () => ({
+  listProposals: vi.fn(async () => ({
+    items: [{ proposal_id: "pp_1", current_state: "DRAFT" }],
+  })),
+}));
+
+describe("ProposalListView", () => {
+  it("renders proposal rows", async () => {
+    render(<ProposalListView />);
+
+    await waitFor(() => {
+      expect(screen.getByText("pp_1")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/state: DRAFT/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Implements Proposal Workspace v1 UI over BFF + DPM.\n\nIncludes:\n- simulate page save draft action\n- proposal workspace list route\n- proposal detail route with submit-for-review\n- integration tests for list/detail flows\n- docs/RFC updates and contribution standards