### PR TITLE
fix: docker build/parity robustness in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/public ./public
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/package-lock.json ./package-lock.json
 COPY --from=deps /app/node_modules ./node_modules

--- a/docker-compose.ci-local.yml
+++ b/docker-compose.ci-local.yml
@@ -4,6 +4,11 @@ services:
     working_dir: /app
     volumes:
       - ./:/app
-    command: ["sh", "-lc", "npm ci && make ci-local"]
+    command:
+      [
+        "sh",
+        "-lc",
+        "npm ci && npm run lint && npm run typecheck && npm run test && npm run build"
+      ]
     environment:
       - BFF_BASE_URL=http://host.docker.internal:8100


### PR DESCRIPTION
Fixes Docker CI failures by removing hard dependency on /public in Dockerfile and replacing in-container make invocation with explicit npm command chain.