### PR TITLE
feat: drive UI navigation from platform capability contract

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -107,6 +107,13 @@ a:hover {
   color: var(--brand-strong);
 }
 
+.nav-link.nav-link-disabled {
+  color: #7a8da8;
+  border-color: #d7e0ed;
+  background: #f2f5fa;
+  cursor: not-allowed;
+}
+
 .page-container {
   width: min(1560px, 100%);
   margin: 0 auto;
@@ -396,6 +403,13 @@ a:hover {
   border-color: #8aacde;
   background: var(--brand-soft);
   color: var(--brand-strong);
+}
+
+.journey-step.disabled {
+  color: #7a8da8;
+  border-color: #d7e0ed;
+  background: #f2f5fa;
+  cursor: not-allowed;
 }
 
 @media (max-width: 1080px) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import Link from "next/link";
 import Providers from "./providers";
+import TopNav from "./top-nav";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -13,26 +14,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <Link href="/" className="brand">
                   Wealth Operations
                 </Link>
-                <nav className="nav-links">
-                  <Link href="/suite" className="nav-link">
-                    Command Center
-                  </Link>
-                  <Link href="/pas/intake" className="nav-link">
-                    Portfolio Intake
-                  </Link>
-                  <Link href="/pa/analytics" className="nav-link">
-                    Analytics Studio
-                  </Link>
-                  <Link href="/proposals" className="nav-link">
-                    Advisory Pipeline
-                  </Link>
-                  <Link href="/proposals/simulate" className="nav-link">
-                    Scenario Builder
-                  </Link>
-                  <Link href="/workbench/PF_1001" className="nav-link">
-                    Decision Console
-                  </Link>
-                </nav>
+                <TopNav />
               </div>
             </header>
             {children}

--- a/src/app/suite/page.tsx
+++ b/src/app/suite/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
-import { Chip, Paper, Stack, ToggleButton, ToggleButtonGroup, Typography } from "@mui/material";
+import { Alert, Chip, Paper, Stack, ToggleButton, ToggleButtonGroup, Typography } from "@mui/material";
 
 import {
   advisoryQueue,
@@ -12,9 +12,12 @@ import {
   intakeBatches,
   OperatingRole,
 } from "@/features/suite/mock-data";
+import { usePlatformCapabilities } from "@/features/platform-capabilities/use-platform-capabilities";
 
 export default function SuitePage() {
   const [activeRole, setActiveRole] = useState<OperatingRole>("ADVISOR");
+  const capabilities = usePlatformCapabilities();
+  const navFlags = capabilities.normalized.navigation;
 
   const roleLabel = useMemo(() => {
     if (activeRole === "RISK") return "Risk Officer";
@@ -28,6 +31,21 @@ export default function SuitePage() {
   );
   const rolePlaybook = useMemo(() => dpmActionPlaybook.filter((item) => item.role === activeRole), [activeRole]);
 
+  function renderRouteAction(label: string, href: string, enabled: boolean) {
+    if (!enabled) {
+      return (
+        <span className="journey-step disabled" aria-disabled="true">
+          {label}
+        </span>
+      );
+    }
+    return (
+      <Link href={href} className="journey-step">
+        {label}
+      </Link>
+    );
+  }
+
   return (
     <main className="page-container">
       <section className="page-header">
@@ -38,6 +56,11 @@ export default function SuitePage() {
           Start with client priorities, execute next-best workflow actions, and close the day with decision-ready outcomes.
         </Typography>
       </section>
+      {capabilities.partialFailure ? (
+        <Alert severity="warning" sx={{ mb: 1 }}>
+          Platform capability negotiation is partially degraded. Some routes are disabled based on currently available services.
+        </Alert>
+      ) : null}
 
       <section className="journey-grid">
         <Paper className="section-card journey-card" elevation={0}>
@@ -48,18 +71,10 @@ export default function SuitePage() {
             Intake data, review analytics context, simulate recommendation, then progress approvals.
           </Typography>
           <div className="journey-steps">
-            <Link href="/pas/intake" className="journey-step">
-              1. Portfolio Intake
-            </Link>
-            <Link href="/pa/analytics" className="journey-step">
-              2. Analytics Context
-            </Link>
-            <Link href="/proposals/simulate" className="journey-step">
-              3. Simulate Proposal
-            </Link>
-            <Link href="/proposals" className="journey-step">
-              4. Submit And Track
-            </Link>
+            {renderRouteAction("1. Portfolio Intake", "/pas/intake", navFlags.portfolio_intake !== false)}
+            {renderRouteAction("2. Analytics Context", "/pa/analytics", navFlags.analytics_studio !== false)}
+            {renderRouteAction("3. Simulate Proposal", "/proposals/simulate", navFlags.scenario_builder !== false)}
+            {renderRouteAction("4. Submit And Track", "/proposals", navFlags.advisory_pipeline !== false)}
           </div>
         </Paper>
 
@@ -71,18 +86,10 @@ export default function SuitePage() {
             Monitor live portfolio state, inspect risk/review queue, and approve execution-ready decisions.
           </Typography>
           <div className="journey-steps">
-            <Link href="/workbench/PF_1001" className="journey-step">
-              1. Decision Console
-            </Link>
-            <Link href="/proposals" className="journey-step">
-              2. Review Pipeline
-            </Link>
-            <Link href="/proposals" className="journey-step">
-              3. Approval Chain
-            </Link>
-            <Link href="/suite" className="journey-step">
-              4. Command Center Metrics
-            </Link>
+            {renderRouteAction("1. Decision Console", "/workbench/PF_1001", navFlags.decision_console !== false)}
+            {renderRouteAction("2. Review Pipeline", "/proposals", navFlags.advisory_pipeline !== false)}
+            {renderRouteAction("3. Approval Chain", "/proposals", navFlags.advisory_pipeline !== false)}
+            {renderRouteAction("4. Command Center Metrics", "/suite", navFlags.command_center !== false)}
           </div>
         </Paper>
       </section>
@@ -204,21 +211,33 @@ export default function SuitePage() {
           </Typography>
           <div className="suite-row">
             <span>New Recommendation</span>
-            <Link href="/proposals/simulate" className="nav-link">
-              Launch Simulation
-            </Link>
+            {navFlags.scenario_builder === false ? (
+              <span className="nav-link nav-link-disabled">Launch Simulation</span>
+            ) : (
+              <Link href="/proposals/simulate" className="nav-link">
+                Launch Simulation
+              </Link>
+            )}
           </div>
           <div className="suite-row">
             <span>Review Existing Proposals</span>
-            <Link href="/proposals" className="nav-link">
-              Open Pipeline
-            </Link>
+            {navFlags.advisory_pipeline === false ? (
+              <span className="nav-link nav-link-disabled">Open Pipeline</span>
+            ) : (
+              <Link href="/proposals" className="nav-link">
+                Open Pipeline
+              </Link>
+            )}
           </div>
           <div className="suite-row">
             <span>Portfolio Decision Context</span>
-            <Link href="/workbench/PF_1001" className="nav-link">
-              Open Workbench
-            </Link>
+            {navFlags.decision_console === false ? (
+              <span className="nav-link nav-link-disabled">Open Workbench</span>
+            ) : (
+              <Link href="/workbench/PF_1001" className="nav-link">
+                Open Workbench
+              </Link>
+            )}
           </div>
         </Paper>
 

--- a/src/app/top-nav.tsx
+++ b/src/app/top-nav.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+
+import { usePlatformCapabilities } from "@/features/platform-capabilities/use-platform-capabilities";
+
+type NavEntry = {
+  label: string;
+  href: string;
+  key: string;
+};
+
+const NAV_ENTRIES: NavEntry[] = [
+  { label: "Command Center", href: "/suite", key: "command_center" },
+  { label: "Portfolio Intake", href: "/pas/intake", key: "portfolio_intake" },
+  { label: "Analytics Studio", href: "/pa/analytics", key: "analytics_studio" },
+  { label: "Advisory Pipeline", href: "/proposals", key: "advisory_pipeline" },
+  { label: "Scenario Builder", href: "/proposals/simulate", key: "scenario_builder" },
+  { label: "Decision Console", href: "/workbench/PF_1001", key: "decision_console" },
+];
+
+export default function TopNav() {
+  const { normalized } = usePlatformCapabilities();
+
+  return (
+    <nav className="nav-links">
+      {NAV_ENTRIES.map((entry) => {
+        const enabled = normalized.navigation[entry.key] !== false;
+        if (!enabled) {
+          return (
+            <span key={entry.href} className="nav-link nav-link-disabled" aria-disabled="true">
+              {entry.label}
+            </span>
+          );
+        }
+        return (
+          <Link key={entry.href} href={entry.href} className="nav-link">
+            {entry.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/features/platform-capabilities/api.ts
+++ b/src/features/platform-capabilities/api.ts
@@ -1,0 +1,40 @@
+import {
+  DEFAULT_NAVIGATION_FLAGS,
+  PlatformCapabilitiesEnvelope,
+  PlatformNormalizedCapabilities,
+} from "./types";
+
+const BFF_PROXY_BASE = "/api/bff/api/v1";
+
+export async function getPlatformCapabilities(
+  consumerSystem = "UI",
+  tenantId = "default"
+): Promise<PlatformCapabilitiesEnvelope["data"]> {
+  const params = new URLSearchParams({
+    consumerSystem,
+    tenantId,
+  });
+  const response = await fetch(`${BFF_PROXY_BASE}/platform/capabilities?${params.toString()}`, {
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`Platform capabilities fetch failed (${response.status}): ${detail}`);
+  }
+  const payload = (await response.json()) as PlatformCapabilitiesEnvelope;
+  return payload.data;
+}
+
+export function fallbackNormalizedCapabilities(): PlatformNormalizedCapabilities {
+  return {
+    navigation: { ...DEFAULT_NAVIGATION_FLAGS },
+    workflowFlags: {},
+    inputModesBySource: {},
+    inputModesUnion: [],
+    moduleHealth: {
+      pas: "unknown",
+      pa: "unknown",
+      dpm: "unknown",
+    },
+  };
+}

--- a/src/features/platform-capabilities/types.ts
+++ b/src/features/platform-capabilities/types.ts
@@ -1,0 +1,34 @@
+export type PlatformNormalizedCapabilities = {
+  navigation: Record<string, boolean>;
+  workflowFlags: Record<string, boolean>;
+  inputModesBySource: Record<string, string[]>;
+  inputModesUnion: string[];
+  moduleHealth: Record<string, string>;
+};
+
+export type PlatformCapabilitiesError = {
+  service: string;
+  status_code: number;
+  detail: string;
+};
+
+export type PlatformCapabilitiesEnvelope = {
+  data: {
+    consumerSystem: string;
+    tenantId: string;
+    contractVersion: string;
+    sources: Record<string, Record<string, unknown>>;
+    partialFailure: boolean;
+    errors: PlatformCapabilitiesError[];
+    normalized: PlatformNormalizedCapabilities;
+  };
+};
+
+export const DEFAULT_NAVIGATION_FLAGS: Record<string, boolean> = {
+  command_center: true,
+  portfolio_intake: true,
+  analytics_studio: true,
+  advisory_pipeline: true,
+  scenario_builder: true,
+  decision_console: true,
+};

--- a/src/features/platform-capabilities/use-platform-capabilities.ts
+++ b/src/features/platform-capabilities/use-platform-capabilities.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { fallbackNormalizedCapabilities, getPlatformCapabilities } from "./api";
+import { PlatformCapabilitiesError, PlatformNormalizedCapabilities } from "./types";
+
+type UsePlatformCapabilitiesResult = {
+  loading: boolean;
+  normalized: PlatformNormalizedCapabilities;
+  partialFailure: boolean;
+  errors: PlatformCapabilitiesError[];
+};
+
+export function usePlatformCapabilities(): UsePlatformCapabilitiesResult {
+  const [loading, setLoading] = useState(true);
+  const [normalized, setNormalized] = useState<PlatformNormalizedCapabilities>(
+    fallbackNormalizedCapabilities()
+  );
+  const [partialFailure, setPartialFailure] = useState(false);
+  const [errors, setErrors] = useState<PlatformCapabilitiesError[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      try {
+        const data = await getPlatformCapabilities("UI", "default");
+        if (!active) return;
+        setNormalized(data.normalized ?? fallbackNormalizedCapabilities());
+        setPartialFailure(Boolean(data.partialFailure));
+        setErrors(data.errors ?? []);
+      } catch {
+        if (!active) return;
+        setNormalized(fallbackNormalizedCapabilities());
+        setPartialFailure(true);
+        setErrors([
+          {
+            service: "bff",
+            status_code: 0,
+            detail: "capability_bootstrap_fallback",
+          },
+        ]);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+    void load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { loading, normalized, partialFailure, errors };
+}

--- a/tests/integration/suite-page.test.tsx
+++ b/tests/integration/suite-page.test.tsx
@@ -1,7 +1,30 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 
 import SuitePage from "../../src/app/suite/page";
+
+vi.mock("@/features/platform-capabilities/use-platform-capabilities", () => ({
+  usePlatformCapabilities: vi.fn(() => ({
+    loading: false,
+    partialFailure: false,
+    errors: [],
+    normalized: {
+      navigation: {
+        command_center: true,
+        portfolio_intake: true,
+        analytics_studio: true,
+        advisory_pipeline: true,
+        scenario_builder: true,
+        decision_console: true,
+      },
+      workflowFlags: {},
+      inputModesBySource: {},
+      inputModesUnion: [],
+      moduleHealth: { pas: "available", pa: "available", dpm: "available" },
+    },
+  })),
+}));
 
 describe("SuitePage", () => {
   it("renders role-based navigation journeys", () => {

--- a/tests/integration/top-nav-capabilities.test.tsx
+++ b/tests/integration/top-nav-capabilities.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import TopNav from "../../src/app/top-nav";
+
+vi.mock("@/features/platform-capabilities/use-platform-capabilities", () => ({
+  usePlatformCapabilities: vi.fn(() => ({
+    loading: false,
+    partialFailure: false,
+    errors: [],
+    normalized: {
+      navigation: {
+        command_center: true,
+        portfolio_intake: true,
+        analytics_studio: false,
+        advisory_pipeline: true,
+        scenario_builder: false,
+        decision_console: true,
+      },
+      workflowFlags: {},
+      inputModesBySource: {},
+      inputModesUnion: [],
+      moduleHealth: { pas: "available", pa: "unavailable", dpm: "available" },
+    },
+  })),
+}));
+
+describe("TopNav", () => {
+  it("disables routes based on normalized navigation capabilities", () => {
+    render(<TopNav />);
+
+    expect(screen.getByRole("link", { name: "Command Center" })).toHaveAttribute("href", "/suite");
+    expect(screen.getByRole("link", { name: "Portfolio Intake" })).toHaveAttribute("href", "/pas/intake");
+    expect(screen.getByRole("link", { name: "Advisory Pipeline" })).toHaveAttribute("href", "/proposals");
+
+    const analyticsDisabled = screen.getByText("Analytics Studio");
+    const scenarioDisabled = screen.getByText("Scenario Builder");
+
+    expect(analyticsDisabled.tagName).toBe("SPAN");
+    expect(analyticsDisabled).toHaveAttribute("aria-disabled", "true");
+    expect(scenarioDisabled.tagName).toBe("SPAN");
+    expect(scenarioDisabled).toHaveAttribute("aria-disabled", "true");
+  });
+});

--- a/tests/unit/platform-capabilities-api.test.ts
+++ b/tests/unit/platform-capabilities-api.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fallbackNormalizedCapabilities, getPlatformCapabilities } from "../../src/features/platform-capabilities/api";
+
+describe("platform capabilities api", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls bff capabilities endpoint", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              consumerSystem: "UI",
+              tenantId: "default",
+              contractVersion: "v1",
+              sources: {},
+              partialFailure: false,
+              errors: [],
+              normalized: {
+                navigation: { command_center: true },
+                workflowFlags: {},
+                inputModesBySource: {},
+                inputModesUnion: [],
+                moduleHealth: {},
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await getPlatformCapabilities("UI", "default");
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/bff/api/v1/platform/capabilities?consumerSystem=UI&tenantId=default",
+      expect.objectContaining({ cache: "no-store" })
+    );
+  });
+
+  it("throws a useful error when bff returns non-200", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("service unavailable", { status: 503 }))
+    );
+
+    await expect(getPlatformCapabilities("UI", "default")).rejects.toThrow(
+      "Platform capabilities fetch failed (503): service unavailable"
+    );
+  });
+
+  it("returns isolated fallback defaults for client-side gating", () => {
+    const a = fallbackNormalizedCapabilities();
+    const b = fallbackNormalizedCapabilities();
+
+    a.navigation.command_center = false;
+
+    expect(b.navigation.command_center).toBe(true);
+    expect(a.moduleHealth).toEqual({ pas: "unknown", pa: "unknown", dpm: "unknown" });
+  });
+});


### PR DESCRIPTION
## Summary
- add platform capabilities feature module and client hook
- gate top navigation and command-center journey actions using BFF normalized capabilities
- add unit/integration tests for capability API behavior and nav gating

## Validation
- npm test
- npm run typecheck