### PR TITLE
feat: show capability policy and module health in suite UI

### DIFF
--- a/src/app/suite/page.tsx
+++ b/src/app/suite/page.tsx
@@ -18,6 +18,9 @@ export default function SuitePage() {
   const [activeRole, setActiveRole] = useState<OperatingRole>("ADVISOR");
   const capabilities = usePlatformCapabilities();
   const navFlags = capabilities.normalized.navigation;
+  const moduleHealth = capabilities.normalized.moduleHealth;
+  const policyVersions = capabilities.normalized.policyVersionsBySource;
+  const sources = ["pas", "pa", "dpm"] as const;
 
   const roleLabel = useMemo(() => {
     if (activeRole === "RISK") return "Risk Officer";
@@ -102,18 +105,13 @@ export default function SuitePage() {
           <Chip size="small" color="success" label="Decision Flow Live" />
         </Stack>
         <div className="kpi-grid">
-          <div className="kpi-box">
-            <p className="kpi-label">Portfolio Data Hub</p>
-            <p className="kpi-value">Storyboard</p>
-          </div>
-          <div className="kpi-box">
-            <p className="kpi-label">Analytics Intelligence</p>
-            <p className="kpi-value">Storyboard</p>
-          </div>
-          <div className="kpi-box">
-            <p className="kpi-label">Decision Workflow</p>
-            <p className="kpi-value">Live via BFF</p>
-          </div>
+          {sources.map((source) => (
+            <div key={source} className="kpi-box">
+              <p className="kpi-label">{source.toUpperCase()} Module Health</p>
+              <p className="kpi-value">{moduleHealth[source] ?? "unknown"}</p>
+              <p className="kpi-label">Policy: {policyVersions[source] ?? "unknown"}</p>
+            </div>
+          ))}
         </div>
       </Paper>
 

--- a/src/features/platform-capabilities/api.ts
+++ b/src/features/platform-capabilities/api.ts
@@ -36,5 +36,10 @@ export function fallbackNormalizedCapabilities(): PlatformNormalizedCapabilities
       pa: "unknown",
       dpm: "unknown",
     },
+    policyVersionsBySource: {
+      pas: "unknown",
+      pa: "unknown",
+      dpm: "unknown",
+    },
   };
 }

--- a/src/features/platform-capabilities/types.ts
+++ b/src/features/platform-capabilities/types.ts
@@ -4,6 +4,7 @@ export type PlatformNormalizedCapabilities = {
   inputModesBySource: Record<string, string[]>;
   inputModesUnion: string[];
   moduleHealth: Record<string, string>;
+  policyVersionsBySource: Record<string, string>;
 };
 
 export type PlatformCapabilitiesError = {

--- a/tests/integration/suite-page.test.tsx
+++ b/tests/integration/suite-page.test.tsx
@@ -22,6 +22,11 @@ vi.mock("@/features/platform-capabilities/use-platform-capabilities", () => ({
       inputModesBySource: {},
       inputModesUnion: [],
       moduleHealth: { pas: "available", pa: "available", dpm: "available" },
+      policyVersionsBySource: {
+        pas: "pas-default-v1",
+        pa: "pa-default-v1",
+        dpm: "dpm-default-v1",
+      },
     },
   })),
 }));
@@ -34,5 +39,8 @@ describe("SuitePage", () => {
     expect(screen.getByText("Portfolio Manager Journey")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /1\. Portfolio Intake/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /1\. Decision Console/i })).toBeInTheDocument();
+    expect(screen.getByText((text) => text.includes("pas-default-v1"))).toBeInTheDocument();
+    expect(screen.getByText((text) => text.includes("pa-default-v1"))).toBeInTheDocument();
+    expect(screen.getByText((text) => text.includes("dpm-default-v1"))).toBeInTheDocument();
   });
 });

--- a/tests/integration/top-nav-capabilities.test.tsx
+++ b/tests/integration/top-nav-capabilities.test.tsx
@@ -22,6 +22,11 @@ vi.mock("@/features/platform-capabilities/use-platform-capabilities", () => ({
       inputModesBySource: {},
       inputModesUnion: [],
       moduleHealth: { pas: "available", pa: "unavailable", dpm: "available" },
+      policyVersionsBySource: {
+        pas: "pas-default-v1",
+        pa: "pa-default-v1",
+        dpm: "dpm-default-v1",
+      },
     },
   })),
 }));

--- a/tests/unit/platform-capabilities-api.test.ts
+++ b/tests/unit/platform-capabilities-api.test.ts
@@ -26,6 +26,7 @@ describe("platform capabilities api", () => {
                 inputModesBySource: {},
                 inputModesUnion: [],
                 moduleHealth: {},
+                policyVersionsBySource: {},
               },
             },
           }),
@@ -61,5 +62,10 @@ describe("platform capabilities api", () => {
 
     expect(b.navigation.command_center).toBe(true);
     expect(a.moduleHealth).toEqual({ pas: "unknown", pa: "unknown", dpm: "unknown" });
+    expect(a.policyVersionsBySource).toEqual({
+      pas: "unknown",
+      pa: "unknown",
+      dpm: "unknown",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extend UI capability types/fallback with policyVersionsBySource
- surface PAS/PA/DPM module health and policy versions in Integration Status panel
- update capability-related UI tests

## Validation
- npm run typecheck
- npm test