### PR TITLE
feat: show PAS policy diagnostics in command center

### DIFF
--- a/src/app/suite/page.tsx
+++ b/src/app/suite/page.tsx
@@ -20,6 +20,7 @@ export default function SuitePage() {
   const navFlags = capabilities.normalized.navigation;
   const moduleHealth = capabilities.normalized.moduleHealth;
   const policyVersions = capabilities.normalized.policyVersionsBySource;
+  const pasPolicyDiagnostics = capabilities.normalized.pasPolicyDiagnostics;
   const sources = ["pas", "pa", "dpm"] as const;
 
   const roleLabel = useMemo(() => {
@@ -112,6 +113,28 @@ export default function SuitePage() {
               <p className="kpi-label">Policy: {policyVersions[source] ?? "unknown"}</p>
             </div>
           ))}
+        </div>
+        <div className="suite-row">
+          <div>
+            <strong>PAS Policy Diagnostics</strong>
+            <p className="muted">
+              {pasPolicyDiagnostics.available ? "available" : "unavailable"} | strict mode:{" "}
+              {pasPolicyDiagnostics.policyProvenance.strictMode ? "on" : "off"}
+            </p>
+            <p className="muted">
+              Rule: {pasPolicyDiagnostics.policyProvenance.matchedRuleId} | Source:{" "}
+              {pasPolicyDiagnostics.policyProvenance.policySource}
+            </p>
+            <p className="muted">
+              Allowed sections:{" "}
+              {pasPolicyDiagnostics.allowedSections.length > 0
+                ? pasPolicyDiagnostics.allowedSections.join(", ")
+                : "none"}
+            </p>
+            {pasPolicyDiagnostics.warnings.length > 0 ? (
+              <p className="muted">Warnings: {pasPolicyDiagnostics.warnings.join(", ")}</p>
+            ) : null}
+          </div>
         </div>
       </Paper>
 

--- a/src/features/platform-capabilities/api.ts
+++ b/src/features/platform-capabilities/api.ts
@@ -41,5 +41,16 @@ export function fallbackNormalizedCapabilities(): PlatformNormalizedCapabilities
       pa: "unknown",
       dpm: "unknown",
     },
+    pasPolicyDiagnostics: {
+      available: false,
+      allowedSections: [],
+      warnings: [],
+      policyProvenance: {
+        policyVersion: "unknown",
+        policySource: "unknown",
+        matchedRuleId: "unknown",
+        strictMode: false,
+      },
+    },
   };
 }

--- a/src/features/platform-capabilities/types.ts
+++ b/src/features/platform-capabilities/types.ts
@@ -1,3 +1,15 @@
+export type PasPolicyDiagnostics = {
+  available: boolean;
+  allowedSections: string[];
+  warnings: string[];
+  policyProvenance: {
+    policyVersion: string;
+    policySource: string;
+    matchedRuleId: string;
+    strictMode: boolean;
+  };
+};
+
 export type PlatformNormalizedCapabilities = {
   navigation: Record<string, boolean>;
   workflowFlags: Record<string, boolean>;
@@ -5,6 +17,7 @@ export type PlatformNormalizedCapabilities = {
   inputModesUnion: string[];
   moduleHealth: Record<string, string>;
   policyVersionsBySource: Record<string, string>;
+  pasPolicyDiagnostics: PasPolicyDiagnostics;
 };
 
 export type PlatformCapabilitiesError = {

--- a/tests/integration/suite-page.test.tsx
+++ b/tests/integration/suite-page.test.tsx
@@ -27,6 +27,17 @@ vi.mock("@/features/platform-capabilities/use-platform-capabilities", () => ({
         pa: "pa-default-v1",
         dpm: "dpm-default-v1",
       },
+      pasPolicyDiagnostics: {
+        available: true,
+        allowedSections: ["OVERVIEW", "HOLDINGS"],
+        warnings: ["SECTIONS_FILTERED_BY_POLICY"],
+        policyProvenance: {
+          policyVersion: "pas-default-v1",
+          policySource: "tenant",
+          matchedRuleId: "tenant.default.consumers.UI",
+          strictMode: true,
+        },
+      },
     },
   })),
 }));
@@ -42,5 +53,9 @@ describe("SuitePage", () => {
     expect(screen.getByText((text) => text.includes("pas-default-v1"))).toBeInTheDocument();
     expect(screen.getByText((text) => text.includes("pa-default-v1"))).toBeInTheDocument();
     expect(screen.getByText((text) => text.includes("dpm-default-v1"))).toBeInTheDocument();
+    expect(screen.getByText((text) => text.includes("strict mode: on"))).toBeInTheDocument();
+    expect(
+      screen.getByText((text) => text.includes("tenant.default.consumers.UI"))
+    ).toBeInTheDocument();
   });
 });

--- a/tests/integration/top-nav-capabilities.test.tsx
+++ b/tests/integration/top-nav-capabilities.test.tsx
@@ -27,6 +27,17 @@ vi.mock("@/features/platform-capabilities/use-platform-capabilities", () => ({
         pa: "pa-default-v1",
         dpm: "dpm-default-v1",
       },
+      pasPolicyDiagnostics: {
+        available: true,
+        allowedSections: ["OVERVIEW"],
+        warnings: [],
+        policyProvenance: {
+          policyVersion: "pas-default-v1",
+          policySource: "default",
+          matchedRuleId: "default",
+          strictMode: false,
+        },
+      },
     },
   })),
 }));

--- a/tests/unit/platform-capabilities-api.test.ts
+++ b/tests/unit/platform-capabilities-api.test.ts
@@ -27,6 +27,17 @@ describe("platform capabilities api", () => {
                 inputModesUnion: [],
                 moduleHealth: {},
                 policyVersionsBySource: {},
+                pasPolicyDiagnostics: {
+                  available: true,
+                  allowedSections: ["OVERVIEW"],
+                  warnings: [],
+                  policyProvenance: {
+                    policyVersion: "pas-default-v1",
+                    policySource: "default",
+                    matchedRuleId: "default",
+                    strictMode: false,
+                  },
+                },
               },
             },
           }),
@@ -67,5 +78,6 @@ describe("platform capabilities api", () => {
       pa: "unknown",
       dpm: "unknown",
     });
+    expect(a.pasPolicyDiagnostics.available).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- extend capability types/fallback with pasPolicyDiagnostics
- render PAS policy diagnostics (strict mode, matched rule, sections, warnings) in suite integration status
- update capability integration/unit tests

## Validation
- npm run typecheck
- npm test