### PR TITLE
fix(workbench): resilient decision console fallback routing

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -14,3 +14,4 @@ Governance boundary:
 | RFC-0006 | Backend-Resolved Reference IDs for Proposal and Workbench Routes | IMPLEMENTED | `docs/rfcs/RFC-0006-backend-resolved-reference-ids-for-proposal-and-workbench-routes.md` |
 | RFC-0007 | Portfolio-First Domain UX and Lifecycle Workspace Navigation | PROPOSED | `docs/rfcs/RFC-0007-portfolio-first-domain-ux-and-lifecycle-workspace-navigation.md` |
 | RFC-0008 | Advisory Iterative Intent Builder for Proposal Simulation | IMPLEMENTED | `docs/rfcs/RFC-0008-advisory-iterative-intent-builder-for-proposal-simulation.md` |
+| RFC-0009 | Decision Console Fallback Routing Resilience | IMPLEMENTED | `docs/rfcs/RFC-0009-decision-console-fallback-routing-resilience.md` |

--- a/docs/rfcs/RFC-0009-decision-console-fallback-routing-resilience.md
+++ b/docs/rfcs/RFC-0009-decision-console-fallback-routing-resilience.md
@@ -1,0 +1,38 @@
+# RFC-0009: Decision Console Fallback Routing Resilience
+
+- Status: IMPLEMENTED
+- Date: 2026-02-24
+- Owners: Advisor Workbench UI
+
+## Problem Statement
+
+The `/workbench` entry route can appear broken when portfolio lookup fails or returns empty, leaving users without a reliable way to open the Decision Console.
+
+## Root Cause
+
+- Entry routing was hard-dependent on BFF lookup response.
+- No deterministic fallback portfolio routing was configured.
+
+## Proposed Solution
+
+Add configurable fallback portfolio IDs for `/workbench` entry routing:
+
+1. Attempt BFF lookup-driven routing first.
+2. If lookup is empty/unavailable, route to first configured fallback portfolio.
+3. Keep explicit empty-state message only when no fallback IDs are configured.
+
+## Architectural Impact
+
+- Improves UI route resilience without changing backend contracts.
+- Preserves existing Workbench detail page behavior and error handling.
+
+## Risks and Trade-offs
+
+- Fallback portfolio may not exist in all environments.
+- Could route to a portfolio that returns an upstream-data warning rather than a full snapshot.
+
+## High-Level Implementation Approach
+
+1. Add `WORKBENCH_FALLBACK_PORTFOLIO_IDS` environment-driven fallback list.
+2. Update `/workbench` entry page routing logic.
+3. Validate via live route checks and lint/typecheck.

--- a/src/app/workbench/page.tsx
+++ b/src/app/workbench/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 
 const BFF_BASE_URL = process.env.BFF_BASE_URL ?? "http://localhost:8100";
+const WORKBENCH_FALLBACK_PORTFOLIO_IDS =
+  process.env.WORKBENCH_FALLBACK_PORTFOLIO_IDS ?? "pf_demo_ui_1,pf_demo_ui_2,pf_demo_ui_3";
 
 type LookupItem = {
   id: string;
@@ -24,11 +26,22 @@ async function getDefaultPortfolioId(): Promise<string | null> {
   }
 }
 
+function getFallbackPortfolioIds(): string[] {
+  return WORKBENCH_FALLBACK_PORTFOLIO_IDS.split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
 export default async function WorkbenchEntryPage() {
   const portfolioId = await getDefaultPortfolioId();
+  const fallbackPortfolioIds = getFallbackPortfolioIds();
 
   if (portfolioId) {
     redirect(`/workbench/${portfolioId}`);
+  }
+
+  if (fallbackPortfolioIds.length > 0) {
+    redirect(`/workbench/${fallbackPortfolioIds[0]}`);
   }
 
   return (
@@ -36,7 +49,7 @@ export default async function WorkbenchEntryPage() {
       <section className="page-header">
         <h1 className="page-title">Decision Console</h1>
         <p className="page-subtitle">
-          No portfolio is currently available from the platform lookup catalog. Create or ingest a portfolio first.
+          No portfolio is currently available from the platform lookup catalog and no fallback IDs are configured.
         </p>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add RFC-0009 for decision console fallback routing resilience
- update /workbench entry route to use configured fallback portfolio IDs when lookup is empty/unavailable
- keep explicit empty-state only when fallback list is not configured

## Validation
- npm run typecheck
- npm run lint
- curl -I http://localhost:3000/workbench