### PR TITLE
feat(workbench): Portfolio 360 with live sandbox controls

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -15,3 +15,4 @@ Governance boundary:
 | RFC-0007 | Portfolio-First Domain UX and Lifecycle Workspace Navigation | PROPOSED | `docs/rfcs/RFC-0007-portfolio-first-domain-ux-and-lifecycle-workspace-navigation.md` |
 | RFC-0008 | Advisory Iterative Intent Builder for Proposal Simulation | IMPLEMENTED | `docs/rfcs/RFC-0008-advisory-iterative-intent-builder-for-proposal-simulation.md` |
 | RFC-0009 | Decision Console Fallback Routing Resilience | IMPLEMENTED | `docs/rfcs/RFC-0009-decision-console-fallback-routing-resilience.md` |
+| RFC-0010 | Workbench Portfolio 360 and Live Sandbox UI | IMPLEMENTED | `docs/rfcs/RFC-0010-workbench-portfolio-360-and-live-sandbox-ui.md` |

--- a/docs/rfcs/RFC-0010-workbench-portfolio-360-and-live-sandbox-ui.md
+++ b/docs/rfcs/RFC-0010-workbench-portfolio-360-and-live-sandbox-ui.md
@@ -1,0 +1,41 @@
+# RFC-0010: Workbench Portfolio 360 and Live Sandbox UI
+
+- Status: IMPLEMENTED
+- Date: 2026-02-24
+- Owners: Advisor Workbench UI
+
+## Problem Statement
+
+Decision Console still behaves as a static overview. Advisors need a single workspace that shows current state, allows iterative scenario changes, and displays projected portfolio state in-session.
+
+## Root Cause
+
+- UI lacked a Portfolio 360 data model.
+- No Workbench integration for simulation session create/apply loop.
+- Current and projected states were not displayed side-by-side.
+
+## Proposed Solution
+
+Implement Portfolio 360 and live sandbox in Workbench UI:
+
+1. Load Portfolio 360 from BFF endpoint with optional session context.
+2. Add sandbox controls to create session and apply simple change intents.
+3. Display current vs projected positions and projected summary deltas.
+4. Surface optional policy feedback from sandbox updates.
+
+## Architectural Impact
+
+- UI now consumes lifecycle-oriented BFF workbench contracts.
+- Workbench route becomes the domain entry point for iterative proposal pre-work.
+
+## Risks and Trade-offs
+
+- Initial sandbox editor is intentionally lightweight (single change submission flow).
+- Richer multi-row scenario editing remains a follow-up UX increment.
+
+## High-Level Implementation Approach
+
+1. Extend workbench types and API client for Portfolio 360 + sandbox APIs.
+2. Add sandbox control component with session lifecycle actions.
+3. Render current/proposed portfolio panels and projected KPI strip.
+4. Add integration tests for new Decision Console behavior.

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -1,21 +1,26 @@
-import { getWorkbenchOverview } from "@/features/workbench/api";
+import { getPortfolio360 } from "@/features/workbench/api";
 import OverviewCards from "@/features/workbench/components/overview-cards";
 import PartialFailureBanner from "@/features/workbench/components/partial-failure-banner";
 import PerformanceSnapshot from "@/features/workbench/components/performance-snapshot";
 import PositionsGrid from "@/features/workbench/components/positions-grid";
 import RebalanceStatus from "@/features/workbench/components/rebalance-status";
+import SandboxControls from "@/features/workbench/components/sandbox-controls";
 import Link from "next/link";
 
 export default async function WorkbenchPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ portfolioId: string }>;
+  searchParams: Promise<{ sessionId?: string }>;
 }) {
   const { portfolioId } = await params;
+  const resolvedSearch = await searchParams;
+  const sessionId = resolvedSearch.sessionId?.trim() || undefined;
 
-  let data;
+  let data: Awaited<ReturnType<typeof getPortfolio360>>;
   try {
-    data = await getWorkbenchOverview(portfolioId);
+    data = await getPortfolio360(portfolioId, sessionId);
   } catch (error) {
     const detail = error instanceof Error ? error.message : "Unknown error";
     return (
@@ -59,6 +64,82 @@ export default async function WorkbenchPage({
         positionCount={data.overview.position_count}
         baseCurrency={data.portfolio.base_currency}
       />
+
+      <SandboxControls portfolioId={data.portfolio.portfolio_id} sessionId={data.active_session_id} />
+
+      {data.projected_summary ? (
+        <section className="section-card">
+          <h3>Projected Summary</h3>
+          <div className="suite-row">
+            <span>Baseline Positions</span>
+            <strong>{data.projected_summary.total_baseline_positions}</strong>
+          </div>
+          <div className="suite-row">
+            <span>Proposed Positions</span>
+            <strong>{data.projected_summary.total_proposed_positions}</strong>
+          </div>
+          <div className="suite-row">
+            <span>Net Delta Quantity</span>
+            <strong>{data.projected_summary.net_delta_quantity.toFixed(4)}</strong>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="section-card">
+        <h3>Portfolio 360 Current Positions</h3>
+        {data.current_positions.length ? (
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr>
+                <th align="left">Security</th>
+                <th align="left">Instrument</th>
+                <th align="left">Asset Class</th>
+                <th align="right">Quantity</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.current_positions.slice(0, 20).map((row) => (
+                <tr key={row.security_id}>
+                  <td>{row.security_id}</td>
+                  <td>{row.instrument_name}</td>
+                  <td>{row.asset_class ?? "N/A"}</td>
+                  <td align="right">{row.quantity.toFixed(4)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="muted">No current positions available in snapshot.</p>
+        )}
+      </section>
+
+      {data.projected_positions.length ? (
+        <section className="section-card">
+          <h3>Live Sandbox Projected Positions</h3>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr>
+                <th align="left">Security</th>
+                <th align="left">Instrument</th>
+                <th align="right">Baseline</th>
+                <th align="right">Proposed</th>
+                <th align="right">Delta</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.projected_positions.slice(0, 20).map((row) => (
+                <tr key={row.security_id}>
+                  <td>{row.security_id}</td>
+                  <td>{row.instrument_name}</td>
+                  <td align="right">{row.baseline_quantity.toFixed(4)}</td>
+                  <td align="right">{row.proposed_quantity.toFixed(4)}</td>
+                  <td align="right">{row.delta_quantity.toFixed(4)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      ) : null}
 
       <PositionsGrid count={data.overview.position_count} />
 

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -1,6 +1,11 @@
-import { WorkbenchOverview } from "./types";
+import {
+  WorkbenchOverview,
+  WorkbenchPortfolio360,
+  WorkbenchSandboxState,
+} from "./types";
 
 const BFF_BASE_URL = process.env.BFF_BASE_URL ?? "http://localhost:8100";
+const BFF_PROXY_BASE = "/api/bff/api/v1";
 
 export async function getWorkbenchOverview(portfolioId: string): Promise<WorkbenchOverview> {
   const response = await fetch(`${BFF_BASE_URL}/api/v1/workbench/${portfolioId}/overview`, {
@@ -12,4 +17,63 @@ export async function getWorkbenchOverview(portfolioId: string): Promise<Workben
   }
 
   return (await response.json()) as WorkbenchOverview;
+}
+
+export async function getPortfolio360(
+  portfolioId: string,
+  sessionId?: string
+): Promise<WorkbenchPortfolio360> {
+  const query = sessionId ? `?session_id=${encodeURIComponent(sessionId)}` : "";
+  const response = await fetch(`${BFF_BASE_URL}/api/v1/workbench/${portfolioId}/portfolio-360${query}`, {
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch portfolio 360 (${response.status})`);
+  }
+  return (await response.json()) as WorkbenchPortfolio360;
+}
+
+export async function createSandboxSession(
+  portfolioId: string,
+  payload: { created_by?: string; ttl_hours?: number }
+): Promise<WorkbenchSandboxState> {
+  const response = await fetch(`${BFF_PROXY_BASE}/workbench/${portfolioId}/sandbox/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Sandbox create failed (${response.status}): ${body}`);
+  }
+  return (await response.json()) as WorkbenchSandboxState;
+}
+
+export async function applySandboxChanges(
+  portfolioId: string,
+  sessionId: string,
+  payload: {
+    changes: Array<{
+      security_id: string;
+      transaction_type: string;
+      quantity?: number;
+      amount?: number;
+      currency?: string;
+    }>;
+    evaluate_policy?: boolean;
+  }
+): Promise<WorkbenchSandboxState> {
+  const response = await fetch(
+    `${BFF_PROXY_BASE}/workbench/${portfolioId}/sandbox/sessions/${sessionId}/changes`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Sandbox apply failed (${response.status}): ${body}`);
+  }
+  return (await response.json()) as WorkbenchSandboxState;
 }

--- a/src/features/workbench/components/sandbox-controls.tsx
+++ b/src/features/workbench/components/sandbox-controls.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Alert, Box, Button, MenuItem, Stack, TextField, Typography } from "@mui/material";
+
+import { applySandboxChanges, createSandboxSession } from "../api";
+
+export default function SandboxControls({
+  portfolioId,
+  sessionId,
+}: {
+  portfolioId: string;
+  sessionId: string | null;
+}) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [securityId, setSecurityId] = useState("");
+  const [transactionType, setTransactionType] = useState<"BUY" | "SELL">("BUY");
+  const [quantity, setQuantity] = useState(1);
+  const [evaluatePolicy, setEvaluatePolicy] = useState(true);
+
+  async function onCreateSession() {
+    setError(null);
+    setLoading(true);
+    try {
+      const response = await createSandboxSession(portfolioId, {
+        created_by: "advisor_1",
+        ttl_hours: 24,
+      });
+      router.push(`/workbench/${encodeURIComponent(portfolioId)}?sessionId=${encodeURIComponent(response.session_id)}`);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create session");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function onApplyChange() {
+    if (!sessionId) {
+      setError("Create a sandbox session first.");
+      return;
+    }
+    if (!securityId.trim()) {
+      setError("Security ID is required.");
+      return;
+    }
+    setError(null);
+    setLoading(true);
+    try {
+      await applySandboxChanges(portfolioId, sessionId, {
+        changes: [
+          {
+            security_id: securityId.trim(),
+            transaction_type: transactionType,
+            quantity,
+          },
+        ],
+        evaluate_policy: evaluatePolicy,
+      });
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to apply changes");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="section-card">
+      <Typography variant="h6">Live Sandbox</Typography>
+      <Typography className="muted" sx={{ mb: 1 }}>
+        Session: {sessionId ?? "none"}.
+      </Typography>
+      <Stack direction={{ xs: "column", md: "row" }} spacing={1} sx={{ mb: 1 }}>
+        <Button variant="outlined" onClick={onCreateSession} disabled={loading}>
+          {loading ? "Working..." : "Create Session"}
+        </Button>
+      </Stack>
+      <Box>
+        <Stack direction={{ xs: "column", md: "row" }} spacing={1}>
+          <TextField
+            label="Security ID"
+            size="small"
+            value={securityId}
+            onChange={(event) => setSecurityId(event.target.value)}
+          />
+          <TextField
+            label="Transaction"
+            size="small"
+            select
+            value={transactionType}
+            onChange={(event) => setTransactionType(event.target.value as "BUY" | "SELL")}
+          >
+            <MenuItem value="BUY">BUY</MenuItem>
+            <MenuItem value="SELL">SELL</MenuItem>
+          </TextField>
+          <TextField
+            label="Quantity"
+            size="small"
+            type="number"
+            value={quantity}
+            onChange={(event) => {
+              const next = Number((event.target as HTMLInputElement).value);
+              setQuantity(Number.isNaN(next) ? 0 : next);
+            }}
+          />
+          <TextField
+            label="Policy Eval"
+            size="small"
+            select
+            value={evaluatePolicy ? "ON" : "OFF"}
+            onChange={(event) => setEvaluatePolicy(event.target.value === "ON")}
+          >
+            <MenuItem value="ON">ON</MenuItem>
+            <MenuItem value="OFF">OFF</MenuItem>
+          </TextField>
+          <Button variant="contained" onClick={onApplyChange} disabled={loading || !sessionId}>
+            {loading ? "Applying..." : "Apply Change"}
+          </Button>
+        </Stack>
+      </Box>
+      {error ? (
+        <Alert severity="error" sx={{ mt: 1 }}>
+          {error}
+        </Alert>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -30,3 +30,60 @@ export type WorkbenchOverview = {
     detail: string;
   }>;
 };
+
+export type WorkbenchPositionView = {
+  security_id: string;
+  instrument_name: string;
+  asset_class: string | null;
+  quantity: number;
+};
+
+export type WorkbenchProjectedPositionView = {
+  security_id: string;
+  instrument_name: string;
+  asset_class: string | null;
+  baseline_quantity: number;
+  proposed_quantity: number;
+  delta_quantity: number;
+};
+
+export type WorkbenchProjectedSummary = {
+  total_baseline_positions: number;
+  total_proposed_positions: number;
+  net_delta_quantity: number;
+};
+
+export type WorkbenchPolicyFeedback = {
+  status: string;
+  detail?: string | null;
+  raw?: Record<string, unknown> | null;
+};
+
+export type WorkbenchPortfolio360 = {
+  correlation_id: string;
+  contract_version: string;
+  as_of_date: string;
+  portfolio: WorkbenchOverview["portfolio"];
+  overview: WorkbenchOverview["overview"];
+  performance_snapshot: WorkbenchOverview["performance_snapshot"] | null;
+  rebalance_snapshot: WorkbenchOverview["rebalance_snapshot"] | null;
+  current_positions: WorkbenchPositionView[];
+  projected_positions: WorkbenchProjectedPositionView[];
+  projected_summary: WorkbenchProjectedSummary | null;
+  active_session_id: string | null;
+  warnings: string[];
+  partial_failures: WorkbenchOverview["partial_failures"];
+};
+
+export type WorkbenchSandboxState = {
+  correlation_id: string;
+  contract_version: string;
+  portfolio_id: string;
+  session_id: string;
+  session_version: number;
+  projected_positions: WorkbenchProjectedPositionView[];
+  projected_summary: WorkbenchProjectedSummary;
+  policy_feedback: WorkbenchPolicyFeedback | null;
+  warnings: string[];
+  partial_failures: WorkbenchOverview["partial_failures"];
+};

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { applySandboxChanges, createSandboxSession } from "../../src/features/workbench/api";
+
+const expectedBaseUrl = "/api/bff/api/v1";
+
+describe("workbench api", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls sandbox session create endpoint", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr",
+            contract_version: "v1",
+            portfolio_id: "PF_1001",
+            session_id: "sess_1",
+            session_version: 1,
+            projected_positions: [],
+            projected_summary: {
+              total_baseline_positions: 0,
+              total_proposed_positions: 0,
+              net_delta_quantity: 0,
+            },
+            warnings: [],
+            partial_failures: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await createSandboxSession("PF_1001", { created_by: "advisor_1", ttl_hours: 24 });
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/workbench/PF_1001/sandbox/sessions`,
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("calls sandbox change apply endpoint", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr",
+            contract_version: "v1",
+            portfolio_id: "PF_1001",
+            session_id: "sess_1",
+            session_version: 2,
+            projected_positions: [],
+            projected_summary: {
+              total_baseline_positions: 1,
+              total_proposed_positions: 1,
+              net_delta_quantity: 2,
+            },
+            policy_feedback: { status: "PASS" },
+            warnings: [],
+            partial_failures: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await applySandboxChanges("PF_1001", "sess_1", {
+      changes: [{ security_id: "EQ_1", transaction_type: "BUY", quantity: 2 }],
+      evaluate_policy: true,
+    });
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/workbench/PF_1001/sandbox/sessions/sess_1/changes`,
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add RFC-0010 for Portfolio 360 + sandbox UI increment
- wire decision console to BFF portfolio-360 endpoint with optional session context
- add live sandbox controls to create session and apply change intents
- render current vs projected position views and projected summary metrics
- add unit tests for new workbench API calls

## Validation
- npm run typecheck
- npm run lint
- npx vitest run tests/unit/workbench-api.test.ts tests/integration/workbench-page.test.tsx