### PR TITLE
feat(workbench): split-view Portfolio 360 with constraint rail

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -16,3 +16,4 @@ Governance boundary:
 | RFC-0008 | Advisory Iterative Intent Builder for Proposal Simulation | IMPLEMENTED | `docs/rfcs/RFC-0008-advisory-iterative-intent-builder-for-proposal-simulation.md` |
 | RFC-0009 | Decision Console Fallback Routing Resilience | IMPLEMENTED | `docs/rfcs/RFC-0009-decision-console-fallback-routing-resilience.md` |
 | RFC-0010 | Workbench Portfolio 360 and Live Sandbox UI | IMPLEMENTED | `docs/rfcs/RFC-0010-workbench-portfolio-360-and-live-sandbox-ui.md` |
+| RFC-0011 | Workbench Split View and Constraint Rail | IMPLEMENTED | `docs/rfcs/RFC-0011-workbench-split-view-and-constraint-rail.md` |

--- a/docs/rfcs/RFC-0011-workbench-split-view-and-constraint-rail.md
+++ b/docs/rfcs/RFC-0011-workbench-split-view-and-constraint-rail.md
@@ -1,0 +1,40 @@
+# RFC-0011: Workbench Split View and Constraint Rail
+
+- Status: IMPLEMENTED
+- Date: 2026-02-24
+- Owners: Advisor Workbench UI
+
+## Problem Statement
+
+Portfolio 360 and sandbox capabilities exist, but the Workbench screen is still card-oriented and does not provide a concise operational split-view for baseline versus projected state with explicit constraint feedback.
+
+## Root Cause
+
+- Workbench layout evolved incrementally from section cards.
+- No dedicated constraint rail to summarize policy/workflow readiness.
+- Live sandbox interactions did not persist policy feedback context on-screen.
+
+## Proposed Solution
+
+Implement a dense, domain-oriented split workspace:
+
+1. Left pane: current portfolio 360 positions (baseline).
+2. Right pane: live sandbox controls, projected summary, projected positions.
+3. Constraint rail: policy gate status, workflow readiness, and warning indicators.
+
+## Architectural Impact
+
+- Improves usability without changing backend contracts.
+- Aligns Workbench UI with advisory simulation decision loops.
+
+## Risks and Trade-offs
+
+- More information density requires careful mobile handling.
+- Policy status reflects latest sandbox evaluation and may be unavailable before first run.
+
+## High-Level Implementation Approach
+
+1. Add split-layout styles and compact position table styles.
+2. Extend sandbox controls with local policy/status state.
+3. Add constraint rail component and wire to sandbox feedback + warnings.
+4. Update Workbench route composition and validate with lint/typecheck/tests.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -412,6 +412,102 @@ a:hover {
   cursor: not-allowed;
 }
 
+.workbench-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.workbench-col {
+  display: grid;
+  gap: 1rem;
+}
+
+.position-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+}
+
+.position-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: #50607a;
+  font-size: 0.74rem;
+  border-bottom: 1px solid #d6dfec;
+  padding: 0.45rem 0.4rem;
+  position: sticky;
+  top: 0;
+  background: #f7fbff;
+}
+
+.position-table td {
+  border-bottom: 1px dashed #d6dfec;
+  padding: 0.48rem 0.4rem;
+}
+
+.table-wrap {
+  max-height: 390px;
+  overflow: auto;
+  border: 1px solid #d7dfec;
+  border-radius: 10px;
+}
+
+.constraint-rail {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.constraint-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.constraint-label {
+  color: #4b5c75;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.constraint-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid #c9d6ea;
+  padding: 0.25rem 0.58rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  max-width: 62%;
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.constraint-pass {
+  border-color: #85bf98;
+  background: #edf8f1;
+  color: #1f6a34;
+}
+
+.constraint-warn {
+  border-color: #ddbb6e;
+  background: #fff7e5;
+  color: #8a5d08;
+}
+
+.constraint-fail {
+  border-color: #db8d8d;
+  background: #fef0f0;
+  color: #8f2f2f;
+}
+
+.constraint-neutral {
+  border-color: #ced8e8;
+  background: #f3f7fc;
+  color: #41526f;
+}
+
 @media (max-width: 1080px) {
   .kpi-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -419,6 +515,10 @@ a:hover {
 
   .suite-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .workbench-split {
+    grid-template-columns: 1fr;
   }
 
 }
@@ -450,6 +550,10 @@ a:hover {
   }
 
   .suite-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .workbench-split {
     grid-template-columns: 1fr;
   }
 

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -65,94 +65,110 @@ export default async function WorkbenchPage({
         baseCurrency={data.portfolio.base_currency}
       />
 
-      <SandboxControls portfolioId={data.portfolio.portfolio_id} sessionId={data.active_session_id} />
+      <section className="workbench-split">
+        <div className="workbench-col">
+          <section className="section-card">
+            <h3>Portfolio 360 Baseline Positions</h3>
+            {data.current_positions.length ? (
+              <div className="table-wrap">
+                <table className="position-table">
+                  <thead>
+                    <tr>
+                      <th align="left">Security</th>
+                      <th align="left">Instrument</th>
+                      <th align="left">Asset Class</th>
+                      <th align="right">Quantity</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.current_positions.map((row) => (
+                      <tr key={row.security_id}>
+                        <td>{row.security_id}</td>
+                        <td>{row.instrument_name}</td>
+                        <td>{row.asset_class ?? "N/A"}</td>
+                        <td align="right">{row.quantity.toFixed(4)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="muted">No current positions available in snapshot.</p>
+            )}
+          </section>
 
-      {data.projected_summary ? (
-        <section className="section-card">
-          <h3>Projected Summary</h3>
-          <div className="suite-row">
-            <span>Baseline Positions</span>
-            <strong>{data.projected_summary.total_baseline_positions}</strong>
-          </div>
-          <div className="suite-row">
-            <span>Proposed Positions</span>
-            <strong>{data.projected_summary.total_proposed_positions}</strong>
-          </div>
-          <div className="suite-row">
-            <span>Net Delta Quantity</span>
-            <strong>{data.projected_summary.net_delta_quantity.toFixed(4)}</strong>
-          </div>
-        </section>
-      ) : null}
+          <PerformanceSnapshot
+            period={data.performance_snapshot?.period ?? "YTD"}
+            returnPct={data.performance_snapshot?.return_pct ?? null}
+            benchmarkReturnPct={data.performance_snapshot?.benchmark_return_pct ?? null}
+          />
 
-      <section className="section-card">
-        <h3>Portfolio 360 Current Positions</h3>
-        {data.current_positions.length ? (
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
-            <thead>
-              <tr>
-                <th align="left">Security</th>
-                <th align="left">Instrument</th>
-                <th align="left">Asset Class</th>
-                <th align="right">Quantity</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.current_positions.slice(0, 20).map((row) => (
-                <tr key={row.security_id}>
-                  <td>{row.security_id}</td>
-                  <td>{row.instrument_name}</td>
-                  <td>{row.asset_class ?? "N/A"}</td>
-                  <td align="right">{row.quantity.toFixed(4)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        ) : (
-          <p className="muted">No current positions available in snapshot.</p>
-        )}
+          <RebalanceStatus
+            status={data.rebalance_snapshot?.status ?? "UNKNOWN"}
+            lastRunId={data.rebalance_snapshot?.last_rebalance_run_id ?? null}
+          />
+        </div>
+
+        <div className="workbench-col">
+          <SandboxControls
+            portfolioId={data.portfolio.portfolio_id}
+            sessionId={data.active_session_id}
+            warnings={data.warnings}
+          />
+
+          {data.projected_summary ? (
+            <section className="section-card">
+              <h3>Projected Summary</h3>
+              <div className="suite-row">
+                <span>Baseline Positions</span>
+                <strong>{data.projected_summary.total_baseline_positions}</strong>
+              </div>
+              <div className="suite-row">
+                <span>Proposed Positions</span>
+                <strong>{data.projected_summary.total_proposed_positions}</strong>
+              </div>
+              <div className="suite-row">
+                <span>Net Delta Quantity</span>
+                <strong>{data.projected_summary.net_delta_quantity.toFixed(4)}</strong>
+              </div>
+            </section>
+          ) : null}
+
+          <section className="section-card">
+            <h3>Live Sandbox Projected Positions</h3>
+            {data.projected_positions.length ? (
+              <div className="table-wrap">
+                <table className="position-table">
+                  <thead>
+                    <tr>
+                      <th align="left">Security</th>
+                      <th align="left">Instrument</th>
+                      <th align="right">Baseline</th>
+                      <th align="right">Proposed</th>
+                      <th align="right">Delta</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.projected_positions.map((row) => (
+                      <tr key={row.security_id}>
+                        <td>{row.security_id}</td>
+                        <td>{row.instrument_name}</td>
+                        <td align="right">{row.baseline_quantity.toFixed(4)}</td>
+                        <td align="right">{row.proposed_quantity.toFixed(4)}</td>
+                        <td align="right">{row.delta_quantity.toFixed(4)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="muted">Create and update a sandbox session to see projected holdings.</p>
+            )}
+          </section>
+        </div>
       </section>
 
-      {data.projected_positions.length ? (
-        <section className="section-card">
-          <h3>Live Sandbox Projected Positions</h3>
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
-            <thead>
-              <tr>
-                <th align="left">Security</th>
-                <th align="left">Instrument</th>
-                <th align="right">Baseline</th>
-                <th align="right">Proposed</th>
-                <th align="right">Delta</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.projected_positions.slice(0, 20).map((row) => (
-                <tr key={row.security_id}>
-                  <td>{row.security_id}</td>
-                  <td>{row.instrument_name}</td>
-                  <td align="right">{row.baseline_quantity.toFixed(4)}</td>
-                  <td align="right">{row.proposed_quantity.toFixed(4)}</td>
-                  <td align="right">{row.delta_quantity.toFixed(4)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </section>
-      ) : null}
-
       <PositionsGrid count={data.overview.position_count} />
-
-      <PerformanceSnapshot
-        period={data.performance_snapshot?.period ?? "YTD"}
-        returnPct={data.performance_snapshot?.return_pct ?? null}
-        benchmarkReturnPct={data.performance_snapshot?.benchmark_return_pct ?? null}
-      />
-
-      <RebalanceStatus
-        status={data.rebalance_snapshot?.status ?? "UNKNOWN"}
-        lastRunId={data.rebalance_snapshot?.last_rebalance_run_id ?? null}
-      />
     </main>
   );
 }

--- a/src/features/workbench/components/sandbox-controls.tsx
+++ b/src/features/workbench/components/sandbox-controls.tsx
@@ -5,13 +5,16 @@ import { useRouter } from "next/navigation";
 import { Alert, Box, Button, MenuItem, Stack, TextField, Typography } from "@mui/material";
 
 import { applySandboxChanges, createSandboxSession } from "../api";
+import { WorkbenchPolicyFeedback } from "../types";
 
 export default function SandboxControls({
   portfolioId,
   sessionId,
+  warnings,
 }: {
   portfolioId: string;
   sessionId: string | null;
+  warnings: string[];
 }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
@@ -20,6 +23,8 @@ export default function SandboxControls({
   const [transactionType, setTransactionType] = useState<"BUY" | "SELL">("BUY");
   const [quantity, setQuantity] = useState(1);
   const [evaluatePolicy, setEvaluatePolicy] = useState(true);
+  const [sessionVersion, setSessionVersion] = useState<number | null>(null);
+  const [policyFeedback, setPolicyFeedback] = useState<WorkbenchPolicyFeedback | null>(null);
 
   async function onCreateSession() {
     setError(null);
@@ -29,6 +34,8 @@ export default function SandboxControls({
         created_by: "advisor_1",
         ttl_hours: 24,
       });
+      setSessionVersion(response.session_version);
+      setPolicyFeedback(response.policy_feedback ?? null);
       router.push(`/workbench/${encodeURIComponent(portfolioId)}?sessionId=${encodeURIComponent(response.session_id)}`);
       router.refresh();
     } catch (err) {
@@ -50,7 +57,7 @@ export default function SandboxControls({
     setError(null);
     setLoading(true);
     try {
-      await applySandboxChanges(portfolioId, sessionId, {
+      const response = await applySandboxChanges(portfolioId, sessionId, {
         changes: [
           {
             security_id: securityId.trim(),
@@ -60,6 +67,8 @@ export default function SandboxControls({
         ],
         evaluate_policy: evaluatePolicy,
       });
+      setSessionVersion(response.session_version);
+      setPolicyFeedback(response.policy_feedback);
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to apply changes");
@@ -72,7 +81,7 @@ export default function SandboxControls({
     <section className="section-card">
       <Typography variant="h6">Live Sandbox</Typography>
       <Typography className="muted" sx={{ mb: 1 }}>
-        Session: {sessionId ?? "none"}.
+        Session: {sessionId ?? "none"} | Version: {sessionVersion ?? "N/A"}
       </Typography>
       <Stack direction={{ xs: "column", md: "row" }} spacing={1} sx={{ mb: 1 }}>
         <Button variant="outlined" onClick={onCreateSession} disabled={loading}>
@@ -127,6 +136,37 @@ export default function SandboxControls({
           {error}
         </Alert>
       ) : null}
+
+      <div className="constraint-rail" style={{ marginTop: 14 }}>
+        <div className="constraint-item">
+          <span className="constraint-label">Policy Gate</span>
+          <strong
+            className={`constraint-pill ${
+              policyFeedback?.status === "PASS"
+                ? "constraint-pass"
+                : policyFeedback?.status === "UNAVAILABLE"
+                  ? "constraint-warn"
+                  : policyFeedback?.status
+                    ? "constraint-fail"
+                    : "constraint-neutral"
+            }`}
+          >
+            {policyFeedback?.status ?? "NOT_EVALUATED"}
+          </strong>
+        </div>
+        <div className="constraint-item">
+          <span className="constraint-label">Workflow Readiness</span>
+          <strong className={`constraint-pill ${warnings.length ? "constraint-warn" : "constraint-pass"}`}>
+            {warnings.length ? "WARNINGS_PRESENT" : "READY"}
+          </strong>
+        </div>
+        <div className="constraint-item">
+          <span className="constraint-label">Policy Detail</span>
+          <strong className="constraint-pill constraint-neutral">
+            {policyFeedback?.detail ?? "Run simulation with policy evaluation enabled."}
+          </strong>
+        </div>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add RFC-0011 for split-view workbench and constraint rail
- redesign workbench layout into baseline vs sandbox split workspace
- add compact position tables optimized for dense operator review
- extend sandbox controls with policy gate and readiness rail
- keep mobile-safe fallback via responsive stacking

## Validation
- npm run typecheck
- npm run lint
- npx vitest run tests/unit/workbench-api.test.ts tests/integration/workbench-page.test.tsx