### PR TITLE
feat(workbench): exception queue and advisor summary panel

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -18,3 +18,4 @@ Governance boundary:
 | RFC-0010 | Workbench Portfolio 360 and Live Sandbox UI | IMPLEMENTED | `docs/rfcs/RFC-0010-workbench-portfolio-360-and-live-sandbox-ui.md` |
 | RFC-0011 | Workbench Split View and Constraint Rail | IMPLEMENTED | `docs/rfcs/RFC-0011-workbench-split-view-and-constraint-rail.md` |
 | RFC-0012 | Workbench Analytics Controls and Delta Panel | IMPLEMENTED | `docs/rfcs/RFC-0012-workbench-analytics-controls-and-delta-panel.md` |
+| RFC-0013 | Workbench Exception Queue and Advisor Summary | IMPLEMENTED | `docs/rfcs/RFC-0013-workbench-exception-queue-and-advisor-summary.md` |

--- a/docs/rfcs/RFC-0013-workbench-exception-queue-and-advisor-summary.md
+++ b/docs/rfcs/RFC-0013-workbench-exception-queue-and-advisor-summary.md
@@ -1,0 +1,36 @@
+# RFC-0013: Workbench Exception Queue and Advisor Summary
+
+- Status: IMPLEMENTED
+- Date: 2026-02-24
+- Owners: Advisor Workbench UI
+
+## Problem Statement
+
+Workbench now supports split-view analytics and sandbox iteration, but users still need faster interpretation of warnings/failures and a concise next-action summary for proposal progression.
+
+## Root Cause
+
+- Warnings and partial failures are visible but not organized as an operator queue.
+- No compact advisor summary card to convert analytics and constraints into clear action guidance.
+
+## Proposed Solution
+
+1. Add an exception queue panel for warnings and partial failures.
+2. Add an advisor summary card with readiness state and recommended next step.
+3. Add direct transition links from summary to proposal simulation and proposal workspace.
+
+## Architectural Impact
+
+- UI-only orchestration improvement.
+- No backend contract changes.
+
+## Risks and Trade-offs
+
+- Readiness logic is heuristic until richer lifecycle gates are exposed from backend policy engines.
+- Summary guidance remains deterministic but intentionally lightweight.
+
+## High-Level Implementation Approach
+
+1. Add reusable Workbench exception and summary components.
+2. Compute readiness from warnings, partial failures, and projected delta activity.
+3. Integrate panels into Workbench layout without reducing existing analytics density.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -508,6 +508,41 @@ a:hover {
   color: #41526f;
 }
 
+.exception-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.exception-item {
+  border: 1px solid #d4dfef;
+  border-radius: 10px;
+  padding: 0.55rem 0.7rem;
+  display: grid;
+  gap: 0.22rem;
+}
+
+.exception-item.warn {
+  border-color: #ddbb6e;
+  background: #fff8ea;
+}
+
+.exception-item.fail {
+  border-color: #d5a3a3;
+  background: #fff1f1;
+}
+
+.summary-ready {
+  color: #1f6a34;
+}
+
+.summary-caution {
+  color: #8a5d08;
+}
+
+.summary-blocked {
+  color: #8f2f2f;
+}
+
 @media (max-width: 1080px) {
   .kpi-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -1,8 +1,10 @@
 import { getPortfolio360 } from "@/features/workbench/api";
 import { AnalyticsGroupBy, resolveBenchmarkReturn } from "@/features/workbench/analytics";
 import AnalyticsControls from "@/features/workbench/components/analytics-controls";
+import AdvisorSummaryCard from "@/features/workbench/components/advisor-summary-card";
 import BenchmarkKpiStrip from "@/features/workbench/components/benchmark-kpi-strip";
 import DeltaAnalyticsPanel from "@/features/workbench/components/delta-analytics-panel";
+import ExceptionQueue from "@/features/workbench/components/exception-queue";
 import OverviewCards from "@/features/workbench/components/overview-cards";
 import PartialFailureBanner from "@/features/workbench/components/partial-failure-banner";
 import PerformanceSnapshot from "@/features/workbench/components/performance-snapshot";
@@ -211,6 +213,18 @@ export default async function WorkbenchPage({
             currentPositions={data.current_positions}
             projectedPositions={data.projected_positions}
             groupBy={groupBy}
+          />
+
+          <ExceptionQueue
+            warnings={data.warnings}
+            partialFailures={data.partial_failures}
+          />
+
+          <AdvisorSummaryCard
+            portfolioId={data.portfolio.portfolio_id}
+            warningCount={data.warnings.length}
+            failureCount={data.partial_failures.length}
+            netDeltaQuantity={data.projected_summary?.net_delta_quantity ?? 0}
           />
         </div>
       </section>

--- a/src/features/workbench/components/advisor-summary-card.tsx
+++ b/src/features/workbench/components/advisor-summary-card.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+
+type Props = {
+  portfolioId: string;
+  warningCount: number;
+  failureCount: number;
+  netDeltaQuantity: number;
+};
+
+function readinessState(props: Props): "BLOCKED" | "CAUTION" | "READY" {
+  if (props.failureCount > 0) {
+    return "BLOCKED";
+  }
+  if (props.warningCount > 0) {
+    return "CAUTION";
+  }
+  return "READY";
+}
+
+function recommendation(state: "BLOCKED" | "CAUTION" | "READY"): string {
+  if (state === "BLOCKED") {
+    return "Resolve upstream exceptions before generating proposal artifacts.";
+  }
+  if (state === "CAUTION") {
+    return "Review warnings and validate simulation assumptions before submit.";
+  }
+  return "Proceed to proposal generation and approval workflow.";
+}
+
+export default function AdvisorSummaryCard(props: Props) {
+  const state = readinessState(props);
+
+  return (
+    <section className="section-card">
+      <h3>Advisor Summary</h3>
+      <div className="suite-row">
+        <span>Readiness</span>
+        <strong className={`summary-${state.toLowerCase()}`}>{state}</strong>
+      </div>
+      <div className="suite-row">
+        <span>Warnings</span>
+        <strong>{props.warningCount}</strong>
+      </div>
+      <div className="suite-row">
+        <span>Failures</span>
+        <strong>{props.failureCount}</strong>
+      </div>
+      <div className="suite-row">
+        <span>Net Delta Quantity</span>
+        <strong>{props.netDeltaQuantity.toFixed(4)}</strong>
+      </div>
+      <p className="muted">{recommendation(state)}</p>
+      <div className="toolbar">
+        <Link
+          className="nav-link"
+          href={`/proposals/simulate?portfolioId=${encodeURIComponent(props.portfolioId)}`}
+        >
+          Open Proposal Simulation
+        </Link>
+        <Link className="nav-link" href="/proposals">
+          Open Proposal Workspace
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/features/workbench/components/exception-queue.tsx
+++ b/src/features/workbench/components/exception-queue.tsx
@@ -1,0 +1,38 @@
+type Failure = {
+  source_service: string;
+  error_code: string;
+  detail: string;
+};
+
+type Props = {
+  warnings: string[];
+  partialFailures: Failure[];
+};
+
+export default function ExceptionQueue(props: Props) {
+  return (
+    <section className="section-card">
+      <h3>Exception Queue</h3>
+      {props.warnings.length === 0 && props.partialFailures.length === 0 ? (
+        <p className="muted">No active warnings or upstream failures.</p>
+      ) : (
+        <div className="exception-list">
+          {props.warnings.map((warning) => (
+            <div className="exception-item warn" key={warning}>
+              <strong>Warning</strong>
+              <span>{warning}</span>
+            </div>
+          ))}
+          {props.partialFailures.map((item) => (
+            <div className="exception-item fail" key={`${item.source_service}-${item.error_code}`}>
+              <strong>
+                {item.source_service} - {item.error_code}
+              </strong>
+              <span>{item.detail}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/tests/integration/workbench-summary-card.test.tsx
+++ b/tests/integration/workbench-summary-card.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import AdvisorSummaryCard from "../../src/features/workbench/components/advisor-summary-card";
+
+describe("AdvisorSummaryCard", () => {
+  it("shows blocked readiness when failures exist", () => {
+    render(
+      <AdvisorSummaryCard
+        portfolioId="PF_1001"
+        warningCount={1}
+        failureCount={2}
+        netDeltaQuantity={3.5}
+      />
+    );
+    expect(screen.getByText("BLOCKED")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Resolve upstream exceptions before generating proposal artifacts/i)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add RFC-0013 for exception queue and advisor summary increment
- add exception queue panel for warnings and partial failures
- add advisor summary panel with readiness state and next-action guidance
- wire summary actions to proposal simulation/workspace
- add integration test coverage for summary readiness rendering

## Validation
- npm run typecheck
- npm run lint
- npx vitest run tests/unit/workbench-analytics.test.ts tests/unit/workbench-api.test.ts tests/integration/workbench-page.test.tsx tests/integration/workbench-summary-card.test.tsx