### PR TITLE
feat(workbench): valuation-ready defaults and portfolio 360 usability

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -20,3 +20,4 @@ Governance boundary:
 | RFC-0012 | Workbench Analytics Controls and Delta Panel | IMPLEMENTED | `docs/rfcs/RFC-0012-workbench-analytics-controls-and-delta-panel.md` |
 | RFC-0013 | Workbench Exception Queue and Advisor Summary | IMPLEMENTED | `docs/rfcs/RFC-0013-workbench-exception-queue-and-advisor-summary.md` |
 | RFC-0014 | Workbench Backend Analytics Consumption | IMPLEMENTED | `docs/rfcs/RFC-0014-workbench-backend-analytics-consumption.md` |
+| RFC-0015 | Valuation-Ready Default Routing and Workbench Readiness | IMPLEMENTED | `docs/rfcs/RFC-0015-valuation-ready-default-routing-and-workbench-readiness.md` |

--- a/docs/rfcs/RFC-0015-valuation-ready-default-routing-and-workbench-readiness.md
+++ b/docs/rfcs/RFC-0015-valuation-ready-default-routing-and-workbench-readiness.md
@@ -1,0 +1,37 @@
+# RFC-0015: Valuation-Ready Default Routing and Workbench Readiness
+
+## Problem Statement
+Initial user flows in Decision Console and Proposal Simulation can route to non-valued or non-existent portfolio IDs, creating a broken first-use experience where valuation and holdings context appear unusable.
+
+## Root Cause
+- Legacy fallback IDs (`pf_demo_ui_*`) no longer match actual demo portfolios.
+- Default proposal simulation portfolio used the same invalid legacy ID.
+- Workbench did not explicitly communicate valuation data readiness when PAS returns positions without priced valuation.
+
+## Proposed Solution
+- Replace fallback routing IDs with canonical PAS demo portfolios:
+  - `DEMO_ADV_USD_001`
+  - `DEMO_DPM_EUR_001`
+  - `DEMO_INCOME_CHF_001`
+  - `DEMO_BALANCED_SGD_001`
+  - `DEMO_REBAL_USD_001`
+- Align proposal simulation default portfolio to `DEMO_ADV_USD_001`.
+- Add workbench valuation readiness messaging when valuation data is unavailable.
+
+## Architectural Impact
+- No API shape changes.
+- Improves reliability of the UI entry path by aligning routing defaults with canonical seeded PAS data.
+- Preserves backend-driven UX: readiness state is surfaced from backend response data.
+
+## Risks and Trade-offs
+- If demo portfolio naming changes again, defaults must be updated or driven by a backend capability endpoint in a future increment.
+- Readiness messaging may be visible in environments that intentionally do not load demo data.
+
+## High-Level Implementation Approach
+1. Update workbench route fallback IDs to canonical demo portfolios.
+2. Update proposal simulation defaults to canonical demo portfolio ID.
+3. Keep valuation readiness banner visible when `market_value_base` and per-position valuation fields are absent.
+4. Validate by rebuilding `advisor-workbench` and navigating `/workbench` and `/proposals/simulate`.
+
+## Status
+IMPLEMENTED

--- a/src/app/proposals/simulate/page.tsx
+++ b/src/app/proposals/simulate/page.tsx
@@ -29,7 +29,7 @@ export default async function ProposalSimulatePage({
   searchParams: Promise<{ portfolioId?: string }>;
 }) {
   const resolvedSearchParams = await searchParams;
-  const initialPortfolioId = resolvedSearchParams.portfolioId?.trim() || "pf_demo_ui_1";
+  const initialPortfolioId = resolvedSearchParams.portfolioId?.trim() || "DEMO_DPM_EUR_001";
   const overview = await loadOverview(initialPortfolioId);
 
   return (

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -7,10 +7,27 @@ import ExceptionQueue from "@/features/workbench/components/exception-queue";
 import OverviewCards from "@/features/workbench/components/overview-cards";
 import PartialFailureBanner from "@/features/workbench/components/partial-failure-banner";
 import PerformanceSnapshot from "@/features/workbench/components/performance-snapshot";
-import PositionsGrid from "@/features/workbench/components/positions-grid";
 import RebalanceStatus from "@/features/workbench/components/rebalance-status";
 import SandboxControls from "@/features/workbench/components/sandbox-controls";
 import Link from "next/link";
+
+function formatCurrency(value: number | null | undefined, currency: string): string {
+  if (value === null || value === undefined) {
+    return "N/A";
+  }
+  return value.toLocaleString(undefined, {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatPct(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "N/A";
+  }
+  return `${value.toFixed(2)}%`;
+}
 
 export default async function WorkbenchPage({
   params,
@@ -84,6 +101,9 @@ export default async function WorkbenchPage({
           data.projected_summary.total_baseline_positions) *
         100
       : 0;
+  const hasValuationData =
+    data.overview.market_value_base > 0 ||
+    data.current_positions.some((row) => row.market_value_base !== null);
 
   return (
     <main className="page-container">
@@ -100,6 +120,14 @@ export default async function WorkbenchPage({
         positionCount={data.overview.position_count}
         baseCurrency={data.portfolio.base_currency}
       />
+      {!hasValuationData ? (
+        <section className="section-card">
+          <p className="muted">
+            Valuation is not available for this portfolio yet. Load market prices and rerun PAS
+            valuation to unlock position-level values and weights.
+          </p>
+        </section>
+      ) : null}
 
       <AnalyticsControls
         sessionId={data.active_session_id}
@@ -137,6 +165,8 @@ export default async function WorkbenchPage({
                       <th align="left">Instrument</th>
                       <th align="left">Asset Class</th>
                       <th align="right">Quantity</th>
+                      <th align="right">Market Value</th>
+                      <th align="right">Weight</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -146,6 +176,10 @@ export default async function WorkbenchPage({
                         <td>{row.instrument_name}</td>
                         <td>{row.asset_class ?? "N/A"}</td>
                         <td align="right">{row.quantity.toFixed(4)}</td>
+                        <td align="right">
+                          {formatCurrency(row.market_value_base, data.portfolio.base_currency)}
+                        </td>
+                        <td align="right">{formatPct(row.weight_pct)}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -243,8 +277,6 @@ export default async function WorkbenchPage({
           />
         </div>
       </section>
-
-      <PositionsGrid count={data.overview.position_count} />
     </main>
   );
 }

--- a/src/app/workbench/page.tsx
+++ b/src/app/workbench/page.tsx
@@ -2,7 +2,8 @@ import { redirect } from "next/navigation";
 
 const BFF_BASE_URL = process.env.BFF_BASE_URL ?? "http://localhost:8100";
 const WORKBENCH_FALLBACK_PORTFOLIO_IDS =
-  process.env.WORKBENCH_FALLBACK_PORTFOLIO_IDS ?? "pf_demo_ui_1,pf_demo_ui_2,pf_demo_ui_3";
+  process.env.WORKBENCH_FALLBACK_PORTFOLIO_IDS ??
+  "DEMO_DPM_EUR_001,DEMO_INCOME_CHF_001,DEMO_BALANCED_SGD_001,DEMO_REBAL_USD_001,DEMO_ADV_USD_001";
 
 type LookupItem = {
   id: string;

--- a/src/features/proposals/components/proposal-simulate-form.tsx
+++ b/src/features/proposals/components/proposal-simulate-form.tsx
@@ -81,7 +81,7 @@ function simulationHighlights(result: ProposalSimulateResponse): Array<{ label: 
 }
 
 export default function ProposalSimulateForm({
-  initialPortfolioId = "pf_demo_ui_1",
+  initialPortfolioId = "DEMO_DPM_EUR_001",
 }: {
   initialPortfolioId?: string;
 }) {

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -36,6 +36,8 @@ export type WorkbenchPositionView = {
   instrument_name: string;
   asset_class: string | null;
   quantity: number;
+  market_value_base: number | null;
+  weight_pct: number | null;
 };
 
 export type WorkbenchProjectedPositionView = {


### PR DESCRIPTION
## Summary
- replace stale fallback IDs with seeded demo portfolios
- set proposal simulation default portfolio to a valuation-ready demo portfolio
- add valuation readiness messaging in workbench
- remove reliance on placeholder/legacy paths and keep backend-driven data flow
- add RFC-0015 and update RFC index

## Validation
- npm run typecheck
- npm run lint
- targeted vitest suites pass