### PR TITLE
feat(workbench): backend reporting snapshot panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Set `BFF_BASE_URL` to point to `advisor-experience-api`.
 - `/proposals/simulate` - simulate and save draft proposal
 - `/proposals` - proposal workspace list
 - `/proposals/[proposalId]` - proposal detail with submit/approval/consent actions and workflow timeline
+- `/workbench/[portfolioId]` - portfolio 360, sandbox projections, backend analytics, and reporting snapshot
 
 ## Docker
 

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -1,4 +1,8 @@
-import { getPortfolio360, getWorkbenchAnalytics } from "@/features/workbench/api";
+import {
+  getPortfolio360,
+  getReportingSnapshot,
+  getWorkbenchAnalytics,
+} from "@/features/workbench/api";
 import AnalyticsControls from "@/features/workbench/components/analytics-controls";
 import AdvisorSummaryCard from "@/features/workbench/components/advisor-summary-card";
 import BenchmarkKpiStrip from "@/features/workbench/components/benchmark-kpi-strip";
@@ -8,6 +12,7 @@ import OverviewCards from "@/features/workbench/components/overview-cards";
 import PartialFailureBanner from "@/features/workbench/components/partial-failure-banner";
 import PerformanceSnapshot from "@/features/workbench/components/performance-snapshot";
 import RebalanceStatus from "@/features/workbench/components/rebalance-status";
+import ReportingSnapshotPanel from "@/features/workbench/components/reporting-snapshot-panel";
 import SandboxControls from "@/features/workbench/components/sandbox-controls";
 import Link from "next/link";
 
@@ -53,6 +58,7 @@ export default async function WorkbenchPage({
 
   let data: Awaited<ReturnType<typeof getPortfolio360>>;
   let analytics: Awaited<ReturnType<typeof getWorkbenchAnalytics>> | null = null;
+  let reportingSnapshot: Awaited<ReturnType<typeof getReportingSnapshot>> | null = null;
   try {
     data = await getPortfolio360(portfolioId, sessionId);
   } catch (error) {
@@ -92,6 +98,12 @@ export default async function WorkbenchPage({
     });
   } catch {
     analytics = null;
+  }
+
+  try {
+    reportingSnapshot = await getReportingSnapshot(portfolioId, data.as_of_date);
+  } catch {
+    reportingSnapshot = null;
   }
 
   const projectedCoveragePct =
@@ -200,6 +212,22 @@ export default async function WorkbenchPage({
             status={data.rebalance_snapshot?.status ?? "UNKNOWN"}
             lastRunId={data.rebalance_snapshot?.last_rebalance_run_id ?? null}
           />
+
+          {reportingSnapshot ? (
+            <ReportingSnapshotPanel
+              asOfDate={reportingSnapshot.asOfDate}
+              sourceService={reportingSnapshot.sourceService}
+              rows={reportingSnapshot.rows}
+            />
+          ) : (
+            <section className="section-card">
+              <h3>Reporting Snapshot</h3>
+              <p className="muted">
+                Reporting service is unavailable. This panel will populate when reporting
+                aggregation is online.
+              </p>
+            </section>
+          )}
         </div>
 
         <div className="workbench-col">

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -2,6 +2,7 @@ import {
   WorkbenchAnalytics,
   WorkbenchOverview,
   WorkbenchPortfolio360,
+  WorkbenchReportingSnapshot,
   WorkbenchSandboxState,
 } from "./types";
 
@@ -105,4 +106,25 @@ export async function getWorkbenchAnalytics(
     throw new Error(`Failed to fetch workbench analytics (${response.status})`);
   }
   return (await response.json()) as WorkbenchAnalytics;
+}
+
+export async function getReportingSnapshot(
+  portfolioId: string,
+  asOfDate: string
+): Promise<WorkbenchReportingSnapshot> {
+  const query = new URLSearchParams();
+  query.set("asOfDate", asOfDate);
+
+  const response = await fetch(
+    `${BFF_BASE_URL}/api/v1/reports/${portfolioId}/snapshot?${query.toString()}`,
+    {
+      cache: "no-store",
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch reporting snapshot (${response.status})`);
+  }
+
+  return (await response.json()) as WorkbenchReportingSnapshot;
 }

--- a/src/features/workbench/components/reporting-snapshot-panel.tsx
+++ b/src/features/workbench/components/reporting-snapshot-panel.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Paper, Typography } from "@mui/material";
+
+type Props = {
+  asOfDate: string;
+  sourceService: string;
+  rows: Array<Record<string, unknown>>;
+};
+
+function renderValue(value: unknown): string {
+  if (typeof value === "number") {
+    return value.toLocaleString(undefined, { maximumFractionDigits: 4 });
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return "N/A";
+  }
+  return JSON.stringify(value);
+}
+
+export default function ReportingSnapshotPanel(props: Props) {
+  return (
+    <Paper className="section-card">
+      <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
+        Reporting Snapshot
+      </Typography>
+      <Typography className="muted" sx={{ mb: 1 }}>
+        As of {props.asOfDate}. Source: {props.sourceService}
+      </Typography>
+      {props.rows.length === 0 ? (
+        <p className="muted">No report rows were returned by the reporting service.</p>
+      ) : (
+        <div className="table-wrap">
+          <table className="position-table">
+            <thead>
+              <tr>
+                <th align="left">Bucket</th>
+                <th align="left">Metric</th>
+                <th align="right">Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {props.rows.map((row, index) => (
+                <tr key={`${String(row.bucket ?? "row")}-${String(row.metric ?? index)}-${index}`}>
+                  <td>{renderValue(row.bucket ?? row.dimension ?? "TOTAL")}</td>
+                  <td>{renderValue(row.metric ?? row.name ?? "value")}</td>
+                  <td align="right">{renderValue(row.value)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Paper>
+  );
+}

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -130,3 +130,13 @@ export type WorkbenchAnalytics = {
   warnings: string[];
   partial_failures: WorkbenchOverview["partial_failures"];
 };
+
+export type WorkbenchReportingSnapshot = {
+  correlationId: string;
+  contractVersion: string;
+  sourceService: string;
+  portfolioId: string;
+  asOfDate: string;
+  generatedAt: string;
+  rows: Array<Record<string, unknown>>;
+};

--- a/tests/integration/reporting-snapshot-panel.test.tsx
+++ b/tests/integration/reporting-snapshot-panel.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import ReportingSnapshotPanel from "../../src/features/workbench/components/reporting-snapshot-panel";
+
+describe("ReportingSnapshotPanel", () => {
+  it("renders rows returned by reporting service", () => {
+    render(
+      <ReportingSnapshotPanel
+        asOfDate="2026-02-24"
+        sourceService="reporting-aggregation-service"
+        rows={[
+          { bucket: "TOTAL", metric: "market_value_base", value: 1250000.12 },
+          { bucket: "TOTAL", metric: "return_ytd_pct", value: 4.2 },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Reporting Snapshot")).toBeInTheDocument();
+    expect(screen.getByText(/As of 2026-02-24/)).toBeInTheDocument();
+    expect(screen.getByText("market_value_base")).toBeInTheDocument();
+    expect(screen.getByText("return_ytd_pct")).toBeInTheDocument();
+  });
+
+  it("renders empty-state when rows are missing", () => {
+    render(
+      <ReportingSnapshotPanel
+        asOfDate="2026-02-24"
+        sourceService="reporting-aggregation-service"
+        rows={[]}
+      />
+    );
+
+    expect(screen.getByText(/No report rows were returned/)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   applySandboxChanges,
   createSandboxSession,
+  getReportingSnapshot,
   getWorkbenchAnalytics,
 } from "../../src/features/workbench/api";
 
@@ -124,6 +125,34 @@ describe("workbench api", () => {
       expect.stringContaining(
         "/api/v1/workbench/PF_1001/analytics?period=YTD&group_by=ASSET_CLASS&benchmark_code=MODEL_60_40&session_id=sess_1"
       ),
+      expect.objectContaining({ cache: "no-store" })
+    );
+  });
+
+  it("calls backend reporting snapshot endpoint", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlationId: "corr",
+            contractVersion: "v1",
+            sourceService: "reporting-aggregation-service",
+            portfolioId: "PF_1001",
+            asOfDate: "2026-02-24",
+            generatedAt: "2026-02-24T07:00:00Z",
+            rows: [{ bucket: "TOTAL", metric: "market_value_base", value: 1250000.12 }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await getReportingSnapshot("PF_1001", "2026-02-24");
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/reports/PF_1001/snapshot?asOfDate=2026-02-24"),
       expect.objectContaining({ cache: "no-store" })
     );
   });


### PR DESCRIPTION
## Summary
- add reporting snapshot API call in workbench client
- render reporting snapshot table in portfolio 360 page when backend data is available
- keep graceful fallback panel when reporting service is unavailable
- add unit and integration tests for reporting snapshot flow

## Validation
- npm run lint
- npm run typecheck
- npm run test