### PR TITLE
feat(workbench): backend-driven analytics studio

### DIFF
--- a/src/app/pa/analytics/page.tsx
+++ b/src/app/pa/analytics/page.tsx
@@ -1,74 +1,194 @@
-"use client";
+import Link from "next/link";
 
-import { Chip, Paper, Stack, Typography } from "@mui/material";
+import { getReportingSnapshot, getWorkbenchAnalytics } from "@/features/workbench/api";
 
-import { analyticsHighlights } from "@/features/suite/mock-data";
+const BFF_BASE_URL = process.env.BFF_BASE_URL ?? "http://localhost:8100";
 
-export default function PaAnalyticsPage() {
+type LookupEnvelope = {
+  items?: Array<{ id: string; label: string }>;
+};
+
+function formatPct(value: number | null): string {
+  if (value === null || value === undefined) {
+    return "N/A";
+  }
+  return `${value.toFixed(2)}%`;
+}
+
+function formatNumber(value: unknown): string {
+  if (typeof value === "number") {
+    return value.toLocaleString(undefined, { maximumFractionDigits: 4 });
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return "N/A";
+  }
+  return JSON.stringify(value);
+}
+
+async function getDefaultPortfolioId(): Promise<string | null> {
+  try {
+    const response = await fetch(`${BFF_BASE_URL}/api/v1/lookups/portfolios?limit=1`, { cache: "no-store" });
+    if (!response.ok) {
+      return null;
+    }
+    const payload = (await response.json()) as LookupEnvelope;
+    return payload.items?.[0]?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function PaAnalyticsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    portfolioId?: string;
+    period?: string;
+    benchmark?: string;
+  }>;
+}) {
+  const resolvedSearch = await searchParams;
+  const portfolioId = resolvedSearch.portfolioId?.trim() || (await getDefaultPortfolioId());
+
+  if (!portfolioId) {
+    return (
+      <main className="page-container">
+        <section className="page-header">
+          <h1 className="page-title">Analytics Studio</h1>
+          <p className="page-subtitle">
+            No portfolio is currently available from platform lookups. Seed demo portfolios to activate
+            analytics views.
+          </p>
+        </section>
+      </main>
+    );
+  }
+
+  const period = resolvedSearch.period?.trim() || "YTD";
+  const benchmark = resolvedSearch.benchmark?.trim() || "MODEL_60_40";
+  let analytics: Awaited<ReturnType<typeof getWorkbenchAnalytics>> | null = null;
+  let reporting: Awaited<ReturnType<typeof getReportingSnapshot>> | null = null;
+
+  try {
+    analytics = await getWorkbenchAnalytics(portfolioId, {
+      period,
+      groupBy: "ASSET_CLASS",
+      benchmark,
+    });
+  } catch {
+    analytics = null;
+  }
+
+  try {
+    reporting = await getReportingSnapshot(portfolioId, new Date().toISOString().slice(0, 10));
+  } catch {
+    reporting = null;
+  }
+
   return (
     <main className="page-container">
       <section className="page-header">
-        <Typography variant="h4" component="h1" className="page-title">
-          Analytics Studio
-        </Typography>
-        <Typography className="page-subtitle">
-          Evaluate performance, attribution, and risk with executive-ready insight panels.
-        </Typography>
+        <h1 className="page-title">Analytics Studio: {portfolioId}</h1>
+        <p className="page-subtitle">
+          Backend-driven analytics from PA with reporting-ready rows from the aggregation service.
+        </p>
       </section>
 
-      <Paper className="section-card" elevation={0}>
-        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
-          <Typography variant="h6" component="h2">
-            Portfolio Intelligence Snapshot
-          </Typography>
-          <Chip size="small" label="Storyboard" />
-        </Stack>
-        <div className="kpi-grid">
-          {analyticsHighlights.map((item) => (
-            <div key={item.label} className="kpi-box">
-              <p className="kpi-label">{item.label}</p>
-              <p className="kpi-value">{item.value}</p>
+      {analytics ? (
+        <section className="section-card">
+          <h2>Performance Snapshot ({analytics.period})</h2>
+          <div className="kpi-grid">
+            <div className="kpi-box">
+              <p className="kpi-label">Portfolio Return</p>
+              <p className="kpi-value">{formatPct(analytics.portfolio_return_pct)}</p>
             </div>
-          ))}
+            <div className="kpi-box">
+              <p className="kpi-label">Benchmark Return</p>
+              <p className="kpi-value">{formatPct(analytics.benchmark_return_pct)}</p>
+            </div>
+            <div className="kpi-box">
+              <p className="kpi-label">Active Return</p>
+              <p className="kpi-value">{formatPct(analytics.active_return_pct)}</p>
+            </div>
+          </div>
+        </section>
+      ) : (
+        <section className="section-card">
+          <p className="muted">PA analytics are unavailable right now. Retry once PA is online.</p>
+        </section>
+      )}
+
+      <section className="workbench-split">
+        <div className="workbench-col">
+          <section className="section-card">
+            <h3>Allocation Buckets</h3>
+            {analytics && analytics.allocation_buckets.length > 0 ? (
+              <div className="table-wrap">
+                <table className="position-table">
+                  <thead>
+                    <tr>
+                      <th align="left">Bucket</th>
+                      <th align="right">Current Wgt</th>
+                      <th align="right">Proposed Wgt</th>
+                      <th align="right">Delta Qty</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {analytics.allocation_buckets.map((bucket) => (
+                      <tr key={bucket.bucket_key}>
+                        <td>{bucket.bucket_label}</td>
+                        <td align="right">{bucket.current_weight_pct.toFixed(2)}%</td>
+                        <td align="right">{bucket.proposed_weight_pct.toFixed(2)}%</td>
+                        <td align="right">{bucket.delta_quantity.toFixed(4)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="muted">No allocation rows returned from analytics API.</p>
+            )}
+          </section>
         </div>
-      </Paper>
 
-      <section className="suite-grid">
-        <Paper className="section-card suite-panel" elevation={0}>
-          <Typography variant="h6" component="h3" sx={{ mb: 1 }}>
-            Attribution Breakdown
-          </Typography>
-          <div className="suite-row">
-            <span>Allocation Effect</span>
-            <strong>+64 bps</strong>
-          </div>
-          <div className="suite-row">
-            <span>Selection Effect</span>
-            <strong>+41 bps</strong>
-          </div>
-          <div className="suite-row">
-            <span>FX Effect</span>
-            <strong>+16 bps</strong>
-          </div>
-        </Paper>
+        <div className="workbench-col">
+          <section className="section-card">
+            <h3>Reporting Rows</h3>
+            {reporting && reporting.rows.length > 0 ? (
+              <div className="table-wrap">
+                <table className="position-table">
+                  <thead>
+                    <tr>
+                      <th align="left">Bucket</th>
+                      <th align="left">Metric</th>
+                      <th align="right">Value</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {reporting.rows.map((row, index) => (
+                      <tr key={`${String(row.bucket ?? "row")}-${String(row.metric ?? index)}-${index}`}>
+                        <td>{formatNumber(row.bucket ?? "TOTAL")}</td>
+                        <td>{formatNumber(row.metric ?? "value")}</td>
+                        <td align="right">{formatNumber(row.value)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="muted">Reporting aggregation rows are unavailable right now.</p>
+            )}
+          </section>
+        </div>
+      </section>
 
-        <Paper className="section-card suite-panel" elevation={0}>
-          <Typography variant="h6" component="h3" sx={{ mb: 1 }}>
-            Risk Signals
-          </Typography>
-          <div className="suite-row">
-            <span>Volatility (1Y)</span>
-            <strong>11.8%</strong>
-          </div>
-          <div className="suite-row">
-            <span>Max Drawdown</span>
-            <strong>-7.2%</strong>
-          </div>
-          <div className="suite-row">
-            <span>Beta vs Benchmark</span>
-            <strong>0.92</strong>
-          </div>
-        </Paper>
+      <section className="toolbar">
+        <Link className="nav-link" href={`/workbench/${portfolioId}`}>
+          Open Decision Console
+        </Link>
       </section>
     </main>
   );

--- a/tests/integration/pa-analytics-page.test.tsx
+++ b/tests/integration/pa-analytics-page.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import PaAnalyticsPage from "../../src/app/pa/analytics/page";
+
+describe("PaAnalyticsPage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders backend-driven analytics and reporting rows", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL) => {
+        const url = input.toString();
+        if (url.includes("/api/v1/lookups/portfolios")) {
+          return {
+            ok: true,
+            json: async () => ({
+              items: [{ id: "DEMO_DPM_EUR_001", label: "DEMO_DPM_EUR_001" }],
+            }),
+          } as Response;
+        }
+        if (url.includes("/api/v1/workbench/DEMO_DPM_EUR_001/analytics")) {
+          return {
+            ok: true,
+            json: async () => ({
+              period: "YTD",
+              portfolio_return_pct: 4.2,
+              benchmark_return_pct: 3.8,
+              active_return_pct: 0.4,
+              allocation_buckets: [
+                {
+                  bucket_key: "EQUITY",
+                  bucket_label: "EQUITY",
+                  current_weight_pct: 55.5,
+                  proposed_weight_pct: 57.0,
+                  delta_quantity: 1200,
+                },
+              ],
+            }),
+          } as Response;
+        }
+        if (url.includes("/api/v1/reports/DEMO_DPM_EUR_001/snapshot")) {
+          return {
+            ok: true,
+            json: async () => ({
+              rows: [{ bucket: "TOTAL", metric: "market_value_base", value: 1250000 }],
+            }),
+          } as Response;
+        }
+        return { ok: false, json: async () => ({}) } as Response;
+      })
+    );
+
+    render(await PaAnalyticsPage({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByRole("heading", { name: /Analytics Studio: DEMO_DPM_EUR_001/i })).toBeInTheDocument();
+    expect(screen.getByText("4.20%")).toBeInTheDocument();
+    expect(screen.getByText("EQUITY")).toBeInTheDocument();
+    expect(screen.getByText("market_value_base")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open Decision Console/i })).toHaveAttribute(
+      "href",
+      "/workbench/DEMO_DPM_EUR_001"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- replace storyboard analytics page with backend-driven PA + reporting data
- resolve portfolio context via BFF lookups and render live allocation/reporting tables
- add integration test for analytics page data rendering and navigation links

## Validation
- npm run lint
- npm run typecheck
- npm run test