### PR TITLE
feat(ui): add portfolio catalog snapshot on foundation page

### DIFF
--- a/src/app/portfolios/page.tsx
+++ b/src/app/portfolios/page.tsx
@@ -38,6 +38,16 @@ type ReportingSnapshot = {
   rows: Array<{ bucket?: string; metric?: string; value?: number | string | null }>;
 };
 
+type PortfolioCatalogRow = {
+  portfolioId: string;
+  asOfDate: string | null;
+  marketValueBase: number | null;
+  positionCount: number | null;
+  performanceYtdPct: number | null;
+  reportingYtdPct: number | null;
+  rebalanceStatus: string | null;
+};
+
 async function getPortfolios(): Promise<LookupItem[]> {
   try {
     const response = await fetch(`${BFF_BASE_URL}/api/v1/lookups/portfolios?limit=100`, { cache: "no-store" });
@@ -96,6 +106,17 @@ function formatCurrency(value: number, currency: string): string {
   return new Intl.NumberFormat("en-US", { style: "currency", currency, maximumFractionDigits: 0 }).format(value);
 }
 
+function extractMetricValue(
+  snapshot: ReportingSnapshot | null,
+  metric: string
+): number | null {
+  const row = snapshot?.rows.find((item) => item.metric === metric);
+  if (!row) {
+    return null;
+  }
+  return typeof row.value === "number" ? row.value : null;
+}
+
 export default async function PortfolioFoundationPage({
   searchParams,
 }: {
@@ -108,10 +129,35 @@ export default async function PortfolioFoundationPage({
   const overview = selectedId ? await getOverview(selectedId) : null;
   const reportingSnapshot =
     overview && selectedId ? await getReportingSnapshot(selectedId, overview.as_of_date) : null;
-  const ytdReportingRow =
-    reportingSnapshot?.rows.find((row) => row.metric === "return_ytd_pct") ?? null;
-  const totalMarketValueRow =
-    reportingSnapshot?.rows.find((row) => row.metric === "market_value_base") ?? null;
+  const reportingYtd = extractMetricValue(reportingSnapshot, "return_ytd_pct");
+  const reportingMarketValue = extractMetricValue(reportingSnapshot, "market_value_base");
+  const catalogRows = await Promise.all(
+    portfolios.slice(0, 12).map(async (portfolio) => {
+      const portfolioOverview = await getOverview(portfolio.id);
+      if (!portfolioOverview) {
+        return {
+          portfolioId: portfolio.id,
+          asOfDate: null,
+          marketValueBase: null,
+          positionCount: null,
+          performanceYtdPct: null,
+          reportingYtdPct: null,
+          rebalanceStatus: null,
+        } satisfies PortfolioCatalogRow;
+      }
+
+      const snapshot = await getReportingSnapshot(portfolio.id, portfolioOverview.as_of_date);
+      return {
+        portfolioId: portfolio.id,
+        asOfDate: portfolioOverview.as_of_date,
+        marketValueBase: portfolioOverview.overview.market_value_base,
+        positionCount: portfolioOverview.overview.position_count,
+        performanceYtdPct: portfolioOverview.performance_snapshot?.return_pct ?? null,
+        reportingYtdPct: extractMetricValue(snapshot, "return_ytd_pct"),
+        rebalanceStatus: portfolioOverview.rebalance_snapshot?.status ?? null,
+      } satisfies PortfolioCatalogRow;
+    })
+  );
 
   return (
     <main className="page-container">
@@ -194,15 +240,13 @@ export default async function PortfolioFoundationPage({
                 </div>
                 <div className="suite-row">
                   <span>Reporting YTD Return</span>
-                  <strong>
-                    {typeof ytdReportingRow?.value === "number" ? `${ytdReportingRow.value.toFixed(2)}%` : "N/A"}
-                  </strong>
+                  <strong>{reportingYtd === null ? "N/A" : `${reportingYtd.toFixed(2)}%`}</strong>
                 </div>
                 <div className="suite-row">
                   <span>Reporting Market Value</span>
                   <strong>
-                    {typeof totalMarketValueRow?.value === "number"
-                      ? formatCurrency(totalMarketValueRow.value, overview.portfolio.base_currency)
+                    {typeof reportingMarketValue === "number"
+                      ? formatCurrency(reportingMarketValue, overview.portfolio.base_currency)
                       : "N/A"}
                   </strong>
                 </div>
@@ -226,6 +270,52 @@ export default async function PortfolioFoundationPage({
           </article>
         </section>
       )}
+
+      {catalogRows.length > 0 ? (
+        <section className="section-card">
+          <h3>Portfolio Catalog Snapshot</h3>
+          <p className="muted">
+            Cross-portfolio summary from PAS/PA/BFF and reporting aggregation outputs.
+          </p>
+          <div className="table-wrap">
+            <table className="position-table">
+              <thead>
+                <tr>
+                  <th align="left">Portfolio</th>
+                  <th align="left">As Of Date</th>
+                  <th align="right">Market Value</th>
+                  <th align="right">Positions</th>
+                  <th align="right">PA Return YTD</th>
+                  <th align="right">Reporting Return YTD</th>
+                  <th align="left">Rebalance</th>
+                </tr>
+              </thead>
+              <tbody>
+                {catalogRows.map((row) => (
+                  <tr key={row.portfolioId}>
+                    <td>
+                      <Link
+                        href={`/portfolios?portfolioId=${encodeURIComponent(row.portfolioId)}`}
+                        className="nav-link"
+                      >
+                        {row.portfolioId}
+                      </Link>
+                    </td>
+                    <td>{row.asOfDate ?? "N/A"}</td>
+                    <td align="right">
+                      {row.marketValueBase === null ? "N/A" : formatCurrency(row.marketValueBase, "USD")}
+                    </td>
+                    <td align="right">{row.positionCount ?? "N/A"}</td>
+                    <td align="right">{row.performanceYtdPct === null ? "N/A" : `${row.performanceYtdPct.toFixed(2)}%`}</td>
+                    <td align="right">{row.reportingYtdPct === null ? "N/A" : `${row.reportingYtdPct.toFixed(2)}%`}</td>
+                    <td>{row.rebalanceStatus ?? "N/A"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ) : null}
     </main>
   );
 }

--- a/tests/integration/portfolios-page.test.tsx
+++ b/tests/integration/portfolios-page.test.tsx
@@ -18,7 +18,10 @@ describe("PortfolioFoundationPage", () => {
           return {
             ok: true,
             json: async () => ({
-              items: [{ id: "PORT_UI_1001", label: "PORT_UI_1001" }],
+              items: [
+                { id: "PORT_UI_1001", label: "PORT_UI_1001" },
+                { id: "PORT_UI_1002", label: "PORT_UI_1002" },
+              ],
             }),
           } as Response;
         }
@@ -49,6 +52,33 @@ describe("PortfolioFoundationPage", () => {
             }),
           } as Response;
         }
+        if (url.includes("/api/v1/workbench/PORT_UI_1002/overview")) {
+          return {
+            ok: true,
+            json: async () => ({
+              as_of_date: "2026-02-24",
+              portfolio: {
+                portfolio_id: "PORT_UI_1002",
+                base_currency: "USD",
+                booking_center_code: "SG",
+              },
+              overview: {
+                market_value_base: 980000,
+                cash_weight_pct: 5.25,
+                position_count: 9,
+              },
+              performance_snapshot: {
+                period: "YTD",
+                return_pct: 3.02,
+                benchmark_return_pct: 2.87,
+              },
+              rebalance_snapshot: {
+                status: "READY",
+                last_rebalance_run_id: "run_002",
+              },
+            }),
+          } as Response;
+        }
         if (url.includes("/api/v1/reports/PORT_UI_1001/snapshot?asOfDate=2026-02-24")) {
           return {
             ok: true,
@@ -60,6 +90,14 @@ describe("PortfolioFoundationPage", () => {
             }),
           } as Response;
         }
+        if (url.includes("/api/v1/reports/PORT_UI_1002/snapshot?asOfDate=2026-02-24")) {
+          return {
+            ok: true,
+            json: async () => ({
+              rows: [{ bucket: "TOTAL", metric: "return_ytd_pct", value: 3.1 }],
+            }),
+          } as Response;
+        }
         return { ok: false, json: async () => ({}) } as Response;
       })
     );
@@ -67,11 +105,14 @@ describe("PortfolioFoundationPage", () => {
     render(await PortfolioFoundationPage({ searchParams: Promise.resolve({}) }));
 
     expect(screen.getByRole("heading", { name: /Portfolio Foundation/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "PORT_UI_1001" })).toBeInTheDocument();
-    expect(screen.getAllByText("$1,250,000")).toHaveLength(2);
-    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: "PORT_UI_1001" }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole("link", { name: "PORT_UI_1002" }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole("heading", { name: /Portfolio Catalog Snapshot/i })).toBeInTheDocument();
+    expect(screen.getAllByText("$1,250,000").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("12").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("8.42%")).toBeInTheDocument();
-    expect(screen.getByText("4.30%")).toBeInTheDocument();
+    expect(screen.getAllByText("4.30%").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("3.10%")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open Decision Console/i })).toHaveAttribute(
       "href",
       "/workbench/PORT_UI_1001"


### PR DESCRIPTION
## Summary
- add a Portfolio Catalog Snapshot table on the Portfolio Foundation page
- source cross-portfolio rows from existing BFF overview and reporting snapshot endpoints
- include PA YTD vs reporting YTD and rebalance status for quick comparison

## Validation
- npm run lint
- npm run typecheck
- npm run test