### PR TITLE
feat(ui): add asset-class allocation snapshot to portfolio foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ playwright-report/
 output/playwright/
 output/pr-monitor.json
 output/agent-status.md
+output/async-docker-build-*.log

--- a/src/app/portfolios/page.tsx
+++ b/src/app/portfolios/page.tsx
@@ -59,6 +59,12 @@ type PortfolioCatalogRow = {
   rebalanceStatus: string | null;
 };
 
+type AllocationBucket = {
+  assetClass: string;
+  weightPct: number;
+  marketValueBase: number;
+};
+
 async function getPortfolios(): Promise<LookupItem[]> {
   try {
     const response = await fetch(`${BFF_BASE_URL}/api/v1/lookups/portfolios?limit=100`, { cache: "no-store" });
@@ -144,6 +150,31 @@ function extractMetricValue(
   return typeof row.value === "number" ? row.value : null;
 }
 
+function buildAllocationBuckets(snapshot: Portfolio360Snapshot | null): AllocationBucket[] {
+  if (!snapshot) {
+    return [];
+  }
+
+  const grouped = new Map<string, { marketValueBase: number; weightPct: number }>();
+  for (const row of snapshot.current_positions) {
+    const key = row.asset_class ?? "UNCLASSIFIED";
+    const current = grouped.get(key) ?? { marketValueBase: 0, weightPct: 0 };
+    grouped.set(key, {
+      marketValueBase: current.marketValueBase + (row.market_value_base ?? 0),
+      weightPct: current.weightPct + (row.weight_pct ?? 0),
+    });
+  }
+
+  return Array.from(grouped.entries())
+    .map(([assetClass, values]) => ({
+      assetClass,
+      marketValueBase: values.marketValueBase,
+      weightPct: values.weightPct,
+    }))
+    .sort((left, right) => right.marketValueBase - left.marketValueBase)
+    .slice(0, 5);
+}
+
 export default async function PortfolioFoundationPage({
   searchParams,
 }: {
@@ -164,6 +195,7 @@ export default async function PortfolioFoundationPage({
       ?.slice()
       .sort((left, right) => (right.market_value_base ?? 0) - (left.market_value_base ?? 0))
       .slice(0, 5) ?? [];
+  const topAllocations = buildAllocationBuckets(portfolio360);
   const catalogRows = await Promise.all(
     portfolios.slice(0, 12).map(async (portfolio) => {
       const portfolioOverview = await getOverview(portfolio.id);
@@ -333,6 +365,33 @@ export default async function PortfolioFoundationPage({
                   </div>
                 ) : (
                   <p className="muted">Portfolio 360 positions are unavailable for this portfolio.</p>
+                )}
+                <h4 style={{ margin: "12px 0 8px", fontSize: "0.95rem" }}>Asset Class Allocation Snapshot</h4>
+                {topAllocations.length ? (
+                  <div className="table-wrap">
+                    <table className="position-table">
+                      <thead>
+                        <tr>
+                          <th align="left">Asset Class</th>
+                          <th align="right">Market Value</th>
+                          <th align="right">Weight</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {topAllocations.map((bucket) => (
+                          <tr key={bucket.assetClass}>
+                            <td>{bucket.assetClass}</td>
+                            <td align="right">
+                              {formatCurrency(bucket.marketValueBase, overview.portfolio.base_currency)}
+                            </td>
+                            <td align="right">{bucket.weightPct.toFixed(2)}%</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <p className="muted">Asset-class allocation is unavailable until positions are loaded.</p>
                 )}
               </>
             )}

--- a/tests/integration/portfolios-page.test.tsx
+++ b/tests/integration/portfolios-page.test.tsx
@@ -119,6 +119,14 @@ describe("PortfolioFoundationPage", () => {
                   market_value_base: 180000,
                   weight_pct: 14.4,
                 },
+                {
+                  security_id: "UST10Y",
+                  instrument_name: "US Treasury 10Y",
+                  asset_class: "FIXED_INCOME",
+                  quantity: 75,
+                  market_value_base: 110000,
+                  weight_pct: 8.8,
+                },
               ],
             }),
           } as Response;
@@ -142,6 +150,9 @@ describe("PortfolioFoundationPage", () => {
     expect(screen.getByText("AAPL.US")).toBeInTheDocument();
     expect(screen.getByText("Apple Inc")).toBeInTheDocument();
     expect(screen.getByText("20.00%")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Asset Class Allocation Snapshot/i })).toBeInTheDocument();
+    expect(screen.getAllByText("EQUITY").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("FIXED_INCOME").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByRole("link", { name: /Open Decision Console/i })).toHaveAttribute(
       "href",
       "/workbench/PORT_UI_1001"


### PR DESCRIPTION
## Summary
- derive top asset-class allocation from backend portfolio-360 positions
- render allocation snapshot table next to top holdings on Portfolio Foundation
- ignore async docker build logs in .gitignore

## Validation
- npm run lint
- npm run typecheck
- npm run test