### PR TITLE
feat(ui): add workbench decision readiness panel

### DIFF
--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -7,6 +7,7 @@ import AnalyticsControls from "@/features/workbench/components/analytics-control
 import AdvisorSummaryCard from "@/features/workbench/components/advisor-summary-card";
 import BenchmarkKpiStrip from "@/features/workbench/components/benchmark-kpi-strip";
 import DeltaAnalyticsPanel from "@/features/workbench/components/delta-analytics-panel";
+import DecisionReadinessPanel from "@/features/workbench/components/decision-readiness-panel";
 import ExceptionQueue from "@/features/workbench/components/exception-queue";
 import OverviewCards from "@/features/workbench/components/overview-cards";
 import PartialFailureBanner from "@/features/workbench/components/partial-failure-banner";
@@ -116,6 +117,8 @@ export default async function WorkbenchPage({
   const hasValuationData =
     data.overview.market_value_base > 0 ||
     data.current_positions.some((row) => row.market_value_base !== null);
+  const hasAnalytics = analytics !== null;
+  const hasReporting = reportingSnapshot !== null;
 
   return (
     <main className="page-container">
@@ -295,6 +298,16 @@ export default async function WorkbenchPage({
           <ExceptionQueue
             warnings={data.warnings}
             partialFailures={data.partial_failures}
+          />
+
+          <DecisionReadinessPanel
+            hasValuationData={hasValuationData}
+            hasAnalytics={hasAnalytics}
+            hasReporting={hasReporting}
+            hasActiveSandbox={Boolean(data.active_session_id)}
+            warningCount={data.warnings.length}
+            failureCount={data.partial_failures.length}
+            hhiProposed={analytics?.risk_proxy.hhi_proposed ?? null}
           />
 
           <AdvisorSummaryCard

--- a/src/features/workbench/components/decision-readiness-panel.tsx
+++ b/src/features/workbench/components/decision-readiness-panel.tsx
@@ -1,0 +1,64 @@
+type Props = {
+  hasValuationData: boolean;
+  hasAnalytics: boolean;
+  hasReporting: boolean;
+  hasActiveSandbox: boolean;
+  warningCount: number;
+  failureCount: number;
+  hhiProposed: number | null;
+};
+
+function statusLabel(ready: boolean): string {
+  return ready ? "READY" : "PENDING";
+}
+
+function concentrationSignal(hhiProposed: number | null): string {
+  if (hhiProposed === null) {
+    return "UNKNOWN";
+  }
+  if (hhiProposed >= 0.25) {
+    return "HIGH";
+  }
+  if (hhiProposed >= 0.15) {
+    return "MEDIUM";
+  }
+  return "LOW";
+}
+
+export default function DecisionReadinessPanel(props: Props) {
+  const dataIntegrityReady = props.warningCount === 0 && props.failureCount === 0;
+  const riskSignal = concentrationSignal(props.hhiProposed);
+
+  return (
+    <section className="section-card">
+      <h3>Decision Readiness</h3>
+      <p className="muted">
+        Backend readiness checks for simulation, advisory review, and execution preparation.
+      </p>
+      <div className="suite-row">
+        <span>Valuation Coverage</span>
+        <strong>{statusLabel(props.hasValuationData)}</strong>
+      </div>
+      <div className="suite-row">
+        <span>Analytics Coverage</span>
+        <strong>{statusLabel(props.hasAnalytics)}</strong>
+      </div>
+      <div className="suite-row">
+        <span>Reporting Coverage</span>
+        <strong>{statusLabel(props.hasReporting)}</strong>
+      </div>
+      <div className="suite-row">
+        <span>Sandbox Session</span>
+        <strong>{statusLabel(props.hasActiveSandbox)}</strong>
+      </div>
+      <div className="suite-row">
+        <span>Data Integrity</span>
+        <strong>{dataIntegrityReady ? "READY" : "ATTENTION"}</strong>
+      </div>
+      <div className="suite-row">
+        <span>Concentration Signal (HHI)</span>
+        <strong>{riskSignal}</strong>
+      </div>
+    </section>
+  );
+}

--- a/tests/unit/decision-readiness-panel.test.tsx
+++ b/tests/unit/decision-readiness-panel.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import DecisionReadinessPanel from "../../src/features/workbench/components/decision-readiness-panel";
+
+describe("DecisionReadinessPanel", () => {
+  it("shows ready states when backend dependencies are available", () => {
+    render(
+      <DecisionReadinessPanel
+        hasValuationData
+        hasAnalytics
+        hasReporting
+        hasActiveSandbox
+        warningCount={0}
+        failureCount={0}
+        hhiProposed={0.12}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: /Decision Readiness/i })).toBeInTheDocument();
+    expect(screen.getAllByText("READY").length).toBeGreaterThanOrEqual(5);
+    expect(screen.getByText("LOW")).toBeInTheDocument();
+  });
+
+  it("shows attention states when dependencies are missing", () => {
+    render(
+      <DecisionReadinessPanel
+        hasValuationData={false}
+        hasAnalytics={false}
+        hasReporting={false}
+        hasActiveSandbox={false}
+        warningCount={2}
+        failureCount={1}
+        hhiProposed={0.3}
+      />
+    );
+
+    expect(screen.getAllByText("PENDING").length).toBeGreaterThanOrEqual(4);
+    expect(screen.getByText("ATTENTION")).toBeInTheDocument();
+    expect(screen.getByText("HIGH")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Decision Readiness panel to workbench using existing backend signals
- surface valuation/analytics/reporting/sandbox readiness plus integrity and concentration signal
- add unit tests for readiness state rendering

## Validation
- npm run lint
- npm run typecheck
- npm run test