### PR TITLE
chore: align workbench naming with lotus conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Unified UI for advisor workflows, currently scoped to DPM proposal simulation.
 - Contribution process: `CONTRIBUTING.md`
 - Docs-with-code standard: `docs/documentation/implementation-documentation-standard.md`
 - PR checklist template: `.github/pull_request_template.md`
-- Platform-wide architecture governance source: `https://github.com/sgajbi/pbwm-platform-docs`
+- Platform-wide architecture governance source: `https://github.com/sgajbi/lotus-platform`
 
 ## Standard Frontend Stack
 
@@ -29,7 +29,7 @@ npm run dev
 
 Open `http://localhost:3000/proposals/simulate`.
 
-Set `BFF_BASE_URL` to point to `advisor-experience-api`.
+Set `BFF_BASE_URL` to point to `lotus-gateway`.
 
 ## Current Routes
 
@@ -62,3 +62,4 @@ make ci-local-docker-down
 - Continuous agent loop with status feed: `npm run auto:agent`
 - Single agent iteration: `npm run auto:agent:once`
 - Targeted PAS refresh: `npm run auto:refresh:pas -- query_service demo_data_loader`
+

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "auto:pr": "powershell -ExecutionPolicy Bypass -File scripts/automation/PR-Monitor.ps1",
     "auto:agent": "powershell -ExecutionPolicy Bypass -File scripts/automation/Run-Agent.ps1",
     "auto:agent:once": "powershell -ExecutionPolicy Bypass -File scripts/automation/Run-Agent.ps1 -Once",
-    "auto:refresh:pas": "powershell -ExecutionPolicy Bypass -File scripts/automation/Service-Refresh.ps1 -ProjectPath C:/Users/Sandeep/projects/portfolio-analytics-system -Services"
+    "auto:refresh:pas": "powershell -ExecutionPolicy Bypass -File scripts/automation/Service-Refresh.ps1 -ProjectPath C:/Users/Sandeep/projects/lotus-core -Services"
   },
   "dependencies": {
     "@emotion/react": "11.14.0",
@@ -46,3 +46,4 @@
     "vitest": "2.1.8"
   }
 }
+

--- a/tests/integration/reporting-snapshot-panel.test.tsx
+++ b/tests/integration/reporting-snapshot-panel.test.tsx
@@ -8,7 +8,7 @@ describe("ReportingSnapshotPanel", () => {
     render(
       <ReportingSnapshotPanel
         asOfDate="2026-02-24"
-        sourceService="reporting-aggregation-service"
+        sourceService="lotus-report"
         rows={[
           { bucket: "TOTAL", metric: "market_value_base", value: 1250000.12 },
           { bucket: "TOTAL", metric: "return_ytd_pct", value: 4.2 },
@@ -26,7 +26,7 @@ describe("ReportingSnapshotPanel", () => {
     render(
       <ReportingSnapshotPanel
         asOfDate="2026-02-24"
-        sourceService="reporting-aggregation-service"
+        sourceService="lotus-report"
         rows={[]}
       />
     );

--- a/tests/integration/workbench-page.test.tsx
+++ b/tests/integration/workbench-page.test.tsx
@@ -112,7 +112,7 @@ describe("WorkbenchPage", () => {
             json: async () => ({
               correlationId: "corr_3",
               contractVersion: "v1",
-              sourceService: "reporting-aggregation-service",
+              sourceService: "lotus-report",
               portfolioId: "PF_1001",
               asOfDate: "2026-02-24",
               generatedAt: "2026-02-24T00:00:00Z",
@@ -142,3 +142,4 @@ describe("WorkbenchPage", () => {
     expect(screen.getAllByText(/UPSTREAM_TIMEOUT/).length).toBeGreaterThanOrEqual(1);
   });
 });
+

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -137,7 +137,7 @@ describe("workbench api", () => {
           JSON.stringify({
             correlationId: "corr",
             contractVersion: "v1",
-            sourceService: "reporting-aggregation-service",
+            sourceService: "lotus-report",
             portfolioId: "PF_1001",
             asOfDate: "2026-02-24",
             generatedAt: "2026-02-24T07:00:00Z",


### PR DESCRIPTION
## Summary
- replace legacy service names with lotus names in workbench docs/tests/config
- keep existing behavior unchanged

## Validation
- platform naming conformance generated in lotus-platform and shows workbench=ok