### PR TITLE
feat: implement portfolio foundation surface

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -22,5 +22,5 @@ Governance boundary:
 | RFC-0014 | Workbench Backend Analytics Consumption | IMPLEMENTED | `docs/rfcs/RFC-0014-workbench-backend-analytics-consumption.md` |
 | RFC-0015 | Valuation-Ready Default Routing and Workbench Readiness | IMPLEMENTED | `docs/rfcs/RFC-0015-valuation-ready-default-routing-and-workbench-readiness.md` |
 | RFC-0016 | Workbench Application Shell and Design-System Foundation | IMPLEMENTED | `docs/rfcs/RFC-0016-workbench-application-shell-and-design-system-foundation.md` |
-| RFC-0017 | Foundation App First-Production Surface | PROPOSED | `docs/rfcs/RFC-0017-foundation-app-first-production-surface.md` |
+| RFC-0017 | Foundation App First-Production Surface | IN PROGRESS | `docs/rfcs/RFC-0017-foundation-app-first-production-surface.md` |
 

--- a/docs/rfcs/RFC-0017-foundation-app-first-production-surface.md
+++ b/docs/rfcs/RFC-0017-foundation-app-first-production-surface.md
@@ -1,6 +1,6 @@
 # RFC-0017: Foundation App First-Production Surface
 
-- Status: PROPOSED
+- Status: IN PROGRESS
 - Date: 2026-03-26
 - Owners: lotus-workbench
 - Requires Approval From:
@@ -232,6 +232,10 @@ Acceptance gate:
 1. the app has a clear route and layout model,
 2. it fits naturally into the new shell.
 
+Implementation status:
+
+1. completed in `lotus-workbench` via the new `Portfolio` route and shell-mounted workspace.
+
 ### Slice 2: Foundation portfolio catalog and summary
 
 Outcome:
@@ -244,6 +248,11 @@ Acceptance gate:
 
 1. the app is already a better ecosystem entry point than the current route mix,
 2. degraded states are clear and usable.
+
+Implementation status:
+
+1. completed in `lotus-workbench` with portfolio rail, summary, review panels, and bounded
+   degraded states.
 
 ### Slice 3: Foundation holdings, allocation, and readiness
 
@@ -258,6 +267,11 @@ Acceptance gate:
 1. users can confidently decide where to go next,
 2. evidence and readiness are understandable without reading raw backend data.
 
+Implementation status:
+
+1. in progress with allocation, top-position, readiness, and data-coverage panels implemented,
+2. completed upstream contract extension tracked in `lotus-gateway` for top-position summary.
+
 ### Slice 4: Upstream issue-routing and cleanup
 
 Outcome:
@@ -270,6 +284,12 @@ Acceptance gate:
 
 1. the implementation improves the ecosystem rather than only the local surface,
 2. ownership discipline is preserved.
+
+Implementation status:
+
+1. upstream gap issues filed in `lotus-gateway`:
+   - `#65` advisor-facing evidence metadata for partial failures
+   - `#66` holdings and top-position summary for the Foundation workspace contract
 
 ## Risks
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -714,6 +714,21 @@ a:hover {
   background: linear-gradient(180deg, #fdfefe 0%, #f4f7f8 100%);
 }
 
+.portfolio-evidence-meta {
+  display: block;
+  margin-top: 0.18rem;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+}
+
+.portfolio-evidence-copy {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
 .portfolio-empty-state {
   max-width: none;
 }

--- a/src/apps/portfolio/components/portfolio-workspace.tsx
+++ b/src/apps/portfolio/components/portfolio-workspace.tsx
@@ -11,9 +11,16 @@ import {
   WorkspaceSide,
 } from "@/design-system";
 
-import { formatCurrency, formatPct } from "../formatters";
+import { formatCurrency, formatPct, formatQuantity } from "../formatters";
 import type { PortfolioWorkspace } from "../types";
-import { getWorkflowActionLabel, mapWorkflowHref } from "../workspace-config";
+import {
+  getCoverageWarningLabel,
+  getEvidenceServiceLabel,
+  getWorkflowActionLabel,
+  getWorkflowTaskLabel,
+  mapWorkflowHref,
+  WORKFLOW_DISPLAY_ORDER,
+} from "../workspace-config";
 import PortfolioRail from "./portfolio-rail";
 
 export default function PortfolioWorkspaceView({
@@ -31,6 +38,19 @@ export default function PortfolioWorkspaceView({
   selectedPortfolioId: string | null;
   workspace: PortfolioWorkspace | null;
 }) {
+  const orderedWorkflowCues = workspace
+    ? [...workspace.workflow_cues].sort((left, right) => {
+        const leftOrder = WORKFLOW_DISPLAY_ORDER.indexOf(
+          left.key as (typeof WORKFLOW_DISPLAY_ORDER)[number]
+        );
+        const rightOrder = WORKFLOW_DISPLAY_ORDER.indexOf(
+          right.key as (typeof WORKFLOW_DISPLAY_ORDER)[number]
+        );
+        return (leftOrder === -1 ? Number.MAX_SAFE_INTEGER : leftOrder) -
+          (rightOrder === -1 ? Number.MAX_SAFE_INTEGER : rightOrder);
+      })
+    : [];
+
   return (
     <WorkspaceLayout>
       <PortfolioRail portfolios={portfolios} selectedPortfolioId={selectedPortfolioId} />
@@ -64,7 +84,7 @@ export default function PortfolioWorkspaceView({
                 </div>
               </div>
               <div className="portfolio-hero-actions">
-                {workspace.workflow_cues.map((cue) => (
+                {orderedWorkflowCues.map((cue) => (
                   <ActionLink
                     key={cue.key}
                     href={mapWorkflowHref(cue.key, workspace.portfolio.portfolio_id)}
@@ -121,7 +141,7 @@ export default function PortfolioWorkspaceView({
                 <div className="portfolio-warning-list">
                   {workspace.warnings.map((warning) => (
                     <StatusChip key={warning} tone="warn">
-                      {warning}
+                      {getCoverageWarningLabel(warning)}
                     </StatusChip>
                   ))}
                 </div>
@@ -161,6 +181,43 @@ export default function PortfolioWorkspaceView({
                   </div>
                 ) : (
                   <p className="muted">Allocation data is not available yet for this portfolio.</p>
+                )}
+              </Panel>
+
+              <Panel>
+                <h3>Top Positions</h3>
+                {workspace.top_positions.length ? (
+                  <div className="table-wrap">
+                    <table className="position-table">
+                      <thead>
+                        <tr>
+                          <th align="left">Position</th>
+                          <th align="left">Asset Class</th>
+                          <th align="right">Quantity</th>
+                          <th align="right">Market Value</th>
+                          <th align="right">Weight</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {workspace.top_positions.map((position) => (
+                          <tr key={position.security_id}>
+                            <td>{position.instrument_name}</td>
+                            <td>{position.asset_class ?? "N/A"}</td>
+                            <td align="right">{formatQuantity(position.quantity)}</td>
+                            <td align="right">
+                              {formatCurrency(
+                                position.market_value_base,
+                                workspace.portfolio.base_currency
+                              )}
+                            </td>
+                            <td align="right">{formatPct(position.weight_pct)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <p className="muted">Position detail is not available yet for this portfolio.</p>
                 )}
               </Panel>
             </WorkspaceGrid>
@@ -205,18 +262,33 @@ export default function PortfolioWorkspaceView({
               />
             </Panel>
 
+            {workspace.partial_failures.length ? (
+              <Panel className="portfolio-side-card">
+                <h3>Data Coverage</h3>
+                <MetricRow label="Active exceptions" value={workspace.partial_failures.length} />
+                <div className="portfolio-guidance-list">
+                  {workspace.partial_failures.map((failure) => (
+                    <div
+                      key={`${failure.source_service}-${failure.error_code}`}
+                      className="portfolio-guidance-item"
+                    >
+                      <strong>{getEvidenceServiceLabel(failure.source_service)}</strong>
+                      <span className="portfolio-evidence-meta">{failure.error_code}</span>
+                      <p className="portfolio-evidence-copy">{failure.detail}</p>
+                    </div>
+                  ))}
+                </div>
+              </Panel>
+            ) : null}
+
             <Panel className="portfolio-side-card">
               <h3>Next Actions</h3>
               <div className="portfolio-guidance-list">
-                <div className="portfolio-guidance-item">
-                  <strong>Review performance</strong>
-                </div>
-                <div className="portfolio-guidance-item">
-                  <strong>Review suitability</strong>
-                </div>
-                <div className="portfolio-guidance-item">
-                  <strong>Prepare recommendation</strong>
-                </div>
+                {orderedWorkflowCues.map((cue) => (
+                  <div key={cue.key} className="portfolio-guidance-item">
+                    <strong>{getWorkflowTaskLabel(cue.key)}</strong>
+                  </div>
+                ))}
               </div>
             </Panel>
           </>

--- a/src/apps/portfolio/formatters.ts
+++ b/src/apps/portfolio/formatters.ts
@@ -18,3 +18,12 @@ export function formatCurrency(
     maximumFractionDigits: 0,
   }).format(value);
 }
+
+export function formatQuantity(value: number | null | undefined): string {
+  if (typeof value !== "number") {
+    return "N/A";
+  }
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 4,
+  }).format(value);
+}

--- a/src/apps/portfolio/types.ts
+++ b/src/apps/portfolio/types.ts
@@ -17,6 +17,15 @@ export type PortfolioAllocationBucket = {
   weight_pct: number | null;
 };
 
+export type PortfolioTopPosition = {
+  security_id: string;
+  instrument_name: string;
+  asset_class: string | null;
+  quantity: number;
+  market_value_base: number | null;
+  weight_pct: number | null;
+};
+
 export type PortfolioWorkflowCue = {
   key: string;
   label: string;
@@ -39,6 +48,7 @@ export type PortfolioWorkspace = {
     position_count: number;
   };
   allocations: PortfolioAllocationBucket[];
+  top_positions: PortfolioTopPosition[];
   performance: {
     period: string;
     return_pct: number | null;

--- a/src/apps/portfolio/workspace-config.ts
+++ b/src/apps/portfolio/workspace-config.ts
@@ -4,6 +4,8 @@ export const FALLBACK_WORK_AREAS = [
   { href: "/workbench", title: "Operations", value: "Available", note: "Console" },
 ] as const;
 
+export const WORKFLOW_DISPLAY_ORDER = ["performance", "risk", "proposal"] as const;
+
 export function mapWorkflowHref(key: string, portfolioId: string): string {
   switch (key) {
     case "performance":
@@ -25,5 +27,52 @@ export function getWorkflowActionLabel(key: string): string {
       return "Review Suitability";
     default:
       return "Open Performance";
+  }
+}
+
+export function getWorkflowTaskLabel(key: string): string {
+  switch (key) {
+    case "proposal":
+      return "Prepare recommendation";
+    case "risk":
+      return "Review suitability";
+    default:
+      return "Review performance";
+  }
+}
+
+export function getCoverageWarningLabel(warning: string): string {
+  switch (warning) {
+    case "FOUNDATION_PERFORMANCE_UNAVAILABLE":
+      return "Performance temporarily unavailable";
+    case "FOUNDATION_REBALANCE_UNAVAILABLE":
+      return "Monitoring temporarily unavailable";
+    case "FOUNDATION_REPORTING_UNAVAILABLE":
+      return "Reporting temporarily unavailable";
+    case "FOUNDATION_PERFORMANCE_INVALID":
+      return "Performance data needs review";
+    default:
+      return warning
+        .toLowerCase()
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, (char) => char.toUpperCase());
+  }
+}
+
+export function getEvidenceServiceLabel(sourceService: string): string {
+  switch (sourceService) {
+    case "lotus-core":
+      return "Portfolio data";
+    case "lotus-performance":
+      return "Performance";
+    case "lotus-report":
+      return "Reporting";
+    case "lotus-manage":
+      return "Monitoring";
+    default:
+      return sourceService
+        .replace(/^lotus-/, "")
+        .replace(/-/g, " ")
+        .replace(/\b\w/g, (char) => char.toUpperCase());
   }
 }

--- a/tests/integration/portfolios-page.test.tsx
+++ b/tests/integration/portfolios-page.test.tsx
@@ -63,13 +63,37 @@ describe("PortfolioFoundationPage", () => {
                   weight_pct: 25.6,
                 },
               ],
+              top_positions: [
+                {
+                  security_id: "EQ_1",
+                  instrument_name: "Apple Inc",
+                  asset_class: "Equities",
+                  quantity: 120,
+                  market_value_base: 250000,
+                  weight_pct: 20,
+                },
+                {
+                  security_id: "FI_1",
+                  instrument_name: "US Treasury 10Y",
+                  asset_class: "Fixed Income",
+                  quantity: 80,
+                  market_value_base: 180000,
+                  weight_pct: 14.4,
+                },
+              ],
               workflow_cues: [
                 { key: "performance", label: "Performance", href: "/ignored" },
                 { key: "risk", label: "Risk", href: "/ignored" },
                 { key: "proposal", label: "Proposal", href: "/ignored" },
               ],
-              warnings: [],
-              partial_failures: [],
+              warnings: ["FOUNDATION_REPORTING_UNAVAILABLE"],
+              partial_failures: [
+                {
+                  source_service: "lotus-report",
+                  error_code: "HTTP_503",
+                  detail: "snapshot service unavailable",
+                },
+              ],
             }),
           } as Response;
         }
@@ -112,8 +136,16 @@ describe("PortfolioFoundationPage", () => {
     expect(screen.getByText("MONITORED")).toBeInTheDocument();
     expect(screen.getByText("2026-02-24T08:32:00Z")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Allocation Shape/i })).toBeInTheDocument();
-    expect(screen.getByText("Equities")).toBeInTheDocument();
-    expect(screen.getByText("Fixed Income")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Top Positions/i })).toBeInTheDocument();
+    expect(screen.getByText("Apple Inc")).toBeInTheDocument();
+    expect(screen.getByText("US Treasury 10Y")).toBeInTheDocument();
+    expect(screen.getAllByText("Equities").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Fixed Income").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("Reporting temporarily unavailable")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Data Coverage/i })).toBeInTheDocument();
+    expect(screen.getByText("Reporting")).toBeInTheDocument();
+    expect(screen.getByText("HTTP_503")).toBeInTheDocument();
+    expect(screen.getByText("snapshot service unavailable")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open Performance/i })).toHaveAttribute(
       "href",
       "/performance?portfolioId=PORT_UI_1001"

--- a/tests/unit/portfolio-workspace-config.test.ts
+++ b/tests/unit/portfolio-workspace-config.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { getWorkflowActionLabel, mapWorkflowHref } from "@/apps/portfolio/workspace-config";
+import {
+  getCoverageWarningLabel,
+  getEvidenceServiceLabel,
+  getWorkflowActionLabel,
+  getWorkflowTaskLabel,
+  mapWorkflowHref,
+} from "@/apps/portfolio/workspace-config";
 
 describe("portfolio workspace config", () => {
   it("maps workflow cues into front-office routes", () => {
@@ -21,5 +27,24 @@ describe("portfolio workspace config", () => {
     expect(getWorkflowActionLabel("risk")).toBe("Review Suitability");
     expect(getWorkflowActionLabel("proposal")).toBe("Prepare Recommendation");
     expect(getWorkflowActionLabel("unknown")).toBe("Open Performance");
+  });
+
+  it("maps workflow cues into concise task labels", () => {
+    expect(getWorkflowTaskLabel("performance")).toBe("Review performance");
+    expect(getWorkflowTaskLabel("risk")).toBe("Review suitability");
+    expect(getWorkflowTaskLabel("proposal")).toBe("Prepare recommendation");
+    expect(getWorkflowTaskLabel("unknown")).toBe("Review performance");
+  });
+
+  it("maps warnings and evidence services into advisor-facing labels", () => {
+    expect(getCoverageWarningLabel("FOUNDATION_REPORTING_UNAVAILABLE")).toBe(
+      "Reporting temporarily unavailable"
+    );
+    expect(getCoverageWarningLabel("FOUNDATION_PERFORMANCE_INVALID")).toBe(
+      "Performance data needs review"
+    );
+    expect(getEvidenceServiceLabel("lotus-report")).toBe("Reporting");
+    expect(getEvidenceServiceLabel("lotus-performance")).toBe("Performance");
+    expect(getEvidenceServiceLabel("custom-service")).toBe("Custom Service");
   });
 });


### PR DESCRIPTION
## Summary
- implement the portfolio-first Foundation surface on top of the new workbench shell
- add allocation, top-position, readiness, and data-coverage panels for the portfolio workspace
- align RFC-0017 status and implementation notes with the shipped slices
- reduce duplication by deriving hero actions and next actions from the same workflow cue model

## Testing
- npm test -- --run tests/unit/portfolio-workspace-config.test.ts tests/integration/portfolios-page.test.tsx
- npm run typecheck
- npm run lint

## Notes
- This PR implements lotus-workbench RFC-0017 in the workbench layer.
- Runtime depends on the matching lotus-gateway Foundation contract PR.
