### PR TITLE
RFC-0022: Stateful Risk Workspace and lotus-risk UI integration

### DIFF
--- a/docs/architecture/RFC-0022-SLICE-1-RISK-WORKSPACE-INVENTORY.md
+++ b/docs/architecture/RFC-0022-SLICE-1-RISK-WORKSPACE-INVENTORY.md
@@ -14,7 +14,7 @@ The approved RFC-0022 v1 direction is:
 3. allow concentration simulation only when tied to an explicit sandbox/session context,
 4. route all Workbench risk reads through Gateway BFF contracts,
 5. remove the old Gateway `/analytics/workbench/risk-proxy` path instead of wrapping it,
-6. block `ACTIVE_RISK` attribution until benchmark exposure-history supportability proves readiness.
+6. expose only supported `ACTIVE_RISK` attribution dimensions and explicitly block unsupported combinations.
 
 ## lotus-risk Baseline
 
@@ -44,7 +44,7 @@ Available canonical `lotus-risk` routes for the Workbench Risk BFF:
 | Drawdown | `POST /analytics/risk/drawdown` | stateful only |
 | Rolling Risk | `POST /analytics/risk/rolling-metrics` | stateful only |
 | Concentration | `POST /analytics/risk/concentration` | stateful; simulation only with sandbox/session |
-| Historical Risk Attribution | `POST /analytics/risk/historical-attribution` | stateful `TOTAL_RISK`; `ACTIVE_RISK` supportability-gated |
+| Historical Risk Attribution | `POST /analytics/risk/historical-attribution` | stateful `TOTAL_RISK`; stateful `ACTIVE_RISK` for `POSITION`, `SECTOR`, `ASSET_CLASS`; `ISSUER` gated |
 | Capabilities | `GET /integration/capabilities` | Gateway capability aggregation |
 
 Legacy route status:

--- a/docs/architecture/RFC-0022-SLICE-1-RISK-WORKSPACE-INVENTORY.md
+++ b/docs/architecture/RFC-0022-SLICE-1-RISK-WORKSPACE-INVENTORY.md
@@ -141,3 +141,40 @@ Next slice:
 ```text
 Slice 2: Gateway legacy risk-proxy removal
 ```
+
+## Slice 2 Completion Note
+
+Status: completed on 2026-04-07.
+
+Gateway branch:
+
+```text
+feat/rfc0022-stateful-risk-workspace-bff
+```
+
+Completed changes:
+
+1. removed the Gateway client method for `/analytics/workbench/risk-proxy`,
+2. removed WorkbenchService's split risk-proxy client dependency,
+3. changed legacy Workbench analytics risk output to an explicit controlled unavailable state,
+4. added a Gateway source guard preventing the removed endpoint and client method from returning,
+5. updated Workbench to treat `risk_proxy` as nullable and show `Concentration Risk: UNAVAILABLE`,
+6. surfaced analytics partial failures in the Workbench page so the risk gap is visible in the
+   operational degraded-state flow.
+
+Slice 2 validation:
+
+```text
+lotus-gateway:
+python -m pytest tests/unit/test_workbench_service.py tests/unit/test_workbench_service_additional.py tests/unit/test_upstream_clients.py tests/unit/test_rfc0022_risk_proxy_guard.py tests/integration/test_workbench_router.py -q
+python -m ruff check src tests
+
+lotus-workbench:
+npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/rfc0022-risk-architecture-guard.test.ts tests/unit/workbench-api.test.ts
+npm run lint
+npm run typecheck
+```
+
+Slice 3 remains responsible for introducing the new stateful Gateway Risk BFF. Slice 2 intentionally
+does not add a replacement metric because every UI feature must be genuinely backed by supported
+backend functionality.

--- a/docs/architecture/RFC-0022-SLICE-1-RISK-WORKSPACE-INVENTORY.md
+++ b/docs/architecture/RFC-0022-SLICE-1-RISK-WORKSPACE-INVENTORY.md
@@ -1,0 +1,143 @@
+# RFC-0022 Slice 1 Risk Workspace Inventory
+
+- Date: 2026-04-07
+- Scope: RFC approval and current-state inventory
+- Workbench branch: `feat/rfc0022-stateful-risk-workspace-ui`
+- Production behavior change: none
+
+## Slice 1 Decision Record
+
+The approved RFC-0022 v1 direction is:
+
+1. add `Risk` as a Performance workspace mode,
+2. surface only stateful risk execution in Workbench,
+3. allow concentration simulation only when tied to an explicit sandbox/session context,
+4. route all Workbench risk reads through Gateway BFF contracts,
+5. remove the old Gateway `/analytics/workbench/risk-proxy` path instead of wrapping it,
+6. block `ACTIVE_RISK` attribution until benchmark exposure-history supportability proves readiness.
+
+## lotus-risk Baseline
+
+Reviewed branch:
+
+```text
+fix/docker-upstream-runtime-validation...origin/fix/docker-upstream-runtime-validation
+```
+
+Working tree note:
+
+```text
+M docs/domain-apis/lotus-core-performance-requirements-for-historical-attribution.md
+M src/app/services/benchmark_exposure_history.py
+M tests/integration/test_historical_attribution_endpoint.py
+M tests/unit/test_benchmark_exposure_history.py
+?? .tmp_live_probe_results.json
+```
+
+Slice 1 treats `lotus-risk` as read-only because active hardening work is in progress.
+
+Available canonical `lotus-risk` routes for the Workbench Risk BFF:
+
+| Capability | Canonical route | UI posture |
+|---|---|---|
+| Risk Snapshot | `POST /analytics/risk/calculate` | stateful only |
+| Drawdown | `POST /analytics/risk/drawdown` | stateful only |
+| Rolling Risk | `POST /analytics/risk/rolling-metrics` | stateful only |
+| Concentration | `POST /analytics/risk/concentration` | stateful; simulation only with sandbox/session |
+| Historical Risk Attribution | `POST /analytics/risk/historical-attribution` | stateful `TOTAL_RISK`; `ACTIVE_RISK` supportability-gated |
+| Capabilities | `GET /integration/capabilities` | Gateway capability aggregation |
+
+Legacy route status:
+
+```text
+POST /analytics/workbench/risk-proxy -> removed from lotus-risk runtime surface
+```
+
+## Gateway Legacy Risk-Proxy Inventory
+
+Command:
+
+```powershell
+rg -n "analytics/workbench/risk-proxy|get_workbench_risk_proxy|riskProxy|risk_proxy|WorkbenchRiskProxy" src tests docs
+```
+
+Production references that must be removed or replaced in later slices:
+
+| Area | Evidence | Required Slice |
+|---|---|---|
+| Gateway client calls removed endpoint | `src/app/clients/lotus_analytics_client.py#get_workbench_risk_proxy` | Slice 2 |
+| Gateway service merges legacy proxy result | `src/app/services/workbench_service.py` risk-proxy merge/fallback block | Slice 2 |
+| Gateway Workbench contract contains legacy proxy field | `src/app/contracts/workbench.py#WorkbenchRiskProxy` and `risk_proxy` | Slice 2 or new BFF cutover |
+
+Test references to update:
+
+| Area | Evidence | Required Slice |
+|---|---|---|
+| Router integration tests | `tests/integration/test_workbench_router.py` | Slice 2 |
+| Workbench service tests | `tests/unit/test_workbench_service.py`, `tests/unit/test_workbench_service_additional.py` | Slice 2 |
+| Upstream client tests | `tests/unit/test_upstream_clients.py` | Slice 2 |
+
+## Workbench Risk Surface Inventory
+
+Command:
+
+```powershell
+rg -n "analytics/workbench/risk-proxy|analytics/risk/|risk\\.dev\\.lotus|risk_proxy|riskProxy|Concentration Signal|HHI|risk-and-suitability" src tests docs
+```
+
+Active UI references to replace or redirect during implementation:
+
+| Area | Evidence | Required Slice |
+|---|---|---|
+| Workbench page reads legacy risk proxy | `src/app/workbench/[portfolioId]/page.tsx` reads `analytics?.risk_proxy.hhi_proposed` | Slice 2 or Slice 3 cutover |
+| Workbench type exposes legacy risk proxy | `src/features/workbench/types.ts` `risk_proxy` | Slice 2 or Slice 3 cutover |
+| Workbench decision readiness renders HHI signal | `src/features/workbench/components/decision-readiness-panel.tsx` | Slice 2 degradation, Slice 3/5 replacement |
+| Portfolio risk nav points to old route | `src/apps/portfolio/workspace-config.ts` `/risk-and-suitability` | Slice 9 |
+| Shell registry has disabled/placeholder risk app route | `src/shell/app-registry.ts` `/risk-and-suitability`, `/risk` | Slice 9 or later shell decision |
+
+Architecture guard added in Slice 1:
+
+```text
+tests/unit/rfc0022-risk-architecture-guard.test.ts
+```
+
+The guard prevents new browser-side code under `src/` from introducing:
+
+1. raw `lotus-risk` analytics paths,
+2. `risk.dev.lotus` service URLs,
+3. the removed `/analytics/workbench/risk-proxy` path.
+
+## Approved Placement
+
+The first-class Risk workspace is a Performance mode:
+
+```text
+Summary | Analysis | Advisor Brief | Risk | Evidence
+```
+
+Rationale:
+
+1. risk is analytical and benchmark-aware,
+2. it shares period, basis, as-of, and benchmark context with Performance,
+3. Portfolio should link into Risk rather than duplicate full risk analytics,
+4. Advisor Brief can cite Risk only after Gateway-backed evidence exists.
+
+## Slice 1 Exit Criteria
+
+Status:
+
+| Criteria | Result |
+|---|---|
+| RFC scope approved | Done |
+| Legacy Gateway risk-proxy inventory recorded | Done |
+| Workbench risk/concentration surface inventory recorded | Done |
+| lotus-risk branch baseline recorded | Done |
+| Statefulness and active-risk gating confirmed | Done |
+| Browser-to-risk direct-call guard added | Done |
+| Production behavior unchanged | Done |
+
+Next slice:
+
+```text
+Slice 2: Gateway legacy risk-proxy removal
+```

--- a/docs/operations/risk-workspace-supportability.md
+++ b/docs/operations/risk-workspace-supportability.md
@@ -1,0 +1,84 @@
+# Risk Workspace Supportability
+
+This note defines the operational supportability posture for the Workbench `Performance > Risk`
+mode implemented under RFC-0022.
+
+## Supported v1 modules
+
+The Risk workspace is backed only by Gateway BFF routes over canonical `lotus-risk` stateful APIs.
+
+| Module | Gateway route | First paint behavior | Detail behavior |
+| --- | --- | --- | --- |
+| Risk Snapshot | `GET /api/v1/workbench/{portfolioId}/risk/summary` | loaded on first paint | no secondary detail fetch |
+| Concentration | `GET /api/v1/workbench/{portfolioId}/risk/concentration` | loaded on first paint | simulation deltas only with explicit `sessionId` |
+| Drawdown | `GET /api/v1/workbench/{portfolioId}/risk/drawdown` | summary and worst episodes on first paint | underwater series only when explicitly expanded |
+| Rolling Risk | `GET /api/v1/workbench/{portfolioId}/risk/rolling` | rolling summaries on first paint | time series only when explicitly expanded |
+| Historical Risk Attribution | `GET /api/v1/workbench/{portfolioId}/risk/attribution` | lazy-loaded after the shell renders | grouping and attribution selector changes refetch only the attribution module |
+
+## Stateful-only rule
+
+Workbench does not surface stateless risk execution.
+
+Allowed execution modes:
+
+1. `stateful` for summary, drawdown, rolling, and attribution.
+2. `stateful` or `simulation` for concentration, where simulation requires an explicit sandbox
+   session.
+
+Blocked behaviors:
+
+1. direct browser calls to `lotus-risk`,
+2. stateless payload authoring in the UI,
+3. free-form return-series upload,
+4. browser-visible service hostnames outside Gateway.
+
+## Active-risk attribution support matrix
+
+The implemented active-risk support matrix is:
+
+| Attribution type | Grouping | State |
+| --- | --- | --- |
+| `TOTAL_RISK` | `POSITION` | ready |
+| `TOTAL_RISK` | `SECTOR` | ready |
+| `TOTAL_RISK` | `ASSET_CLASS` | ready |
+| `TOTAL_RISK` | `ISSUER` | ready |
+| `ACTIVE_RISK` | `POSITION` | ready |
+| `ACTIVE_RISK` | `SECTOR` | ready |
+| `ACTIVE_RISK` | `ASSET_CLASS` | ready |
+| `ACTIVE_RISK` | `ISSUER` | blocked |
+
+`ACTIVE_RISK + ISSUER` remains blocked until upstream benchmark issuer exposure semantics exist.
+
+## Supportability states
+
+Every risk module returns explicit supportability items normalized to:
+
+1. `ready`
+2. `partial`
+3. `unavailable`
+4. `blocked`
+
+The UI must render the upstream reason text when a state is not `ready`.
+
+## Cache and refresh posture
+
+Gateway owns bounded caching for repeated identical risk requests.
+
+Rules:
+
+1. cache keys include portfolio, period, basis, benchmark, as-of date, reporting currency, and
+   session context where relevant,
+2. heavy detail payloads are not fetched on first paint,
+3. module refreshes stay isolated to the module that owns the query,
+4. a failed heavy module must not blank the rest of Risk mode.
+
+## Legacy compatibility posture
+
+The old workbench analytics `risk_proxy` field is removed from the production contract.
+
+Implications:
+
+1. `src/app/workbench/[portfolioId]` links to the live Risk workspace instead of reading a legacy
+   HHI value,
+2. concentration analytics belong to the dedicated Risk BFF contract,
+3. `/analytics/workbench/risk-proxy` remains removed and must not be reintroduced.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -27,4 +27,5 @@ Governance boundary:
 | RFC-0019 | Modular Portfolio Book and Ledger Experience | PROPOSED | `docs/rfcs/RFC-0019-modular-portfolio-book-and-ledger-experience.md` |
 | RFC-0020 | AI Advisor Brief Copilot for Portfolio and Performance | PROPOSED | `docs/rfcs/RFC-0020-ai-advisor-brief-copilot.md` |
 | RFC-0021 | UI Architecture Hardening and Design-System Governance | IMPLEMENTED | `docs/rfcs/RFC-0021-ui-architecture-hardening-and-design-system-governance.md` |
+| RFC-0022 | Stateful Risk Workspace and lotus-risk UI Integration | PROPOSED | `docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md` |
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -27,5 +27,5 @@ Governance boundary:
 | RFC-0019 | Modular Portfolio Book and Ledger Experience | PROPOSED | `docs/rfcs/RFC-0019-modular-portfolio-book-and-ledger-experience.md` |
 | RFC-0020 | AI Advisor Brief Copilot for Portfolio and Performance | PROPOSED | `docs/rfcs/RFC-0020-ai-advisor-brief-copilot.md` |
 | RFC-0021 | UI Architecture Hardening and Design-System Governance | IMPLEMENTED | `docs/rfcs/RFC-0021-ui-architecture-hardening-and-design-system-governance.md` |
-| RFC-0022 | Stateful Risk Workspace and lotus-risk UI Integration | PROPOSED | `docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md` |
+| RFC-0022 | Stateful Risk Workspace and lotus-risk UI Integration | APPROVED | `docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md` |
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -27,5 +27,5 @@ Governance boundary:
 | RFC-0019 | Modular Portfolio Book and Ledger Experience | PROPOSED | `docs/rfcs/RFC-0019-modular-portfolio-book-and-ledger-experience.md` |
 | RFC-0020 | AI Advisor Brief Copilot for Portfolio and Performance | PROPOSED | `docs/rfcs/RFC-0020-ai-advisor-brief-copilot.md` |
 | RFC-0021 | UI Architecture Hardening and Design-System Governance | IMPLEMENTED | `docs/rfcs/RFC-0021-ui-architecture-hardening-and-design-system-governance.md` |
-| RFC-0022 | Stateful Risk Workspace and lotus-risk UI Integration | APPROVED | `docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md` |
+| RFC-0022 | Stateful Risk Workspace and lotus-risk UI Integration | IMPLEMENTED | `docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md` |
 

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -46,6 +46,30 @@ The result should feel like a private-banking risk cockpit:
 7. fast enough for front-office use,
 8. modular enough for future independent risk panels.
 
+This RFC is intentionally not a dashboard request. It is a cross-repo integration and UI
+architecture proposal. The implementation must create a durable risk capability seam that future
+Workbench, Advisor Brief, Portfolio, Reporting, and Suitability surfaces can consume without
+reintroducing direct service calls, page-local risk vocabulary, or bespoke risk panels.
+
+## Approval Posture
+
+Approval should be treated as approval for these hard decisions:
+
+1. `Risk` becomes a first-class Performance workspace mode for v1.
+2. Workbench surfaces only stateful risk execution, except sandbox-linked concentration simulation.
+3. Gateway owns the front-office Risk BFF contract.
+4. The old Gateway `/analytics/workbench/risk-proxy` integration is removed, not wrapped.
+5. `ACTIVE_RISK` attribution is blocked until benchmark exposure-history supportability is proven.
+6. Each risk module is delivered as an independently testable slice using RFC-0021 shared primitives.
+
+Approval should not be treated as approval for:
+
+1. a top-level standalone `Risk` app in this RFC,
+2. direct browser-to-`lotus-risk` calls,
+3. stateless request builders or user-uploaded return series in Workbench,
+4. fixture-only risk panels that remain after live Gateway contracts exist,
+5. speculative charting or decorative visuals without advisor decision value.
+
 ## Why This RFC Is Needed
 
 The Workbench product now has stable `Portfolio`, `Performance`, and `Advisor Brief` surfaces.
@@ -118,6 +142,18 @@ Current Gateway posture:
 
 This RFC requires removing that old connection fully.
 
+Verified legacy-removal inventory at RFC time:
+
+| Area | Current reference | Required disposition |
+|---|---|---|
+| Gateway client | `src/app/clients/lotus_analytics_client.py#get_workbench_risk_proxy` | Delete and replace with typed risk client methods for canonical `lotus-risk` routes. |
+| Gateway service | `src/app/services/workbench_service.py` `riskProxy` merge/fallback logic | Remove legacy proxy merge. Replace downstream HHI usage with new concentration BFF contract. |
+| Gateway contract | `src/app/contracts/workbench.py` `WorkbenchRiskProxy` | Retire only when no active Workbench contract needs the field; otherwise mark as legacy/degraded until new contract cutover. |
+| Gateway tests | `tests/integration/test_workbench_router.py`, `tests/unit/test_workbench_service*.py` risk-proxy assertions | Replace with degraded-state and new Risk BFF assertions. |
+| Workbench app | `src/app/workbench/[portfolioId]/page.tsx` reads `analytics.risk_proxy` | Remove after Risk BFF concentration source is available. |
+| Workbench types/tests | `src/features/workbench/types.ts`, `tests/integration/workbench-page.test.tsx`, `tests/unit/workbench-api.test.ts` | Replace `risk_proxy` display assumptions with new BFF risk contracts or controlled unavailable state. |
+| lotus-risk docs | `docs/domain-apis/legacy-endpoints.md` marks endpoint removed | Keep as historical source of truth; do not reintroduce compatibility. |
+
 ### lotus-workbench
 
 Current Workbench posture:
@@ -127,6 +163,32 @@ Current Workbench posture:
 3. `Performance` has strong summary, analysis, advisor brief, and evidence modes,
 4. no first-class Risk mode exists,
 5. RFC-0021 shared UI architecture is available and must be used for the new risk surface.
+
+## Non-Goals
+
+This RFC explicitly does not cover:
+
+1. building a new standalone top-level Risk application shell,
+2. changing `lotus-risk` analytics formulas or methodology,
+3. exposing stateless or caller-supplied data entry in Workbench,
+4. replacing Performance attribution with risk attribution,
+5. adding AI-generated risk commentary before source-grounded risk facts exist,
+6. building a charting system independent of RFC-0021 shared primitives,
+7. changing portfolio valuation, transaction, or benchmark source-of-truth ownership,
+8. shipping a compatibility shim for `/analytics/workbench/risk-proxy`.
+
+## Cross-Repo Ownership
+
+| Concern | Owning repo | Rule |
+|---|---|---|
+| Risk analytics computation | `lotus-risk` | Workbench and Gateway must not recompute metrics. |
+| Front-office BFF contracts | `lotus-gateway` | Gateway owns stateful request construction, supportability, caching, and display-shaped contracts. |
+| UI composition and interaction | `lotus-workbench` | Workbench owns presentation, navigation, module state, and shared design-system conformance. |
+| Capability aggregation and runtime wiring | `lotus-platform` | Platform owns service routing and local/deployed capability health. |
+| Benchmark and exposure source data | `lotus-core` / `lotus-performance` via service contracts | Risk UI must gate unavailable benchmark/exposure facts rather than infer them. |
+
+Any implementation that moves computation into Workbench, bypasses Gateway, or duplicates risk
+methodology in the UI violates this RFC.
 
 ## Decision
 
@@ -369,6 +431,13 @@ GET /api/v1/workbench/{portfolioId}/risk
 Use split endpoints for lower latency and module-level refresh. Use the aggregate endpoint only if
 it is proven useful for first paint.
 
+The preferred implementation is split-first:
+
+1. `risk/summary` and `risk/concentration` are first-paint candidates,
+2. `risk/drawdown`, `risk/rolling`, and `risk/attribution` are module-level queries,
+3. an aggregate endpoint may exist only if it reuses the same services and does not become a second
+   contract dialect.
+
 ### Common Query Parameters
 
 All endpoints should support:
@@ -381,6 +450,16 @@ All endpoints should support:
 6. `reportingCurrency`,
 7. `asOfDate`,
 8. `sessionId`.
+
+Parameter rules:
+
+1. `period` must map to a bounded, documented reporting period, not an arbitrary free-form label.
+2. `detailBasis` must align with existing Workbench performance basis naming where possible.
+3. `benchmarkCode` is optional in request shape but required for benchmark-relative metrics to be
+   `ready`.
+4. `sessionId` must only affect concentration simulation; it must not silently change other risk
+   modules.
+5. `asOfDate` and reporting period must be echoed back by Gateway after normalization.
 
 ### Common Response Fields
 
@@ -396,6 +475,59 @@ Every endpoint should return:
 8. `warnings`,
 9. `partialFailures`,
 10. `metadata`.
+
+Contract envelope direction:
+
+```ts
+type WorkbenchRiskModuleState = "ready" | "partial" | "unavailable" | "blocked";
+
+type WorkbenchRiskSupportabilityState =
+  | "ready"
+  | "partial"
+  | "unavailable"
+  | "blocked";
+
+type WorkbenchRiskSupportabilityItem = {
+  key: string;
+  label: string;
+  state: WorkbenchRiskSupportabilityState;
+  reason?: string;
+  sourceService?: "lotus-risk" | "lotus-performance" | "lotus-core" | "lotus-gateway";
+};
+
+type WorkbenchRiskModuleEnvelope<TPayload> = {
+  contractVersion: "risk-workspace.v1";
+  correlationId: string;
+  portfolioId: string;
+  period: string;
+  asOfDate: string;
+  benchmarkCode?: string | null;
+  sourceService: "lotus-risk";
+  state: WorkbenchRiskModuleState;
+  payload: TPayload | null;
+  supportability: WorkbenchRiskSupportabilityItem[];
+  warnings: string[];
+  partialFailures: Array<{
+    sourceService: string;
+    code: string;
+    message: string;
+  }>;
+  metadata: {
+    generatedAt: string;
+    methodologyVersion?: string | null;
+    inputMode: "stateful" | "simulation";
+    cacheStatus?: "hit" | "miss" | "bypass";
+  };
+};
+```
+
+The exact language may evolve during implementation, but the shape must preserve these principles:
+
+1. one envelope per module,
+2. state and supportability are first-class,
+3. `payload` can be absent without the page failing,
+4. raw engine enum leakage is mapped before reaching display components,
+5. input mode is auditable.
 
 ### Supportability Model
 
@@ -551,6 +683,55 @@ Rules:
 6. all tables use `AnalyticsTable`,
 7. all values use shared financial/risk formatters.
 
+### Micro-Frontend-Style Boundaries
+
+Each risk module must be independently movable and testable:
+
+1. `api/` owns BFF calls, query keys, and cache/refetch rules.
+2. `contracts/` owns TypeScript DTOs matching Gateway responses.
+3. `view-model/` owns risk-specific display mapping and business copy.
+4. `components/` owns rendering and shared primitive composition.
+5. `fixtures/` owns representative BFF-shaped payloads for tests and Storybook-like future usage.
+
+Forbidden dependencies:
+
+1. panel components importing raw Gateway fetch helpers directly,
+2. panels importing other panel view models,
+3. view models importing React,
+4. Gateway DTO parsing inside JSX,
+5. risk-specific CSS classes that duplicate RFC-0021 primitives without an explicit reason.
+
+### Risk-Specific Shared Formatters
+
+Add shared risk formatters only when existing financial formatters do not cover the domain:
+
+1. volatility and tracking error as percentages,
+2. Sharpe, Sortino, beta, and information ratio as ratios,
+3. VaR and expected shortfall with currency/percentage mode based on Gateway contract,
+4. HHI as an index score with optional interpretation band,
+5. time-under-water as duration,
+6. attribution contribution as percentage contribution or risk units based on metric.
+
+Formatter tests must include negative values, missing values, zero, extreme concentration values,
+and precision expectations.
+
+## Common Quality Gates for Every Slice
+
+Every implementation slice after approval must provide:
+
+1. a small, meaningful commit or commit set scoped to that slice,
+2. unit tests for transformed business logic, not only render smoke tests,
+3. at least one failure/partial/unavailable-state test for any new runtime path,
+4. no direct browser-to-`lotus-risk` URL references,
+5. no production reference to `/analytics/workbench/risk-proxy` after Slice 2,
+6. `npm run lint` and `npm run typecheck` for Workbench slices,
+7. Gateway lint and focused unit/integration tests for Gateway slices,
+8. documentation update when behavior, supportability, or operator workflow changes,
+9. explicit branch-clean status before moving to the next slice.
+
+Do not move to the next slice if the current slice has uncommitted changes, failing focused tests,
+or hidden fixture-only behavior that will block live integration.
+
 ## Proposed Implementation Slices
 
 ### Slice 1: RFC approval and current-state inventory
@@ -572,13 +753,15 @@ Tasks:
 Tests:
 
 1. no code tests required,
-2. RFC review checklist must be completed.
+2. RFC review checklist must be completed,
+3. inventory grep evidence must be recorded in the implementation notes before Slice 2 starts.
 
 Acceptance:
 
 1. stakeholders approve stateful-only UI scope,
 2. stakeholders approve removal of the legacy Gateway risk-proxy path,
 3. stakeholders approve Performance `Risk` mode placement.
+4. stakeholders accept that `ACTIVE_RISK` remains blocked unless supportability proves readiness.
 
 ### Slice 2: Gateway legacy risk-proxy removal
 
@@ -601,13 +784,15 @@ Tests:
 
 1. Gateway unit tests for Workbench analytics without risk-proxy fallback,
 2. Gateway integration tests proving no legacy path is called,
-3. contract grep/guard test if appropriate.
+3. contract grep/guard test if appropriate,
+4. Workbench tests proving old HHI panels degrade cleanly if the new BFF is not yet wired.
 
 Acceptance:
 
 1. `rg "/analytics/workbench/risk-proxy"` returns no production references,
 2. Gateway tests are green,
-3. Workbench still renders controlled degraded risk state.
+3. Workbench still renders controlled degraded risk state,
+4. no compatibility shim or alias endpoint is introduced.
 
 ### Slice 3: Gateway Risk BFF foundation
 
@@ -638,7 +823,8 @@ Acceptance:
 
 1. risk summary and concentration BFF endpoints return stable contracts,
 2. no UI needs raw `lotus-risk` response fields,
-3. failures are partial/degraded, not page-breaking.
+3. failures are partial/degraded, not page-breaking,
+4. supportability explains missing benchmark, risk-free, issuer, or sandbox dependencies.
 
 ### Slice 4: Workbench Risk mode shell and fixture-backed UI
 
@@ -662,13 +848,15 @@ Tests:
 2. component tests for Risk shell and supportability rail,
 3. view-model tests for fixture data,
 4. integration test proving `Risk` mode renders and does not call raw risk endpoints from browser,
-5. responsive smoke for no horizontal overflow.
+5. responsive smoke for no horizontal overflow,
+6. accessibility assertions for tab semantics and blocked-state explanatory copy.
 
 Acceptance:
 
 1. `Risk` mode is visually consistent with `Summary`, `Analysis`, and `Advisor Brief`,
 2. no stateless UX is exposed,
-3. state handling is complete.
+3. state handling is complete,
+4. first-paint panels remain useful when detail modules are still loading.
 
 ### Slice 5: Live Workbench integration for Risk Snapshot and Concentration
 
@@ -691,13 +879,16 @@ Tests:
 1. MSW/fake fetch or integration tests for successful BFF payloads,
 2. partial-failure rendering tests,
 3. query-key tests if query keys are generated separately,
-4. sandbox concentration contract tests.
+4. sandbox concentration contract tests,
+5. cache/refetch tests proving portfolio, period, basis, benchmark, and session changes invalidate
+   the correct query scope.
 
 Acceptance:
 
 1. Risk Snapshot is live through Gateway,
 2. Concentration is live through Gateway,
-3. portfolio/sandbox context changes invalidate only the relevant risk queries.
+3. portfolio/sandbox context changes invalidate only the relevant risk queries,
+4. concentration simulation is impossible without an explicit sandbox/session context.
 
 ### Slice 6: Drawdown module
 
@@ -719,12 +910,14 @@ Tests:
 1. Gateway request-shape tests,
 2. drawdown view-model tests,
 3. drawdown panel state tests,
-4. table tests for episode sorting and numeric formatting.
+4. table tests for episode sorting and numeric formatting,
+5. detail-on-demand tests proving underwater series is not requested for first paint.
 
 Acceptance:
 
 1. advisors can identify drawdown severity in seconds,
-2. detailed episode evidence is available without cluttering first paint.
+2. detailed episode evidence is available without cluttering first paint,
+3. benchmark-relative drawdown is gated when benchmark series is unavailable.
 
 ### Slice 7: Rolling Risk module
 
@@ -746,13 +939,15 @@ Tests:
 1. Gateway request-shape tests for benchmark/risk-free metric selection,
 2. view-model tests for quality flags,
 3. component tests for window switching,
-4. latency-conscious query tests where practical.
+4. latency-conscious query tests where practical,
+5. tests proving time-series detail is opt-in and not loaded by default.
 
 Acceptance:
 
 1. first paint does not request large rolling time series by default,
 2. rolling detail is available on demand,
-3. benchmark/risk-free unavailability is explicit.
+3. benchmark/risk-free unavailability is explicit,
+4. window switching does not refresh unrelated risk modules.
 
 ### Slice 8: Historical Risk Attribution module
 
@@ -775,13 +970,15 @@ Tests:
 1. Gateway request-shape tests for `TOTAL_RISK`,
 2. blocked-state tests for `ACTIVE_RISK`,
 3. contributor table tests,
-4. residual formatting tests.
+4. residual formatting tests,
+5. grouping selector tests proving unavailable groupings are disabled with clear rationale.
 
 Acceptance:
 
 1. total-risk contributors are visible,
 2. active-risk is not falsely represented as available,
-3. blocked-state copy explains the benchmark exposure-history dependency.
+3. blocked-state copy explains the benchmark exposure-history dependency,
+4. contributor sorting and residual rows are deterministic.
 
 ### Slice 9: Portfolio and Advisor Brief cross-links
 
@@ -800,13 +997,15 @@ Tests:
 
 1. Portfolio link tests,
 2. Advisor Brief evidence gating tests,
-3. route query parameter tests for opening Risk mode.
+3. route query parameter tests for opening Risk mode,
+4. tests proving Advisor Brief does not cite risk facts when Gateway risk evidence is absent.
 
 Acceptance:
 
 1. Portfolio remains summary-first,
 2. Risk remains the analytical drilldown home,
-3. Advisor Brief cites risk only when evidence is source-grounded.
+3. Advisor Brief cites risk only when evidence is source-grounded,
+4. no duplicated risk tables appear in Portfolio.
 
 ### Slice 10: Production hardening and RFC closeout
 
@@ -827,7 +1026,8 @@ Tests:
 1. Workbench lint/typecheck/unit/integration/e2e smoke,
 2. Gateway unit/integration tests,
 3. lotus-risk existing branch tests as reference, without modifying uncommitted hardening work,
-4. live local platform probe if services are available.
+4. live local platform probe if services are available,
+5. cross-repo grep guard for old risk-proxy path and browser-to-risk direct calls.
 
 Acceptance:
 
@@ -835,7 +1035,8 @@ Acceptance:
 2. no old risk-proxy references remain,
 3. Risk mode supports stateful-only UI paths,
 4. supportability behavior is explicit and auditable,
-5. RFC status can move from `PROPOSED` to `IMPLEMENTED`.
+5. RFC status can move from `PROPOSED` to `IMPLEMENTED`,
+6. all affected repos are left on clean branches after merge.
 
 ## UI Quality Bar
 
@@ -875,6 +1076,17 @@ Rules:
 6. module refresh should be independent where possible,
 7. a failed heavy module must not block the whole Risk mode.
 
+Target latency posture:
+
+1. Risk mode shell should render immediately from existing Performance context.
+2. Risk Snapshot and Concentration should be optimized for first useful paint.
+3. Drawdown, Rolling Risk, and Attribution should not block first useful paint.
+4. Detail expansions should use module-level queries and preserve existing module content during
+   refresh.
+5. Cache TTLs must be short and explicit because risk data is as-of and portfolio-context sensitive.
+6. Cache keys must include portfolio, period, basis, benchmark, as-of date, reporting currency, and
+   sandbox session where relevant.
+
 ## Accessibility Requirements
 
 1. all tabbed navigation uses semantic tab roles,
@@ -890,7 +1102,11 @@ Rules:
 2. calling all risk endpoints at first paint could create high latency,
 3. surfacing active-risk attribution too early could mislead users,
 4. legacy risk-proxy compatibility could hide integration debt,
-5. risk terms could become too technical for advisors if raw engine vocabulary leaks.
+5. risk terms could become too technical for advisors if raw engine vocabulary leaks,
+6. partial benchmark/risk-free/source-data coverage could make the UI look broken if supportability
+   is not designed first,
+7. a monolithic risk endpoint could become slow and hard to reason about,
+8. duplicated Portfolio and Performance risk displays could create inconsistent decisions.
 
 ## Mitigations
 
@@ -899,7 +1115,25 @@ Rules:
 3. heavy modules are lazy or detail-on-demand,
 4. active-risk attribution is supportability-gated,
 5. old risk-proxy endpoint is removed, not wrapped,
-6. UI copy is reviewed for advisor-facing business language.
+6. UI copy is reviewed for advisor-facing business language,
+7. supportability rail is implemented before complex detail modules,
+8. Portfolio only links to Risk and surfaces minimal exceptions,
+9. module-level query boundaries are preserved.
+
+## Requirement Traceability
+
+| Requirement | RFC decision | Primary implementation evidence expected |
+|---|---|---|
+| Use all `lotus-risk` features | Risk Snapshot, Drawdown, Rolling Risk, Concentration, Historical Risk Attribution panels | Gateway BFF endpoints and Workbench modules for all five panels. |
+| UI is stateful-only | Browser exposes no stateless request builders; Gateway constructs stateful requests | Gateway request-shape tests and Workbench copy/tests. |
+| Remove old risk-proxy | Delete old Gateway client/service path and Workbench consumers | Grep guard plus Gateway/Workbench tests. |
+| Micro-frontend-style UI | `src/apps/performance/risk/*` isolated api/contracts/view-model/components/fixtures | Folder structure and panel-level tests. |
+| Shared UI system | RFC-0021 primitives mandatory | Component imports and integration tests. |
+| Banking-grade UX | Summary first, supportability rail, provenance, detail on demand | Risk mode browser/integration tests and visual review. |
+| Simulation support | Concentration simulation only with sandbox session | Concentration Gateway and Workbench session tests. |
+| Active-risk safety | `ACTIVE_RISK` blocked until exposure-history supportability is ready | Attribution blocked-state tests. |
+| Performance | Split queries, lazy heavy modules, bounded cache | Query-key/cache tests and live probe evidence. |
+| Advisor Brief/Portfolio integration | Links/evidence only, no duplicated full risk workspace | Route/evidence gating tests. |
 
 ## Definition of Done
 

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -871,6 +871,8 @@ Slice 3 evidence:
 
 ### Slice 4: Workbench Risk mode shell and fixture-backed UI
 
+Status: completed on 2026-04-07.
+
 Outcome:
 
 1. `Risk` appears as a Performance mode,
@@ -900,6 +902,19 @@ Acceptance:
 2. no stateless UX is exposed,
 3. state handling is complete,
 4. first-paint panels remain useful when detail modules are still loading.
+
+Slice 4 evidence:
+
+1. Workbench added `Risk` to the Performance mode navigation while keeping Summary as first paint.
+2. Workbench added a contract-shaped fixture view model in
+   `src/apps/performance/risk-workspace-view-model.ts` that mirrors the Gateway
+   `risk-workspace.v1` envelope and explicitly labels `input_mode` as stateful-only.
+3. Workbench added modular Risk mode components for status, snapshot, concentration,
+   supportability, and provenance under `src/apps/performance/components/risk`.
+4. Workbench validation evidence:
+   - `npm test -- --run tests/unit/performance-risk-view-model.test.ts tests/unit/performance-risk-mode.test.tsx tests/unit/performance-workspace-mode-switch.test.tsx tests/unit/performance-workspace-view.test.tsx tests/integration/performance-analytics-page.test.tsx`
+   - `npm run lint`
+   - `npm run typecheck`
 
 ### Slice 5: Live Workbench integration for Risk Snapshot and Concentration
 

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -1107,6 +1107,8 @@ Slice 8 evidence:
 
 ### Slice 9: Portfolio and Advisor Brief cross-links
 
+Status: completed on 2026-04-07.
+
 Outcome:
 
 1. Portfolio and Advisor Brief can reference the Risk Workspace without duplicating it.
@@ -1131,6 +1133,24 @@ Acceptance:
 2. Risk remains the analytical drilldown home,
 3. Advisor Brief cites risk only when evidence is source-grounded,
 4. no duplicated risk tables appear in Portfolio.
+
+Slice 9 evidence:
+
+1. Workbench removed the stale Portfolio risk deep link to `/risk-and-suitability` and now routes
+   all portfolio risk entry points to the canonical Performance Risk mode via
+   `/performance?portfolioId=...&mode=risk`.
+2. Workbench normalized portfolio workflow cues, next actions, and concentration insights so they
+   all open the same Risk workspace rather than preserving backend-echoed raw hrefs.
+3. Workbench added URL-backed Performance mode routing, so `mode=risk` and other mode deep links
+   survive tab changes and control updates instead of dropping back to summary-only URLs.
+4. Workbench removed the obsolete standalone shell `Suitability` navigation entry, which was no
+   longer backed by a live route after Risk moved into the Performance workspace.
+5. Advisor Brief gateway normalization now drops risk metrics, risk evidence chips, and risk
+   drilldown actions when the Gateway contract does not mark risk evidence as `ready`.
+6. Validation:
+   - `npm test -- --run tests/unit/portfolio-workspace-config.test.ts tests/unit/portfolio-view-model.test.ts tests/unit/performance-advisor-brief-view-model.test.ts tests/unit/performance-workspace-view.test.tsx tests/unit/performance-workspace-client.test.tsx tests/unit/performance-workspace-entry.test.tsx tests/unit/shell-app-registry.test.ts tests/integration/top-nav-capabilities.test.tsx tests/integration/performance-analytics-page.test.tsx`
+   - `npm run lint`
+   - `npm run typecheck`
 
 ### Slice 10: Production hardening and RFC closeout
 

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -22,8 +22,8 @@ Current `lotus-risk` capabilities include:
 2. stateful drawdown analytics,
 3. stateful rolling risk diagnostics,
 4. stateful and simulation-aware concentration analytics,
-5. stateful historical risk attribution, with `TOTAL_RISK` available and `ACTIVE_RISK` gated by
-   benchmark exposure-history support,
+5. stateful historical risk attribution, with `TOTAL_RISK` available and `ACTIVE_RISK` available
+   for `POSITION`, `SECTOR`, and `ASSET_CLASS`, while `ISSUER` remains explicitly gated,
 6. integration capability publication for platform capability aggregation.
 
 `lotus-workbench` does not yet present these as a first-class front-office risk workspace.
@@ -117,7 +117,8 @@ Observed current state:
 5. `POST /analytics/risk/historical-attribution`
    - modes: `stateless`, `stateful`
    - stateful `TOTAL_RISK` exists
-   - stateful `ACTIVE_RISK` remains gated by benchmark exposure-history integration
+   - stateful `ACTIVE_RISK` is available for `POSITION`, `SECTOR`, and `ASSET_CLASS`
+   - stateful `ACTIVE_RISK` + `ISSUER` remains gated until benchmark issuer exposure semantics exist
 6. `GET /integration/capabilities`
    - publishes `risk_snapshot`, `concentration_risk`, `drawdown_analytics`,
      `rolling_risk_analytics`, and `historical_risk_attribution`
@@ -634,12 +635,9 @@ POST /analytics/risk/historical-attribution
 Initial use:
 
 1. `input_mode=stateful`,
-2. `attribution_types=["TOTAL_RISK"]`,
-3. `metrics=["VOLATILITY"]`,
-4. groupings: `POSITION`, `ISSUER`, `SECTOR`, `ASSET_CLASS` where supported.
-
-Do not expose `ACTIVE_RISK` as enabled until Gateway supportability proves benchmark exposure
-history is available.
+2. support `TOTAL_RISK` for `POSITION`, `ISSUER`, `SECTOR`, `ASSET_CLASS`,
+3. support `ACTIVE_RISK` for `POSITION`, `SECTOR`, and `ASSET_CLASS`,
+4. keep `ACTIVE_RISK + ISSUER` explicitly blocked with clear supportability rationale.
 
 ## Risk Workspace Component Architecture
 
@@ -1061,22 +1059,21 @@ Slice 7 evidence:
 
 Outcome:
 
-1. Workbench surfaces stateful total-risk attribution.
+1. Workbench surfaces stateful total-risk and supported active-risk attribution.
 
 Tasks:
 
 1. add Gateway `risk/attribution`,
 2. wire `HistoricalRiskAttributionPanel`,
-3. expose `TOTAL_RISK` initially,
-4. keep `ACTIVE_RISK` disabled/blocked until supportability says benchmark exposure history is
-   ready,
+3. expose `TOTAL_RISK` and supported `ACTIVE_RISK` dimensions,
+4. keep `ACTIVE_RISK + ISSUER` disabled/blocked with explicit rationale,
 5. render contributors and residual diagnostics,
 6. make grouping dimensions switchable when supported.
 
 Tests:
 
-1. Gateway request-shape tests for `TOTAL_RISK`,
-2. blocked-state tests for `ACTIVE_RISK`,
+1. Gateway request-shape tests for `TOTAL_RISK` and supported `ACTIVE_RISK`,
+2. blocked-state tests for `ACTIVE_RISK + ISSUER` and missing benchmark context,
 3. contributor table tests,
 4. residual formatting tests,
 5. grouping selector tests proving unavailable groupings are disabled with clear rationale.
@@ -1087,6 +1084,26 @@ Acceptance:
 2. active-risk is not falsely represented as available,
 3. blocked-state copy explains the benchmark exposure-history dependency,
 4. contributor sorting and residual rows are deterministic.
+
+Slice 8 evidence:
+
+1. Gateway added `GET /api/v1/workbench/{portfolioId}/risk/attribution` with a typed
+   stateful-only BFF contract that directly reflects the merged `lotus-risk` and
+   `lotus-performance` support matrix.
+2. Gateway now supports `TOTAL_RISK` for `POSITION`, `ISSUER`, `SECTOR`, and `ASSET_CLASS`,
+   and supports `ACTIVE_RISK` for `POSITION`, `SECTOR`, and `ASSET_CLASS`.
+3. Gateway explicitly blocks `ACTIVE_RISK + ISSUER` and `ACTIVE_RISK` without benchmark context
+   before any upstream call is made.
+4. Workbench added a modular `RiskAttributionPanel`, a typed risk attribution client, and
+   lazy attribution query handling that reuses cache keys instead of issuing duplicate fetches.
+5. Workbench surfaces only backend-supported attribution combinations. It does not fabricate
+   unsupported active-risk behavior and it does not preserve the older blanket gating assumption.
+6. Validation:
+   - `lotus-gateway`: `python -m pytest tests/unit/test_risk_workspace_service.py tests/unit/test_upstream_clients.py tests/integration/test_workbench_router.py -q`
+   - `lotus-gateway`: `python -m ruff check src tests`
+   - `lotus-workbench`: `npm test -- --run tests/unit/performance-risk-view-model.test.ts tests/unit/performance-risk-mode.test.tsx tests/integration/performance-analytics-page.test.tsx`
+   - `lotus-workbench`: `npm run lint`
+   - `lotus-workbench`: `npm run typecheck`
 
 ### Slice 9: Portfolio and Advisor Brief cross-links
 

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -822,6 +822,8 @@ Acceptance:
 
 ### Slice 3: Gateway Risk BFF foundation
 
+Status: completed on 2026-04-07.
+
 Outcome:
 
 1. Gateway exposes typed stateful risk BFF contracts,
@@ -851,6 +853,21 @@ Acceptance:
 2. no UI needs raw `lotus-risk` response fields,
 3. failures are partial/degraded, not page-breaking,
 4. supportability explains missing benchmark, risk-free, issuer, or sandbox dependencies.
+
+Slice 3 evidence:
+
+1. Gateway branch `feat/rfc0022-stateful-risk-workspace-bff` added typed risk workspace
+   contracts in `src/app/contracts/risk_workspace.py`.
+2. Gateway added `RiskWorkspaceService` in `src/app/services/risk_workspace_service.py` to
+   construct stateful-only `lotus-risk` payloads, normalize supportability, preserve correlation
+   IDs, and cache repeated identical risk BFF reads.
+3. Gateway added Workbench BFF routes for:
+   - `GET /api/v1/workbench/{portfolioId}/risk/summary`
+   - `GET /api/v1/workbench/{portfolioId}/risk/concentration`
+4. Gateway validation evidence:
+   - `python -m pytest tests/unit/test_risk_workspace_service.py tests/unit/test_async_ttl_cache.py tests/unit/test_upstream_clients.py tests/unit/test_rfc0022_risk_proxy_guard.py tests/integration/test_workbench_router.py -q`
+   - `python -m pytest tests/unit/test_workbench_service.py tests/unit/test_workbench_service_additional.py tests/unit/test_upstream_clients.py tests/unit/test_rfc0022_risk_proxy_guard.py tests/integration/test_workbench_router.py -q`
+   - `python -m ruff check src tests`
 
 ### Slice 4: Workbench Risk mode shell and fixture-backed UI
 

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -918,6 +918,8 @@ Slice 4 evidence:
 
 ### Slice 5: Live Workbench integration for Risk Snapshot and Concentration
 
+Status: completed on 2026-04-07.
+
 Outcome:
 
 1. Workbench calls Gateway for stateful Risk Snapshot and Concentration.
@@ -947,6 +949,19 @@ Acceptance:
 2. Concentration is live through Gateway,
 3. portfolio/sandbox context changes invalidate only the relevant risk queries,
 4. concentration simulation is impossible without an explicit sandbox/session context.
+
+Slice 5 evidence:
+
+1. Workbench added live client fetchers for:
+   - `GET /api/bff/api/v1/workbench/{portfolioId}/risk/summary`
+   - `GET /api/bff/api/v1/workbench/{portfolioId}/risk/concentration`
+2. Workbench added `usePerformanceRiskContract` to isolate request-shape caching and refetch logic.
+3. Risk mode now renders live Gateway BFF results and uses explicit unavailable envelopes on failure
+   instead of fixture fallback.
+4. Workbench validation evidence:
+   - `npm test -- --run tests/unit/performance-risk-view-model.test.ts tests/unit/performance-risk-mode.test.tsx tests/unit/performance-workspace-mode-switch.test.tsx tests/unit/performance-workspace-view.test.tsx tests/integration/performance-analytics-page.test.tsx`
+   - `npm run lint`
+   - `npm run typecheck`
 
 ### Slice 6: Drawdown module
 

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -776,6 +776,21 @@ Acceptance:
 
 ### Slice 2: Gateway legacy risk-proxy removal
 
+Status: completed on 2026-04-07.
+
+Evidence:
+
+1. Gateway branch:
+   `feat/rfc0022-stateful-risk-workspace-bff`
+2. Gateway guard:
+   `tests/unit/test_rfc0022_risk_proxy_guard.py`
+3. Workbench degraded-state handling:
+   `src/app/workbench/[portfolioId]/page.tsx`
+4. Workbench architecture guard:
+   `tests/unit/rfc0022-risk-architecture-guard.test.ts`
+5. Slice 2 status note:
+   `docs/architecture/RFC-0022-SLICE-1-RISK-WORKSPACE-INVENTORY.md`
+
 Outcome:
 
 1. old Gateway risk-proxy connection is removed,

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -1,6 +1,6 @@
 # RFC-0022: Stateful Risk Workspace and lotus-risk UI Integration
 
-- Status: PROPOSED
+- Status: APPROVED
 - Date: 2026-04-07
 - Owners:
   - lotus-workbench maintainers
@@ -735,6 +735,17 @@ or hidden fixture-only behavior that will block live integration.
 ## Proposed Implementation Slices
 
 ### Slice 1: RFC approval and current-state inventory
+
+Status: completed on 2026-04-07.
+
+Evidence:
+
+1. Slice 1 inventory artifact:
+   `docs/architecture/RFC-0022-SLICE-1-RISK-WORKSPACE-INVENTORY.md`
+2. Workbench architectural guard:
+   `tests/unit/rfc0022-risk-architecture-guard.test.ts`
+3. Approval scope captured in this RFC's `Approval Posture`, `Non-Goals`,
+   `Cross-Repo Ownership`, and `Requirement Traceability` sections.
 
 Outcome:
 

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -1038,6 +1038,25 @@ Acceptance:
 3. benchmark/risk-free unavailability is explicit,
 4. window switching does not refresh unrelated risk modules.
 
+Slice 7 evidence:
+
+1. Gateway added `GET /api/v1/workbench/{portfolioId}/risk/rolling` with a typed
+   stateful-only BFF contract and an explicit `include_time_series` on-demand detail flag.
+2. Gateway added request-shape, cache-key, quality-flag, Sharpe fallback, malformed-upstream,
+   and router coverage for rolling risk.
+3. Workbench added live rolling client wiring, rolling view-model mapping, and a modular
+   `RiskRollingPanel`.
+4. Workbench keeps first paint lean by requesting rolling summaries only; rolling series is
+   fetched only after explicit disclosure expansion.
+5. Workbench now uses descriptive disclosure aria labels, improving shared accessibility while
+   keeping the disclosure primitive reusable across modules.
+6. Validation:
+   - `lotus-gateway`: `python -m pytest tests/unit/test_risk_workspace_service.py tests/unit/test_upstream_clients.py tests/integration/test_workbench_router.py -q`
+   - `lotus-gateway`: `python -m ruff check src tests`
+   - `lotus-workbench`: `npm test -- --run tests/unit/performance-risk-view-model.test.ts tests/unit/performance-risk-mode.test.tsx tests/integration/performance-analytics-page.test.tsx`
+   - `lotus-workbench`: `npm run lint`
+   - `lotus-workbench`: `npm run typecheck`
+
 ### Slice 8: Historical Risk Attribution module
 
 Outcome:

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -1,6 +1,6 @@
 # RFC-0022: Stateful Risk Workspace and lotus-risk UI Integration
 
-- Status: APPROVED
+- Status: IMPLEMENTED
 - Date: 2026-04-07
 - Owners:
   - lotus-workbench maintainers
@@ -59,7 +59,8 @@ Approval should be treated as approval for these hard decisions:
 2. Workbench surfaces only stateful risk execution, except sandbox-linked concentration simulation.
 3. Gateway owns the front-office Risk BFF contract.
 4. The old Gateway `/analytics/workbench/risk-proxy` integration is removed, not wrapped.
-5. `ACTIVE_RISK` attribution is blocked until benchmark exposure-history supportability is proven.
+5. `ACTIVE_RISK` attribution is available only where upstream support exists; `ISSUER` remains
+   explicitly blocked.
 6. Each risk module is delivered as an independently testable slice using RFC-0021 shared primitives.
 
 Approval should not be treated as approval for:
@@ -211,7 +212,7 @@ Allowed execution modes by panel:
 | Drawdown | stateful | Benchmark-relative summary only when supportability allows it. |
 | Rolling Risk | stateful | Risk-free and benchmark-dependent metrics are supportability-gated. |
 | Concentration | stateful by default; simulation when sandbox session exists | Simulation is allowed only for concentration because `lotus-risk` supports it. |
-| Historical Risk Attribution | stateful `TOTAL_RISK` first | `ACTIVE_RISK` must remain gated until benchmark exposure history is available. |
+| Historical Risk Attribution | stateful | `TOTAL_RISK` is available across supported groupings; `ACTIVE_RISK` is available for `POSITION`, `SECTOR`, and `ASSET_CLASS`, while `ISSUER` remains blocked. |
 
 ## Architectural Principles
 
@@ -770,7 +771,8 @@ Acceptance:
 1. stakeholders approve stateful-only UI scope,
 2. stakeholders approve removal of the legacy Gateway risk-proxy path,
 3. stakeholders approve Performance `Risk` mode placement.
-4. stakeholders accept that `ACTIVE_RISK` remains blocked unless supportability proves readiness.
+4. stakeholders accept that `ACTIVE_RISK` is surfaced only for supported grouping dimensions and
+   remains blocked for `ISSUER`.
 
 ### Slice 2: Gateway legacy risk-proxy removal
 
@@ -1183,6 +1185,35 @@ Acceptance:
 5. RFC status can move from `PROPOSED` to `IMPLEMENTED`,
 6. all affected repos are left on clean branches after merge.
 
+Status: completed on 2026-04-07.
+
+Slice 10 evidence:
+
+1. Gateway removed the legacy `WorkbenchRiskProxy` type from the monolithic workbench analytics
+   contract and stopped serializing `risk_proxy` on `/api/v1/workbench/{portfolioId}/analytics`.
+2. Workbench removed the legacy analytics `risk_proxy` field from `src/features/workbench/types.ts`
+   and replaced the old `Decision Readiness` concentration signal with a canonical `Open Risk`
+   drilldown into `/performance?portfolioId=...&mode=risk`.
+3. Gateway strengthened `tests/unit/test_rfc0022_risk_proxy_guard.py` so the deleted legacy
+   contract type cannot be reintroduced silently.
+4. Workbench added a focused architecture guard proving the legacy workbench analytics contract and
+   old workbench page no longer depend on removed `risk_proxy` fields.
+5. Operator notes were added in `docs/operations/risk-workspace-supportability.md`, covering:
+   - stateful-only execution rules,
+   - first-paint versus on-demand module behavior,
+   - the final active-risk attribution support matrix,
+   - the explicit removal of the legacy workbench analytics `risk_proxy` field.
+6. Validation:
+   - `lotus-gateway`: `python -m pytest tests/unit/test_workbench_service.py tests/unit/test_workbench_service_additional.py tests/unit/test_rfc0022_risk_proxy_guard.py tests/integration/test_workbench_router.py -q`
+   - `lotus-gateway`: `python -m ruff check src tests`
+   - `lotus-workbench`: `npm test -- --run tests/unit/decision-readiness-panel.test.tsx tests/unit/workbench-api.test.ts tests/unit/rfc0022-risk-architecture-guard.test.ts tests/integration/workbench-page.test.tsx tests/integration/performance-analytics-page.test.tsx`
+   - `lotus-workbench`: `npm run lint`
+   - `lotus-workbench`: `npm run typecheck`
+7. Canonical local live probes were attempted against `gateway.dev.lotus` and
+   `workbench.dev.lotus`; the environment returned `404` and `502`, so slice closure relies on the
+   green contract, integration, lint, and typecheck evidence rather than a healthy local stack
+   probe.
+
 ## UI Quality Bar
 
 The Risk Workspace must feel:
@@ -1258,7 +1289,8 @@ Target latency posture:
 1. Gateway BFF contract is mandatory before live UI integration,
 2. initial UI shell can be fixture-backed but must match Gateway-shaped contracts,
 3. heavy modules are lazy or detail-on-demand,
-4. active-risk attribution is supportability-gated,
+4. active-risk attribution follows the upstream support matrix and keeps unsupported issuer
+   attribution blocked,
 5. old risk-proxy endpoint is removed, not wrapped,
 6. UI copy is reviewed for advisor-facing business language,
 7. supportability rail is implemented before complex detail modules,
@@ -1276,7 +1308,7 @@ Target latency posture:
 | Shared UI system | RFC-0021 primitives mandatory | Component imports and integration tests. |
 | Banking-grade UX | Summary first, supportability rail, provenance, detail on demand | Risk mode browser/integration tests and visual review. |
 | Simulation support | Concentration simulation only with sandbox session | Concentration Gateway and Workbench session tests. |
-| Active-risk safety | `ACTIVE_RISK` blocked until exposure-history supportability is ready | Attribution blocked-state tests. |
+| Active-risk safety | `ACTIVE_RISK` only where upstream support exists; `ISSUER` stays blocked | Attribution blocked-state tests. |
 | Performance | Split queries, lazy heavy modules, bounded cache | Query-key/cache tests and live probe evidence. |
 | Advisor Brief/Portfolio integration | Links/evidence only, no duplicated full risk workspace | Route/evidence gating tests. |
 
@@ -1291,7 +1323,8 @@ This RFC can be marked `IMPLEMENTED` only when:
    context,
 5. Risk Snapshot, Drawdown, Rolling Risk, Concentration, and Total-Risk Attribution are rendered
    with supportability states,
-6. active-risk attribution is blocked/gated until benchmark exposure history is available,
+6. active-risk attribution follows the supported upstream matrix and keeps `ISSUER` explicitly
+   blocked,
 7. Portfolio links into Risk without duplicating full risk analytics,
 8. all new panels use RFC-0021 shared primitives,
 9. tests cover contracts, state handling, supportability, cache behavior, and navigation,

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -1,0 +1,931 @@
+# RFC-0022: Stateful Risk Workspace and lotus-risk UI Integration
+
+- Status: PROPOSED
+- Date: 2026-04-07
+- Owners:
+  - lotus-workbench maintainers
+  - lotus-gateway maintainers
+  - lotus-risk maintainers
+- Requires Approval From:
+  - lotus-workbench maintainers
+  - lotus-gateway maintainers
+  - lotus-risk maintainers
+  - lotus-platform maintainers
+
+## Summary
+
+`lotus-risk` now exposes a materially richer analytics surface than `lotus-workbench` consumes.
+
+Current `lotus-risk` capabilities include:
+
+1. stateful portfolio risk metrics,
+2. stateful drawdown analytics,
+3. stateful rolling risk diagnostics,
+4. stateful and simulation-aware concentration analytics,
+5. stateful historical risk attribution, with `TOTAL_RISK` available and `ACTIVE_RISK` gated by
+   benchmark exposure-history support,
+6. integration capability publication for platform capability aggregation.
+
+`lotus-workbench` does not yet present these as a first-class front-office risk workspace.
+`lotus-gateway` still has an older `risk_proxy` path that calls a removed legacy
+`/analytics/workbench/risk-proxy` endpoint shape. That connection must be removed and replaced
+with a clean Gateway BFF contract over the canonical `lotus-risk` APIs.
+
+This RFC proposes a modular, micro-frontend-style Risk Workspace inside the Workbench product,
+surfaced through shared UI primitives from RFC-0021 and backed only by stateful `lotus-risk`
+execution modes in the UI.
+
+The result should feel like a private-banking risk cockpit:
+
+1. source-grounded,
+2. stateful,
+3. portfolio-context aware,
+4. benchmark-aware where data is available,
+5. simulation-aware for concentration,
+6. auditable,
+7. fast enough for front-office use,
+8. modular enough for future independent risk panels.
+
+## Why This RFC Is Needed
+
+The Workbench product now has stable `Portfolio`, `Performance`, and `Advisor Brief` surfaces.
+The next high-value analytical gap is risk.
+
+Advisors and investment teams need to answer questions such as:
+
+1. Is this portfolio taking appropriate risk for the mandate?
+2. Did the portfolio underperform because it took too much, too little, or the wrong type of risk?
+3. How severe was the worst drawdown path and is the book still underwater?
+4. Are rolling risk conditions deteriorating?
+5. Is the proposed trade increasing concentration risk?
+6. Which contributors explain total risk?
+7. Which risk facts are available, partial, unavailable, or blocked by upstream evidence?
+
+Today, those answers are not presented coherently in Workbench. Existing UI mentions concentration
+in a limited readiness panel, but it does not expose the full `lotus-risk` capability set.
+
+## Current Source Reality
+
+### lotus-risk
+
+The current `lotus-risk` feature branch reviewed for this RFC is:
+
+1. `fix/docker-upstream-runtime-validation`
+
+Observed current state:
+
+1. `POST /analytics/risk/calculate`
+   - modes: `stateless`, `stateful`
+   - portfolio metrics: volatility, drawdown, Sharpe, Sortino, beta, tracking error, information
+     ratio, VaR
+2. `POST /analytics/risk/drawdown`
+   - modes: `stateless`, `stateful`
+   - max drawdown, episodes, time-under-water, ulcer index, DaR/CDaR, optional underwater series,
+     optional benchmark-relative summary
+3. `POST /analytics/risk/rolling-metrics`
+   - modes: `stateless`, `stateful`
+   - rolling volatility, rolling Sharpe, rolling beta, rolling tracking error, rolling information
+     ratio, rolling max drawdown
+4. `POST /analytics/risk/concentration`
+   - modes: `stateless`, `stateful`, `simulation`
+   - portfolio HHI, single-position concentration, issuer concentration, coverage diagnostics,
+     simulation session metadata
+5. `POST /analytics/risk/historical-attribution`
+   - modes: `stateless`, `stateful`
+   - stateful `TOTAL_RISK` exists
+   - stateful `ACTIVE_RISK` remains gated by benchmark exposure-history integration
+6. `GET /integration/capabilities`
+   - publishes `risk_snapshot`, `concentration_risk`, `drawdown_analytics`,
+     `rolling_risk_analytics`, and `historical_risk_attribution`
+
+Important working-tree note:
+
+1. the reviewed `lotus-risk` branch had an existing uncommitted change in
+   `src/app/integrations/lotus_core_client.py`,
+2. that change adds benchmark assignment, benchmark market-series, and index catalog client methods,
+3. this RFC does not assume that uncommitted work is merged, but it treats benchmark exposure and
+   active-risk readiness as supportability-gated.
+
+### lotus-gateway
+
+Current Gateway posture:
+
+1. `risk_analytics_base_url` exists,
+2. platform capability aggregation already calls risk capabilities,
+3. Workbench analytics still references an older `get_workbench_risk_proxy` path,
+4. that client calls `/analytics/workbench/risk-proxy`,
+5. `lotus-risk` endpoint matrix marks that endpoint removed.
+
+This RFC requires removing that old connection fully.
+
+### lotus-workbench
+
+Current Workbench posture:
+
+1. `Portfolio` has limited concentration/readiness copy,
+2. `Workbench` has a narrow HHI signal,
+3. `Performance` has strong summary, analysis, advisor brief, and evidence modes,
+4. no first-class Risk mode exists,
+5. RFC-0021 shared UI architecture is available and must be used for the new risk surface.
+
+## Decision
+
+Create a first-class `Risk` mode in the Workbench analytical experience, backed by a new
+Gateway-owned Risk BFF contract.
+
+The UI must only surface stateful risk execution:
+
+1. no stateless payload authoring in the UI,
+2. no raw return-series upload in the UI,
+3. no user-supplied exposure histories in the UI,
+4. no direct browser-to-`lotus-risk` calls.
+
+Allowed execution modes by panel:
+
+| Risk Panel | UI Execution Mode | Notes |
+|---|---|---|
+| Risk Snapshot | stateful | Uses portfolio ID, as-of, period, basis, benchmark context. |
+| Drawdown | stateful | Benchmark-relative summary only when supportability allows it. |
+| Rolling Risk | stateful | Risk-free and benchmark-dependent metrics are supportability-gated. |
+| Concentration | stateful by default; simulation when sandbox session exists | Simulation is allowed only for concentration because `lotus-risk` supports it. |
+| Historical Risk Attribution | stateful `TOTAL_RISK` first | `ACTIVE_RISK` must remain gated until benchmark exposure history is available. |
+
+## Architectural Principles
+
+### 1. Gateway BFF owns UI contract shaping
+
+The browser must not call `lotus-risk` directly.
+
+Target flow:
+
+```text
+lotus-workbench
+  -> lotus-gateway /api/v1/workbench/{portfolioId}/risk/*
+    -> lotus-risk /analytics/risk/*
+```
+
+Gateway responsibilities:
+
+1. enforce the stateful-only UI contract,
+2. construct canonical `lotus-risk` requests,
+3. preserve correlation IDs,
+4. normalize supportability and partial-failure states,
+5. cache safe repeated reads,
+6. map raw analytics into front-office display contracts,
+7. hide stateless and low-level engine concerns from the UI.
+
+### 2. Remove the old risk-proxy path
+
+The current Gateway connection to `/analytics/workbench/risk-proxy` must be removed.
+
+Removal means:
+
+1. delete the legacy client method,
+2. delete legacy fallback logic from Workbench analytics,
+3. replace old HHI proxy mapping with the new stateful concentration BFF result,
+4. update tests so no path references `/analytics/workbench/risk-proxy`,
+5. update docs that still describe the old path.
+
+No compatibility shim should be introduced for the removed legacy endpoint.
+
+### 3. Risk UI is modular, not monolithic
+
+Risk should be built as a set of independently testable modules:
+
+1. Risk workspace shell,
+2. risk snapshot module,
+3. drawdown module,
+4. rolling risk module,
+5. concentration module,
+6. historical risk attribution module,
+7. supportability rail,
+8. evidence/provenance strip.
+
+Each module should have:
+
+1. its own view model,
+2. its own fixture-backed contract tests,
+3. its own loading/empty/partial/unavailable/error states,
+4. its own focused query boundary where appropriate,
+5. a shared parent context for period, basis, benchmark, and portfolio identity.
+
+This is a micro-frontend-style implementation within the Workbench codebase. It does not require a
+separate deployable frontend bundle yet.
+
+### 4. Shared UI system is mandatory
+
+The Risk Workspace must use RFC-0021 shared primitives:
+
+1. `AppPageShell`,
+2. `WorkbenchPageFrame`,
+3. `SectionBlock`,
+4. `ModeTabs`,
+5. `SemanticBadge`,
+6. `ActionButton`,
+7. `AnalyticsTable`,
+8. `ScreenStatePanel`,
+9. `CapabilityStatePanel`,
+10. `WorkbenchSummaryMetricStrip`,
+11. shared financial formatters,
+12. shared query policy.
+
+No page-local risk UI system should be created.
+
+### 5. Business language over engine language
+
+The UI must not expose raw model internals unless they are meaningful to an advisor.
+
+Examples:
+
+1. show `Volatility`, not `VOLATILITY`,
+2. show `Tracking Error`, not `TRACKING_ERROR`,
+3. show `Data coverage partial`, not only `quality_flags`,
+4. show `Issuer coverage partial`, not only `coverage_status=partial`,
+5. show `Active-risk attribution unavailable: benchmark exposure history not available`, not a
+   generic failure.
+
+### 6. Summary first, detail on demand
+
+The first view must answer the advisor's question quickly:
+
+1. risk level,
+2. drawdown severity,
+3. benchmark-relative risk,
+4. concentration pressure,
+5. coverage/supportability.
+
+Detailed tables and series should be below the fold or behind module expansion.
+
+## Proposed UX
+
+### Navigation
+
+Add `Risk` as a mode in the Performance workspace:
+
+```text
+Summary | Analysis | Advisor Brief | Risk | Evidence
+```
+
+Rationale:
+
+1. risk is analytical and benchmark-aware,
+2. it belongs next to Performance rather than inside Portfolio details,
+3. Portfolio can link into Risk for concentration and readiness actions,
+4. Advisor Brief can cite Risk as a future source once Risk BFF evidence exists.
+
+### Risk Mode Layout
+
+```text
+Performance > Risk
+
+Context Bar:
+Portfolio | Benchmark | Period | Basis | As of | Risk supportability
+
+Main:
+Risk Snapshot
+  - Volatility
+  - Sharpe
+  - Sortino
+  - Beta
+  - Tracking Error
+  - Information Ratio
+  - VaR / Expected Shortfall
+
+Drawdown
+  - Max Drawdown
+  - Time Under Water
+  - Ulcer Index
+  - DaR / CDaR
+  - Worst Episodes
+  - Underwater Path
+
+Rolling Risk
+  - Window selector
+  - Rolling Volatility
+  - Rolling Sharpe
+  - Rolling Beta
+  - Rolling Tracking Error
+  - Rolling Information Ratio
+
+Concentration
+  - HHI current
+  - HHI proposed / delta when sandbox exists
+  - Top position weight
+  - Top-N cumulative weight
+  - Issuer HHI
+  - Issuer coverage
+
+Historical Risk Attribution
+  - Total risk attribution
+  - Contributors by position / issuer / sector / asset class
+  - Active risk attribution gated by supportability
+
+Right Rail:
+Supportability
+  - Returns series
+  - Benchmark series
+  - Risk-free series
+  - Issuer enrichment
+  - Exposure history
+  - Sandbox session
+
+Provenance:
+  - source service
+  - contract version
+  - methodology version
+  - correlation ID
+  - as-of / period
+```
+
+### Portfolio Integration
+
+Portfolio should not duplicate the full Risk Workspace.
+
+Portfolio should surface only decision-useful entry points:
+
+1. `Open Risk` action,
+2. concentration readiness status,
+3. top concentration exception when HHI or top position pressure is high,
+4. sandbox concentration delta when an active sandbox session exists.
+
+## Gateway BFF Contract Direction
+
+Add new Gateway endpoints under `workbench`:
+
+```text
+GET /api/v1/workbench/{portfolioId}/risk/summary
+GET /api/v1/workbench/{portfolioId}/risk/drawdown
+GET /api/v1/workbench/{portfolioId}/risk/rolling
+GET /api/v1/workbench/{portfolioId}/risk/concentration
+GET /api/v1/workbench/{portfolioId}/risk/attribution
+```
+
+The first implementation may also include an aggregate endpoint:
+
+```text
+GET /api/v1/workbench/{portfolioId}/risk
+```
+
+Use split endpoints for lower latency and module-level refresh. Use the aggregate endpoint only if
+it is proven useful for first paint.
+
+### Common Query Parameters
+
+All endpoints should support:
+
+1. `period`,
+2. `detailBasis`,
+3. `benchmarkCode`,
+4. `reportStartDate`,
+5. `reportEndDate`,
+6. `reportingCurrency`,
+7. `asOfDate`,
+8. `sessionId`.
+
+### Common Response Fields
+
+Every endpoint should return:
+
+1. `correlationId`,
+2. `contractVersion`,
+3. `portfolioId`,
+4. `period`,
+5. `asOfDate`,
+6. `sourceService`,
+7. `supportability`,
+8. `warnings`,
+9. `partialFailures`,
+10. `metadata`.
+
+### Supportability Model
+
+Gateway must normalize raw risk availability into UI-safe supportability states:
+
+```text
+ready | partial | unavailable | blocked | loading
+```
+
+Example supportability dimensions:
+
+1. portfolio returns,
+2. benchmark returns,
+3. risk-free series,
+4. issuer enrichment,
+5. exposure history,
+6. sandbox session,
+7. methodology metadata.
+
+## lotus-risk Usage Rules
+
+### Risk Snapshot
+
+Call:
+
+```text
+POST /analytics/risk/calculate
+```
+
+Use:
+
+1. `input_mode=stateful`,
+2. `stateful_input.portfolio_id`,
+3. `stateful_input.as_of_date`,
+4. `stateful_input.periods`,
+5. `stateful_input.net_or_gross`,
+6. `stateful_input.reporting_currency`,
+7. `stateful_input.metrics`.
+
+Initial metrics:
+
+1. `VOLATILITY`,
+2. `SHARPE`,
+3. `SORTINO`,
+4. `BETA`,
+5. `TRACKING_ERROR`,
+6. `INFORMATION_RATIO`,
+7. `VAR`.
+
+### Drawdown
+
+Call:
+
+```text
+POST /analytics/risk/drawdown
+```
+
+Use:
+
+1. `input_mode=stateful`,
+2. `analysis_options.include_episode_list=true`,
+3. `analysis_options.include_underwater_series=false` for summary first,
+4. `include_underwater_series=true` only for expanded detail.
+
+### Rolling Risk
+
+Call:
+
+```text
+POST /analytics/risk/rolling-metrics
+```
+
+Use:
+
+1. `input_mode=stateful`,
+2. default windows `[21, 63, 126, 252]`,
+3. `include_time_series=false` for first paint,
+4. `include_time_series=true` for detail charts on demand.
+
+### Concentration
+
+Call:
+
+```text
+POST /analytics/risk/concentration
+```
+
+Use:
+
+1. `input_mode=stateful` when no sandbox session exists,
+2. `input_mode=simulation` when the user has an active Workbench sandbox session and wants
+   current/proposed concentration,
+3. `issuer_grouping_level=ultimate_parent` by default,
+4. `enrichment_policy=merge_caller_then_core` by default.
+
+### Historical Risk Attribution
+
+Call:
+
+```text
+POST /analytics/risk/historical-attribution
+```
+
+Initial use:
+
+1. `input_mode=stateful`,
+2. `attribution_types=["TOTAL_RISK"]`,
+3. `metrics=["VOLATILITY"]`,
+4. groupings: `POSITION`, `ISSUER`, `SECTOR`, `ASSET_CLASS` where supported.
+
+Do not expose `ACTIVE_RISK` as enabled until Gateway supportability proves benchmark exposure
+history is available.
+
+## Risk Workspace Component Architecture
+
+Proposed Workbench module structure:
+
+```text
+src/apps/performance/risk/
+  api/
+    risk-workspace-api.ts
+    risk-query-keys.ts
+  contracts/
+    risk-workspace-contract.ts
+  view-model/
+    risk-summary-view-model.ts
+    drawdown-view-model.ts
+    rolling-risk-view-model.ts
+    concentration-view-model.ts
+    risk-attribution-view-model.ts
+  components/
+    performance-risk-mode.tsx
+    risk-workspace-header.tsx
+    risk-supportability-rail.tsx
+    risk-snapshot-panel.tsx
+    drawdown-panel.tsx
+    rolling-risk-panel.tsx
+    concentration-panel.tsx
+    historical-risk-attribution-panel.tsx
+    risk-provenance-strip.tsx
+    risk-module-state.tsx
+  fixtures/
+    risk-workspace-fixtures.ts
+```
+
+Rules:
+
+1. each panel owns only its display and view-model transformation,
+2. query orchestration is centralized in `api/`,
+3. cross-panel context is passed through a small typed context object,
+4. no panel calls Gateway directly except through shared hooks/api functions,
+5. all panels use shared screen state components,
+6. all tables use `AnalyticsTable`,
+7. all values use shared financial/risk formatters.
+
+## Proposed Implementation Slices
+
+### Slice 1: RFC approval and current-state inventory
+
+Outcome:
+
+1. approved RFC,
+2. final inventory of lotus-risk endpoints and Gateway legacy risk usage,
+3. no production behavior change.
+
+Tasks:
+
+1. approve this RFC,
+2. confirm the `lotus-risk` feature branch baseline,
+3. list all Gateway references to `/analytics/workbench/risk-proxy`,
+4. list Workbench surfaces that currently mention concentration/risk,
+5. confirm whether `Risk` should be a Performance mode or a top-level shell app.
+
+Tests:
+
+1. no code tests required,
+2. RFC review checklist must be completed.
+
+Acceptance:
+
+1. stakeholders approve stateful-only UI scope,
+2. stakeholders approve removal of the legacy Gateway risk-proxy path,
+3. stakeholders approve Performance `Risk` mode placement.
+
+### Slice 2: Gateway legacy risk-proxy removal
+
+Outcome:
+
+1. old Gateway risk-proxy connection is removed,
+2. no Workbench UI depends on the removed `/analytics/workbench/risk-proxy` endpoint.
+
+Tasks:
+
+1. remove `get_workbench_risk_proxy`,
+2. remove legacy risk-proxy fallback from `WorkbenchService`,
+3. replace narrow HHI usage with either:
+   - no risk data until the new BFF exists, or
+   - a clearly marked placeholder state,
+4. update tests to prove Gateway no longer calls `/analytics/workbench/risk-proxy`,
+5. update docs if they reference the old path.
+
+Tests:
+
+1. Gateway unit tests for Workbench analytics without risk-proxy fallback,
+2. Gateway integration tests proving no legacy path is called,
+3. contract grep/guard test if appropriate.
+
+Acceptance:
+
+1. `rg "/analytics/workbench/risk-proxy"` returns no production references,
+2. Gateway tests are green,
+3. Workbench still renders controlled degraded risk state.
+
+### Slice 3: Gateway Risk BFF foundation
+
+Outcome:
+
+1. Gateway exposes typed stateful risk BFF contracts,
+2. Workbench can consume fixture-like live contracts without knowing lotus-risk internals.
+
+Tasks:
+
+1. add Gateway risk contracts,
+2. add Gateway risk service,
+3. add Gateway risk router endpoints,
+4. implement `risk/summary` and `risk/concentration` first,
+5. normalize supportability, warnings, and partial failures,
+6. add bounded cache keys for repeated identical risk requests,
+7. preserve correlation IDs and upstream metadata.
+
+Tests:
+
+1. request-shape unit tests for `lotus-risk` stateful payloads,
+2. supportability mapping tests,
+3. cache key tests,
+4. router integration tests with fake `lotus-risk`,
+5. failure-path tests for unavailable risk service.
+
+Acceptance:
+
+1. risk summary and concentration BFF endpoints return stable contracts,
+2. no UI needs raw `lotus-risk` response fields,
+3. failures are partial/degraded, not page-breaking.
+
+### Slice 4: Workbench Risk mode shell and fixture-backed UI
+
+Outcome:
+
+1. `Risk` appears as a Performance mode,
+2. fixture-backed UI proves final composition and interaction model.
+
+Tasks:
+
+1. add `Risk` to shared mode navigation,
+2. add `PerformanceRiskMode`,
+3. implement header/context/status rail/provenance shell,
+4. implement fixture-backed Risk Snapshot and Concentration panels,
+5. include all screen states: loading, ready, partial, empty, unavailable, error,
+6. keep UI stateful-only in naming and copy.
+
+Tests:
+
+1. unit tests for mode navigation,
+2. component tests for Risk shell and supportability rail,
+3. view-model tests for fixture data,
+4. integration test proving `Risk` mode renders and does not call raw risk endpoints from browser,
+5. responsive smoke for no horizontal overflow.
+
+Acceptance:
+
+1. `Risk` mode is visually consistent with `Summary`, `Analysis`, and `Advisor Brief`,
+2. no stateless UX is exposed,
+3. state handling is complete.
+
+### Slice 5: Live Workbench integration for Risk Snapshot and Concentration
+
+Outcome:
+
+1. Workbench calls Gateway for stateful Risk Snapshot and Concentration.
+
+Tasks:
+
+1. add Workbench API client functions,
+2. add query keys and cache policy,
+3. wire `RiskSnapshotPanel`,
+4. wire `ConcentrationPanel`,
+5. show issuer coverage diagnostics,
+6. show sandbox concentration delta when `sessionId` exists,
+7. add supportability-driven disabled/partial states.
+
+Tests:
+
+1. MSW/fake fetch or integration tests for successful BFF payloads,
+2. partial-failure rendering tests,
+3. query-key tests if query keys are generated separately,
+4. sandbox concentration contract tests.
+
+Acceptance:
+
+1. Risk Snapshot is live through Gateway,
+2. Concentration is live through Gateway,
+3. portfolio/sandbox context changes invalidate only the relevant risk queries.
+
+### Slice 6: Drawdown module
+
+Outcome:
+
+1. Workbench surfaces stateful drawdown analytics.
+
+Tasks:
+
+1. add Gateway `risk/drawdown`,
+2. wire `DrawdownPanel`,
+3. render max drawdown, time-under-water, ulcer index, DaR/CDaR,
+4. render worst episodes table,
+5. add optional underwater series detail on demand,
+6. handle benchmark-relative drawdown supportability.
+
+Tests:
+
+1. Gateway request-shape tests,
+2. drawdown view-model tests,
+3. drawdown panel state tests,
+4. table tests for episode sorting and numeric formatting.
+
+Acceptance:
+
+1. advisors can identify drawdown severity in seconds,
+2. detailed episode evidence is available without cluttering first paint.
+
+### Slice 7: Rolling Risk module
+
+Outcome:
+
+1. Workbench surfaces stateful rolling risk diagnostics.
+
+Tasks:
+
+1. add Gateway `risk/rolling`,
+2. wire `RollingRiskPanel`,
+3. render rolling window summaries,
+4. add window selector,
+5. render quality flags clearly,
+6. make time-series detail optional to control payload size and latency.
+
+Tests:
+
+1. Gateway request-shape tests for benchmark/risk-free metric selection,
+2. view-model tests for quality flags,
+3. component tests for window switching,
+4. latency-conscious query tests where practical.
+
+Acceptance:
+
+1. first paint does not request large rolling time series by default,
+2. rolling detail is available on demand,
+3. benchmark/risk-free unavailability is explicit.
+
+### Slice 8: Historical Risk Attribution module
+
+Outcome:
+
+1. Workbench surfaces stateful total-risk attribution.
+
+Tasks:
+
+1. add Gateway `risk/attribution`,
+2. wire `HistoricalRiskAttributionPanel`,
+3. expose `TOTAL_RISK` initially,
+4. keep `ACTIVE_RISK` disabled/blocked until supportability says benchmark exposure history is
+   ready,
+5. render contributors and residual diagnostics,
+6. make grouping dimensions switchable when supported.
+
+Tests:
+
+1. Gateway request-shape tests for `TOTAL_RISK`,
+2. blocked-state tests for `ACTIVE_RISK`,
+3. contributor table tests,
+4. residual formatting tests.
+
+Acceptance:
+
+1. total-risk contributors are visible,
+2. active-risk is not falsely represented as available,
+3. blocked-state copy explains the benchmark exposure-history dependency.
+
+### Slice 9: Portfolio and Advisor Brief cross-links
+
+Outcome:
+
+1. Portfolio and Advisor Brief can reference the Risk Workspace without duplicating it.
+
+Tasks:
+
+1. add `Open Risk` actions from Portfolio readiness/concentration areas,
+2. link concentration exceptions to Risk mode,
+3. allow Advisor Brief source metrics to include risk facts only when Gateway evidence exists,
+4. avoid duplicating full risk modules in Portfolio.
+
+Tests:
+
+1. Portfolio link tests,
+2. Advisor Brief evidence gating tests,
+3. route query parameter tests for opening Risk mode.
+
+Acceptance:
+
+1. Portfolio remains summary-first,
+2. Risk remains the analytical drilldown home,
+3. Advisor Brief cites risk only when evidence is source-grounded.
+
+### Slice 10: Production hardening and RFC closeout
+
+Outcome:
+
+1. end-to-end risk UI is production-ready for the approved v1 scope.
+
+Tasks:
+
+1. run cross-repo validation,
+2. update docs and capability matrix,
+3. add runbook notes for risk supportability,
+4. mark RFC implemented only after Gateway, Workbench, and relevant risk contracts are validated,
+5. remove any fixture-only code paths not explicitly intended as degraded fallback.
+
+Tests:
+
+1. Workbench lint/typecheck/unit/integration/e2e smoke,
+2. Gateway unit/integration tests,
+3. lotus-risk existing branch tests as reference, without modifying uncommitted hardening work,
+4. live local platform probe if services are available.
+
+Acceptance:
+
+1. all required CI checks pass,
+2. no old risk-proxy references remain,
+3. Risk mode supports stateful-only UI paths,
+4. supportability behavior is explicit and auditable,
+5. RFC status can move from `PROPOSED` to `IMPLEMENTED`.
+
+## UI Quality Bar
+
+The Risk Workspace must feel:
+
+1. banking-grade,
+2. sophisticated,
+3. analytical,
+4. calm,
+5. evidence-led,
+6. precise,
+7. modular,
+8. not a generic dashboard.
+
+Required UI characteristics:
+
+1. executive metric hierarchy,
+2. dense but legible risk facts,
+3. compact supportability rail,
+4. clear provenance,
+5. no decorative charting,
+6. no consumer AI/chat styling,
+7. strong empty/partial/unavailable states,
+8. no unexplained technical flags in advisor-facing copy.
+
+## Performance and Latency Requirements
+
+Risk modules can become expensive if requested monolithically.
+
+Rules:
+
+1. first paint should request only summary-sized payloads,
+2. drawdown underwater series is detail-on-demand,
+3. rolling time-series output is detail-on-demand,
+4. historical attribution is lazy-loaded after the main risk snapshot,
+5. repeated identical Gateway requests should be cached briefly,
+6. module refresh should be independent where possible,
+7. a failed heavy module must not block the whole Risk mode.
+
+## Accessibility Requirements
+
+1. all tabbed navigation uses semantic tab roles,
+2. every chart-like module has textual metric summaries,
+3. supportability state is not color-only,
+4. tables have meaningful headers and numeric alignment,
+5. disabled/blocked `ACTIVE_RISK` has clear explanatory text,
+6. focus states use the shared RFC-0021 focus treatment.
+
+## Risks
+
+1. building UI before Gateway contracts could create throwaway view models,
+2. calling all risk endpoints at first paint could create high latency,
+3. surfacing active-risk attribution too early could mislead users,
+4. legacy risk-proxy compatibility could hide integration debt,
+5. risk terms could become too technical for advisors if raw engine vocabulary leaks.
+
+## Mitigations
+
+1. Gateway BFF contract is mandatory before live UI integration,
+2. initial UI shell can be fixture-backed but must match Gateway-shaped contracts,
+3. heavy modules are lazy or detail-on-demand,
+4. active-risk attribution is supportability-gated,
+5. old risk-proxy endpoint is removed, not wrapped,
+6. UI copy is reviewed for advisor-facing business language.
+
+## Definition of Done
+
+This RFC can be marked `IMPLEMENTED` only when:
+
+1. old Gateway `/analytics/workbench/risk-proxy` usage is removed,
+2. Gateway exposes new stateful Risk BFF endpoints,
+3. Workbench has a first-class `Risk` mode,
+4. UI surfaces only stateful risk execution, except concentration simulation linked to sandbox
+   context,
+5. Risk Snapshot, Drawdown, Rolling Risk, Concentration, and Total-Risk Attribution are rendered
+   with supportability states,
+6. active-risk attribution is blocked/gated until benchmark exposure history is available,
+7. Portfolio links into Risk without duplicating full risk analytics,
+8. all new panels use RFC-0021 shared primitives,
+9. tests cover contracts, state handling, supportability, cache behavior, and navigation,
+10. CI is green across affected repos,
+11. docs and runbooks describe the v1 risk UI behavior and limitations.
+
+## Approval Requested
+
+Approve this RFC if the team agrees that:
+
+1. Workbench should add a first-class `Risk` analytical mode,
+2. the UI should surface only stateful risk API flows,
+3. concentration simulation is allowed only when tied to an active sandbox/session context,
+4. the old Gateway risk-proxy connection should be fully removed,
+5. the implementation must proceed through modular, shared-system-aligned slices rather than a
+   monolithic dashboard build.

--- a/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
+++ b/docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md
@@ -992,6 +992,22 @@ Acceptance:
 2. detailed episode evidence is available without cluttering first paint,
 3. benchmark-relative drawdown is gated when benchmark series is unavailable.
 
+Slice 6 evidence:
+
+1. Gateway added `GET /api/v1/workbench/{portfolioId}/risk/drawdown` with a typed stateful-only
+   BFF contract and an explicit `include_underwater_series` on-demand detail flag.
+2. Gateway added request-shape, cache-key, malformed upstream, and router coverage for drawdown.
+3. Workbench added live drawdown client wiring, drawdown view-model mapping, and a modular
+   `RiskDrawdownPanel`.
+4. Workbench only requests underwater series after explicit disclosure expansion; first paint keeps
+   underwater detail out of the request path.
+5. Validation evidence:
+   - `python -m pytest tests/unit/test_risk_workspace_service.py tests/unit/test_upstream_clients.py tests/integration/test_workbench_router.py -q`
+   - `python -m ruff check src tests`
+   - `npm test -- --run tests/unit/performance-risk-view-model.test.ts tests/unit/performance-risk-mode.test.tsx tests/integration/performance-analytics-page.test.tsx`
+   - `npm run lint`
+   - `npm run typecheck`
+
 ### Slice 7: Rolling Risk module
 
 Outcome:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3536,6 +3536,26 @@ a:hover {
   }
 }
 
+@media (max-width: 1100px) {
+  .performance-risk-grid,
+  .performance-risk-context-grid,
+  .performance-risk-metric-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .performance-risk-status-bar {
+    justify-items: start;
+  }
+
+  .performance-risk-status-items {
+    justify-content: flex-start;
+  }
+
+  .performance-risk-status-note {
+    text-align: left;
+  }
+}
+
 .portfolio-header-context-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -4526,7 +4546,8 @@ a:hover {
 .performance-lotus-stage-chart::before,
 .performance-lotus-stage-secondary::before,
 .performance-lotus-stage-analysis::before,
-.performance-lotus-stage-evidence::before {
+.performance-lotus-stage-evidence::before,
+.performance-risk-shell::before {
   content: "";
   position: absolute;
   left: 0;
@@ -4998,6 +5019,139 @@ a:hover {
 
 .performance-advisor-brief-stage {
   width: 100%;
+}
+
+.performance-risk-stage {
+  width: 100%;
+}
+
+.performance-risk-shell.section-block {
+  display: grid;
+  gap: 1rem;
+  padding: 1.1rem 1.2rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(23, 32, 43, 0.08);
+  background:
+    linear-gradient(180deg, rgba(241, 245, 249, 0.9) 0%, rgba(255, 255, 255, 1) 18%),
+    #ffffff;
+  overflow: hidden;
+}
+
+.performance-risk-status-bar {
+  display: grid;
+  justify-items: end;
+  gap: 0.35rem;
+}
+
+.performance-risk-status-items {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
+.performance-risk-status-note {
+  max-width: 44ch;
+  text-align: right;
+}
+
+.performance-risk-context-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.75rem;
+  padding: 0.85rem 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.performance-risk-context-item {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.performance-risk-synopsis {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(87, 121, 157, 0.18);
+  border-radius: 12px;
+  background: rgba(247, 250, 252, 0.82);
+}
+
+.performance-risk-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.34fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.performance-risk-main-column,
+.performance-risk-side-rail {
+  display: grid;
+  gap: 1rem;
+}
+
+.performance-risk-panel.section-block {
+  box-shadow: none;
+}
+
+.performance-risk-panel .section-block-body {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.performance-risk-metric-strip {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.performance-risk-supportability-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.performance-risk-supportability-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: start;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.performance-risk-supportability-row:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.performance-risk-provenance-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  align-items: center;
+  padding-top: 0.85rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  color: var(--text-muted);
+}
+
+.performance-risk-provenance-item {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: baseline;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.performance-risk-provenance-item strong {
+  color: var(--text);
+  font-weight: 650;
+}
+
+.performance-risk-partial-failure-row {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid rgba(202, 138, 4, 0.18);
+  border-radius: 10px;
+  background: rgba(255, 251, 235, 0.72);
 }
 
 .performance-advisor-brief-shell {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5105,6 +5105,21 @@ a:hover {
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
+.performance-risk-relative-note {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.8rem 0.95rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 10px;
+  background: rgba(248, 250, 252, 0.72);
+}
+
+.performance-risk-underwater-detail {
+  display: grid;
+  gap: 0.65rem;
+  padding-top: 0.25rem;
+}
+
 .performance-risk-supportability-list {
   display: grid;
   gap: 0.75rem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5105,6 +5105,17 @@ a:hover {
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
+.performance-risk-window-toolbar {
+  justify-self: start;
+}
+
+.performance-risk-quality-flags {
+  padding: 0.55rem 0.7rem;
+  border: 1px solid rgba(202, 138, 4, 0.14);
+  border-radius: 10px;
+  background: rgba(255, 251, 235, 0.52);
+}
+
 .performance-risk-relative-note {
   display: grid;
   gap: 0.2rem;
@@ -5115,6 +5126,12 @@ a:hover {
 }
 
 .performance-risk-underwater-detail {
+  display: grid;
+  gap: 0.65rem;
+  padding-top: 0.25rem;
+}
+
+.performance-risk-rolling-detail {
   display: grid;
   gap: 0.65rem;
   padding-top: 0.25rem;

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -310,7 +310,9 @@ export default async function WorkbenchPage({
                 hasActiveSandbox={Boolean(data.active_session_id)}
                 warningCount={warnings.length}
                 failureCount={partialFailures.length}
-                hhiProposed={analytics?.risk_proxy?.hhi_proposed ?? null}
+                riskWorkspaceHref={`/performance?portfolioId=${encodeURIComponent(
+                  data.portfolio.portfolio_id
+                )}&mode=risk`}
               />
 
               <AdvisorSummaryCard

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -126,6 +126,11 @@ export default async function WorkbenchPage({
     data.current_positions.some((row) => row.market_value_base !== null);
   const hasAnalytics = analytics !== null;
   const hasReporting = reportingSnapshot !== null;
+  const warnings = [...data.warnings, ...(analytics?.warnings ?? [])];
+  const partialFailures = [
+    ...data.partial_failures,
+    ...(analytics?.partial_failures ?? []),
+  ];
 
   return (
     <main className="page-container">
@@ -134,15 +139,15 @@ export default async function WorkbenchPage({
         subtitle={`As of: ${data.as_of_date}`}
         actions={
           <>
-            <SemanticBadge tone={data.partial_failures.length > 0 ? "warn" : "success"}>
-              {data.partial_failures.length > 0 ? "Partial upstream coverage" : "Operationally ready"}
+            <SemanticBadge tone={partialFailures.length > 0 ? "warn" : "success"}>
+              {partialFailures.length > 0 ? "Partial upstream coverage" : "Operationally ready"}
             </SemanticBadge>
             <SemanticBadge>{data.active_session_id ? "Sandbox active" : "Sandbox idle"}</SemanticBadge>
           </>
         }
       >
         <WorkbenchSectionStack>
-          <PartialFailureBanner items={data.partial_failures} />
+          <PartialFailureBanner items={partialFailures} />
 
           <OverviewCards
             marketValueBase={data.overview.market_value_base}
@@ -243,7 +248,7 @@ export default async function WorkbenchPage({
               <SandboxControls
                 portfolioId={data.portfolio.portfolio_id}
                 sessionId={data.active_session_id}
-                warnings={data.warnings}
+                warnings={warnings}
               />
 
               {data.projected_summary ? (
@@ -294,8 +299,8 @@ export default async function WorkbenchPage({
               />
 
               <ExceptionQueue
-                warnings={data.warnings}
-                partialFailures={data.partial_failures}
+                warnings={warnings}
+                partialFailures={partialFailures}
               />
 
               <DecisionReadinessPanel
@@ -303,15 +308,15 @@ export default async function WorkbenchPage({
                 hasAnalytics={hasAnalytics}
                 hasReporting={hasReporting}
                 hasActiveSandbox={Boolean(data.active_session_id)}
-                warningCount={data.warnings.length}
-                failureCount={data.partial_failures.length}
-                hhiProposed={analytics?.risk_proxy.hhi_proposed ?? null}
+                warningCount={warnings.length}
+                failureCount={partialFailures.length}
+                hhiProposed={analytics?.risk_proxy?.hhi_proposed ?? null}
               />
 
               <AdvisorSummaryCard
                 portfolioId={data.portfolio.portfolio_id}
-                warningCount={data.warnings.length}
-                failureCount={data.partial_failures.length}
+                warningCount={warnings.length}
+                failureCount={partialFailures.length}
                 netDeltaQuantity={data.projected_summary?.net_delta_quantity ?? 0}
               />
             </div>

--- a/src/apps/performance/advisor-brief-view-model.ts
+++ b/src/apps/performance/advisor-brief-view-model.ts
@@ -716,9 +716,11 @@ function normalizeAdvisorTargetMode(targetMode: string): PerformanceWorkspaceMod
     ? "analysis"
     : targetMode === "advisor"
       ? "advisor"
-      : targetMode === "evidence"
-        ? "evidence"
-        : "summary";
+      : targetMode === "risk"
+        ? "risk"
+        : targetMode === "evidence"
+          ? "evidence"
+          : "summary";
 }
 
 function normalizeSupportabilityTone(

--- a/src/apps/performance/advisor-brief-view-model.ts
+++ b/src/apps/performance/advisor-brief-view-model.ts
@@ -298,39 +298,20 @@ function buildGatewayAdvisorBriefViewModel(
     advisorBrief.benchmark_code ?? workspace.benchmark_code ?? undefined,
     workspace.benchmark_options ?? []
   );
+  const hasBackedRiskEvidence = hasReadyRiskEvidence(advisorBrief.source_metrics);
   return {
     status: advisorBrief.status,
     title: `Advisor Brief • ${advisorBrief.portfolio_id}`,
     summary: advisorBrief.summary,
-    talkingPoints: advisorBrief.talking_points.map((item) => ({
-      headline: item.headline,
-      detail: item.detail,
-      tone: item.tone,
-      evidenceRefs: item.evidence_refs.map((evidenceRef) => ({
-        metricLabel: evidenceRef.metric_label,
-        metricValue: evidenceRef.metric_value,
-        sourceSurface: evidenceRef.source_surface,
-        route: evidenceRef.route,
-        targetMode: normalizeAdvisorTargetMode(evidenceRef.target_mode),
-      })),
-    })),
-    recommendedActions: advisorBrief.recommended_actions.map((action) => ({
-      label: action.label,
-      route: action.route,
-      targetMode: normalizeAdvisorTargetMode(action.target_mode),
-    })),
-    risksAndExceptions: advisorBrief.risks_and_exceptions.map((item) => ({
-      headline: item.headline,
-      detail: item.detail,
-      tone: item.tone,
-      evidenceRefs: item.evidence_refs.map((evidenceRef) => ({
-        metricLabel: evidenceRef.metric_label,
-        metricValue: evidenceRef.metric_value,
-        sourceSurface: evidenceRef.source_surface,
-        route: evidenceRef.route,
-        targetMode: normalizeAdvisorTargetMode(evidenceRef.target_mode),
-      })),
-    })),
+    talkingPoints: normalizeGatewayNarrativeItems(advisorBrief.talking_points, hasBackedRiskEvidence),
+    recommendedActions: normalizeGatewayActions(
+      advisorBrief.recommended_actions,
+      hasBackedRiskEvidence
+    ),
+    risksAndExceptions: normalizeGatewayNarrativeItems(
+      advisorBrief.risks_and_exceptions,
+      hasBackedRiskEvidence
+    ),
     sourceMetrics: normalizeGatewaySourceMetrics({
       advisorBrief,
       workspace,
@@ -339,6 +320,7 @@ function buildGatewayAdvisorBriefViewModel(
         selectedPerformance.end_market_value,
         workspace.portfolio.base_currency
       ),
+      hasBackedRiskEvidence,
     }),
     supportability: advisorBrief.supportability.map((item) => ({
       label: item.label,
@@ -371,11 +353,13 @@ function normalizeGatewaySourceMetrics({
   workspace,
   benchmarkLabel,
   endingMarketValue,
+  hasBackedRiskEvidence,
 }: {
   advisorBrief: WorkbenchPerformanceAdvisorBrief;
   workspace: WorkbenchPerformanceWorkspace;
   benchmarkLabel: string;
   endingMarketValue: string;
+  hasBackedRiskEvidence: boolean;
 }): PerformanceAdvisorBriefMetric[] {
   const route = buildPerformanceHref({
     portfolioId: workspace.portfolio.portfolio_id,
@@ -389,16 +373,18 @@ function normalizeGatewaySourceMetrics({
     reportEndDate: advisorBrief.report_end_date,
   });
 
-  const normalizedMetrics = advisorBrief.source_metrics.map((metric) => {
-    const isBenchmarkMetric = metric.label.toLowerCase() === "benchmark return";
-    return {
-      label: metric.label,
-      value: metric.value,
-      supportingText: isBenchmarkMetric ? benchmarkLabel : metric.support_label,
-      route: metric.route,
-      targetMode: normalizeAdvisorTargetMode(metric.target_mode),
-    } satisfies PerformanceAdvisorBriefMetric;
-  });
+  const normalizedMetrics = advisorBrief.source_metrics
+    .filter((metric) => shouldIncludeAdvisorRiskTarget(metric.target_mode, hasBackedRiskEvidence))
+    .map((metric) => {
+      const isBenchmarkMetric = metric.label.toLowerCase() === "benchmark return";
+      return {
+        label: metric.label,
+        value: metric.value,
+        supportingText: isBenchmarkMetric ? benchmarkLabel : metric.support_label,
+        route: metric.route,
+        targetMode: normalizeAdvisorTargetMode(metric.target_mode),
+      } satisfies PerformanceAdvisorBriefMetric;
+    });
 
   if (normalizedMetrics.some((metric) => metric.label === "Ending MV")) {
     return normalizedMetrics;
@@ -414,6 +400,68 @@ function normalizeGatewaySourceMetrics({
       targetMode: "summary",
     },
   ];
+}
+
+function normalizeGatewayNarrativeItems(
+  items: WorkbenchPerformanceAdvisorBrief["talking_points"],
+  hasBackedRiskEvidence: boolean
+): PerformanceAdvisorBriefItem[] {
+  return items.flatMap((item) => {
+    const evidenceRefs = item.evidence_refs
+      .filter((evidenceRef) =>
+        shouldIncludeAdvisorRiskTarget(evidenceRef.target_mode, hasBackedRiskEvidence)
+      )
+      .map((evidenceRef) => ({
+        metricLabel: evidenceRef.metric_label,
+        metricValue: evidenceRef.metric_value,
+        sourceSurface: evidenceRef.source_surface,
+        route: evidenceRef.route,
+        targetMode: normalizeAdvisorTargetMode(evidenceRef.target_mode),
+      }));
+
+    if (item.evidence_refs.length > 0 && evidenceRefs.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        headline: item.headline,
+        detail: item.detail,
+        tone: item.tone,
+        evidenceRefs,
+      },
+    ];
+  });
+}
+
+function normalizeGatewayActions(
+  actions: WorkbenchPerformanceAdvisorBrief["recommended_actions"],
+  hasBackedRiskEvidence: boolean
+): PerformanceAdvisorBriefAction[] {
+  return actions
+    .filter((action) => shouldIncludeAdvisorRiskTarget(action.target_mode, hasBackedRiskEvidence))
+    .map((action) => ({
+      label: action.label,
+      route: action.route,
+      targetMode: normalizeAdvisorTargetMode(action.target_mode),
+    }));
+}
+
+function hasReadyRiskEvidence(
+  sourceMetrics: WorkbenchPerformanceAdvisorBrief["source_metrics"]
+): boolean {
+  return sourceMetrics.some(
+    (metric) =>
+      normalizeAdvisorTargetMode(metric.target_mode) === "risk" &&
+      (metric.state?.toLowerCase() ?? "") === "ready"
+  );
+}
+
+function shouldIncludeAdvisorRiskTarget(
+  targetMode: string,
+  hasBackedRiskEvidence: boolean
+): boolean {
+  return normalizeAdvisorTargetMode(targetMode) !== "risk" || hasBackedRiskEvidence;
 }
 
 function resolveAdvisorBriefStatus({

--- a/src/apps/performance/components/advisor-brief/lotus-drilldown-list.tsx
+++ b/src/apps/performance/components/advisor-brief/lotus-drilldown-list.tsx
@@ -5,6 +5,7 @@ const MODE_LABELS: Record<PerformanceWorkspaceMode, string> = {
   summary: "Open Return Path",
   analysis: "Open Analysis",
   advisor: "Open Advisor Brief",
+  risk: "Open Risk",
   evidence: "Open Evidence",
 };
 

--- a/src/apps/performance/components/performance-risk-mode.tsx
+++ b/src/apps/performance/components/performance-risk-mode.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 import {
   ScreenStatePanel,
   SectionBlock,
@@ -9,6 +11,7 @@ import { buildPerformanceRiskViewModel } from "../risk-workspace-view-model";
 import { usePerformanceRiskContract } from "../use-performance-risk-contract";
 import type { PerformanceRiskModeProps } from "./performance-workspace-types";
 import RiskConcentrationPanel from "./risk/risk-concentration-panel";
+import RiskDrawdownPanel from "./risk/risk-drawdown-panel";
 import RiskProvenanceStrip from "./risk/risk-provenance-strip";
 import RiskSnapshotPanel from "./risk/risk-snapshot-panel";
 import RiskStatusBar from "./risk/risk-status-bar";
@@ -20,12 +23,26 @@ export default function PerformanceRiskMode({
   detailBasis,
   isDetailsPending,
 }: PerformanceRiskModeProps) {
-  const { riskSummary, riskConcentration, isLoading } = usePerformanceRiskContract({
+  const [underwaterExpanded, setUnderwaterExpanded] = useState(false);
+  const {
+    riskSummary,
+    riskConcentration,
+    riskDrawdown,
+    riskDrawdownDetail,
+    isLoading,
+    isDrawdownDetailLoading,
+    requestDrawdownDetail,
+  } = usePerformanceRiskContract({
     workspace,
     period,
     detailBasis,
     isDetailsPending,
   });
+
+  useEffect(() => {
+    setUnderwaterExpanded(false);
+  }, [detailBasis, period, workspace.as_of_date, workspace.benchmark_code, workspace.portfolio.portfolio_id]);
+
   const viewModel = buildPerformanceRiskViewModel({
     workspace,
     period,
@@ -33,6 +50,9 @@ export default function PerformanceRiskMode({
     isDetailsPending: isLoading,
     riskSummary,
     riskConcentration,
+    riskDrawdown,
+    riskDrawdownDetail,
+    isDrawdownDetailLoading,
   });
 
   const statePanel =
@@ -84,6 +104,17 @@ export default function PerformanceRiskMode({
           <div className="performance-risk-grid">
             <div className="performance-risk-main-column">
               <RiskSnapshotPanel viewModel={viewModel} />
+              <RiskDrawdownPanel
+                viewModel={viewModel}
+                underwaterExpanded={underwaterExpanded}
+                onToggleUnderwater={() => {
+                  const nextExpanded = !underwaterExpanded;
+                  setUnderwaterExpanded(nextExpanded);
+                  if (nextExpanded) {
+                    requestDrawdownDetail();
+                  }
+                }}
+              />
               <RiskConcentrationPanel viewModel={viewModel} />
             </div>
             <aside className="performance-risk-side-rail" aria-label="Risk support rail">

--- a/src/apps/performance/components/performance-risk-mode.tsx
+++ b/src/apps/performance/components/performance-risk-mode.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/design-system";
 
 import { buildPerformanceRiskViewModel } from "../risk-workspace-view-model";
+import { usePerformanceRiskContract } from "../use-performance-risk-contract";
 import type { PerformanceRiskModeProps } from "./performance-workspace-types";
 import RiskConcentrationPanel from "./risk/risk-concentration-panel";
 import RiskProvenanceStrip from "./risk/risk-provenance-strip";
@@ -19,11 +20,19 @@ export default function PerformanceRiskMode({
   detailBasis,
   isDetailsPending,
 }: PerformanceRiskModeProps) {
-  const viewModel = buildPerformanceRiskViewModel({
+  const { riskSummary, riskConcentration, isLoading } = usePerformanceRiskContract({
     workspace,
     period,
     detailBasis,
     isDetailsPending,
+  });
+  const viewModel = buildPerformanceRiskViewModel({
+    workspace,
+    period,
+    detailBasis,
+    isDetailsPending: isLoading,
+    riskSummary,
+    riskConcentration,
   });
 
   const statePanel =

--- a/src/apps/performance/components/performance-risk-mode.tsx
+++ b/src/apps/performance/components/performance-risk-mode.tsx
@@ -13,6 +13,7 @@ import type { PerformanceRiskModeProps } from "./performance-workspace-types";
 import RiskConcentrationPanel from "./risk/risk-concentration-panel";
 import RiskDrawdownPanel from "./risk/risk-drawdown-panel";
 import RiskProvenanceStrip from "./risk/risk-provenance-strip";
+import RiskRollingPanel from "./risk/risk-rolling-panel";
 import RiskSnapshotPanel from "./risk/risk-snapshot-panel";
 import RiskStatusBar from "./risk/risk-status-bar";
 import RiskSupportabilityPanel from "./risk/risk-supportability-panel";
@@ -24,14 +25,19 @@ export default function PerformanceRiskMode({
   isDetailsPending,
 }: PerformanceRiskModeProps) {
   const [underwaterExpanded, setUnderwaterExpanded] = useState(false);
+  const [rollingExpanded, setRollingExpanded] = useState(false);
   const {
     riskSummary,
     riskConcentration,
     riskDrawdown,
     riskDrawdownDetail,
+    riskRolling,
+    riskRollingDetail,
     isLoading,
     isDrawdownDetailLoading,
+    isRollingDetailLoading,
     requestDrawdownDetail,
+    requestRollingDetail,
   } = usePerformanceRiskContract({
     workspace,
     period,
@@ -41,6 +47,7 @@ export default function PerformanceRiskMode({
 
   useEffect(() => {
     setUnderwaterExpanded(false);
+    setRollingExpanded(false);
   }, [detailBasis, period, workspace.as_of_date, workspace.benchmark_code, workspace.portfolio.portfolio_id]);
 
   const viewModel = buildPerformanceRiskViewModel({
@@ -52,7 +59,10 @@ export default function PerformanceRiskMode({
     riskConcentration,
     riskDrawdown,
     riskDrawdownDetail,
+    riskRolling,
+    riskRollingDetail,
     isDrawdownDetailLoading,
+    isRollingDetailLoading,
   });
 
   const statePanel =
@@ -112,6 +122,17 @@ export default function PerformanceRiskMode({
                   setUnderwaterExpanded(nextExpanded);
                   if (nextExpanded) {
                     requestDrawdownDetail();
+                  }
+                }}
+              />
+              <RiskRollingPanel
+                viewModel={viewModel}
+                rollingExpanded={rollingExpanded}
+                onToggleRolling={() => {
+                  const nextExpanded = !rollingExpanded;
+                  setRollingExpanded(nextExpanded);
+                  if (nextExpanded) {
+                    requestRollingDetail();
                   }
                 }}
               />

--- a/src/apps/performance/components/performance-risk-mode.tsx
+++ b/src/apps/performance/components/performance-risk-mode.tsx
@@ -12,6 +12,7 @@ import { usePerformanceRiskContract } from "../use-performance-risk-contract";
 import type { PerformanceRiskModeProps } from "./performance-workspace-types";
 import RiskConcentrationPanel from "./risk/risk-concentration-panel";
 import RiskDrawdownPanel from "./risk/risk-drawdown-panel";
+import RiskAttributionPanel from "./risk/risk-attribution-panel";
 import RiskProvenanceStrip from "./risk/risk-provenance-strip";
 import RiskRollingPanel from "./risk/risk-rolling-panel";
 import RiskSnapshotPanel from "./risk/risk-snapshot-panel";
@@ -29,13 +30,16 @@ export default function PerformanceRiskMode({
   const {
     riskSummary,
     riskConcentration,
+    riskAttribution,
     riskDrawdown,
     riskDrawdownDetail,
     riskRolling,
     riskRollingDetail,
     isLoading,
+    isAttributionLoading,
     isDrawdownDetailLoading,
     isRollingDetailLoading,
+    requestAttribution,
     requestDrawdownDetail,
     requestRollingDetail,
   } = usePerformanceRiskContract({
@@ -57,10 +61,12 @@ export default function PerformanceRiskMode({
     isDetailsPending: isLoading,
     riskSummary,
     riskConcentration,
+    riskAttribution,
     riskDrawdown,
     riskDrawdownDetail,
     riskRolling,
     riskRollingDetail,
+    isAttributionLoading,
     isDrawdownDetailLoading,
     isRollingDetailLoading,
   });
@@ -135,6 +141,10 @@ export default function PerformanceRiskMode({
                     requestRollingDetail();
                   }
                 }}
+              />
+              <RiskAttributionPanel
+                viewModel={viewModel}
+                onSelectAttribution={requestAttribution}
               />
               <RiskConcentrationPanel viewModel={viewModel} />
             </div>

--- a/src/apps/performance/components/performance-risk-mode.tsx
+++ b/src/apps/performance/components/performance-risk-mode.tsx
@@ -1,0 +1,89 @@
+import {
+  ScreenStatePanel,
+  SectionBlock,
+  Text,
+  WorkbenchStatusRow,
+} from "@/design-system";
+
+import { buildPerformanceRiskViewModel } from "../risk-workspace-view-model";
+import type { PerformanceRiskModeProps } from "./performance-workspace-types";
+import RiskConcentrationPanel from "./risk/risk-concentration-panel";
+import RiskProvenanceStrip from "./risk/risk-provenance-strip";
+import RiskSnapshotPanel from "./risk/risk-snapshot-panel";
+import RiskStatusBar from "./risk/risk-status-bar";
+import RiskSupportabilityPanel from "./risk/risk-supportability-panel";
+
+export default function PerformanceRiskMode({
+  workspace,
+  period,
+  detailBasis,
+  isDetailsPending,
+}: PerformanceRiskModeProps) {
+  const viewModel = buildPerformanceRiskViewModel({
+    workspace,
+    period,
+    detailBasis,
+    isDetailsPending,
+  });
+
+  const statePanel =
+    viewModel.state === "loading" ||
+    viewModel.state === "empty" ||
+    viewModel.state === "unavailable" ||
+    viewModel.state === "error" ? (
+      <ScreenStatePanel
+        kind={viewModel.state}
+        title={viewModel.title}
+        body={viewModel.synopsis}
+        surface="analysis"
+        chart={viewModel.state === "loading"}
+        rows={3}
+      />
+    ) : null;
+
+  return (
+    <section className="performance-risk-stage" aria-label="Risk">
+      <SectionBlock
+        title="Stateful Risk"
+        subtitle="Portfolio risk, concentration pressure, and supportability for the selected performance context."
+        className="performance-risk-shell performance-lotus-stage"
+        actions={<RiskStatusBar state={viewModel.state} warnings={viewModel.warnings} />}
+      >
+        <div className="performance-risk-context-grid" aria-label="Risk context">
+          {viewModel.contextItems.map((item) => (
+            <div key={item.label} className="performance-risk-context-item">
+              <Text variant="label">{item.label}</Text>
+              <Text variant="cardTitle">{item.value}</Text>
+            </div>
+          ))}
+        </div>
+        <div className="performance-risk-synopsis">
+          <Text variant="eyebrow">Risk briefing</Text>
+          <Text variant="body">{viewModel.synopsis}</Text>
+        </div>
+        {viewModel.partialFailures.length ? (
+          <WorkbenchStatusRow
+            label="Risk partial failures"
+            className="performance-risk-partial-failure-row"
+            items={viewModel.partialFailures.map((failure) => ({
+              value: failure,
+              tone: "warn" as const,
+            }))}
+          />
+        ) : null}
+        {statePanel ?? (
+          <div className="performance-risk-grid">
+            <div className="performance-risk-main-column">
+              <RiskSnapshotPanel viewModel={viewModel} />
+              <RiskConcentrationPanel viewModel={viewModel} />
+            </div>
+            <aside className="performance-risk-side-rail" aria-label="Risk support rail">
+              <RiskSupportabilityPanel viewModel={viewModel} />
+            </aside>
+          </div>
+        )}
+        <RiskProvenanceStrip viewModel={viewModel} />
+      </SectionBlock>
+    </section>
+  );
+}

--- a/src/apps/performance/components/performance-workspace-client.tsx
+++ b/src/apps/performance/components/performance-workspace-client.tsx
@@ -16,6 +16,7 @@ import type {
 import { buildPerformanceHref } from "../navigation";
 import { assemblePerformanceWorkspace } from "../workspace-assembler";
 import PerformanceWorkspaceView from "./performance-workspace-view";
+import type { PerformanceWorkspaceMode } from "./performance-workspace-mode-switch";
 
 type PerformanceWorkspaceClientProps = {
   initialSummary: WorkbenchPerformanceWorkspaceSummary | null;
@@ -26,6 +27,7 @@ type PerformanceWorkspaceClientProps = {
   initialContributionDimension: string;
   initialAttributionDimension: string;
   initialChartFrequency: string;
+  initialMode?: PerformanceWorkspaceMode;
   initialBenchmark?: string;
 };
 
@@ -52,6 +54,7 @@ export default function PerformanceWorkspaceClient({
   initialContributionDimension,
   initialAttributionDimension,
   initialChartFrequency,
+  initialMode = "summary",
   initialBenchmark,
 }: PerformanceWorkspaceClientProps) {
   const router = useRouter();
@@ -107,6 +110,7 @@ export default function PerformanceWorkspaceClient({
     initialDetails ?? null
   );
   const [isSummaryUpdating, setIsSummaryUpdating] = useState(false);
+  const [mode, setMode] = useState<PerformanceWorkspaceMode>(initialMode);
   const [controls, setControls] = useState<PerformanceControlState | null>(
     initialControls
   );
@@ -169,7 +173,7 @@ export default function PerformanceWorkspaceClient({
       return;
     }
     startTransition(() => {
-      router.replace(buildPerformanceHref(initialControls), { scroll: false });
+      router.replace(buildPerformanceHref({ ...initialControls, mode }), { scroll: false });
     });
   }, [
     initialAttributionDimension,
@@ -182,6 +186,7 @@ export default function PerformanceWorkspaceClient({
     initialPortfolioId,
     initialSummary?.report_end_date,
     initialSummary?.report_start_date,
+    mode,
     router,
   ]);
 
@@ -234,7 +239,7 @@ export default function PerformanceWorkspaceClient({
     requestSequenceRef.current = requestId;
 
     startTransition(() => {
-      router.replace(buildPerformanceHref(nextControls), { scroll: false });
+      router.replace(buildPerformanceHref({ ...nextControls, mode }), { scroll: false });
     });
 
     if (!shouldRefreshSummary(controls, nextControls)) {
@@ -387,12 +392,24 @@ export default function PerformanceWorkspaceClient({
   return (
     <PerformanceWorkspaceView
       workspace={workspace}
+      mode={mode}
       period={controls?.period ?? initialPeriod}
       detailBasis={controls?.detailBasis ?? initialDetailBasis}
       contributionDimension={controls?.contributionDimension ?? initialContributionDimension}
       attributionDimension={controls?.attributionDimension ?? initialAttributionDimension}
       chartFrequency={controls?.chartFrequency ?? initialChartFrequency}
       benchmark={controls?.benchmark}
+      onModeChange={(nextMode) => {
+        setMode(nextMode);
+        if (!controls) {
+          return;
+        }
+        startTransition(() => {
+          router.replace(buildPerformanceHref({ ...controls, mode: nextMode }), {
+            scroll: false,
+          });
+        });
+      }}
       onRequestChange={handleRequestChange}
       isUpdating={isUpdating}
       isDetailsPending={isDetailsPending}

--- a/src/apps/performance/components/performance-workspace-mode-switch.tsx
+++ b/src/apps/performance/components/performance-workspace-mode-switch.tsx
@@ -11,12 +11,14 @@ export type PerformanceWorkspaceMode =
   | "summary"
   | "analysis"
   | "advisor"
+  | "risk"
   | "evidence";
 
 const WORKSPACE_MODES: Array<{ key: PerformanceWorkspaceMode; label: string }> = [
   { key: "summary", label: "Summary" },
   { key: "analysis", label: "Analysis" },
   { key: "advisor", label: "Advisor Brief" },
+  { key: "risk", label: "Risk" },
   { key: "evidence", label: "Evidence" },
 ];
 

--- a/src/apps/performance/components/performance-workspace-types.ts
+++ b/src/apps/performance/components/performance-workspace-types.ts
@@ -116,12 +116,14 @@ export type PerformanceRiskModeProps = PerformanceWorkspaceControls & {
 
 export type PerformanceWorkspaceViewProps = {
   workspace: WorkbenchPerformanceWorkspace | null;
+  mode: PerformanceWorkspaceMode;
   period: string;
   detailBasis: string;
   contributionDimension: string;
   attributionDimension: string;
   chartFrequency: string;
   benchmark?: string;
+  onModeChange: (mode: PerformanceWorkspaceMode) => void;
   onRequestChange?: (patch: PerformanceWorkspaceRequestPatch) => void;
   isUpdating?: boolean;
   isDetailsPending?: boolean;

--- a/src/apps/performance/components/performance-workspace-types.ts
+++ b/src/apps/performance/components/performance-workspace-types.ts
@@ -109,6 +109,11 @@ export type PerformanceAdvisorBriefModeProps = PerformanceWorkspaceControls & {
   onSelectMode: (mode: PerformanceWorkspaceMode) => void;
 };
 
+export type PerformanceRiskModeProps = PerformanceWorkspaceControls & {
+  workspace: WorkbenchPerformanceWorkspace;
+  capabilities: PerformanceWorkspaceCapabilities;
+};
+
 export type PerformanceWorkspaceViewProps = {
   workspace: WorkbenchPerformanceWorkspace | null;
   period: string;

--- a/src/apps/performance/components/performance-workspace-view.tsx
+++ b/src/apps/performance/components/performance-workspace-view.tsx
@@ -1,5 +1,4 @@
 import dynamic from "next/dynamic";
-import { useState } from "react";
 
 import {
   DeferredWorkbenchMount,
@@ -15,7 +14,6 @@ import {
   getPerformanceWorkspacePresentation,
 } from "../view-model";
 import PerformanceWorkspaceModeSwitch, {
-  type PerformanceWorkspaceMode,
 } from "./performance-workspace-mode-switch";
 import PerformanceAdvisorBriefMode from "./performance-advisor-brief-mode";
 import PerformanceRiskMode from "./performance-risk-mode";
@@ -54,18 +52,18 @@ const DeferredPerformanceEvidenceMode = dynamic(() => import("./performance-evid
 
 export default function PerformanceWorkspaceView({
   workspace,
+  mode,
   period,
   detailBasis,
   contributionDimension,
   attributionDimension,
   chartFrequency,
   benchmark,
+  onModeChange,
   onRequestChange,
   isUpdating = false,
   isDetailsPending = false,
 }: PerformanceWorkspaceViewProps) {
-  const [mode, setMode] = useState<PerformanceWorkspaceMode>("summary");
-
   const presentation = workspace ? getPerformanceWorkspacePresentation(workspace) : null;
   const capabilities = workspace ? getPerformanceWorkspaceCapabilities(workspace) : null;
   const selectedBenchmarkCode = workspace?.benchmark_code ?? benchmark ?? undefined;
@@ -129,7 +127,7 @@ export default function PerformanceWorkspaceView({
       workspace={workspace}
       {...controls}
       capabilities={capabilities!}
-      onSelectMode={setMode}
+      onSelectMode={onModeChange}
     />
   ) : mode === "risk" ? (
     <PerformanceRiskMode
@@ -170,7 +168,7 @@ export default function PerformanceWorkspaceView({
             actions={
               <PerformanceWorkspaceModeSwitch
                 value={mode}
-                onChange={setMode}
+                onChange={onModeChange}
                 capabilities={capabilities}
               />
             }

--- a/src/apps/performance/components/performance-workspace-view.tsx
+++ b/src/apps/performance/components/performance-workspace-view.tsx
@@ -18,6 +18,7 @@ import PerformanceWorkspaceModeSwitch, {
   type PerformanceWorkspaceMode,
 } from "./performance-workspace-mode-switch";
 import PerformanceAdvisorBriefMode from "./performance-advisor-brief-mode";
+import PerformanceRiskMode from "./performance-risk-mode";
 import PerformanceSummaryMode from "./performance-summary-mode";
 import type {
   PerformanceWorkspaceControls,
@@ -129,6 +130,12 @@ export default function PerformanceWorkspaceView({
       {...controls}
       capabilities={capabilities!}
       onSelectMode={setMode}
+    />
+  ) : mode === "risk" ? (
+    <PerformanceRiskMode
+      workspace={workspace}
+      {...controls}
+      capabilities={capabilities!}
     />
   ) : (
     <DeferredWorkbenchMount

--- a/src/apps/performance/components/risk/risk-attribution-panel.tsx
+++ b/src/apps/performance/components/risk/risk-attribution-panel.tsx
@@ -1,0 +1,140 @@
+import {
+  AnalyticsTable,
+  SectionBlock,
+  Text,
+  WorkbenchSegmentedControl,
+  WorkbenchStatusRow,
+  WorkbenchSummaryMetricStrip,
+} from "@/design-system";
+
+import type { PerformanceRiskViewModel } from "../../risk-workspace-view-model";
+
+type RiskAttributionPanelProps = {
+  viewModel: PerformanceRiskViewModel;
+  onSelectAttribution: (attributionType: string, groupingDimension: string) => void;
+};
+
+export default function RiskAttributionPanel({
+  viewModel,
+  onSelectAttribution,
+}: RiskAttributionPanelProps) {
+  const controls = viewModel.attributionControls;
+
+  return (
+    <SectionBlock
+      title="Historical Risk Attribution"
+      subtitle="Stateful decomposition of realized total and active risk across supported business dimensions."
+      className="performance-risk-panel performance-risk-attribution-panel"
+    >
+      {controls ? (
+        <div className="performance-risk-attribution-toolbar">
+          <WorkbenchSegmentedControl
+            value={controls.selectedAttributionType}
+            onChange={(nextValue) => onSelectAttribution(nextValue, controls.selectedGroupingDimension)}
+            options={controls.attributionTypes.map((option) => ({
+              key: option.key,
+              label: option.label,
+              disabled: option.disabled,
+              title: option.reason ?? undefined,
+            }))}
+            ariaLabel="Risk attribution type"
+          />
+          <WorkbenchSegmentedControl
+            value={controls.selectedGroupingDimension}
+            onChange={(nextValue) => onSelectAttribution(controls.selectedAttributionType, nextValue)}
+            options={controls.groupingDimensions.map((option) => ({
+              key: option.key,
+              label: option.label,
+              disabled: option.disabled,
+              title: option.reason ?? undefined,
+            }))}
+            ariaLabel="Risk attribution grouping"
+          />
+        </div>
+      ) : null}
+
+      {viewModel.attributionTotals ? (
+        <WorkbenchSummaryMetricStrip
+          ariaLabel="Risk attribution totals"
+          className="performance-risk-metric-strip"
+          items={[
+            {
+              key: "metric",
+              label: "Selection",
+              value: viewModel.attributionTotals.metric,
+              support: viewModel.attributionTotals.support,
+            },
+            {
+              key: "total",
+              label: "Total",
+              value: viewModel.attributionTotals.totalValue,
+              support: "Reported total metric",
+            },
+            {
+              key: "sum",
+              label: "Reconciled Sum",
+              value: viewModel.attributionTotals.reconciledSum,
+              support: "Sum of contributors",
+            },
+            {
+              key: "residual",
+              label: "Residual",
+              value: viewModel.attributionTotals.residual,
+              support: "Residual after reconciliation",
+            },
+          ]}
+        />
+      ) : null}
+
+      {viewModel.attributionWarnings.length ? (
+        <WorkbenchStatusRow
+          label="Attribution notes"
+          className="performance-risk-quality-flags"
+          items={viewModel.attributionWarnings.map((warning) => ({
+            value: warning,
+            tone: "warn" as const,
+          }))}
+        />
+      ) : null}
+
+      {viewModel.attributionState === "loading" ? (
+        <Text variant="metadata">Loading historical risk attribution.</Text>
+      ) : viewModel.attributionState === "blocked" ? (
+        <Text variant="metadata">
+          The selected attribution combination is blocked by the current stateful support matrix.
+        </Text>
+      ) : viewModel.attributionState === "unavailable" ? (
+        <Text variant="metadata">
+          Historical risk attribution is not available for the selected portfolio context.
+        </Text>
+      ) : (
+        <AnalyticsTable
+          ariaLabel="Historical risk attribution table"
+          variant="analysis"
+          density="compact"
+          columns={[
+            { key: "group", label: "Group" },
+            { key: "avgWeight", label: "Avg Weight", align: "right" },
+            { key: "marginalContribution", label: "Marginal", align: "right" },
+            { key: "componentContribution", label: "Component", align: "right" },
+            { key: "contributionShare", label: "Share", align: "right" },
+          ]}
+          rows={viewModel.attributionRows.map((row) => ({
+            key: row.key,
+            cells: [
+              row.group,
+              row.avgWeight,
+              row.marginalContribution,
+              row.componentContribution,
+              row.contributionShare,
+            ],
+          }))}
+          emptyState={{
+            title: "No attribution contributors",
+            body: "Historical risk attribution did not return contributor rows for the selected controls.",
+          }}
+        />
+      )}
+    </SectionBlock>
+  );
+}

--- a/src/apps/performance/components/risk/risk-concentration-panel.tsx
+++ b/src/apps/performance/components/risk/risk-concentration-panel.tsx
@@ -1,0 +1,46 @@
+import { AnalyticsTable, SectionBlock, WorkbenchSummaryMetricStrip } from "@/design-system";
+
+import type { PerformanceRiskViewModel } from "../../risk-workspace-view-model";
+
+export default function RiskConcentrationPanel({
+  viewModel,
+}: {
+  viewModel: PerformanceRiskViewModel;
+}) {
+  return (
+    <SectionBlock
+      title="Concentration"
+      subtitle="Current stateful concentration pressure and issuer coverage diagnostics."
+      className="performance-risk-panel performance-risk-concentration-panel"
+    >
+      <WorkbenchSummaryMetricStrip
+        ariaLabel="Risk concentration headline metrics"
+        className="performance-risk-metric-strip"
+        items={viewModel.concentrationMetrics.map((metric) => ({
+          key: metric.key,
+          label: metric.label,
+          value: metric.value,
+          support: metric.support,
+        }))}
+      />
+      <AnalyticsTable
+        ariaLabel="Risk concentration diagnostic table"
+        variant="analysis"
+        density="compact"
+        columns={[
+          { key: "metric", label: "Metric" },
+          { key: "value", label: "Value", align: "right" },
+          { key: "support", label: "Meaning" },
+        ]}
+        rows={viewModel.concentrationMetrics.map((metric) => ({
+          key: metric.key,
+          cells: [metric.label, metric.value, metric.support],
+        }))}
+        emptyState={{
+          title: "No concentration diagnostics",
+          body: "Stateful concentration analytics are not available for this portfolio context.",
+        }}
+      />
+    </SectionBlock>
+  );
+}

--- a/src/apps/performance/components/risk/risk-drawdown-panel.tsx
+++ b/src/apps/performance/components/risk/risk-drawdown-panel.tsx
@@ -1,0 +1,115 @@
+import {
+  AnalyticsTable,
+  DisclosureToggleButton,
+  SectionBlock,
+  Text,
+  WorkbenchSummaryMetricStrip,
+} from "@/design-system";
+
+import type { PerformanceRiskViewModel } from "../../risk-workspace-view-model";
+
+type RiskDrawdownPanelProps = {
+  viewModel: PerformanceRiskViewModel;
+  underwaterExpanded: boolean;
+  onToggleUnderwater: () => void;
+};
+
+export default function RiskDrawdownPanel({
+  viewModel,
+  underwaterExpanded,
+  onToggleUnderwater,
+}: RiskDrawdownPanelProps) {
+  return (
+    <SectionBlock
+      title="Drawdown"
+      subtitle="Worst realized path loss, recovery posture, and drawdown episode evidence."
+      className="performance-risk-panel performance-risk-drawdown-panel"
+      actions={
+        <DisclosureToggleButton
+          expanded={underwaterExpanded}
+          onToggle={onToggleUnderwater}
+          expandedToggleLabel="Collapse underwater path"
+          collapsedToggleLabel="Expand underwater path"
+        />
+      }
+    >
+      <WorkbenchSummaryMetricStrip
+        ariaLabel="Risk drawdown headline metrics"
+        className="performance-risk-metric-strip"
+        items={viewModel.drawdownHeadlineMetrics.map((metric) => ({
+          key: metric.key,
+          label: metric.label,
+          value: metric.value,
+          support: metric.support,
+          unavailable: metric.state === "unavailable",
+        }))}
+      />
+      {viewModel.drawdownRelativeMetric ? (
+        <div className="performance-risk-relative-note" aria-label="Relative drawdown summary">
+          <Text variant="label">{viewModel.drawdownRelativeMetric.label}</Text>
+          <Text variant="cardTitle">{viewModel.drawdownRelativeMetric.value}</Text>
+          <Text variant="metadata">{viewModel.drawdownRelativeMetric.support}</Text>
+        </div>
+      ) : null}
+      <AnalyticsTable
+        ariaLabel="Risk drawdown episode table"
+        variant="analysis"
+        density="compact"
+        columns={[
+          { key: "episode", label: "Episode" },
+          { key: "depth", label: "Depth", align: "right" },
+          { key: "peak", label: "Peak" },
+          { key: "trough", label: "Trough" },
+          { key: "recovery", label: "Recovery" },
+          { key: "days", label: "Days", align: "right" },
+          { key: "status", label: "Status" },
+        ]}
+        rows={viewModel.drawdownEpisodes.map((episode) => ({
+          key: episode.key,
+          cells: [
+            episode.episode,
+            episode.depth,
+            episode.peakDate,
+            episode.troughDate,
+            episode.recoveryDate,
+            episode.totalDays,
+            episode.status,
+          ],
+        }))}
+        emptyState={{
+          title: "No drawdown episodes",
+          body: "Stateful drawdown episodes are not available for this portfolio context.",
+        }}
+      />
+      {underwaterExpanded ? (
+        <div className="performance-risk-underwater-detail" aria-label="Underwater path detail">
+          {viewModel.underwaterDetailState === "loading" ? (
+            <Text variant="metadata">Loading underwater path.</Text>
+          ) : viewModel.underwaterDetailState === "unavailable" ? (
+            <Text variant="metadata">
+              Underwater path detail is not available for the selected portfolio context.
+            </Text>
+          ) : (
+            <AnalyticsTable
+              ariaLabel="Risk underwater series table"
+              variant="analysis"
+              density="compact"
+              columns={[
+                { key: "date", label: "Date" },
+                { key: "drawdown", label: "Drawdown", align: "right" },
+              ]}
+              rows={viewModel.underwaterSeries.map((point) => ({
+                key: point.key,
+                cells: [point.date, point.drawdown],
+              }))}
+              emptyState={{
+                title: "No underwater series",
+                body: "Underwater detail has not been returned for this drawdown request.",
+              }}
+            />
+          )}
+        </div>
+      ) : null}
+    </SectionBlock>
+  );
+}

--- a/src/apps/performance/components/risk/risk-provenance-strip.tsx
+++ b/src/apps/performance/components/risk/risk-provenance-strip.tsx
@@ -1,0 +1,22 @@
+import { Text } from "@/design-system";
+
+import type { PerformanceRiskViewModel } from "../../risk-workspace-view-model";
+
+export default function RiskProvenanceStrip({
+  viewModel,
+}: {
+  viewModel: PerformanceRiskViewModel;
+}) {
+  return (
+    <section className="performance-risk-provenance-strip" aria-label="Risk provenance">
+      {viewModel.provenance.map((item) => (
+        <span key={item.label} className="performance-risk-provenance-item">
+          <Text variant="metadata" as="span">
+            {item.label}
+          </Text>
+          <strong>{item.value}</strong>
+        </span>
+      ))}
+    </section>
+  );
+}

--- a/src/apps/performance/components/risk/risk-rolling-panel.tsx
+++ b/src/apps/performance/components/risk/risk-rolling-panel.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+
+import {
+  AnalyticsTable,
+  DisclosureToggleButton,
+  SectionBlock,
+  Text,
+  WorkbenchSegmentedControl,
+  WorkbenchStatusRow,
+  WorkbenchSummaryMetricStrip,
+} from "@/design-system";
+
+import type { PerformanceRiskViewModel } from "../../risk-workspace-view-model";
+
+type RiskRollingPanelProps = {
+  viewModel: PerformanceRiskViewModel;
+  rollingExpanded: boolean;
+  onToggleRolling: () => void;
+};
+
+export default function RiskRollingPanel({
+  viewModel,
+  rollingExpanded,
+  onToggleRolling,
+}: RiskRollingPanelProps) {
+  const defaultWindowKey = viewModel.rollingWindows[0]?.key ?? "";
+  const [selectedWindowKey, setSelectedWindowKey] = useState(defaultWindowKey);
+
+  useEffect(() => {
+    setSelectedWindowKey(defaultWindowKey);
+  }, [defaultWindowKey]);
+
+  const selectedWindow =
+    viewModel.rollingWindows.find((window) => window.key === selectedWindowKey) ??
+    viewModel.rollingWindows[0] ??
+    null;
+
+  return (
+    <SectionBlock
+      title="Rolling Risk"
+      subtitle="Windowed risk behavior for realized volatility, drawdown pressure, and benchmark-relative drift."
+      className="performance-risk-panel performance-risk-rolling-panel"
+      actions={
+        <DisclosureToggleButton
+          expanded={rollingExpanded}
+          onToggle={onToggleRolling}
+          expandedToggleLabel="Collapse rolling series"
+          collapsedToggleLabel="Expand rolling series"
+        />
+      }
+    >
+      {viewModel.rollingWindows.length > 1 ? (
+        <WorkbenchSegmentedControl
+          value={selectedWindow?.key ?? defaultWindowKey}
+          onChange={setSelectedWindowKey}
+          options={viewModel.rollingWindows.map((window) => ({
+            key: window.key,
+            label: window.label,
+          }))}
+          ariaLabel="Rolling risk windows"
+          className="performance-risk-window-toolbar"
+        />
+      ) : null}
+      <WorkbenchSummaryMetricStrip
+        ariaLabel="Rolling risk headline metrics"
+        className="performance-risk-metric-strip"
+        items={(selectedWindow?.headlineMetrics ?? []).map((metric) => ({
+          key: metric.key,
+          label: metric.label,
+          value: metric.value,
+          support: metric.support,
+          unavailable: metric.state === "unavailable",
+        }))}
+      />
+      {viewModel.rollingQualityFlags.length ? (
+        <WorkbenchStatusRow
+          label="Rolling quality flags"
+          className="performance-risk-quality-flags"
+          items={viewModel.rollingQualityFlags.map((flag) => ({
+            value: flag,
+            tone: "warn" as const,
+          }))}
+        />
+      ) : null}
+      <AnalyticsTable
+        ariaLabel="Rolling risk summary table"
+        variant="analysis"
+        density="compact"
+        columns={[
+          { key: "metric", label: "Metric" },
+          { key: "latest", label: "Latest", align: "right" },
+          { key: "average", label: "Average", align: "right" },
+          { key: "p05", label: "P05", align: "right" },
+          { key: "p95", label: "P95", align: "right" },
+          { key: "support", label: "Interpretation" },
+        ]}
+        rows={(selectedWindow?.summaryRows ?? []).map((row) => ({
+          key: row.key,
+          cells: [row.metric, row.latest, row.average, row.p05, row.p95, row.support],
+        }))}
+        emptyState={{
+          title: "No rolling risk metrics",
+          body: "Rolling risk windows are not available for this portfolio context.",
+        }}
+      />
+      {rollingExpanded ? (
+        <div className="performance-risk-rolling-detail" aria-label="Rolling series detail">
+          {viewModel.rollingDetailState === "loading" ? (
+            <Text variant="metadata">Loading rolling series.</Text>
+          ) : viewModel.rollingDetailState === "unavailable" ? (
+            <Text variant="metadata">
+              Rolling series detail is not available for the selected portfolio context.
+            </Text>
+          ) : (
+            <AnalyticsTable
+              ariaLabel="Rolling risk series table"
+              variant="analysis"
+              density="compact"
+              columns={[
+                { key: "date", label: "Date" },
+                ...((selectedWindow?.seriesMetricKeys ?? []).map((metricKey) => ({
+                  key: metricKey,
+                  label:
+                    selectedWindow?.summaryRows.find((row) => row.key.endsWith(metricKey))?.metric ??
+                    metricKey,
+                  align: "right" as const,
+                })) ?? []),
+              ]}
+              rows={(selectedWindow?.seriesRows ?? []).map((row) => ({
+                key: row.key,
+                cells: [
+                  row.date,
+                  ...(selectedWindow?.seriesMetricKeys.map(
+                    (metricKey) => row.values[metricKey] ?? "N/A"
+                  ) ?? []),
+                ],
+              }))}
+              emptyState={{
+                title: "No rolling series",
+                body: "Rolling series detail has not been returned for this window.",
+              }}
+            />
+          )}
+        </div>
+      ) : null}
+    </SectionBlock>
+  );
+}

--- a/src/apps/performance/components/risk/risk-snapshot-panel.tsx
+++ b/src/apps/performance/components/risk/risk-snapshot-panel.tsx
@@ -1,0 +1,49 @@
+import { AnalyticsTable, SectionBlock, WorkbenchSummaryMetricStrip } from "@/design-system";
+
+import type { PerformanceRiskViewModel } from "../../risk-workspace-view-model";
+
+export default function RiskSnapshotPanel({
+  viewModel,
+}: {
+  viewModel: PerformanceRiskViewModel;
+}) {
+  const rows = viewModel.snapshotMetrics.map((metric) => ({
+    key: metric.key,
+    cells: [metric.label, metric.value, metric.support],
+  }));
+
+  return (
+    <SectionBlock
+      title="Risk Snapshot"
+      subtitle="Stateful volatility, drawdown-adjacent, and benchmark-relative risk indicators."
+      className="performance-risk-panel performance-risk-snapshot-panel"
+    >
+      <WorkbenchSummaryMetricStrip
+        ariaLabel="Risk snapshot headline metrics"
+        className="performance-risk-metric-strip"
+        items={viewModel.snapshotMetrics.slice(0, 4).map((metric) => ({
+          key: metric.key,
+          label: metric.label,
+          value: metric.value,
+          support: metric.support,
+          unavailable: metric.state === "unavailable",
+        }))}
+      />
+      <AnalyticsTable
+        ariaLabel="Risk snapshot metric table"
+        variant="analysis"
+        density="compact"
+        columns={[
+          { key: "metric", label: "Metric" },
+          { key: "value", label: "Value", align: "right" },
+          { key: "support", label: "Supportability" },
+        ]}
+        rows={rows}
+        emptyState={{
+          title: "No risk metrics",
+          body: "Stateful risk metrics are not available for this portfolio context.",
+        }}
+      />
+    </SectionBlock>
+  );
+}

--- a/src/apps/performance/components/risk/risk-status-bar.tsx
+++ b/src/apps/performance/components/risk/risk-status-bar.tsx
@@ -1,0 +1,46 @@
+import { SemanticBadge, Text } from "@/design-system";
+
+import type { PerformanceRiskState } from "../../risk-workspace-view-model";
+
+const STATUS_LABELS: Record<PerformanceRiskState, string> = {
+  loading: "Loading",
+  ready: "Ready",
+  partial: "Partial",
+  empty: "Empty",
+  unavailable: "Unavailable",
+  error: "Error",
+};
+
+const STATUS_TONES: Record<PerformanceRiskState, "default" | "success" | "warn" | "danger"> = {
+  loading: "default",
+  ready: "success",
+  partial: "warn",
+  empty: "default",
+  unavailable: "danger",
+  error: "danger",
+};
+
+export default function RiskStatusBar({
+  state,
+  warnings,
+}: {
+  state: PerformanceRiskState;
+  warnings: string[];
+}) {
+  return (
+    <div className="performance-risk-status-bar" aria-label="Risk mode status">
+      <div className="performance-risk-status-items">
+        <SemanticBadge tone={STATUS_TONES[state]} emphasis="strong">
+          {STATUS_LABELS[state]}
+        </SemanticBadge>
+        <SemanticBadge>Stateful only</SemanticBadge>
+        <SemanticBadge tone={warnings.length ? "warn" : "success"}>
+          {warnings.length ? "Review notes" : "Source-grounded"}
+        </SemanticBadge>
+      </div>
+      <Text variant="metadata" className="performance-risk-status-note">
+        Gateway Risk BFF contract. No stateless risk execution is surfaced in Workbench.
+      </Text>
+    </div>
+  );
+}

--- a/src/apps/performance/components/risk/risk-supportability-panel.tsx
+++ b/src/apps/performance/components/risk/risk-supportability-panel.tsx
@@ -1,0 +1,36 @@
+import { SectionBlock, SemanticBadge, Text } from "@/design-system";
+
+import type { PerformanceRiskViewModel } from "../../risk-workspace-view-model";
+
+const STATE_TONE = {
+  ready: "success",
+  partial: "warn",
+  unavailable: "danger",
+  blocked: "danger",
+} as const;
+
+export default function RiskSupportabilityPanel({
+  viewModel,
+}: {
+  viewModel: PerformanceRiskViewModel;
+}) {
+  return (
+    <SectionBlock
+      title="Supportability"
+      subtitle="Source readiness for the stateful risk contract."
+      className="performance-risk-panel performance-risk-supportability-panel"
+    >
+      <div className="performance-risk-supportability-list">
+        {viewModel.supportability.map((item) => (
+          <div key={item.key} className="performance-risk-supportability-row">
+            <div>
+              <Text variant="cardTitle">{item.label}</Text>
+              {item.reason ? <Text variant="metadata">{item.reason}</Text> : null}
+            </div>
+            <SemanticBadge tone={STATE_TONE[item.state]}>{item.state}</SemanticBadge>
+          </div>
+        ))}
+      </div>
+    </SectionBlock>
+  );
+}

--- a/src/apps/performance/navigation.ts
+++ b/src/apps/performance/navigation.ts
@@ -1,4 +1,5 @@
 import { CANONICAL_PERFORMANCE_PERIOD_OPTIONS } from "./periods";
+import type { PerformanceWorkspaceMode } from "./components/performance-workspace-mode-switch";
 
 export const PERIOD_OPTIONS = CANONICAL_PERFORMANCE_PERIOD_OPTIONS;
 export const BASIS_OPTIONS = ["NET", "GROSS"] as const;
@@ -24,6 +25,7 @@ export function buildPerformanceHref({
   benchmark,
   reportStartDate,
   reportEndDate,
+  mode,
 }: {
   portfolioId: string;
   period: string;
@@ -34,10 +36,14 @@ export function buildPerformanceHref({
   benchmark?: string;
   reportStartDate?: string;
   reportEndDate?: string;
+  mode?: PerformanceWorkspaceMode;
 }) {
   const query = new URLSearchParams();
   const isExplicitWindow = period === "EXPLICIT";
   query.set("portfolioId", portfolioId);
+  if (mode && mode !== "summary") {
+    query.set("mode", mode);
+  }
   query.set("period", period);
   query.set("detailBasis", detailBasis);
   query.set("contributionDimension", contributionDimension);

--- a/src/apps/performance/performance-analytics-page.tsx
+++ b/src/apps/performance/performance-analytics-page.tsx
@@ -3,6 +3,7 @@ import {
 } from "@/features/workbench/api";
 import { resolveGatewayBaseUrl } from "@/features/platform-runtime/service-addressing";
 import { AppPageShell } from "@/design-system";
+import type { PerformanceWorkspaceMode } from "./components/performance-workspace-mode-switch";
 import PerformanceWorkspaceEntry from "./components/performance-workspace-entry";
 
 type LookupEnvelope = {
@@ -14,6 +15,13 @@ const DEFAULT_BENCHMARK_BY_PORTFOLIO: Record<string, string> = {
   PB_SG_GLOBAL_BAL_001: "BMK_PB_GLOBAL_BALANCED_60_40",
   DEMO_ADV_USD_001: "BMK_GLOBAL_BALANCED_60_40",
 };
+const PERFORMANCE_WORKSPACE_MODES = new Set<PerformanceWorkspaceMode>([
+  "summary",
+  "analysis",
+  "advisor",
+  "risk",
+  "evidence",
+]);
 
 async function getPortfolioOptions(limit = 8): Promise<Array<{ id: string; label: string }>> {
   try {
@@ -41,6 +49,7 @@ export default async function PerformanceAnalyticsPage({
     contributionDimension?: string;
     attributionDimension?: string;
     chartFrequency?: string;
+    mode?: string;
     benchmark?: string;
     reportStartDate?: string;
     reportEndDate?: string;
@@ -64,6 +73,11 @@ export default async function PerformanceAnalyticsPage({
   const attributionDimension =
     resolvedSearch.attributionDimension?.trim() || legacyDetailDimension || "asset_class";
   const chartFrequency = resolvedSearch.chartFrequency?.trim() || "monthly";
+  const initialMode = PERFORMANCE_WORKSPACE_MODES.has(
+    (resolvedSearch.mode?.trim() ?? "summary") as PerformanceWorkspaceMode
+  )
+    ? ((resolvedSearch.mode?.trim() ?? "summary") as PerformanceWorkspaceMode)
+    : "summary";
   const benchmark =
     resolvedSearch.benchmark?.trim() ||
     (selectedPortfolioId ? DEFAULT_BENCHMARK_BY_PORTFOLIO[selectedPortfolioId] : undefined);
@@ -107,6 +121,7 @@ export default async function PerformanceAnalyticsPage({
         initialContributionDimension={contributionDimension}
         initialAttributionDimension={attributionDimension}
         initialChartFrequency={chartFrequency}
+        initialMode={initialMode}
         initialBenchmark={benchmark}
       />
     </AppPageShell>

--- a/src/apps/performance/risk-workspace-view-model.ts
+++ b/src/apps/performance/risk-workspace-view-model.ts
@@ -1,118 +1,15 @@
-import type { WorkbenchPerformanceWorkspace } from "@/features/workbench/types";
+import type {
+  WorkbenchPerformanceWorkspace,
+  WorkbenchRiskConcentrationResponse,
+  WorkbenchRiskMetric,
+  WorkbenchRiskModuleState,
+  WorkbenchRiskSummaryResponse,
+} from "@/features/workbench/types";
 import {
   formatDateValue,
   formatNumber,
   formatPercent,
 } from "@/design-system/utils/financial-formatters";
-
-type RiskModuleState = "ready" | "partial" | "unavailable" | "blocked";
-type RiskSupportabilityState = RiskModuleState;
-
-export type WorkbenchRiskSupportabilityItem = {
-  key: string;
-  label: string;
-  state: RiskSupportabilityState;
-  reason?: string | null;
-  source_service?: string | null;
-};
-
-export type WorkbenchRiskMetric = {
-  key: string;
-  label: string;
-  value: number | null;
-  state: RiskModuleState;
-  reason?: string | null;
-  details?: Record<string, unknown> | null;
-};
-
-export type WorkbenchRiskSummaryResponse = {
-  correlation_id: string;
-  contract_version: "risk-workspace.v1";
-  portfolio_id: string;
-  period: string;
-  as_of_date: string;
-  benchmark_code?: string | null;
-  source_service: "lotus-risk";
-  state: RiskModuleState;
-  payload: {
-    periods: Array<{
-      key: string;
-      label: string;
-      start_date: string;
-      end_date: string;
-      metrics: WorkbenchRiskMetric[];
-    }>;
-  } | null;
-  supportability: WorkbenchRiskSupportabilityItem[];
-  warnings: string[];
-  partial_failures: Array<{
-    source_service: string;
-    error_code: string;
-    detail: string;
-  }>;
-  metadata: {
-    generated_at: string;
-    input_mode: "stateful";
-    methodology_version?: string | null;
-    cache_status?: "hit" | "miss" | "bypass" | null;
-  };
-};
-
-export type WorkbenchRiskConcentrationResponse = {
-  correlation_id: string;
-  contract_version: "risk-workspace.v1";
-  portfolio_id: string;
-  period: string;
-  as_of_date: string;
-  benchmark_code?: string | null;
-  source_service: "lotus-risk";
-  state: RiskModuleState;
-  payload: {
-    risk_proxy: {
-      hhi_current: number;
-      hhi_proposed: number;
-      hhi_delta: number;
-    };
-    single_position_concentration: {
-      top_position_weight_current: number;
-      top_position_weight_proposed: number;
-      top_position_weight_delta: number;
-      top_n_cumulative_weight_current: number;
-      top_n_cumulative_weight_proposed: number;
-      top_n_cumulative_weight_delta: number;
-      top_n: number;
-    };
-    issuer_concentration: {
-      hhi_current: number;
-      hhi_proposed: number;
-      hhi_delta: number;
-      top_issuer_weight_current: number;
-      top_issuer_weight_proposed: number;
-      top_issuer_weight_delta: number;
-      coverage_status: string;
-      covered_position_count_current: number;
-      covered_position_count_proposed: number;
-      total_position_count_current: number;
-      total_position_count_proposed: number;
-      note?: string | null;
-    };
-    valuation_context?: Record<string, unknown> | null;
-    risk_metadata?: Record<string, unknown> | null;
-  } | null;
-  supportability: WorkbenchRiskSupportabilityItem[];
-  warnings: string[];
-  partial_failures: Array<{
-    source_service: string;
-    error_code: string;
-    detail: string;
-  }>;
-  metadata: {
-    generated_at: string;
-    input_mode: "stateful";
-    methodology_version?: string | null;
-    cache_status?: "hit" | "miss" | "bypass" | null;
-  };
-};
 
 export type PerformanceRiskState =
   | "loading"
@@ -143,7 +40,7 @@ export type PerformanceRiskViewModel = {
   supportability: Array<{
     key: string;
     label: string;
-    state: RiskSupportabilityState;
+    state: WorkbenchRiskModuleState;
     reason?: string | null;
   }>;
   provenance: Array<{ label: string; value: string }>;
@@ -158,7 +55,6 @@ export type BuildPerformanceRiskViewModelOptions = {
   isDetailsPending?: boolean;
   riskSummary?: WorkbenchRiskSummaryResponse | null;
   riskConcentration?: WorkbenchRiskConcentrationResponse | null;
-  unavailable?: boolean;
 };
 
 export function buildPerformanceRiskViewModel({
@@ -168,35 +64,43 @@ export function buildPerformanceRiskViewModel({
   isDetailsPending = false,
   riskSummary,
   riskConcentration,
-  unavailable = false,
 }: BuildPerformanceRiskViewModelOptions): PerformanceRiskViewModel {
   if (isDetailsPending) {
     return buildStateViewModel(workspace, period, detailBasis, "loading");
   }
-  if (unavailable) {
-    return buildStateViewModel(workspace, period, detailBasis, "unavailable");
-  }
 
-  const summary = riskSummary ?? buildFixtureRiskSummary(workspace, period, detailBasis);
+  const summary =
+    riskSummary ??
+    buildUnavailableRiskSummary({
+      workspace,
+      period,
+      detailBasis,
+      detail: "Risk summary is not available from the Gateway BFF.",
+    });
   const concentration =
-    riskConcentration ?? buildFixtureRiskConcentration(workspace, period);
+    riskConcentration ??
+    buildUnavailableRiskConcentration({
+      workspace,
+      period,
+      detail: "Risk concentration is not available from the Gateway BFF.",
+    });
+
   const supportability = [...summary.supportability, ...concentration.supportability];
   const hasPayload = Boolean(summary.payload?.periods.length || concentration.payload);
-
   const state = !hasPayload
-    ? "empty"
-    : summary.state === "unavailable" || concentration.state === "unavailable"
-      ? "partial"
-      : summary.state === "partial" || concentration.state === "partial"
-        ? "partial"
-        : "ready";
+    ? "unavailable"
+    : summary.state === "ready" && concentration.state === "ready"
+      ? "ready"
+      : "partial";
 
   return {
     state,
-    title: "Stateful Risk",
+    title: state === "unavailable" ? "Risk unavailable" : "Stateful Risk",
     synopsis:
-      state === "partial"
-        ? "Risk is available with coverage notes. Review issuer and benchmark supportability before using the result externally."
+      state === "unavailable"
+        ? "Stateful risk is not available for the selected portfolio context."
+        : state === "partial"
+        ? "Risk is available with coverage notes. Review issuer and benchmark supportability before external use."
         : "Stateful portfolio risk is available for the selected performance context.",
     contextItems: buildContextItems(workspace, period, detailBasis, summary.as_of_date),
     snapshotMetrics: mapSnapshotMetrics(summary),
@@ -222,50 +126,7 @@ export function buildPerformanceRiskViewModel({
   };
 }
 
-function buildStateViewModel(
-  workspace: WorkbenchPerformanceWorkspace,
-  period: string,
-  detailBasis: string,
-  state: PerformanceRiskState
-): PerformanceRiskViewModel {
-  const asOfDate = workspace.as_of_date;
-  const title =
-    state === "loading"
-      ? "Loading stateful risk"
-      : state === "unavailable"
-        ? "Risk unavailable"
-        : "Risk not available";
-  return {
-    state,
-    title,
-    synopsis:
-      state === "loading"
-        ? "Risk snapshot and concentration modules are loading from the Gateway BFF contract."
-        : "Stateful risk is not available for the selected portfolio context.",
-    contextItems: buildContextItems(workspace, period, detailBasis, asOfDate),
-    snapshotMetrics: [],
-    concentrationMetrics: [],
-    supportability: [
-      {
-        key: "risk_bff",
-        label: "Risk BFF",
-        state: state === "loading" ? "partial" : "unavailable",
-        reason:
-          state === "loading"
-            ? "Gateway risk contract is being prepared."
-            : "Gateway risk BFF response is not available.",
-      },
-    ],
-    provenance: [
-      { label: "Contract", value: "risk-workspace.v1" },
-      { label: "Input Mode", value: "Stateful only" },
-    ],
-    warnings: state === "loading" ? [] : ["RISK_WORKSPACE_UNAVAILABLE"],
-    partialFailures: [],
-  };
-}
-
-function buildFixtureRiskSummary(
+export function buildFixtureRiskSummary(
   workspace: WorkbenchPerformanceWorkspace,
   period: string,
   detailBasis: string
@@ -275,6 +136,7 @@ function buildFixtureRiskSummary(
   const activeReturn = selectedPerformance.active_return_pct ?? 0;
   const volatility = Math.max(Math.abs(activeReturn) * 1.8, 7.25);
   const trackingError = Math.max(Math.abs(activeReturn) * 0.8, 2.15);
+
   return {
     correlation_id: "fixture-risk-summary",
     contract_version: "risk-workspace.v1",
@@ -324,7 +186,9 @@ function buildFixtureRiskSummary(
         key: "benchmark_returns",
         label: "Benchmark returns",
         state: workspace.benchmark_code ? "ready" : "unavailable",
-        reason: workspace.benchmark_code ? null : "Benchmark-relative risk requires benchmark context.",
+        reason: workspace.benchmark_code
+          ? null
+          : "Benchmark-relative risk requires benchmark context.",
         source_service: "lotus-risk",
       },
       {
@@ -346,7 +210,7 @@ function buildFixtureRiskSummary(
   };
 }
 
-function buildFixtureRiskConcentration(
+export function buildFixtureRiskConcentration(
   workspace: WorkbenchPerformanceWorkspace,
   period: string
 ): WorkbenchRiskConcentrationResponse {
@@ -413,14 +277,130 @@ function buildFixtureRiskConcentration(
   };
 }
 
-function metric(
-  key: string,
-  label: string,
-  value: number | null,
-  state: RiskModuleState,
-  details?: Record<string, unknown>
-): WorkbenchRiskMetric {
-  return { key, label, value, state, details };
+export function buildUnavailableRiskSummary({
+  workspace,
+  period,
+  detailBasis,
+  detail,
+}: {
+  workspace: WorkbenchPerformanceWorkspace;
+  period: string;
+  detailBasis: string;
+  detail: string;
+}): WorkbenchRiskSummaryResponse {
+  return {
+    correlation_id: "risk-summary-unavailable",
+    contract_version: "risk-workspace.v1",
+    portfolio_id: workspace.portfolio.portfolio_id,
+    period,
+    as_of_date: workspace.as_of_date,
+    benchmark_code: workspace.benchmark_code,
+    source_service: "lotus-risk",
+    state: "unavailable",
+    payload: null,
+    supportability: [
+      {
+        key: "risk_summary",
+        label: "Risk summary",
+        state: "unavailable",
+        reason: `${detail} (${detailBasis} basis)`,
+        source_service: "lotus-risk",
+      },
+    ],
+    warnings: ["RISK_SUMMARY_UNAVAILABLE"],
+    partial_failures: [
+      { source_service: "risk", error_code: "RISK_SUMMARY_UNAVAILABLE", detail },
+    ],
+    metadata: {
+      generated_at: workspace.as_of_date,
+      input_mode: "stateful",
+      cache_status: "miss",
+    },
+  };
+}
+
+export function buildUnavailableRiskConcentration({
+  workspace,
+  period,
+  detail,
+}: {
+  workspace: WorkbenchPerformanceWorkspace;
+  period: string;
+  detail: string;
+}): WorkbenchRiskConcentrationResponse {
+  return {
+    correlation_id: "risk-concentration-unavailable",
+    contract_version: "risk-workspace.v1",
+    portfolio_id: workspace.portfolio.portfolio_id,
+    period,
+    as_of_date: workspace.as_of_date,
+    benchmark_code: workspace.benchmark_code,
+    source_service: "lotus-risk",
+    state: "unavailable",
+    payload: null,
+    supportability: [
+      {
+        key: "risk_concentration",
+        label: "Risk concentration",
+        state: "unavailable",
+        reason: detail,
+        source_service: "lotus-risk",
+      },
+    ],
+    warnings: ["RISK_CONCENTRATION_UNAVAILABLE"],
+    partial_failures: [
+      { source_service: "risk", error_code: "RISK_CONCENTRATION_UNAVAILABLE", detail },
+    ],
+    metadata: {
+      generated_at: workspace.as_of_date,
+      input_mode: "stateful",
+      cache_status: "miss",
+    },
+  };
+}
+
+function buildStateViewModel(
+  workspace: WorkbenchPerformanceWorkspace,
+  period: string,
+  detailBasis: string,
+  state: PerformanceRiskState
+): PerformanceRiskViewModel {
+  const asOfDate = workspace.as_of_date;
+  const title =
+    state === "loading"
+      ? "Loading stateful risk"
+      : state === "unavailable"
+        ? "Risk unavailable"
+        : "Risk not available";
+
+  return {
+    state,
+    title,
+    synopsis:
+      state === "loading"
+        ? "Risk snapshot and concentration modules are loading from the Gateway BFF contract."
+        : "Stateful risk is not available for the selected portfolio context.",
+    contextItems: buildContextItems(workspace, period, detailBasis, asOfDate),
+    snapshotMetrics: [],
+    concentrationMetrics: [],
+    supportability: [
+      {
+        key: "risk_bff",
+        label: "Risk BFF",
+        state: state === "loading" ? "partial" : "unavailable",
+        reason:
+          state === "loading"
+            ? "Gateway risk contract is loading."
+            : "Gateway risk BFF response is not available.",
+      },
+    ],
+    provenance: [
+      { label: "Contract", value: "risk-workspace.v1" },
+      { label: "Input Mode", value: "Stateful only" },
+    ],
+    warnings: state === "loading" ? [] : ["RISK_WORKSPACE_UNAVAILABLE"],
+    partialFailures: [],
+  };
 }
 
 function buildContextItems(
@@ -438,6 +418,16 @@ function buildContextItems(
   ];
 }
 
+function metric(
+  key: string,
+  label: string,
+  value: number | null,
+  state: WorkbenchRiskModuleState,
+  details?: Record<string, unknown>
+): WorkbenchRiskMetric {
+  return { key, label, value, state, details };
+}
+
 function mapSnapshotMetrics(response: WorkbenchRiskSummaryResponse) {
   const metrics = response.payload?.periods[0]?.metrics ?? [];
   return metrics.map((item) => ({
@@ -447,13 +437,6 @@ function mapSnapshotMetrics(response: WorkbenchRiskSummaryResponse) {
     support: item.reason ?? (item.state === "ready" ? "Stateful risk metric" : "Not available"),
     state: resolveMetricState(item.state),
   }));
-}
-
-function resolveMetricState(state: RiskModuleState): PerformanceRiskState {
-  if (state === "ready" || state === "partial" || state === "unavailable") {
-    return state;
-  }
-  return "unavailable";
 }
 
 function mapConcentrationMetrics(response: WorkbenchRiskConcentrationResponse) {
@@ -497,4 +480,11 @@ function formatRiskMetric(metric: WorkbenchRiskMetric) {
     return formatPercent(metric.value);
   }
   return formatNumber(metric.value, { maximumFractionDigits: 2 });
+}
+
+function resolveMetricState(state: WorkbenchRiskModuleState): PerformanceRiskState {
+  if (state === "ready" || state === "partial" || state === "unavailable") {
+    return state;
+  }
+  return "unavailable";
 }

--- a/src/apps/performance/risk-workspace-view-model.ts
+++ b/src/apps/performance/risk-workspace-view-model.ts
@@ -1,0 +1,500 @@
+import type { WorkbenchPerformanceWorkspace } from "@/features/workbench/types";
+import {
+  formatDateValue,
+  formatNumber,
+  formatPercent,
+} from "@/design-system/utils/financial-formatters";
+
+type RiskModuleState = "ready" | "partial" | "unavailable" | "blocked";
+type RiskSupportabilityState = RiskModuleState;
+
+export type WorkbenchRiskSupportabilityItem = {
+  key: string;
+  label: string;
+  state: RiskSupportabilityState;
+  reason?: string | null;
+  source_service?: string | null;
+};
+
+export type WorkbenchRiskMetric = {
+  key: string;
+  label: string;
+  value: number | null;
+  state: RiskModuleState;
+  reason?: string | null;
+  details?: Record<string, unknown> | null;
+};
+
+export type WorkbenchRiskSummaryResponse = {
+  correlation_id: string;
+  contract_version: "risk-workspace.v1";
+  portfolio_id: string;
+  period: string;
+  as_of_date: string;
+  benchmark_code?: string | null;
+  source_service: "lotus-risk";
+  state: RiskModuleState;
+  payload: {
+    periods: Array<{
+      key: string;
+      label: string;
+      start_date: string;
+      end_date: string;
+      metrics: WorkbenchRiskMetric[];
+    }>;
+  } | null;
+  supportability: WorkbenchRiskSupportabilityItem[];
+  warnings: string[];
+  partial_failures: Array<{
+    source_service: string;
+    error_code: string;
+    detail: string;
+  }>;
+  metadata: {
+    generated_at: string;
+    input_mode: "stateful";
+    methodology_version?: string | null;
+    cache_status?: "hit" | "miss" | "bypass" | null;
+  };
+};
+
+export type WorkbenchRiskConcentrationResponse = {
+  correlation_id: string;
+  contract_version: "risk-workspace.v1";
+  portfolio_id: string;
+  period: string;
+  as_of_date: string;
+  benchmark_code?: string | null;
+  source_service: "lotus-risk";
+  state: RiskModuleState;
+  payload: {
+    risk_proxy: {
+      hhi_current: number;
+      hhi_proposed: number;
+      hhi_delta: number;
+    };
+    single_position_concentration: {
+      top_position_weight_current: number;
+      top_position_weight_proposed: number;
+      top_position_weight_delta: number;
+      top_n_cumulative_weight_current: number;
+      top_n_cumulative_weight_proposed: number;
+      top_n_cumulative_weight_delta: number;
+      top_n: number;
+    };
+    issuer_concentration: {
+      hhi_current: number;
+      hhi_proposed: number;
+      hhi_delta: number;
+      top_issuer_weight_current: number;
+      top_issuer_weight_proposed: number;
+      top_issuer_weight_delta: number;
+      coverage_status: string;
+      covered_position_count_current: number;
+      covered_position_count_proposed: number;
+      total_position_count_current: number;
+      total_position_count_proposed: number;
+      note?: string | null;
+    };
+    valuation_context?: Record<string, unknown> | null;
+    risk_metadata?: Record<string, unknown> | null;
+  } | null;
+  supportability: WorkbenchRiskSupportabilityItem[];
+  warnings: string[];
+  partial_failures: Array<{
+    source_service: string;
+    error_code: string;
+    detail: string;
+  }>;
+  metadata: {
+    generated_at: string;
+    input_mode: "stateful";
+    methodology_version?: string | null;
+    cache_status?: "hit" | "miss" | "bypass" | null;
+  };
+};
+
+export type PerformanceRiskState =
+  | "loading"
+  | "ready"
+  | "partial"
+  | "empty"
+  | "unavailable"
+  | "error";
+
+export type PerformanceRiskViewModel = {
+  state: PerformanceRiskState;
+  title: string;
+  synopsis: string;
+  contextItems: Array<{ label: string; value: string }>;
+  snapshotMetrics: Array<{
+    key: string;
+    label: string;
+    value: string;
+    support: string;
+    state: PerformanceRiskState;
+  }>;
+  concentrationMetrics: Array<{
+    key: string;
+    label: string;
+    value: string;
+    support: string;
+  }>;
+  supportability: Array<{
+    key: string;
+    label: string;
+    state: RiskSupportabilityState;
+    reason?: string | null;
+  }>;
+  provenance: Array<{ label: string; value: string }>;
+  warnings: string[];
+  partialFailures: string[];
+};
+
+export type BuildPerformanceRiskViewModelOptions = {
+  workspace: WorkbenchPerformanceWorkspace;
+  period: string;
+  detailBasis: string;
+  isDetailsPending?: boolean;
+  riskSummary?: WorkbenchRiskSummaryResponse | null;
+  riskConcentration?: WorkbenchRiskConcentrationResponse | null;
+  unavailable?: boolean;
+};
+
+export function buildPerformanceRiskViewModel({
+  workspace,
+  period,
+  detailBasis,
+  isDetailsPending = false,
+  riskSummary,
+  riskConcentration,
+  unavailable = false,
+}: BuildPerformanceRiskViewModelOptions): PerformanceRiskViewModel {
+  if (isDetailsPending) {
+    return buildStateViewModel(workspace, period, detailBasis, "loading");
+  }
+  if (unavailable) {
+    return buildStateViewModel(workspace, period, detailBasis, "unavailable");
+  }
+
+  const summary = riskSummary ?? buildFixtureRiskSummary(workspace, period, detailBasis);
+  const concentration =
+    riskConcentration ?? buildFixtureRiskConcentration(workspace, period);
+  const supportability = [...summary.supportability, ...concentration.supportability];
+  const hasPayload = Boolean(summary.payload?.periods.length || concentration.payload);
+
+  const state = !hasPayload
+    ? "empty"
+    : summary.state === "unavailable" || concentration.state === "unavailable"
+      ? "partial"
+      : summary.state === "partial" || concentration.state === "partial"
+        ? "partial"
+        : "ready";
+
+  return {
+    state,
+    title: "Stateful Risk",
+    synopsis:
+      state === "partial"
+        ? "Risk is available with coverage notes. Review issuer and benchmark supportability before using the result externally."
+        : "Stateful portfolio risk is available for the selected performance context.",
+    contextItems: buildContextItems(workspace, period, detailBasis, summary.as_of_date),
+    snapshotMetrics: mapSnapshotMetrics(summary),
+    concentrationMetrics: mapConcentrationMetrics(concentration),
+    supportability: supportability.map((item) => ({
+      key: item.key,
+      label: item.label,
+      state: item.state,
+      reason: item.reason,
+    })),
+    provenance: [
+      { label: "Contract", value: summary.contract_version },
+      { label: "Source", value: "lotus-risk via lotus-gateway" },
+      { label: "Input Mode", value: "Stateful only" },
+      { label: "Cache", value: summary.metadata.cache_status ?? "miss" },
+      { label: "Generated", value: formatDateValue(summary.metadata.generated_at) },
+    ],
+    warnings: [...summary.warnings, ...concentration.warnings],
+    partialFailures: [
+      ...summary.partial_failures.map((failure) => failure.detail),
+      ...concentration.partial_failures.map((failure) => failure.detail),
+    ],
+  };
+}
+
+function buildStateViewModel(
+  workspace: WorkbenchPerformanceWorkspace,
+  period: string,
+  detailBasis: string,
+  state: PerformanceRiskState
+): PerformanceRiskViewModel {
+  const asOfDate = workspace.as_of_date;
+  const title =
+    state === "loading"
+      ? "Loading stateful risk"
+      : state === "unavailable"
+        ? "Risk unavailable"
+        : "Risk not available";
+  return {
+    state,
+    title,
+    synopsis:
+      state === "loading"
+        ? "Risk snapshot and concentration modules are loading from the Gateway BFF contract."
+        : "Stateful risk is not available for the selected portfolio context.",
+    contextItems: buildContextItems(workspace, period, detailBasis, asOfDate),
+    snapshotMetrics: [],
+    concentrationMetrics: [],
+    supportability: [
+      {
+        key: "risk_bff",
+        label: "Risk BFF",
+        state: state === "loading" ? "partial" : "unavailable",
+        reason:
+          state === "loading"
+            ? "Gateway risk contract is being prepared."
+            : "Gateway risk BFF response is not available.",
+      },
+    ],
+    provenance: [
+      { label: "Contract", value: "risk-workspace.v1" },
+      { label: "Input Mode", value: "Stateful only" },
+    ],
+    warnings: state === "loading" ? [] : ["RISK_WORKSPACE_UNAVAILABLE"],
+    partialFailures: [],
+  };
+}
+
+function buildFixtureRiskSummary(
+  workspace: WorkbenchPerformanceWorkspace,
+  period: string,
+  detailBasis: string
+): WorkbenchRiskSummaryResponse {
+  const selectedPerformance =
+    detailBasis === "GROSS" ? workspace.gross_performance : workspace.net_performance;
+  const activeReturn = selectedPerformance.active_return_pct ?? 0;
+  const volatility = Math.max(Math.abs(activeReturn) * 1.8, 7.25);
+  const trackingError = Math.max(Math.abs(activeReturn) * 0.8, 2.15);
+  return {
+    correlation_id: "fixture-risk-summary",
+    contract_version: "risk-workspace.v1",
+    portfolio_id: workspace.portfolio.portfolio_id,
+    period,
+    as_of_date: workspace.as_of_date,
+    benchmark_code: workspace.benchmark_code,
+    source_service: "lotus-risk",
+    state: workspace.benchmark_code ? "partial" : "unavailable",
+    payload: {
+      periods: [
+        {
+          key: period,
+          label: period,
+          start_date: workspace.report_start_date,
+          end_date: workspace.report_end_date,
+          metrics: [
+            metric("VOLATILITY", "Volatility", volatility, "ready"),
+            metric("SHARPE", "Sharpe", 0.82, "ready"),
+            metric("SORTINO", "Sortino", 1.05, "ready"),
+            metric("BETA", "Beta", 0.94, workspace.benchmark_code ? "ready" : "unavailable"),
+            metric(
+              "TRACKING_ERROR",
+              "Tracking Error",
+              trackingError,
+              workspace.benchmark_code ? "ready" : "unavailable"
+            ),
+            metric(
+              "INFORMATION_RATIO",
+              "Information Ratio",
+              activeReturn / trackingError,
+              workspace.benchmark_code ? "ready" : "unavailable"
+            ),
+            metric("VAR", "Value at Risk", -1.74, "ready", { expected_shortfall: -2.26 }),
+          ],
+        },
+      ],
+    },
+    supportability: [
+      {
+        key: "portfolio_returns",
+        label: "Portfolio returns",
+        state: "ready",
+        source_service: "lotus-risk",
+      },
+      {
+        key: "benchmark_returns",
+        label: "Benchmark returns",
+        state: workspace.benchmark_code ? "ready" : "unavailable",
+        reason: workspace.benchmark_code ? null : "Benchmark-relative risk requires benchmark context.",
+        source_service: "lotus-risk",
+      },
+      {
+        key: "risk_free_series",
+        label: "Risk-free series",
+        state: "partial",
+        reason: "Sharpe uses the configured zero risk-free fallback until a curve is published.",
+        source_service: "lotus-risk",
+      },
+    ],
+    warnings: ["RISK_UI_FIXTURE_CONTRACT"],
+    partial_failures: [],
+    metadata: {
+      generated_at: workspace.as_of_date,
+      input_mode: "stateful",
+      methodology_version: "risk-workspace.fixture.v1",
+      cache_status: "bypass",
+    },
+  };
+}
+
+function buildFixtureRiskConcentration(
+  workspace: WorkbenchPerformanceWorkspace,
+  period: string
+): WorkbenchRiskConcentrationResponse {
+  return {
+    correlation_id: "fixture-risk-concentration",
+    contract_version: "risk-workspace.v1",
+    portfolio_id: workspace.portfolio.portfolio_id,
+    period,
+    as_of_date: workspace.as_of_date,
+    benchmark_code: workspace.benchmark_code,
+    source_service: "lotus-risk",
+    state: "partial",
+    payload: {
+      risk_proxy: { hhi_current: 1260, hhi_proposed: 1260, hhi_delta: 0 },
+      single_position_concentration: {
+        top_position_weight_current: 0.184,
+        top_position_weight_proposed: 0.184,
+        top_position_weight_delta: 0,
+        top_n_cumulative_weight_current: 0.528,
+        top_n_cumulative_weight_proposed: 0.528,
+        top_n_cumulative_weight_delta: 0,
+        top_n: 10,
+      },
+      issuer_concentration: {
+        hhi_current: 1448,
+        hhi_proposed: 1448,
+        hhi_delta: 0,
+        top_issuer_weight_current: 0.214,
+        top_issuer_weight_proposed: 0.214,
+        top_issuer_weight_delta: 0,
+        coverage_status: "partial",
+        covered_position_count_current: 8,
+        covered_position_count_proposed: 8,
+        total_position_count_current: 10,
+        total_position_count_proposed: 10,
+        note: "Issuer enrichment is partial in the current stateful risk contract.",
+      },
+      valuation_context: { reporting_currency: workspace.portfolio.base_currency },
+      risk_metadata: { fixture: true },
+    },
+    supportability: [
+      {
+        key: "portfolio_positions",
+        label: "Portfolio positions",
+        state: "ready",
+        source_service: "lotus-risk",
+      },
+      {
+        key: "issuer_enrichment",
+        label: "Issuer enrichment",
+        state: "partial",
+        reason: "Issuer coverage is partial in the current stateful risk contract.",
+        source_service: "lotus-risk",
+      },
+    ],
+    warnings: ["RISK_CONCENTRATION_FIXTURE_CONTRACT"],
+    partial_failures: [],
+    metadata: {
+      generated_at: workspace.as_of_date,
+      input_mode: "stateful",
+      methodology_version: "concentration.fixture.v1",
+      cache_status: "bypass",
+    },
+  };
+}
+
+function metric(
+  key: string,
+  label: string,
+  value: number | null,
+  state: RiskModuleState,
+  details?: Record<string, unknown>
+): WorkbenchRiskMetric {
+  return { key, label, value, state, details };
+}
+
+function buildContextItems(
+  workspace: WorkbenchPerformanceWorkspace,
+  period: string,
+  detailBasis: string,
+  asOfDate: string
+) {
+  return [
+    { label: "Portfolio", value: workspace.portfolio.portfolio_id },
+    { label: "Period", value: period },
+    { label: "Basis", value: detailBasis },
+    { label: "Benchmark", value: workspace.benchmark_code ?? "Unassigned" },
+    { label: "As of", value: formatDateValue(asOfDate) },
+  ];
+}
+
+function mapSnapshotMetrics(response: WorkbenchRiskSummaryResponse) {
+  const metrics = response.payload?.periods[0]?.metrics ?? [];
+  return metrics.map((item) => ({
+    key: item.key,
+    label: item.label,
+    value: formatRiskMetric(item),
+    support: item.reason ?? (item.state === "ready" ? "Stateful risk metric" : "Not available"),
+    state: resolveMetricState(item.state),
+  }));
+}
+
+function resolveMetricState(state: RiskModuleState): PerformanceRiskState {
+  if (state === "ready" || state === "partial" || state === "unavailable") {
+    return state;
+  }
+  return "unavailable";
+}
+
+function mapConcentrationMetrics(response: WorkbenchRiskConcentrationResponse) {
+  const payload = response.payload;
+  if (!payload) {
+    return [];
+  }
+  return [
+    {
+      key: "hhi_current",
+      label: "HHI",
+      value: formatNumber(payload.risk_proxy.hhi_current, { maximumFractionDigits: 0 }),
+      support: "Current portfolio concentration",
+    },
+    {
+      key: "top_position_weight",
+      label: "Top Position",
+      value: formatPercent(payload.single_position_concentration.top_position_weight_current * 100),
+      support: "Largest single-position weight",
+    },
+    {
+      key: "top_issuer_weight",
+      label: "Top Issuer",
+      value: formatPercent(payload.issuer_concentration.top_issuer_weight_current * 100),
+      support: "Largest issuer exposure",
+    },
+    {
+      key: "issuer_coverage",
+      label: "Issuer Coverage",
+      value: `${payload.issuer_concentration.covered_position_count_current}/${payload.issuer_concentration.total_position_count_current}`,
+      support: payload.issuer_concentration.note ?? "Issuer enrichment coverage",
+    },
+  ];
+}
+
+function formatRiskMetric(metric: WorkbenchRiskMetric) {
+  if (typeof metric.value !== "number") {
+    return "N/A";
+  }
+  if (["VOLATILITY", "TRACKING_ERROR", "VAR"].includes(metric.key)) {
+    return formatPercent(metric.value);
+  }
+  return formatNumber(metric.value, { maximumFractionDigits: 2 });
+}

--- a/src/apps/performance/risk-workspace-view-model.ts
+++ b/src/apps/performance/risk-workspace-view-model.ts
@@ -1,6 +1,8 @@
 import type {
   WorkbenchPerformanceWorkspace,
   WorkbenchRiskConcentrationResponse,
+  WorkbenchRiskDrawdownResponse,
+  WorkbenchRiskDrawdownSummary,
   WorkbenchRiskMetric,
   WorkbenchRiskModuleState,
   WorkbenchRiskSummaryResponse,
@@ -37,6 +39,35 @@ export type PerformanceRiskViewModel = {
     value: string;
     support: string;
   }>;
+  drawdownHeadlineMetrics: Array<{
+    key: string;
+    label: string;
+    value: string;
+    support: string;
+    state: PerformanceRiskState;
+  }>;
+  drawdownEpisodes: Array<{
+    key: string;
+    episode: string;
+    depth: string;
+    peakDate: string;
+    troughDate: string;
+    recoveryDate: string;
+    totalDays: string;
+    status: string;
+  }>;
+  drawdownRelativeMetric: {
+    label: string;
+    value: string;
+    support: string;
+    state: PerformanceRiskState;
+  } | null;
+  underwaterSeries: Array<{
+    key: string;
+    date: string;
+    drawdown: string;
+  }>;
+  underwaterDetailState: "idle" | "loading" | "ready" | "unavailable";
   supportability: Array<{
     key: string;
     label: string;
@@ -55,6 +86,9 @@ export type BuildPerformanceRiskViewModelOptions = {
   isDetailsPending?: boolean;
   riskSummary?: WorkbenchRiskSummaryResponse | null;
   riskConcentration?: WorkbenchRiskConcentrationResponse | null;
+  riskDrawdown?: WorkbenchRiskDrawdownResponse | null;
+  riskDrawdownDetail?: WorkbenchRiskDrawdownResponse | null;
+  isDrawdownDetailLoading?: boolean;
 };
 
 export function buildPerformanceRiskViewModel({
@@ -64,6 +98,9 @@ export function buildPerformanceRiskViewModel({
   isDetailsPending = false,
   riskSummary,
   riskConcentration,
+  riskDrawdown,
+  riskDrawdownDetail,
+  isDrawdownDetailLoading = false,
 }: BuildPerformanceRiskViewModelOptions): PerformanceRiskViewModel {
   if (isDetailsPending) {
     return buildStateViewModel(workspace, period, detailBasis, "loading");
@@ -82,11 +119,27 @@ export function buildPerformanceRiskViewModel({
     buildUnavailableRiskConcentration({
       workspace,
       period,
-      detail: "Risk concentration is not available from the Gateway BFF.",
+        detail: "Risk concentration is not available from the Gateway BFF.",
     });
+  const drawdown =
+    riskDrawdown ??
+    buildUnavailableRiskDrawdown({
+      workspace,
+      period,
+      detailBasis,
+      detail: "Risk drawdown is not available from the Gateway BFF.",
+      includeUnderwaterSeries: false,
+    });
+  const drawdownDetail = riskDrawdownDetail ?? null;
 
-  const supportability = [...summary.supportability, ...concentration.supportability];
-  const hasPayload = Boolean(summary.payload?.periods.length || concentration.payload);
+  const supportability = [
+    ...mapSupportabilityGroup("summary", summary.supportability),
+    ...mapSupportabilityGroup("concentration", concentration.supportability),
+    ...mapSupportabilityGroup("drawdown", drawdown.supportability),
+  ];
+  const hasPayload = Boolean(
+    summary.payload?.periods.length || concentration.payload || drawdown.payload?.periods.length
+  );
   const state = !hasPayload
     ? "unavailable"
     : summary.state === "ready" && concentration.state === "ready"
@@ -105,6 +158,15 @@ export function buildPerformanceRiskViewModel({
     contextItems: buildContextItems(workspace, period, detailBasis, summary.as_of_date),
     snapshotMetrics: mapSnapshotMetrics(summary),
     concentrationMetrics: mapConcentrationMetrics(concentration),
+    drawdownHeadlineMetrics: mapDrawdownHeadlineMetrics(drawdown),
+    drawdownEpisodes: mapDrawdownEpisodes(drawdown),
+    drawdownRelativeMetric: mapRelativeDrawdownMetric(drawdown),
+    underwaterSeries: mapUnderwaterSeries(drawdownDetail),
+    underwaterDetailState: resolveUnderwaterDetailState({
+      drawdown,
+      drawdownDetail,
+      isDrawdownDetailLoading,
+    }),
     supportability: supportability.map((item) => ({
       key: item.key,
       label: item.label,
@@ -118,10 +180,11 @@ export function buildPerformanceRiskViewModel({
       { label: "Cache", value: summary.metadata.cache_status ?? "miss" },
       { label: "Generated", value: formatDateValue(summary.metadata.generated_at) },
     ],
-    warnings: [...summary.warnings, ...concentration.warnings],
+    warnings: [...summary.warnings, ...concentration.warnings, ...drawdown.warnings],
     partialFailures: [
       ...summary.partial_failures.map((failure) => failure.detail),
       ...concentration.partial_failures.map((failure) => failure.detail),
+      ...drawdown.partial_failures.map((failure) => failure.detail),
     ],
   };
 }
@@ -277,6 +340,126 @@ export function buildFixtureRiskConcentration(
   };
 }
 
+export function buildFixtureRiskDrawdown(
+  workspace: WorkbenchPerformanceWorkspace,
+  period: string,
+  detailBasis: string,
+  options?: {
+    includeUnderwaterSeries?: boolean;
+    includeBenchmarkRelative?: boolean;
+  }
+): WorkbenchRiskDrawdownResponse {
+  const includeUnderwaterSeries = options?.includeUnderwaterSeries ?? false;
+  const includeBenchmarkRelative = options?.includeBenchmarkRelative ?? Boolean(workspace.benchmark_code);
+  return {
+    correlation_id: "fixture-risk-drawdown",
+    contract_version: "risk-workspace.v1",
+    portfolio_id: workspace.portfolio.portfolio_id,
+    period,
+    as_of_date: workspace.as_of_date,
+    benchmark_code: workspace.benchmark_code,
+    source_service: "lotus-risk",
+    state: includeBenchmarkRelative ? "partial" : "partial",
+    payload: {
+      periods: [
+        {
+          key: period,
+          label: period,
+          start_date: workspace.report_start_date,
+          end_date: workspace.report_end_date,
+          summary: {
+            max_drawdown: -0.124533,
+            max_drawdown_peak_date: "2026-01-12",
+            max_drawdown_trough_date: "2026-02-03",
+            max_drawdown_recovery_date: null,
+            is_recovered: false,
+            days_to_trough: 16,
+            days_to_recovery: null,
+            time_under_water_days: 34,
+            average_drawdown: -0.041208,
+            ulcer_index: 0.053901,
+            drawdown_at_risk_95: -0.101552,
+            conditional_drawdown_at_risk_95: -0.117884,
+          },
+          episodes: [
+            {
+              episode_id: "dd_0001",
+              peak_date: "2026-01-12",
+              trough_date: "2026-02-03",
+              recovery_date: null,
+              depth: -0.124533,
+              days_to_trough: 16,
+              days_to_recovery: null,
+              total_days: 34,
+              is_recovered: false,
+            },
+            {
+              episode_id: "dd_0002",
+              peak_date: "2026-02-12",
+              trough_date: "2026-02-13",
+              recovery_date: "2026-02-19",
+              depth: -0.055,
+              days_to_trough: 1,
+              days_to_recovery: 4,
+              total_days: 7,
+              is_recovered: true,
+            },
+          ],
+          relative_to_benchmark: includeBenchmarkRelative
+            ? {
+                max_drawdown: -0.0821,
+                max_drawdown_peak_date: "2026-01-11",
+                max_drawdown_trough_date: "2026-02-01",
+              }
+            : null,
+          underwater_series: includeUnderwaterSeries
+            ? [
+                { date: "2026-01-20", drawdown: -0.0521 },
+                { date: "2026-01-21", drawdown: -0.061 },
+                { date: "2026-01-22", drawdown: -0.0734 },
+              ]
+            : null,
+          error: null,
+        },
+      ],
+    },
+    supportability: [
+      {
+        key: "portfolio_returns",
+        label: "Portfolio returns",
+        state: "ready",
+        source_service: "lotus-risk",
+      },
+      {
+        key: "benchmark_relative_drawdown",
+        label: "Benchmark-relative drawdown",
+        state: includeBenchmarkRelative ? "ready" : "partial",
+        reason: includeBenchmarkRelative
+          ? null
+          : "Benchmark-relative drawdown requires benchmark context.",
+        source_service: "lotus-risk",
+      },
+      {
+        key: "underwater_series",
+        label: "Underwater series",
+        state: includeUnderwaterSeries ? "ready" : "partial",
+        reason: includeUnderwaterSeries
+          ? null
+          : "Underwater series is available on demand and is not included in first paint.",
+        source_service: "lotus-risk",
+      },
+    ],
+    warnings: includeUnderwaterSeries ? [] : ["RISK_DRAWDOWN_UNDERWATER_DEFERRED"],
+    partial_failures: [],
+    metadata: {
+      generated_at: workspace.as_of_date,
+      input_mode: "stateful",
+      methodology_version: "drawdown.fixture.v1",
+      cache_status: "bypass",
+    },
+  };
+}
+
 export function buildUnavailableRiskSummary({
   workspace,
   period,
@@ -359,6 +542,50 @@ export function buildUnavailableRiskConcentration({
   };
 }
 
+export function buildUnavailableRiskDrawdown({
+  workspace,
+  period,
+  detailBasis,
+  detail,
+  includeUnderwaterSeries,
+}: {
+  workspace: WorkbenchPerformanceWorkspace;
+  period: string;
+  detailBasis: string;
+  detail: string;
+  includeUnderwaterSeries: boolean;
+}): WorkbenchRiskDrawdownResponse {
+  return {
+    correlation_id: "risk-drawdown-unavailable",
+    contract_version: "risk-workspace.v1",
+    portfolio_id: workspace.portfolio.portfolio_id,
+    period,
+    as_of_date: workspace.as_of_date,
+    benchmark_code: workspace.benchmark_code,
+    source_service: "lotus-risk",
+    state: "unavailable",
+    payload: null,
+    supportability: [
+      {
+        key: "risk_drawdown",
+        label: includeUnderwaterSeries ? "Risk drawdown detail" : "Risk drawdown",
+        state: "unavailable",
+        reason: `${detail} (${detailBasis} basis)`,
+        source_service: "lotus-risk",
+      },
+    ],
+    warnings: ["RISK_DRAWDOWN_UNAVAILABLE"],
+    partial_failures: [
+      { source_service: "risk", error_code: "RISK_DRAWDOWN_UNAVAILABLE", detail },
+    ],
+    metadata: {
+      generated_at: workspace.as_of_date,
+      input_mode: "stateful",
+      cache_status: "miss",
+    },
+  };
+}
+
 function buildStateViewModel(
   workspace: WorkbenchPerformanceWorkspace,
   period: string,
@@ -383,6 +610,11 @@ function buildStateViewModel(
     contextItems: buildContextItems(workspace, period, detailBasis, asOfDate),
     snapshotMetrics: [],
     concentrationMetrics: [],
+    drawdownHeadlineMetrics: [],
+    drawdownEpisodes: [],
+    drawdownRelativeMetric: null,
+    underwaterSeries: [],
+    underwaterDetailState: "idle",
     supportability: [
       {
         key: "risk_bff",
@@ -472,6 +704,117 @@ function mapConcentrationMetrics(response: WorkbenchRiskConcentrationResponse) {
   ];
 }
 
+function mapDrawdownHeadlineMetrics(response: WorkbenchRiskDrawdownResponse) {
+  const summary = response.payload?.periods[0]?.summary;
+  if (!summary) {
+    return [];
+  }
+  return [
+    {
+      key: "max_drawdown",
+      label: "Max Drawdown",
+      value: formatDrawdownPercent(summary.max_drawdown),
+      support: buildDrawdownDateRange(summary),
+      state: resolveModuleState(response.state),
+    },
+    {
+      key: "time_under_water_days",
+      label: "Time Under Water",
+      value: formatInteger(summary.time_under_water_days),
+      support: "Business days below prior peak",
+      state: resolveModuleState(response.state),
+    },
+    {
+      key: "ulcer_index",
+      label: "Ulcer Index",
+      value: formatDrawdownPercent(summary.ulcer_index),
+      support: "Path severity across underwater observations",
+      state: resolveModuleState(response.state),
+    },
+    {
+      key: "drawdown_at_risk_95",
+      label: "DaR 95",
+      value: formatDrawdownPercent(summary.drawdown_at_risk_95),
+      support: "Episode-tail drawdown threshold",
+      state: resolveModuleState(response.state),
+    },
+    {
+      key: "conditional_drawdown_at_risk_95",
+      label: "CDaR 95",
+      value: formatDrawdownPercent(summary.conditional_drawdown_at_risk_95),
+      support: "Average of worst drawdown tail",
+      state: resolveModuleState(response.state),
+    },
+  ];
+}
+
+function mapDrawdownEpisodes(response: WorkbenchRiskDrawdownResponse) {
+  const episodes = response.payload?.periods[0]?.episodes ?? [];
+  return episodes.map((episode) => ({
+    key: episode.episode_id,
+    episode: episode.episode_id.toUpperCase(),
+    depth: formatDrawdownPercent(episode.depth),
+    peakDate: formatDateValue(episode.peak_date),
+    troughDate: formatDateValue(episode.trough_date),
+    recoveryDate: episode.recovery_date ? formatDateValue(episode.recovery_date) : "Open",
+    totalDays: formatInteger(episode.total_days),
+    status: episode.is_recovered ? "Recovered" : "Open",
+  }));
+}
+
+function mapRelativeDrawdownMetric(response: WorkbenchRiskDrawdownResponse) {
+  const relative = response.payload?.periods[0]?.relative_to_benchmark;
+  const supportability = response.supportability.find(
+    (item) => item.key === "benchmark_relative_drawdown"
+  );
+  if (!relative && !supportability) {
+    return null;
+  }
+  return {
+    label: "Relative Max Drawdown",
+    value: relative ? formatDrawdownPercent(relative.max_drawdown) : "N/A",
+    support:
+      supportability?.reason ??
+      (relative
+        ? `${formatDateValue(relative.max_drawdown_peak_date ?? "")} to ${formatDateValue(
+            relative.max_drawdown_trough_date ?? ""
+          )}`
+        : "Benchmark-relative drawdown not available."),
+    state: resolveMetricState(supportability?.state ?? "unavailable"),
+  };
+}
+
+function mapUnderwaterSeries(response: WorkbenchRiskDrawdownResponse | null) {
+  const points = response?.payload?.periods[0]?.underwater_series ?? [];
+  return points.map((point) => ({
+    key: `${point.date}-${point.drawdown}`,
+    date: formatDateValue(point.date),
+    drawdown: formatDrawdownPercent(point.drawdown),
+  }));
+}
+
+function resolveUnderwaterDetailState({
+  drawdown,
+  drawdownDetail,
+  isDrawdownDetailLoading,
+}: {
+  drawdown: WorkbenchRiskDrawdownResponse;
+  drawdownDetail: WorkbenchRiskDrawdownResponse | null;
+  isDrawdownDetailLoading: boolean;
+}): "idle" | "loading" | "ready" | "unavailable" {
+  if (isDrawdownDetailLoading) {
+    return "loading";
+  }
+  if (drawdownDetail?.payload?.periods[0]?.underwater_series?.length) {
+    return "ready";
+  }
+  if (drawdownDetail?.state === "unavailable") {
+    return "unavailable";
+  }
+  const supportability = drawdown.supportability.find((item) => item.key === "underwater_series");
+  return supportability?.state === "unavailable" ? "unavailable" : "idle";
+}
+
 function formatRiskMetric(metric: WorkbenchRiskMetric) {
   if (typeof metric.value !== "number") {
     return "N/A";
@@ -482,9 +825,46 @@ function formatRiskMetric(metric: WorkbenchRiskMetric) {
   return formatNumber(metric.value, { maximumFractionDigits: 2 });
 }
 
-function resolveMetricState(state: WorkbenchRiskModuleState): PerformanceRiskState {
+function formatDrawdownPercent(value: number | null | undefined) {
+  if (typeof value !== "number") {
+    return "N/A";
+  }
+  return formatPercent(value * 100);
+}
+
+function formatInteger(value: number | null | undefined) {
+  if (typeof value !== "number") {
+    return "N/A";
+  }
+  return formatNumber(value, { maximumFractionDigits: 0 });
+}
+
+function buildDrawdownDateRange(summary: WorkbenchRiskDrawdownSummary) {
+  if (!summary.max_drawdown_peak_date || !summary.max_drawdown_trough_date) {
+    return "Peak/trough timing unavailable";
+  }
+  return `${formatDateValue(summary.max_drawdown_peak_date)} to ${formatDateValue(
+    summary.max_drawdown_trough_date
+  )}`;
+}
+
+function resolveModuleState(state: WorkbenchRiskModuleState): PerformanceRiskState {
   if (state === "ready" || state === "partial" || state === "unavailable") {
     return state;
   }
   return "unavailable";
+}
+
+function resolveMetricState(state: WorkbenchRiskModuleState): PerformanceRiskState {
+  return resolveModuleState(state);
+}
+
+function mapSupportabilityGroup(
+  group: "summary" | "concentration" | "drawdown",
+  items: PerformanceRiskViewModel["supportability"]
+) {
+  return items.map((item) => ({
+    ...item,
+    key: `${group}:${item.key}`,
+  }));
 }

--- a/src/apps/performance/risk-workspace-view-model.ts
+++ b/src/apps/performance/risk-workspace-view-model.ts
@@ -1,5 +1,6 @@
 import type {
   WorkbenchPerformanceWorkspace,
+  WorkbenchRiskAttributionResponse,
   WorkbenchRiskConcentrationResponse,
   WorkbenchRiskDrawdownResponse,
   WorkbenchRiskDrawdownSummary,
@@ -97,6 +98,39 @@ export type PerformanceRiskViewModel = {
   }>;
   rollingQualityFlags: string[];
   rollingDetailState: "idle" | "loading" | "ready" | "unavailable";
+  attributionControls: {
+    selectedAttributionType: string;
+    selectedGroupingDimension: string;
+    attributionTypes: Array<{
+      key: string;
+      label: string;
+      disabled: boolean;
+      reason?: string | null;
+    }>;
+    groupingDimensions: Array<{
+      key: string;
+      label: string;
+      disabled: boolean;
+      reason?: string | null;
+    }>;
+  } | null;
+  attributionRows: Array<{
+    key: string;
+    group: string;
+    avgWeight: string;
+    marginalContribution: string;
+    componentContribution: string;
+    contributionShare: string;
+  }>;
+  attributionTotals: {
+    metric: string;
+    totalValue: string;
+    reconciledSum: string;
+    residual: string;
+    support: string;
+  } | null;
+  attributionState: "idle" | "loading" | "ready" | "blocked" | "unavailable";
+  attributionWarnings: string[];
   supportability: Array<{
     key: string;
     label: string;
@@ -115,10 +149,12 @@ export type BuildPerformanceRiskViewModelOptions = {
   isDetailsPending?: boolean;
   riskSummary?: WorkbenchRiskSummaryResponse | null;
   riskConcentration?: WorkbenchRiskConcentrationResponse | null;
+  riskAttribution?: WorkbenchRiskAttributionResponse | null;
   riskDrawdown?: WorkbenchRiskDrawdownResponse | null;
   riskDrawdownDetail?: WorkbenchRiskDrawdownResponse | null;
   riskRolling?: WorkbenchRiskRollingResponse | null;
   riskRollingDetail?: WorkbenchRiskRollingResponse | null;
+  isAttributionLoading?: boolean;
   isDrawdownDetailLoading?: boolean;
   isRollingDetailLoading?: boolean;
 };
@@ -132,10 +168,12 @@ export function buildPerformanceRiskViewModel({
   isDetailsPending = false,
   riskSummary,
   riskConcentration,
+  riskAttribution,
   riskDrawdown,
   riskDrawdownDetail,
   riskRolling,
   riskRollingDetail,
+  isAttributionLoading = false,
   isDrawdownDetailLoading = false,
   isRollingDetailLoading = false,
 }: BuildPerformanceRiskViewModelOptions): PerformanceRiskViewModel {
@@ -158,6 +196,7 @@ export function buildPerformanceRiskViewModel({
       period,
       detail: "Risk concentration is not available from the Gateway BFF.",
     });
+  const attribution = riskAttribution ?? null;
   const drawdown =
     riskDrawdown ??
     buildUnavailableRiskDrawdown({
@@ -182,12 +221,14 @@ export function buildPerformanceRiskViewModel({
   const supportability = [
     ...mapSupportabilityGroup("summary", summary.supportability),
     ...mapSupportabilityGroup("concentration", concentration.supportability),
+    ...mapSupportabilityGroup("attribution", attribution?.supportability ?? []),
     ...mapSupportabilityGroup("drawdown", drawdown.supportability),
     ...mapSupportabilityGroup("rolling", rolling.supportability),
   ];
   const hasPayload = Boolean(
     summary.payload?.periods.length ||
       concentration.payload ||
+      attribution?.payload?.periods.length ||
       drawdown.payload?.periods.length ||
       rolling.payload?.periods.length
   );
@@ -226,6 +267,11 @@ export function buildPerformanceRiskViewModel({
       rollingDetail,
       isRollingDetailLoading,
     }),
+    attributionControls: mapAttributionControls(attribution),
+    attributionRows: mapAttributionRows(attribution),
+    attributionTotals: mapAttributionTotals(attribution),
+    attributionState: resolveAttributionState({ attribution, isAttributionLoading }),
+    attributionWarnings: attribution?.warnings ?? [],
     supportability: supportability.map((item) => ({
       key: item.key,
       label: item.label,
@@ -242,12 +288,14 @@ export function buildPerformanceRiskViewModel({
     warnings: [
       ...summary.warnings,
       ...concentration.warnings,
+      ...(attribution?.warnings ?? []),
       ...drawdown.warnings,
       ...rolling.warnings,
     ],
     partialFailures: [
       ...summary.partial_failures.map((failure) => failure.detail),
       ...concentration.partial_failures.map((failure) => failure.detail),
+      ...(attribution?.partial_failures.map((failure) => failure.detail) ?? []),
       ...drawdown.partial_failures.map((failure) => failure.detail),
       ...rolling.partial_failures.map((failure) => failure.detail),
     ],
@@ -618,6 +666,212 @@ export function buildFixtureRiskRolling(
   };
 }
 
+export function buildFixtureRiskAttribution(
+  workspace: WorkbenchPerformanceWorkspace,
+  period: string,
+  detailBasis: string,
+  options?: {
+    attributionType?: "TOTAL_RISK" | "ACTIVE_RISK";
+    groupingDimension?: "POSITION" | "SECTOR" | "ASSET_CLASS" | "ISSUER";
+  }
+): WorkbenchRiskAttributionResponse {
+  const attributionType = options?.attributionType ?? "TOTAL_RISK";
+  const groupingDimension = options?.groupingDimension ?? "SECTOR";
+  const activeRiskReady = Boolean(workspace.benchmark_code);
+  const issuerBlocked = attributionType === "ACTIVE_RISK" && groupingDimension === "ISSUER";
+  const blockedWithoutBenchmark = attributionType === "ACTIVE_RISK" && !workspace.benchmark_code;
+  const state = issuerBlocked || blockedWithoutBenchmark ? "blocked" : "ready";
+  const contributors =
+    groupingDimension === "ASSET_CLASS"
+      ? [
+          {
+            group_key: "EQUITY",
+            group_label: "Equity",
+            weight_average: 0.62,
+            marginal_contribution: 0.018,
+            component_contribution: 0.016,
+            percent_contribution: 0.47,
+          },
+          {
+            group_key: "FIXED_INCOME",
+            group_label: "Fixed Income",
+            weight_average: 0.24,
+            marginal_contribution: 0.011,
+            component_contribution: 0.009,
+            percent_contribution: 0.26,
+          },
+        ]
+      : [
+          {
+            group_key: "SECTOR_TECH",
+            group_label: "Technology",
+            weight_average: 0.41,
+            marginal_contribution: 0.019,
+            component_contribution: 0.017,
+            percent_contribution: 0.41,
+          },
+          {
+            group_key: "SECTOR_HEALTH",
+            group_label: "Healthcare",
+            weight_average: 0.18,
+            marginal_contribution: 0.008,
+            component_contribution: 0.006,
+            percent_contribution: 0.15,
+          },
+        ];
+  const supportability: NonNullable<WorkbenchRiskAttributionResponse["supportability"]> = [
+    {
+      key: "portfolio_returns",
+      label: "Portfolio returns",
+      state: "ready",
+      source_service: "lotus-risk",
+    },
+    {
+      key: "exposure_history",
+      label: "Exposure history",
+      state: "ready",
+      source_service: "lotus-core",
+    },
+    ...(attributionType === "ACTIVE_RISK"
+      ? [
+          {
+            key: "benchmark_returns",
+            label: "Benchmark returns",
+            state: workspace.benchmark_code ? ("ready" as const) : ("blocked" as const),
+            reason: workspace.benchmark_code ? null : "Active risk requires benchmark context.",
+            source_service: "lotus-performance",
+          },
+          {
+            key: "benchmark_exposure_context",
+            label: "Benchmark exposure context",
+            state:
+              groupingDimension === "ISSUER"
+                ? ("blocked" as const)
+                : workspace.benchmark_code
+                  ? ("ready" as const)
+                  : ("blocked" as const),
+            reason:
+              groupingDimension === "ISSUER"
+                ? "Issuer benchmark exposure semantics are not available."
+                : workspace.benchmark_code
+                  ? null
+                  : "Active risk requires benchmark context.",
+            source_service: "lotus-performance",
+          },
+        ]
+      : [
+          {
+            key: "benchmark_exposure_context",
+            label: "Benchmark exposure context",
+            state: groupingDimension === "ISSUER" ? ("partial" as const) : ("ready" as const),
+            reason:
+              groupingDimension === "ISSUER"
+                ? "Issuer benchmark exposure semantics remain unavailable for active-risk decomposition."
+                : null,
+            source_service: "lotus-performance",
+          },
+        ]),
+  ];
+
+  return {
+    correlation_id: "fixture-risk-attribution",
+    contract_version: "risk-workspace.v1",
+    portfolio_id: workspace.portfolio.portfolio_id,
+    period,
+    as_of_date: workspace.as_of_date,
+    benchmark_code: workspace.benchmark_code,
+    source_service: "lotus-risk",
+    state,
+    payload: {
+      controls: {
+        attribution_types: [
+          { key: "TOTAL_RISK", label: "Total Risk", state: "ready", reason: null },
+          {
+            key: "ACTIVE_RISK",
+            label: "Active Risk",
+            state: activeRiskReady ? "ready" : "blocked",
+            reason: activeRiskReady ? null : "Active risk requires benchmark context.",
+          },
+        ],
+        grouping_dimensions: [
+          {
+            key: "POSITION",
+            label: "Position",
+            state: "ready",
+            reason: null,
+            supported_attribution_types: activeRiskReady
+              ? ["TOTAL_RISK", "ACTIVE_RISK"]
+              : ["TOTAL_RISK"],
+          },
+          {
+            key: "SECTOR",
+            label: "Sector",
+            state: "ready",
+            reason: null,
+            supported_attribution_types: activeRiskReady
+              ? ["TOTAL_RISK", "ACTIVE_RISK"]
+              : ["TOTAL_RISK"],
+          },
+          {
+            key: "ASSET_CLASS",
+            label: "Asset Class",
+            state: "ready",
+            reason: null,
+            supported_attribution_types: activeRiskReady
+              ? ["TOTAL_RISK", "ACTIVE_RISK"]
+              : ["TOTAL_RISK"],
+          },
+          {
+            key: "ISSUER",
+            label: "Issuer",
+            state: attributionType === "TOTAL_RISK" ? "partial" : "blocked",
+            reason:
+              attributionType === "TOTAL_RISK"
+                ? "Issuer is supported for total risk only."
+                : "Active risk by issuer remains unavailable until benchmark issuer exposure semantics are approved.",
+            supported_attribution_types: ["TOTAL_RISK"],
+          },
+        ],
+        selected_attribution_type: attributionType,
+        selected_grouping_dimension: groupingDimension,
+      },
+      periods:
+        state === "ready"
+          ? [
+              {
+                key: period,
+                label: period,
+                start_date: workspace.report_start_date,
+                end_date: workspace.report_end_date,
+                attribution_sets: [
+                  {
+                    attribution_type: attributionType,
+                    metric: attributionType === "ACTIVE_RISK" ? "TRACKING_ERROR" : "VOLATILITY",
+                    grouping_dimension: groupingDimension,
+                    total_value: attributionType === "ACTIVE_RISK" ? 0.034 : 0.121,
+                    reconciled_sum: attributionType === "ACTIVE_RISK" ? 0.033 : 0.119,
+                    residual: attributionType === "ACTIVE_RISK" ? 0.001 : 0.002,
+                    contributors,
+                    quality_flags: [],
+                  },
+                ],
+                error: null,
+              },
+            ]
+          : [],
+    },
+    supportability,
+    warnings: state === "ready" ? [] : ["RISK_ATTRIBUTION_BLOCKED"],
+    partial_failures: [],
+    metadata: {
+      generated_at: workspace.as_of_date,
+      input_mode: "stateful",
+      methodology_version: `historical_attribution.fixture.${detailBasis.toLowerCase()}.v1`,
+      cache_status: "bypass",
+    },
+  };
+}
+
 export function buildUnavailableRiskSummary({
   workspace,
   period,
@@ -788,6 +1042,46 @@ export function buildUnavailableRiskRolling({
   };
 }
 
+export function buildUnavailableRiskAttribution({
+  workspace,
+  period,
+  detail,
+}: {
+  workspace: WorkbenchPerformanceWorkspace;
+  period: string;
+  detail: string;
+}): WorkbenchRiskAttributionResponse {
+  return {
+    correlation_id: "risk-attribution-unavailable",
+    contract_version: "risk-workspace.v1",
+    portfolio_id: workspace.portfolio.portfolio_id,
+    period,
+    as_of_date: workspace.as_of_date,
+    benchmark_code: workspace.benchmark_code,
+    source_service: "lotus-risk",
+    state: "unavailable",
+    payload: null,
+    supportability: [
+      {
+        key: "risk_attribution",
+        label: "Historical risk attribution",
+        state: "unavailable",
+        reason: detail,
+        source_service: "lotus-risk",
+      },
+    ],
+    warnings: ["RISK_ATTRIBUTION_UNAVAILABLE"],
+    partial_failures: [
+      { source_service: "risk", error_code: "RISK_ATTRIBUTION_UNAVAILABLE", detail },
+    ],
+    metadata: {
+      generated_at: workspace.as_of_date,
+      input_mode: "stateful",
+      cache_status: "miss",
+    },
+  };
+}
+
 function buildStateViewModel(
   workspace: WorkbenchPerformanceWorkspace,
   period: string,
@@ -820,6 +1114,11 @@ function buildStateViewModel(
     rollingWindows: [],
     rollingQualityFlags: [],
     rollingDetailState: "idle",
+    attributionControls: null,
+    attributionRows: [],
+    attributionTotals: null,
+    attributionState: "idle",
+    attributionWarnings: [],
     supportability: [
       {
         key: "risk_bff",
@@ -1351,11 +1650,84 @@ function resolveMetricState(state: WorkbenchRiskModuleState): PerformanceRiskSta
 }
 
 function mapSupportabilityGroup(
-  group: "summary" | "concentration" | "drawdown" | "rolling",
+  group: "summary" | "concentration" | "attribution" | "drawdown" | "rolling",
   items: PerformanceRiskViewModel["supportability"]
 ) {
   return items.map((item) => ({
     ...item,
     key: `${group}:${item.key}`,
   }));
+}
+
+function mapAttributionControls(response: WorkbenchRiskAttributionResponse | null) {
+  if (!response?.payload) {
+    return null;
+  }
+  return {
+    selectedAttributionType: response.payload.controls.selected_attribution_type,
+    selectedGroupingDimension: response.payload.controls.selected_grouping_dimension,
+    attributionTypes: response.payload.controls.attribution_types.map((option) => ({
+      key: option.key,
+      label: option.label,
+      disabled: option.state !== "ready",
+      reason: option.reason,
+    })),
+    groupingDimensions: response.payload.controls.grouping_dimensions.map((option) => ({
+      key: option.key,
+      label: option.label,
+      disabled: option.state === "blocked" || option.state === "unavailable",
+      reason: option.reason,
+    })),
+  };
+}
+
+function mapAttributionRows(response: WorkbenchRiskAttributionResponse | null) {
+  const selectedSet = response?.payload?.periods[0]?.attribution_sets[0];
+  if (!selectedSet) {
+    return [];
+  }
+  return selectedSet.contributors.map((contributor) => ({
+    key: contributor.group_key,
+    group: contributor.group_label,
+    avgWeight: formatPercent((contributor.weight_average ?? 0) * 100),
+    marginalContribution: formatPercent((contributor.marginal_contribution ?? 0) * 100),
+    componentContribution: formatPercent((contributor.component_contribution ?? 0) * 100),
+    contributionShare: formatPercent((contributor.percent_contribution ?? 0) * 100),
+  }));
+}
+
+function mapAttributionTotals(response: WorkbenchRiskAttributionResponse | null) {
+  const selectedSet = response?.payload?.periods[0]?.attribution_sets[0];
+  if (!selectedSet) {
+    return null;
+  }
+  return {
+    metric: `${selectedSet.attribution_type.replaceAll("_", " ")} • ${selectedSet.metric.replaceAll("_", " ")}`,
+    totalValue: formatPercent((selectedSet.total_value ?? 0) * 100),
+    reconciledSum: formatPercent((selectedSet.reconciled_sum ?? 0) * 100),
+    residual: formatPercent((selectedSet.residual ?? 0) * 100),
+    support: selectedSet.grouping_dimension.replaceAll("_", " "),
+  };
+}
+
+function resolveAttributionState({
+  attribution,
+  isAttributionLoading,
+}: {
+  attribution: WorkbenchRiskAttributionResponse | null;
+  isAttributionLoading: boolean;
+}): "idle" | "loading" | "ready" | "blocked" | "unavailable" {
+  if (isAttributionLoading) {
+    return "loading";
+  }
+  if (!attribution) {
+    return "idle";
+  }
+  if (attribution.state === "blocked") {
+    return "blocked";
+  }
+  if (attribution.state === "unavailable") {
+    return "unavailable";
+  }
+  return "ready";
 }

--- a/src/apps/performance/risk-workspace-view-model.ts
+++ b/src/apps/performance/risk-workspace-view-model.ts
@@ -5,6 +5,7 @@ import type {
   WorkbenchRiskDrawdownSummary,
   WorkbenchRiskMetric,
   WorkbenchRiskModuleState,
+  WorkbenchRiskRollingResponse,
   WorkbenchRiskSummaryResponse,
 } from "@/features/workbench/types";
 import {
@@ -68,6 +69,34 @@ export type PerformanceRiskViewModel = {
     drawdown: string;
   }>;
   underwaterDetailState: "idle" | "loading" | "ready" | "unavailable";
+  rollingWindows: Array<{
+    key: string;
+    label: string;
+    headlineMetrics: Array<{
+      key: string;
+      label: string;
+      value: string;
+      support: string;
+      state: PerformanceRiskState;
+    }>;
+    summaryRows: Array<{
+      key: string;
+      metric: string;
+      latest: string;
+      average: string;
+      p05: string;
+      p95: string;
+      support: string;
+    }>;
+    seriesRows: Array<{
+      key: string;
+      date: string;
+      values: Record<string, string>;
+    }>;
+    seriesMetricKeys: string[];
+  }>;
+  rollingQualityFlags: string[];
+  rollingDetailState: "idle" | "loading" | "ready" | "unavailable";
   supportability: Array<{
     key: string;
     label: string;
@@ -88,8 +117,13 @@ export type BuildPerformanceRiskViewModelOptions = {
   riskConcentration?: WorkbenchRiskConcentrationResponse | null;
   riskDrawdown?: WorkbenchRiskDrawdownResponse | null;
   riskDrawdownDetail?: WorkbenchRiskDrawdownResponse | null;
+  riskRolling?: WorkbenchRiskRollingResponse | null;
+  riskRollingDetail?: WorkbenchRiskRollingResponse | null;
   isDrawdownDetailLoading?: boolean;
+  isRollingDetailLoading?: boolean;
 };
+
+type RiskRollingPayload = NonNullable<WorkbenchRiskRollingResponse["payload"]>;
 
 export function buildPerformanceRiskViewModel({
   workspace,
@@ -100,7 +134,10 @@ export function buildPerformanceRiskViewModel({
   riskConcentration,
   riskDrawdown,
   riskDrawdownDetail,
+  riskRolling,
+  riskRollingDetail,
   isDrawdownDetailLoading = false,
+  isRollingDetailLoading = false,
 }: BuildPerformanceRiskViewModelOptions): PerformanceRiskViewModel {
   if (isDetailsPending) {
     return buildStateViewModel(workspace, period, detailBasis, "loading");
@@ -119,7 +156,7 @@ export function buildPerformanceRiskViewModel({
     buildUnavailableRiskConcentration({
       workspace,
       period,
-        detail: "Risk concentration is not available from the Gateway BFF.",
+      detail: "Risk concentration is not available from the Gateway BFF.",
     });
   const drawdown =
     riskDrawdown ??
@@ -130,19 +167,34 @@ export function buildPerformanceRiskViewModel({
       detail: "Risk drawdown is not available from the Gateway BFF.",
       includeUnderwaterSeries: false,
     });
+  const rolling =
+    riskRolling ??
+    buildUnavailableRiskRolling({
+      workspace,
+      period,
+      detailBasis,
+      detail: "Rolling risk is not available from the Gateway BFF.",
+      includeTimeSeries: false,
+    });
   const drawdownDetail = riskDrawdownDetail ?? null;
+  const rollingDetail = riskRollingDetail ?? null;
 
   const supportability = [
     ...mapSupportabilityGroup("summary", summary.supportability),
     ...mapSupportabilityGroup("concentration", concentration.supportability),
     ...mapSupportabilityGroup("drawdown", drawdown.supportability),
+    ...mapSupportabilityGroup("rolling", rolling.supportability),
   ];
   const hasPayload = Boolean(
-    summary.payload?.periods.length || concentration.payload || drawdown.payload?.periods.length
+    summary.payload?.periods.length ||
+      concentration.payload ||
+      drawdown.payload?.periods.length ||
+      rolling.payload?.periods.length
   );
+  const moduleStates = [summary.state, concentration.state, drawdown.state, rolling.state];
   const state = !hasPayload
     ? "unavailable"
-    : summary.state === "ready" && concentration.state === "ready"
+    : moduleStates.every((moduleState) => moduleState === "ready")
       ? "ready"
       : "partial";
 
@@ -167,6 +219,13 @@ export function buildPerformanceRiskViewModel({
       drawdownDetail,
       isDrawdownDetailLoading,
     }),
+    rollingWindows: mapRollingWindows(rolling, rollingDetail),
+    rollingQualityFlags: rolling.payload?.periods[0]?.quality_flags ?? [],
+    rollingDetailState: resolveRollingDetailState({
+      rolling,
+      rollingDetail,
+      isRollingDetailLoading,
+    }),
     supportability: supportability.map((item) => ({
       key: item.key,
       label: item.label,
@@ -180,11 +239,17 @@ export function buildPerformanceRiskViewModel({
       { label: "Cache", value: summary.metadata.cache_status ?? "miss" },
       { label: "Generated", value: formatDateValue(summary.metadata.generated_at) },
     ],
-    warnings: [...summary.warnings, ...concentration.warnings, ...drawdown.warnings],
+    warnings: [
+      ...summary.warnings,
+      ...concentration.warnings,
+      ...drawdown.warnings,
+      ...rolling.warnings,
+    ],
     partialFailures: [
       ...summary.partial_failures.map((failure) => failure.detail),
       ...concentration.partial_failures.map((failure) => failure.detail),
       ...drawdown.partial_failures.map((failure) => failure.detail),
+      ...rolling.partial_failures.map((failure) => failure.detail),
     ],
   };
 }
@@ -460,6 +525,99 @@ export function buildFixtureRiskDrawdown(
   };
 }
 
+export function buildFixtureRiskRolling(
+  workspace: WorkbenchPerformanceWorkspace,
+  period: string,
+  detailBasis: string,
+  options?: {
+    includeTimeSeries?: boolean;
+  }
+): WorkbenchRiskRollingResponse {
+  const includeTimeSeries = options?.includeTimeSeries ?? false;
+  const includeBenchmarkMetrics = Boolean(workspace.benchmark_code);
+  return {
+    correlation_id: "fixture-risk-rolling",
+    contract_version: "risk-workspace.v1",
+    portfolio_id: workspace.portfolio.portfolio_id,
+    period,
+    as_of_date: workspace.as_of_date,
+    benchmark_code: workspace.benchmark_code,
+    source_service: "lotus-risk",
+    state: includeBenchmarkMetrics ? "partial" : "partial",
+    payload: {
+      periods: [
+        {
+          key: period,
+          label: period,
+          start_date: workspace.report_start_date,
+          end_date: workspace.report_end_date,
+          series_count: 66,
+          window_results: [21, 63, 126, 252].map((windowLength, index) => ({
+            window_length: windowLength,
+            metric_summaries: buildFixtureRollingMetricSummaries({
+              windowLength,
+              includeBenchmarkMetrics,
+            }),
+            metric_series: includeTimeSeries
+              ? buildFixtureRollingSeries({
+                  windowLength,
+                  includeBenchmarkMetrics,
+                  offset: index,
+                })
+              : null,
+          })),
+          quality_flags: includeBenchmarkMetrics
+            ? ["metric:ROLLING_BETA:benchmark_variance_zero"]
+            : [],
+          error: null,
+        },
+      ],
+    },
+    supportability: [
+      {
+        key: "portfolio_returns",
+        label: "Portfolio returns",
+        state: "ready",
+        source_service: "lotus-risk",
+      },
+      {
+        key: "benchmark_returns",
+        label: "Benchmark returns",
+        state: includeBenchmarkMetrics ? "ready" : "partial",
+        reason: includeBenchmarkMetrics
+          ? null
+          : "Benchmark-relative rolling metrics require benchmark context.",
+        source_service: "lotus-risk",
+      },
+      {
+        key: "risk_free_series",
+        label: "Risk-free series",
+        state: "partial",
+        reason:
+          "Rolling Sharpe uses the configured risk-free source and may degrade when the upstream curve is unavailable.",
+        source_service: "lotus-risk",
+      },
+      {
+        key: "rolling_time_series",
+        label: "Rolling time series",
+        state: includeTimeSeries ? "ready" : "partial",
+        reason: includeTimeSeries
+          ? null
+          : "Rolling time series is available on demand and is excluded from first paint.",
+        source_service: "lotus-risk",
+      },
+    ],
+    warnings: includeTimeSeries ? [] : ["RISK_ROLLING_TIME_SERIES_DEFERRED"],
+    partial_failures: [],
+    metadata: {
+      generated_at: workspace.as_of_date,
+      input_mode: "stateful",
+      methodology_version: `rolling.fixture.${detailBasis.toLowerCase()}.v1`,
+      cache_status: "bypass",
+    },
+  };
+}
+
 export function buildUnavailableRiskSummary({
   workspace,
   period,
@@ -586,6 +744,50 @@ export function buildUnavailableRiskDrawdown({
   };
 }
 
+export function buildUnavailableRiskRolling({
+  workspace,
+  period,
+  detailBasis,
+  detail,
+  includeTimeSeries,
+}: {
+  workspace: WorkbenchPerformanceWorkspace;
+  period: string;
+  detailBasis: string;
+  detail: string;
+  includeTimeSeries: boolean;
+}): WorkbenchRiskRollingResponse {
+  return {
+    correlation_id: "risk-rolling-unavailable",
+    contract_version: "risk-workspace.v1",
+    portfolio_id: workspace.portfolio.portfolio_id,
+    period,
+    as_of_date: workspace.as_of_date,
+    benchmark_code: workspace.benchmark_code,
+    source_service: "lotus-risk",
+    state: "unavailable",
+    payload: null,
+    supportability: [
+      {
+        key: "risk_rolling",
+        label: includeTimeSeries ? "Rolling risk detail" : "Rolling risk",
+        state: "unavailable",
+        reason: `${detail} (${detailBasis} basis)`,
+        source_service: "lotus-risk",
+      },
+    ],
+    warnings: ["RISK_ROLLING_UNAVAILABLE"],
+    partial_failures: [
+      { source_service: "risk", error_code: "RISK_ROLLING_UNAVAILABLE", detail },
+    ],
+    metadata: {
+      generated_at: workspace.as_of_date,
+      input_mode: "stateful",
+      cache_status: "miss",
+    },
+  };
+}
+
 function buildStateViewModel(
   workspace: WorkbenchPerformanceWorkspace,
   period: string,
@@ -615,6 +817,9 @@ function buildStateViewModel(
     drawdownRelativeMetric: null,
     underwaterSeries: [],
     underwaterDetailState: "idle",
+    rollingWindows: [],
+    rollingQualityFlags: [],
+    rollingDetailState: "idle",
     supportability: [
       {
         key: "risk_bff",
@@ -815,6 +1020,133 @@ function resolveUnderwaterDetailState({
   return supportability?.state === "unavailable" ? "unavailable" : "idle";
 }
 
+function mapRollingWindows(
+  rolling: WorkbenchRiskRollingResponse,
+  rollingDetail: WorkbenchRiskRollingResponse | null
+) {
+  const summaryWindows = rolling.payload?.periods[0]?.window_results ?? [];
+  const detailWindows = new Map(
+    (rollingDetail?.payload?.periods[0]?.window_results ?? []).map((window) => [
+      window.window_length,
+      window,
+    ])
+  );
+
+  return summaryWindows.map((window) => {
+    const detailWindow = detailWindows.get(window.window_length) ?? null;
+    const metricKeys = Array.from(
+      new Set([
+        ...Object.keys(window.metric_summaries),
+        ...Object.keys(detailWindow?.metric_summaries ?? {}),
+      ])
+    );
+    return {
+      key: String(window.window_length),
+      label: buildRollingWindowLabel(window.window_length),
+      headlineMetrics: metricKeys.map((metricKey) => {
+        const summary = window.metric_summaries[metricKey];
+        return {
+          key: `${window.window_length}-${metricKey}`,
+          label: resolveRollingMetricLabel(metricKey),
+          value: formatRollingMetricSummaryValue(metricKey, summary?.latest ?? null),
+          support: buildRollingMetricSupport(metricKey, summary),
+          state: summary ? ("ready" as PerformanceRiskState) : ("unavailable" as PerformanceRiskState),
+        };
+      }),
+      summaryRows: metricKeys.map((metricKey) => {
+        const summary = window.metric_summaries[metricKey];
+        return {
+          key: `${window.window_length}-${metricKey}`,
+          metric: resolveRollingMetricLabel(metricKey),
+          latest: formatRollingMetricSummaryValue(metricKey, summary?.latest ?? null),
+          average: formatRollingMetricSummaryValue(metricKey, summary?.average ?? null),
+          p05: formatRollingMetricSummaryValue(metricKey, summary?.p05 ?? null),
+          p95: formatRollingMetricSummaryValue(metricKey, summary?.p95 ?? null),
+          support: buildRollingMetricSupport(metricKey, summary),
+        };
+      }),
+      seriesRows: mapRollingSeriesRows(detailWindow?.metric_series ?? []),
+      seriesMetricKeys: metricKeys,
+    };
+  });
+}
+
+function resolveRollingDetailState({
+  rolling,
+  rollingDetail,
+  isRollingDetailLoading,
+}: {
+  rolling: WorkbenchRiskRollingResponse;
+  rollingDetail: WorkbenchRiskRollingResponse | null;
+  isRollingDetailLoading: boolean;
+}): "idle" | "loading" | "ready" | "unavailable" {
+  if (isRollingDetailLoading) {
+    return "loading";
+  }
+  if (
+    rollingDetail?.payload?.periods[0]?.window_results?.some(
+      (window) => (window.metric_series?.length ?? 0) > 0
+    )
+  ) {
+    return "ready";
+  }
+  if (rollingDetail?.state === "unavailable") {
+    return "unavailable";
+  }
+  const supportability = rolling.supportability.find((item) => item.key === "rolling_time_series");
+  return supportability?.state === "unavailable" ? "unavailable" : "idle";
+}
+
+function mapRollingSeriesRows(
+  series: RiskRollingPayload["periods"][number]["window_results"][number]["metric_series"]
+) {
+  return (series ?? []).map((point) => ({
+    key: point.date,
+    date: formatDateValue(point.date),
+    values: Object.fromEntries(
+      Object.entries(point.metric_values).map(([metricKey, value]) => [
+        metricKey,
+        formatRollingMetricSummaryValue(metricKey, value),
+      ])
+    ),
+  }));
+}
+
+function buildRollingMetricSupport(
+  metricKey: string,
+  summary:
+    | RiskRollingPayload["periods"][number]["window_results"][number]["metric_summaries"][string]
+    | undefined
+) {
+  if (!summary) {
+    return "Metric not returned for this rolling request.";
+  }
+  return `Avg ${formatRollingMetricSummaryValue(metricKey, summary.average)} • P05 ${formatRollingMetricSummaryValue(metricKey, summary.p05)} • P95 ${formatRollingMetricSummaryValue(metricKey, summary.p95)}`;
+}
+
+function buildRollingWindowLabel(windowLength: number) {
+  return `${windowLength}D`;
+}
+
+function resolveRollingMetricLabel(metricKey: string) {
+  switch (metricKey) {
+    case "ROLLING_VOLATILITY":
+      return "Volatility";
+    case "ROLLING_MAX_DRAWDOWN":
+      return "Max Drawdown";
+    case "ROLLING_SHARPE":
+      return "Sharpe";
+    case "ROLLING_BETA":
+      return "Beta";
+    case "ROLLING_TRACKING_ERROR":
+      return "Tracking Error";
+    case "ROLLING_INFORMATION_RATIO":
+      return "Information Ratio";
+    default:
+      return metricKey.replaceAll("_", " ");
+  }
+}
+
 function formatRiskMetric(metric: WorkbenchRiskMetric) {
   if (typeof metric.value !== "number") {
     return "N/A";
@@ -839,6 +1171,165 @@ function formatInteger(value: number | null | undefined) {
   return formatNumber(value, { maximumFractionDigits: 0 });
 }
 
+function formatRollingMetricSummaryValue(metricKey: string, value: number | null | undefined) {
+  if (typeof value !== "number") {
+    return "N/A";
+  }
+  if (
+    metricKey === "ROLLING_VOLATILITY" ||
+    metricKey === "ROLLING_MAX_DRAWDOWN" ||
+    metricKey === "ROLLING_TRACKING_ERROR"
+  ) {
+    return formatPercent(value * 100);
+  }
+  return formatNumber(value, { maximumFractionDigits: 2 });
+}
+
+function buildFixtureRollingMetricSummaries({
+  windowLength,
+  includeBenchmarkMetrics,
+}: {
+  windowLength: number;
+  includeBenchmarkMetrics: boolean;
+}) {
+  const volatilityBase = 0.109 + windowLength / 5000;
+  const maxDrawdownBase = -0.017 - windowLength / 5000;
+  const summaries: Record<
+    string,
+    {
+      latest: number | null;
+      average: number | null;
+      minimum: number | null;
+      maximum: number | null;
+      p05: number | null;
+      p50: number | null;
+      p95: number | null;
+    }
+  > = {
+    ROLLING_VOLATILITY: {
+      latest: volatilityBase,
+      average: volatilityBase - 0.008,
+      minimum: volatilityBase - 0.026,
+      maximum: volatilityBase + 0.021,
+      p05: volatilityBase - 0.02,
+      p50: volatilityBase - 0.004,
+      p95: volatilityBase + 0.018,
+    },
+    ROLLING_MAX_DRAWDOWN: {
+      latest: maxDrawdownBase,
+      average: maxDrawdownBase + 0.005,
+      minimum: maxDrawdownBase - 0.02,
+      maximum: maxDrawdownBase + 0.011,
+      p05: maxDrawdownBase - 0.016,
+      p50: maxDrawdownBase + 0.003,
+      p95: maxDrawdownBase + 0.009,
+    },
+    ROLLING_SHARPE: {
+      latest: 0.74 + windowLength / 1000,
+      average: 0.68 + windowLength / 1000,
+      minimum: 0.31 + windowLength / 1200,
+      maximum: 1.14 + windowLength / 900,
+      p05: 0.42 + windowLength / 1200,
+      p50: 0.71 + windowLength / 1000,
+      p95: 1.02 + windowLength / 900,
+    },
+  };
+  if (includeBenchmarkMetrics) {
+    summaries.ROLLING_BETA = {
+      latest: 0.91 + windowLength / 5000,
+      average: 0.88 + windowLength / 5000,
+      minimum: 0.74,
+      maximum: 1.08,
+      p05: 0.78,
+      p50: 0.89,
+      p95: 1.02,
+    };
+    summaries.ROLLING_TRACKING_ERROR = {
+      latest: 0.024 + windowLength / 10000,
+      average: 0.022 + windowLength / 10000,
+      minimum: 0.015,
+      maximum: 0.034,
+      p05: 0.017,
+      p50: 0.022,
+      p95: 0.031,
+    };
+    summaries.ROLLING_INFORMATION_RATIO = {
+      latest: 0.29 + windowLength / 2000,
+      average: 0.24 + windowLength / 2000,
+      minimum: -0.08,
+      maximum: 0.61,
+      p05: 0.01,
+      p50: 0.27,
+      p95: 0.55,
+    };
+  }
+  return summaries;
+}
+
+function buildFixtureRollingSeries({
+  windowLength,
+  includeBenchmarkMetrics,
+  offset,
+}: {
+  windowLength: number;
+  includeBenchmarkMetrics: boolean;
+  offset: number;
+}) {
+  return [
+    {
+      date: `2026-03-${String(15 + offset).padStart(2, "0")}`,
+      metric_values: buildFixtureRollingSeriesMetricValues({
+        windowLength,
+        includeBenchmarkMetrics,
+        volatility: 0.112 + windowLength / 5200,
+        maxDrawdown: -0.018 - windowLength / 5200,
+      }),
+    },
+    {
+      date: `2026-03-${String(22 + offset).padStart(2, "0")}`,
+      metric_values: buildFixtureRollingSeriesMetricValues({
+        windowLength,
+        includeBenchmarkMetrics,
+        volatility: 0.118 + windowLength / 5200,
+        maxDrawdown: -0.022 - windowLength / 5200,
+      }),
+    },
+    {
+      date: `2026-03-${String(29 + offset).padStart(2, "0")}`,
+      metric_values: buildFixtureRollingSeriesMetricValues({
+        windowLength,
+        includeBenchmarkMetrics,
+        volatility: 0.121 + windowLength / 5200,
+        maxDrawdown: -0.028 - windowLength / 5200,
+      }),
+    },
+  ];
+}
+
+function buildFixtureRollingSeriesMetricValues({
+  windowLength,
+  includeBenchmarkMetrics,
+  volatility,
+  maxDrawdown,
+}: {
+  windowLength: number;
+  includeBenchmarkMetrics: boolean;
+  volatility: number;
+  maxDrawdown: number;
+}) {
+  const values: Record<string, number> = {
+    ROLLING_VOLATILITY: volatility,
+    ROLLING_MAX_DRAWDOWN: maxDrawdown,
+    ROLLING_SHARPE: 0.67 + windowLength / 1100,
+  };
+  if (includeBenchmarkMetrics) {
+    values.ROLLING_BETA = 0.9 + windowLength / 5200;
+    values.ROLLING_TRACKING_ERROR = 0.023 + windowLength / 11000;
+    values.ROLLING_INFORMATION_RATIO = 0.25 + windowLength / 2200;
+  }
+  return values;
+}
+
 function buildDrawdownDateRange(summary: WorkbenchRiskDrawdownSummary) {
   if (!summary.max_drawdown_peak_date || !summary.max_drawdown_trough_date) {
     return "Peak/trough timing unavailable";
@@ -860,7 +1351,7 @@ function resolveMetricState(state: WorkbenchRiskModuleState): PerformanceRiskSta
 }
 
 function mapSupportabilityGroup(
-  group: "summary" | "concentration" | "drawdown",
+  group: "summary" | "concentration" | "drawdown" | "rolling",
   items: PerformanceRiskViewModel["supportability"]
 ) {
   return items.map((item) => ({

--- a/src/apps/performance/use-performance-risk-contract.ts
+++ b/src/apps/performance/use-performance-risk-contract.ts
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
+  getWorkbenchRiskAttributionClient,
   getWorkbenchRiskConcentrationClient,
   getWorkbenchRiskDrawdownClient,
   getWorkbenchRiskRollingClient,
@@ -10,6 +11,7 @@ import {
 } from "@/features/workbench/api";
 import type {
   WorkbenchPerformanceWorkspace,
+  WorkbenchRiskAttributionResponse,
   WorkbenchRiskConcentrationResponse,
   WorkbenchRiskDrawdownResponse,
   WorkbenchRiskRollingResponse,
@@ -17,6 +19,7 @@ import type {
 } from "@/features/workbench/types";
 
 import {
+  buildUnavailableRiskAttribution,
   buildUnavailableRiskConcentration,
   buildUnavailableRiskDrawdown,
   buildUnavailableRiskRolling,
@@ -26,13 +29,16 @@ import {
 type PerformanceRiskContractState = {
   riskSummary: WorkbenchRiskSummaryResponse | null;
   riskConcentration: WorkbenchRiskConcentrationResponse | null;
+  riskAttribution: WorkbenchRiskAttributionResponse | null;
   riskDrawdown: WorkbenchRiskDrawdownResponse | null;
   riskDrawdownDetail: WorkbenchRiskDrawdownResponse | null;
   riskRolling: WorkbenchRiskRollingResponse | null;
   riskRollingDetail: WorkbenchRiskRollingResponse | null;
   isLoading: boolean;
+  isAttributionLoading: boolean;
   isDrawdownDetailLoading: boolean;
   isRollingDetailLoading: boolean;
+  requestAttribution: (attributionType: string, groupingDimension: string) => void;
   requestDrawdownDetail: () => void;
   requestRollingDetail: () => void;
 };
@@ -51,6 +57,7 @@ export function usePerformanceRiskContract({
   const workspaceRef = useRef(workspace);
   const summaryCacheRef = useRef<Map<string, WorkbenchRiskSummaryResponse>>(new Map());
   const concentrationCacheRef = useRef<Map<string, WorkbenchRiskConcentrationResponse>>(new Map());
+  const attributionCacheRef = useRef<Map<string, WorkbenchRiskAttributionResponse>>(new Map());
   const drawdownCacheRef = useRef<Map<string, WorkbenchRiskDrawdownResponse>>(new Map());
   const drawdownDetailCacheRef = useRef<Map<string, WorkbenchRiskDrawdownResponse>>(new Map());
   const rollingCacheRef = useRef<Map<string, WorkbenchRiskRollingResponse>>(new Map());
@@ -58,10 +65,12 @@ export function usePerformanceRiskContract({
   const requestSequenceRef = useRef(0);
   const drawdownDetailRequestSequenceRef = useRef(0);
   const rollingDetailRequestSequenceRef = useRef(0);
+  const attributionRequestSequenceRef = useRef(0);
   const [riskSummary, setRiskSummary] = useState<WorkbenchRiskSummaryResponse | null>(null);
   const [riskConcentration, setRiskConcentration] = useState<WorkbenchRiskConcentrationResponse | null>(
     null
   );
+  const [riskAttribution, setRiskAttribution] = useState<WorkbenchRiskAttributionResponse | null>(null);
   const [riskDrawdown, setRiskDrawdown] = useState<WorkbenchRiskDrawdownResponse | null>(null);
   const [riskDrawdownDetail, setRiskDrawdownDetail] = useState<WorkbenchRiskDrawdownResponse | null>(
     null
@@ -71,8 +80,11 @@ export function usePerformanceRiskContract({
     null
   );
   const [isLoading, setIsLoading] = useState(false);
+  const [isAttributionLoading, setIsAttributionLoading] = useState(false);
   const [isDrawdownDetailLoading, setIsDrawdownDetailLoading] = useState(false);
   const [isRollingDetailLoading, setIsRollingDetailLoading] = useState(false);
+  const [selectedAttributionType, setSelectedAttributionType] = useState("TOTAL_RISK");
+  const [selectedGroupingDimension, setSelectedGroupingDimension] = useState("SECTOR");
 
   useEffect(() => {
     workspaceRef.current = workspace;
@@ -204,11 +216,13 @@ export function usePerformanceRiskContract({
     if (isDetailsPending) {
       setRiskSummary(null);
       setRiskConcentration(null);
+      setRiskAttribution(null);
       setRiskDrawdown(null);
       setRiskDrawdownDetail(null);
       setRiskRolling(null);
       setRiskRollingDetail(null);
       setIsLoading(true);
+      setIsAttributionLoading(false);
       setIsDrawdownDetailLoading(false);
       setIsRollingDetailLoading(false);
       return;
@@ -349,6 +363,101 @@ export function usePerformanceRiskContract({
     workspace.portfolio.portfolio_id,
   ]);
 
+  const attributionKey = useMemo(
+    () =>
+      JSON.stringify({
+        portfolioId: workspace.portfolio.portfolio_id,
+        period,
+        detailBasis,
+        benchmark: workspace.benchmark_code ?? null,
+        asOfDate: workspace.as_of_date,
+        reportingCurrency: workspace.portfolio.base_currency,
+        attributionType: selectedAttributionType,
+        groupingDimension: selectedGroupingDimension,
+      }),
+    [
+      detailBasis,
+      period,
+      selectedAttributionType,
+      selectedGroupingDimension,
+      workspace.as_of_date,
+      workspace.benchmark_code,
+      workspace.portfolio.base_currency,
+      workspace.portfolio.portfolio_id,
+    ]
+  );
+
+  useEffect(() => {
+    setSelectedAttributionType("TOTAL_RISK");
+    setSelectedGroupingDimension("SECTOR");
+    setRiskAttribution(null);
+    setIsAttributionLoading(false);
+  }, [detailBasis, period, workspace.as_of_date, workspace.benchmark_code, workspace.portfolio.portfolio_id]);
+
+  const requestAttribution = (attributionType: string, groupingDimension: string) => {
+    if (isDetailsPending) {
+      return;
+    }
+    setSelectedAttributionType(attributionType);
+    setSelectedGroupingDimension(groupingDimension);
+  };
+
+  useEffect(() => {
+    if (isDetailsPending) {
+      return;
+    }
+    const cachedResponse = attributionCacheRef.current.get(attributionKey) ?? null;
+    if (cachedResponse) {
+      setRiskAttribution(cachedResponse);
+      setIsAttributionLoading(false);
+      return;
+    }
+    const requestId = attributionRequestSequenceRef.current + 1;
+    attributionRequestSequenceRef.current = requestId;
+    setIsAttributionLoading(true);
+    void getWorkbenchRiskAttributionClient(workspace.portfolio.portfolio_id, {
+      period,
+      detailBasis,
+      benchmark: workspace.benchmark_code ?? undefined,
+      asOfDate: workspace.as_of_date,
+      reportingCurrency: workspace.portfolio.base_currency,
+      attributionType: selectedAttributionType,
+      groupingDimension: selectedGroupingDimension,
+    })
+      .then((response) => {
+        if (attributionRequestSequenceRef.current !== requestId) {
+          return;
+        }
+        attributionCacheRef.current.set(attributionKey, response);
+        setRiskAttribution(response);
+        setIsAttributionLoading(false);
+      })
+      .catch(() => {
+        const unavailableResponse = buildUnavailableRiskAttribution({
+          workspace: workspaceRef.current,
+          period,
+          detail: "Risk attribution fetch failed.",
+        });
+        if (attributionRequestSequenceRef.current !== requestId) {
+          return;
+        }
+        attributionCacheRef.current.set(attributionKey, unavailableResponse);
+        setRiskAttribution(unavailableResponse);
+        setIsAttributionLoading(false);
+      });
+  }, [
+    attributionKey,
+    detailBasis,
+    isDetailsPending,
+    period,
+    selectedAttributionType,
+    selectedGroupingDimension,
+    workspace.as_of_date,
+    workspace.benchmark_code,
+    workspace.portfolio.base_currency,
+    workspace.portfolio.portfolio_id,
+  ]);
+
   const requestDrawdownDetail = () => {
     if (isDetailsPending) {
       return;
@@ -432,13 +541,16 @@ export function usePerformanceRiskContract({
   return {
     riskSummary,
     riskConcentration,
+    riskAttribution,
     riskDrawdown,
     riskDrawdownDetail,
     riskRolling,
     riskRollingDetail,
     isLoading,
+    isAttributionLoading,
     isDrawdownDetailLoading,
     isRollingDetailLoading,
+    requestAttribution,
     requestDrawdownDetail,
     requestRollingDetail,
   };

--- a/src/apps/performance/use-performance-risk-contract.ts
+++ b/src/apps/performance/use-performance-risk-contract.ts
@@ -1,0 +1,175 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  getWorkbenchRiskConcentrationClient,
+  getWorkbenchRiskSummaryClient,
+} from "@/features/workbench/api";
+import type {
+  WorkbenchPerformanceWorkspace,
+  WorkbenchRiskConcentrationResponse,
+  WorkbenchRiskSummaryResponse,
+} from "@/features/workbench/types";
+
+import {
+  buildUnavailableRiskConcentration,
+  buildUnavailableRiskSummary,
+} from "./risk-workspace-view-model";
+
+type PerformanceRiskContractState = {
+  riskSummary: WorkbenchRiskSummaryResponse | null;
+  riskConcentration: WorkbenchRiskConcentrationResponse | null;
+  isLoading: boolean;
+};
+
+export function usePerformanceRiskContract({
+  workspace,
+  period,
+  detailBasis,
+  isDetailsPending,
+}: {
+  workspace: WorkbenchPerformanceWorkspace;
+  period: string;
+  detailBasis: string;
+  isDetailsPending: boolean;
+}): PerformanceRiskContractState {
+  const workspaceRef = useRef(workspace);
+  const summaryCacheRef = useRef<Map<string, WorkbenchRiskSummaryResponse>>(new Map());
+  const concentrationCacheRef = useRef<Map<string, WorkbenchRiskConcentrationResponse>>(new Map());
+  const requestSequenceRef = useRef(0);
+  const [riskSummary, setRiskSummary] = useState<WorkbenchRiskSummaryResponse | null>(null);
+  const [riskConcentration, setRiskConcentration] = useState<WorkbenchRiskConcentrationResponse | null>(
+    null
+  );
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    workspaceRef.current = workspace;
+  }, [workspace]);
+
+  const summaryKey = useMemo(
+    () =>
+      JSON.stringify({
+        portfolioId: workspace.portfolio.portfolio_id,
+        period,
+        detailBasis,
+        benchmark: workspace.benchmark_code ?? null,
+        asOfDate: workspace.as_of_date,
+        reportingCurrency: workspace.portfolio.base_currency,
+      }),
+    [
+      detailBasis,
+      period,
+      workspace.as_of_date,
+      workspace.benchmark_code,
+      workspace.portfolio.base_currency,
+      workspace.portfolio.portfolio_id,
+    ]
+  );
+
+  const concentrationKey = useMemo(
+    () =>
+      JSON.stringify({
+        portfolioId: workspace.portfolio.portfolio_id,
+        period,
+        benchmark: workspace.benchmark_code ?? null,
+        asOfDate: workspace.as_of_date,
+        reportingCurrency: workspace.portfolio.base_currency,
+      }),
+    [
+      period,
+      workspace.as_of_date,
+      workspace.benchmark_code,
+      workspace.portfolio.base_currency,
+      workspace.portfolio.portfolio_id,
+    ]
+  );
+
+  useEffect(() => {
+    if (isDetailsPending) {
+      setRiskSummary(null);
+      setRiskConcentration(null);
+      setIsLoading(true);
+      return;
+    }
+
+    const cachedSummary = summaryCacheRef.current.get(summaryKey) ?? null;
+    const cachedConcentration = concentrationCacheRef.current.get(concentrationKey) ?? null;
+
+    setRiskSummary(cachedSummary);
+    setRiskConcentration(cachedConcentration);
+
+    const needsSummary = !cachedSummary;
+    const needsConcentration = !cachedConcentration;
+    if (!needsSummary && !needsConcentration) {
+      setIsLoading(false);
+      return;
+    }
+
+    const requestId = requestSequenceRef.current + 1;
+    requestSequenceRef.current = requestId;
+    setIsLoading(true);
+
+    const summaryPromise = needsSummary
+      ? getWorkbenchRiskSummaryClient(workspace.portfolio.portfolio_id, {
+          period,
+          detailBasis,
+          benchmark: workspace.benchmark_code ?? undefined,
+          asOfDate: workspace.as_of_date,
+          reportingCurrency: workspace.portfolio.base_currency,
+        }).catch((error: unknown) =>
+          buildUnavailableRiskSummary({
+            workspace: workspaceRef.current,
+            period,
+            detailBasis,
+            detail: error instanceof Error ? error.message : "Risk summary fetch failed.",
+          })
+        )
+      : Promise.resolve(cachedSummary);
+
+    const concentrationPromise = needsConcentration
+      ? getWorkbenchRiskConcentrationClient(workspace.portfolio.portfolio_id, {
+          period,
+          benchmark: workspace.benchmark_code ?? undefined,
+          asOfDate: workspace.as_of_date,
+          reportingCurrency: workspace.portfolio.base_currency,
+        }).catch((error: unknown) =>
+          buildUnavailableRiskConcentration({
+            workspace: workspaceRef.current,
+            period,
+            detail: error instanceof Error ? error.message : "Risk concentration fetch failed.",
+          })
+        )
+      : Promise.resolve(cachedConcentration);
+
+    void Promise.all([summaryPromise, concentrationPromise]).then(
+      ([nextSummary, nextConcentration]) => {
+        if (requestSequenceRef.current !== requestId) {
+          return;
+        }
+        if (nextSummary) {
+          summaryCacheRef.current.set(summaryKey, nextSummary);
+          setRiskSummary(nextSummary);
+        }
+        if (nextConcentration) {
+          concentrationCacheRef.current.set(concentrationKey, nextConcentration);
+          setRiskConcentration(nextConcentration);
+        }
+        setIsLoading(false);
+      }
+    );
+  }, [
+    concentrationKey,
+    detailBasis,
+    isDetailsPending,
+    period,
+    summaryKey,
+    workspace.as_of_date,
+    workspace.benchmark_code,
+    workspace.portfolio.base_currency,
+    workspace.portfolio.portfolio_id,
+  ]);
+
+  return { riskSummary, riskConcentration, isLoading };
+}

--- a/src/apps/performance/use-performance-risk-contract.ts
+++ b/src/apps/performance/use-performance-risk-contract.ts
@@ -4,23 +4,30 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   getWorkbenchRiskConcentrationClient,
+  getWorkbenchRiskDrawdownClient,
   getWorkbenchRiskSummaryClient,
 } from "@/features/workbench/api";
 import type {
   WorkbenchPerformanceWorkspace,
   WorkbenchRiskConcentrationResponse,
+  WorkbenchRiskDrawdownResponse,
   WorkbenchRiskSummaryResponse,
 } from "@/features/workbench/types";
 
 import {
   buildUnavailableRiskConcentration,
+  buildUnavailableRiskDrawdown,
   buildUnavailableRiskSummary,
 } from "./risk-workspace-view-model";
 
 type PerformanceRiskContractState = {
   riskSummary: WorkbenchRiskSummaryResponse | null;
   riskConcentration: WorkbenchRiskConcentrationResponse | null;
+  riskDrawdown: WorkbenchRiskDrawdownResponse | null;
+  riskDrawdownDetail: WorkbenchRiskDrawdownResponse | null;
   isLoading: boolean;
+  isDrawdownDetailLoading: boolean;
+  requestDrawdownDetail: () => void;
 };
 
 export function usePerformanceRiskContract({
@@ -37,12 +44,20 @@ export function usePerformanceRiskContract({
   const workspaceRef = useRef(workspace);
   const summaryCacheRef = useRef<Map<string, WorkbenchRiskSummaryResponse>>(new Map());
   const concentrationCacheRef = useRef<Map<string, WorkbenchRiskConcentrationResponse>>(new Map());
+  const drawdownCacheRef = useRef<Map<string, WorkbenchRiskDrawdownResponse>>(new Map());
+  const drawdownDetailCacheRef = useRef<Map<string, WorkbenchRiskDrawdownResponse>>(new Map());
   const requestSequenceRef = useRef(0);
+  const drawdownDetailRequestSequenceRef = useRef(0);
   const [riskSummary, setRiskSummary] = useState<WorkbenchRiskSummaryResponse | null>(null);
   const [riskConcentration, setRiskConcentration] = useState<WorkbenchRiskConcentrationResponse | null>(
     null
   );
+  const [riskDrawdown, setRiskDrawdown] = useState<WorkbenchRiskDrawdownResponse | null>(null);
+  const [riskDrawdownDetail, setRiskDrawdownDetail] = useState<WorkbenchRiskDrawdownResponse | null>(
+    null
+  );
   const [isLoading, setIsLoading] = useState(false);
+  const [isDrawdownDetailLoading, setIsDrawdownDetailLoading] = useState(false);
 
   useEffect(() => {
     workspaceRef.current = workspace;
@@ -86,23 +101,72 @@ export function usePerformanceRiskContract({
     ]
   );
 
+  const drawdownKey = useMemo(
+    () =>
+      JSON.stringify({
+        portfolioId: workspace.portfolio.portfolio_id,
+        period,
+        detailBasis,
+        benchmark: workspace.benchmark_code ?? null,
+        asOfDate: workspace.as_of_date,
+        reportingCurrency: workspace.portfolio.base_currency,
+        includeUnderwaterSeries: false,
+      }),
+    [
+      detailBasis,
+      period,
+      workspace.as_of_date,
+      workspace.benchmark_code,
+      workspace.portfolio.base_currency,
+      workspace.portfolio.portfolio_id,
+    ]
+  );
+
+  const drawdownDetailKey = useMemo(
+    () =>
+      JSON.stringify({
+        portfolioId: workspace.portfolio.portfolio_id,
+        period,
+        detailBasis,
+        benchmark: workspace.benchmark_code ?? null,
+        asOfDate: workspace.as_of_date,
+        reportingCurrency: workspace.portfolio.base_currency,
+        includeUnderwaterSeries: true,
+      }),
+    [
+      detailBasis,
+      period,
+      workspace.as_of_date,
+      workspace.benchmark_code,
+      workspace.portfolio.base_currency,
+      workspace.portfolio.portfolio_id,
+    ]
+  );
+
   useEffect(() => {
     if (isDetailsPending) {
       setRiskSummary(null);
       setRiskConcentration(null);
+      setRiskDrawdown(null);
+      setRiskDrawdownDetail(null);
       setIsLoading(true);
+      setIsDrawdownDetailLoading(false);
       return;
     }
 
     const cachedSummary = summaryCacheRef.current.get(summaryKey) ?? null;
     const cachedConcentration = concentrationCacheRef.current.get(concentrationKey) ?? null;
+    const cachedDrawdown = drawdownCacheRef.current.get(drawdownKey) ?? null;
 
     setRiskSummary(cachedSummary);
     setRiskConcentration(cachedConcentration);
+    setRiskDrawdown(cachedDrawdown);
+    setRiskDrawdownDetail(drawdownDetailCacheRef.current.get(drawdownDetailKey) ?? null);
 
     const needsSummary = !cachedSummary;
     const needsConcentration = !cachedConcentration;
-    if (!needsSummary && !needsConcentration) {
+    const needsDrawdown = !cachedDrawdown;
+    if (!needsSummary && !needsConcentration && !needsDrawdown) {
       setIsLoading(false);
       return;
     }
@@ -143,8 +207,27 @@ export function usePerformanceRiskContract({
         )
       : Promise.resolve(cachedConcentration);
 
-    void Promise.all([summaryPromise, concentrationPromise]).then(
-      ([nextSummary, nextConcentration]) => {
+    const drawdownPromise = needsDrawdown
+      ? getWorkbenchRiskDrawdownClient(workspace.portfolio.portfolio_id, {
+          period,
+          detailBasis,
+          benchmark: workspace.benchmark_code ?? undefined,
+          asOfDate: workspace.as_of_date,
+          reportingCurrency: workspace.portfolio.base_currency,
+          includeUnderwaterSeries: false,
+        }).catch((error: unknown) =>
+          buildUnavailableRiskDrawdown({
+            workspace: workspaceRef.current,
+            period,
+            detailBasis,
+            detail: error instanceof Error ? error.message : "Risk drawdown fetch failed.",
+            includeUnderwaterSeries: false,
+          })
+        )
+      : Promise.resolve(cachedDrawdown);
+
+    void Promise.all([summaryPromise, concentrationPromise, drawdownPromise]).then(
+      ([nextSummary, nextConcentration, nextDrawdown]) => {
         if (requestSequenceRef.current !== requestId) {
           return;
         }
@@ -156,12 +239,18 @@ export function usePerformanceRiskContract({
           concentrationCacheRef.current.set(concentrationKey, nextConcentration);
           setRiskConcentration(nextConcentration);
         }
+        if (nextDrawdown) {
+          drawdownCacheRef.current.set(drawdownKey, nextDrawdown);
+          setRiskDrawdown(nextDrawdown);
+        }
         setIsLoading(false);
       }
     );
   }, [
     concentrationKey,
     detailBasis,
+    drawdownDetailKey,
+    drawdownKey,
     isDetailsPending,
     period,
     summaryKey,
@@ -171,5 +260,53 @@ export function usePerformanceRiskContract({
     workspace.portfolio.portfolio_id,
   ]);
 
-  return { riskSummary, riskConcentration, isLoading };
+  const requestDrawdownDetail = () => {
+    if (isDetailsPending) {
+      return;
+    }
+    const cachedDetail = drawdownDetailCacheRef.current.get(drawdownDetailKey) ?? null;
+    if (cachedDetail) {
+      setRiskDrawdownDetail(cachedDetail);
+      return;
+    }
+    const requestId = drawdownDetailRequestSequenceRef.current + 1;
+    drawdownDetailRequestSequenceRef.current = requestId;
+    setIsDrawdownDetailLoading(true);
+    void getWorkbenchRiskDrawdownClient(workspaceRef.current.portfolio.portfolio_id, {
+      period,
+      detailBasis,
+      benchmark: workspaceRef.current.benchmark_code ?? undefined,
+      asOfDate: workspaceRef.current.as_of_date,
+      reportingCurrency: workspaceRef.current.portfolio.base_currency,
+      includeUnderwaterSeries: true,
+    })
+      .catch((error: unknown) =>
+        buildUnavailableRiskDrawdown({
+          workspace: workspaceRef.current,
+          period,
+          detailBasis,
+          detail:
+            error instanceof Error ? error.message : "Risk drawdown detail fetch failed.",
+          includeUnderwaterSeries: true,
+        })
+      )
+      .then((response) => {
+        if (drawdownDetailRequestSequenceRef.current !== requestId) {
+          return;
+        }
+        drawdownDetailCacheRef.current.set(drawdownDetailKey, response);
+        setRiskDrawdownDetail(response);
+        setIsDrawdownDetailLoading(false);
+      });
+  };
+
+  return {
+    riskSummary,
+    riskConcentration,
+    riskDrawdown,
+    riskDrawdownDetail,
+    isLoading,
+    isDrawdownDetailLoading,
+    requestDrawdownDetail,
+  };
 }

--- a/src/apps/performance/use-performance-risk-contract.ts
+++ b/src/apps/performance/use-performance-risk-contract.ts
@@ -5,18 +5,21 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   getWorkbenchRiskConcentrationClient,
   getWorkbenchRiskDrawdownClient,
+  getWorkbenchRiskRollingClient,
   getWorkbenchRiskSummaryClient,
 } from "@/features/workbench/api";
 import type {
   WorkbenchPerformanceWorkspace,
   WorkbenchRiskConcentrationResponse,
   WorkbenchRiskDrawdownResponse,
+  WorkbenchRiskRollingResponse,
   WorkbenchRiskSummaryResponse,
 } from "@/features/workbench/types";
 
 import {
   buildUnavailableRiskConcentration,
   buildUnavailableRiskDrawdown,
+  buildUnavailableRiskRolling,
   buildUnavailableRiskSummary,
 } from "./risk-workspace-view-model";
 
@@ -25,9 +28,13 @@ type PerformanceRiskContractState = {
   riskConcentration: WorkbenchRiskConcentrationResponse | null;
   riskDrawdown: WorkbenchRiskDrawdownResponse | null;
   riskDrawdownDetail: WorkbenchRiskDrawdownResponse | null;
+  riskRolling: WorkbenchRiskRollingResponse | null;
+  riskRollingDetail: WorkbenchRiskRollingResponse | null;
   isLoading: boolean;
   isDrawdownDetailLoading: boolean;
+  isRollingDetailLoading: boolean;
   requestDrawdownDetail: () => void;
+  requestRollingDetail: () => void;
 };
 
 export function usePerformanceRiskContract({
@@ -46,8 +53,11 @@ export function usePerformanceRiskContract({
   const concentrationCacheRef = useRef<Map<string, WorkbenchRiskConcentrationResponse>>(new Map());
   const drawdownCacheRef = useRef<Map<string, WorkbenchRiskDrawdownResponse>>(new Map());
   const drawdownDetailCacheRef = useRef<Map<string, WorkbenchRiskDrawdownResponse>>(new Map());
+  const rollingCacheRef = useRef<Map<string, WorkbenchRiskRollingResponse>>(new Map());
+  const rollingDetailCacheRef = useRef<Map<string, WorkbenchRiskRollingResponse>>(new Map());
   const requestSequenceRef = useRef(0);
   const drawdownDetailRequestSequenceRef = useRef(0);
+  const rollingDetailRequestSequenceRef = useRef(0);
   const [riskSummary, setRiskSummary] = useState<WorkbenchRiskSummaryResponse | null>(null);
   const [riskConcentration, setRiskConcentration] = useState<WorkbenchRiskConcentrationResponse | null>(
     null
@@ -56,8 +66,13 @@ export function usePerformanceRiskContract({
   const [riskDrawdownDetail, setRiskDrawdownDetail] = useState<WorkbenchRiskDrawdownResponse | null>(
     null
   );
+  const [riskRolling, setRiskRolling] = useState<WorkbenchRiskRollingResponse | null>(null);
+  const [riskRollingDetail, setRiskRollingDetail] = useState<WorkbenchRiskRollingResponse | null>(
+    null
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [isDrawdownDetailLoading, setIsDrawdownDetailLoading] = useState(false);
+  const [isRollingDetailLoading, setIsRollingDetailLoading] = useState(false);
 
   useEffect(() => {
     workspaceRef.current = workspace;
@@ -143,30 +158,79 @@ export function usePerformanceRiskContract({
     ]
   );
 
+  const rollingKey = useMemo(
+    () =>
+      JSON.stringify({
+        portfolioId: workspace.portfolio.portfolio_id,
+        period,
+        detailBasis,
+        benchmark: workspace.benchmark_code ?? null,
+        asOfDate: workspace.as_of_date,
+        reportingCurrency: workspace.portfolio.base_currency,
+        includeTimeSeries: false,
+      }),
+    [
+      detailBasis,
+      period,
+      workspace.as_of_date,
+      workspace.benchmark_code,
+      workspace.portfolio.base_currency,
+      workspace.portfolio.portfolio_id,
+    ]
+  );
+
+  const rollingDetailKey = useMemo(
+    () =>
+      JSON.stringify({
+        portfolioId: workspace.portfolio.portfolio_id,
+        period,
+        detailBasis,
+        benchmark: workspace.benchmark_code ?? null,
+        asOfDate: workspace.as_of_date,
+        reportingCurrency: workspace.portfolio.base_currency,
+        includeTimeSeries: true,
+      }),
+    [
+      detailBasis,
+      period,
+      workspace.as_of_date,
+      workspace.benchmark_code,
+      workspace.portfolio.base_currency,
+      workspace.portfolio.portfolio_id,
+    ]
+  );
+
   useEffect(() => {
     if (isDetailsPending) {
       setRiskSummary(null);
       setRiskConcentration(null);
       setRiskDrawdown(null);
       setRiskDrawdownDetail(null);
+      setRiskRolling(null);
+      setRiskRollingDetail(null);
       setIsLoading(true);
       setIsDrawdownDetailLoading(false);
+      setIsRollingDetailLoading(false);
       return;
     }
 
     const cachedSummary = summaryCacheRef.current.get(summaryKey) ?? null;
     const cachedConcentration = concentrationCacheRef.current.get(concentrationKey) ?? null;
     const cachedDrawdown = drawdownCacheRef.current.get(drawdownKey) ?? null;
+    const cachedRolling = rollingCacheRef.current.get(rollingKey) ?? null;
 
     setRiskSummary(cachedSummary);
     setRiskConcentration(cachedConcentration);
     setRiskDrawdown(cachedDrawdown);
     setRiskDrawdownDetail(drawdownDetailCacheRef.current.get(drawdownDetailKey) ?? null);
+    setRiskRolling(cachedRolling);
+    setRiskRollingDetail(rollingDetailCacheRef.current.get(rollingDetailKey) ?? null);
 
     const needsSummary = !cachedSummary;
     const needsConcentration = !cachedConcentration;
     const needsDrawdown = !cachedDrawdown;
-    if (!needsSummary && !needsConcentration && !needsDrawdown) {
+    const needsRolling = !cachedRolling;
+    if (!needsSummary && !needsConcentration && !needsDrawdown && !needsRolling) {
       setIsLoading(false);
       return;
     }
@@ -226,8 +290,27 @@ export function usePerformanceRiskContract({
         )
       : Promise.resolve(cachedDrawdown);
 
-    void Promise.all([summaryPromise, concentrationPromise, drawdownPromise]).then(
-      ([nextSummary, nextConcentration, nextDrawdown]) => {
+    const rollingPromise = needsRolling
+      ? getWorkbenchRiskRollingClient(workspace.portfolio.portfolio_id, {
+          period,
+          detailBasis,
+          benchmark: workspace.benchmark_code ?? undefined,
+          asOfDate: workspace.as_of_date,
+          reportingCurrency: workspace.portfolio.base_currency,
+          includeTimeSeries: false,
+        }).catch((error: unknown) =>
+          buildUnavailableRiskRolling({
+            workspace: workspaceRef.current,
+            period,
+            detailBasis,
+            detail: error instanceof Error ? error.message : "Risk rolling fetch failed.",
+            includeTimeSeries: false,
+          })
+        )
+      : Promise.resolve(cachedRolling);
+
+    void Promise.all([summaryPromise, concentrationPromise, drawdownPromise, rollingPromise]).then(
+      ([nextSummary, nextConcentration, nextDrawdown, nextRolling]) => {
         if (requestSequenceRef.current !== requestId) {
           return;
         }
@@ -243,6 +326,10 @@ export function usePerformanceRiskContract({
           drawdownCacheRef.current.set(drawdownKey, nextDrawdown);
           setRiskDrawdown(nextDrawdown);
         }
+        if (nextRolling) {
+          rollingCacheRef.current.set(rollingKey, nextRolling);
+          setRiskRolling(nextRolling);
+        }
         setIsLoading(false);
       }
     );
@@ -253,6 +340,8 @@ export function usePerformanceRiskContract({
     drawdownKey,
     isDetailsPending,
     period,
+    rollingDetailKey,
+    rollingKey,
     summaryKey,
     workspace.as_of_date,
     workspace.benchmark_code,
@@ -300,13 +389,57 @@ export function usePerformanceRiskContract({
       });
   };
 
+  const requestRollingDetail = () => {
+    if (isDetailsPending) {
+      return;
+    }
+    const cachedDetail = rollingDetailCacheRef.current.get(rollingDetailKey) ?? null;
+    if (cachedDetail) {
+      setRiskRollingDetail(cachedDetail);
+      return;
+    }
+    const requestId = rollingDetailRequestSequenceRef.current + 1;
+    rollingDetailRequestSequenceRef.current = requestId;
+    setIsRollingDetailLoading(true);
+    void getWorkbenchRiskRollingClient(workspaceRef.current.portfolio.portfolio_id, {
+      period,
+      detailBasis,
+      benchmark: workspaceRef.current.benchmark_code ?? undefined,
+      asOfDate: workspaceRef.current.as_of_date,
+      reportingCurrency: workspaceRef.current.portfolio.base_currency,
+      includeTimeSeries: true,
+    })
+      .catch((error: unknown) =>
+        buildUnavailableRiskRolling({
+          workspace: workspaceRef.current,
+          period,
+          detailBasis,
+          detail:
+            error instanceof Error ? error.message : "Risk rolling detail fetch failed.",
+          includeTimeSeries: true,
+        })
+      )
+      .then((response) => {
+        if (rollingDetailRequestSequenceRef.current !== requestId) {
+          return;
+        }
+        rollingDetailCacheRef.current.set(rollingDetailKey, response);
+        setRiskRollingDetail(response);
+        setIsRollingDetailLoading(false);
+      });
+  };
+
   return {
     riskSummary,
     riskConcentration,
     riskDrawdown,
     riskDrawdownDetail,
+    riskRolling,
+    riskRollingDetail,
     isLoading,
     isDrawdownDetailLoading,
+    isRollingDetailLoading,
     requestDrawdownDetail,
+    requestRollingDetail,
   };
 }

--- a/src/apps/portfolio/components/portfolio-workspace-client.tsx
+++ b/src/apps/portfolio/components/portfolio-workspace-client.tsx
@@ -22,6 +22,7 @@ import {
   buildPortfolioWorkspaceContext,
   derivePortfolioWorkspace,
   getPortfolioDefaultFilterValue,
+  getOrderedWorkflowCues,
   type PortfolioTimeWindow,
   type PortfolioWorkspaceControls,
 } from "../view-model";
@@ -294,7 +295,7 @@ export default function PortfolioWorkspaceClient({
                 onFilterReset={handleFilterReset}
                 onFilterChipRemove={handleFilterChipRemove}
                 onExport={handleExport}
-                quickActions={initialWorkspace?.workflow_cues ?? []}
+                quickActions={workspaceState ? getOrderedWorkflowCues(workspaceState) : []}
               />
             )
           }

--- a/src/apps/portfolio/view-model.ts
+++ b/src/apps/portfolio/view-model.ts
@@ -1,5 +1,7 @@
 import {
+  getWorkflowActionLabel,
   getWorkflowTaskLabel,
+  mapWorkflowHref,
   WORKFLOW_DISPLAY_ORDER,
 } from "./workspace-config";
 import { formatDate } from "./formatters";
@@ -756,9 +758,10 @@ export function buildPortfolioInsights(workspace: PortfolioWorkspace): Portfolio
     insights.push({
       key: "equity-concentration-high",
       title: "Large position dominates portfolio risk",
-      detail: "One holding has become large enough to dominate current portfolio concentration.",
+      detail:
+        "One holding has become large enough to dominate current portfolio concentration. Open Risk to review concentration pressure.",
       severity: "warning",
-      href: "#portfolio-insights",
+      href: mapWorkflowHref("risk", workspace.portfolio.portfolio_id),
     });
   }
 
@@ -787,6 +790,7 @@ export function buildPortfolioInsights(workspace: PortfolioWorkspace): Portfolio
 
 export function getOrderedWorkflowCues(workspace: PortfolioWorkspace): PortfolioWorkflowCue[] {
   const supportedWorkflowKeys = new Set<string>(WORKFLOW_DISPLAY_ORDER);
+  const portfolioId = workspace.portfolio.portfolio_id;
 
   return [...workspace.workflow_cues]
     .filter((cue) => supportedWorkflowKeys.has(cue.key))
@@ -803,7 +807,11 @@ export function getOrderedWorkflowCues(workspace: PortfolioWorkspace): Portfolio
 
       return (leftOrder === -1 ? Number.MAX_SAFE_INTEGER : leftOrder) -
         (rightOrder === -1 ? Number.MAX_SAFE_INTEGER : rightOrder);
-    });
+    })
+    .map((cue) => ({
+      ...cue,
+      href: mapWorkflowHref(cue.key, portfolioId),
+    }));
 }
 
 export function buildPortfolioWorkflowActions(
@@ -873,8 +881,8 @@ export function buildPortfolioWorkflowActions(
     title: getWorkflowTaskLabel(cue.key),
     impact: getWorkflowImpactLabel(cue.key),
     target: `Target: ${cue.label} workflow for this portfolio`,
-    href: cue.href,
-    cta_label: cue.label,
+    href: mapWorkflowHref(cue.key, workspace.portfolio.portfolio_id),
+    cta_label: getWorkflowActionLabel(cue.key),
     recommended: index === 0,
   }));
 }

--- a/src/apps/portfolio/workspace-config.ts
+++ b/src/apps/portfolio/workspace-config.ts
@@ -10,7 +10,7 @@ export function mapWorkflowHref(key: string, portfolioId: string): string {
     case "performance":
       return `/performance?portfolioId=${encodeURIComponent(portfolioId)}`;
     case "risk":
-      return `/risk-and-suitability?portfolioId=${encodeURIComponent(portfolioId)}`;
+      return `/performance?portfolioId=${encodeURIComponent(portfolioId)}&mode=risk`;
     default:
       return `/portfolio?portfolioId=${encodeURIComponent(portfolioId)}`;
   }
@@ -19,7 +19,7 @@ export function mapWorkflowHref(key: string, portfolioId: string): string {
 export function getWorkflowActionLabel(key: string): string {
   switch (key) {
     case "risk":
-      return "Review Suitability";
+      return "Open Risk";
     default:
       return "Performance";
   }
@@ -28,7 +28,7 @@ export function getWorkflowActionLabel(key: string): string {
 export function getWorkflowTaskLabel(key: string): string {
   switch (key) {
     case "risk":
-      return "Review suitability";
+      return "Review risk";
     default:
       return "Review performance";
   }

--- a/src/design-system/components/disclosure-toggle-button.tsx
+++ b/src/design-system/components/disclosure-toggle-button.tsx
@@ -51,7 +51,7 @@ export default function DisclosureToggleButton({
       type="button"
       className={cx("disclosure-toggle-button", className)}
       aria-expanded={expanded}
-      aria-label={label}
+      aria-label={toggleLabel || label}
       onClick={onToggle}
     >
       {content}

--- a/src/features/platform-runtime/service-addressing.ts
+++ b/src/features/platform-runtime/service-addressing.ts
@@ -1,11 +1,26 @@
 const BFF_PROXY_BASE_URL = "/api/bff";
 const API_VERSION_PREFIX = "/api/v1";
 const DEFAULT_LOTUS_ENVIRONMENT = "dev";
+const DISALLOWED_LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0"]);
 
 export type ServiceRequestTarget = "server" | "client";
 
 function normalizeBaseUrl(value: string): string {
   return value.replace(/\/+$/, "");
+}
+
+function assertCanonicalGatewayBaseUrl(value: string): string {
+  const normalized = normalizeBaseUrl(value);
+  const parsed = new URL(normalized);
+  const hostname = parsed.hostname.trim().toLowerCase();
+
+  if (DISALLOWED_LOCAL_HOSTS.has(hostname)) {
+    throw new Error(
+      `BFF_BASE_URL must use a canonical Lotus hostname, not local loopback (${hostname}).`
+    );
+  }
+
+  return normalized;
 }
 
 export function resolveLotusEnvironment(): string {
@@ -16,15 +31,15 @@ export function resolveLotusEnvironment(): string {
 export function resolveGatewayBaseUrl(): string {
   const configured = process.env.BFF_BASE_URL?.trim();
   if (configured && configured.length > 0) {
-    return normalizeBaseUrl(configured);
+    return assertCanonicalGatewayBaseUrl(configured);
   }
 
   const environment = resolveLotusEnvironment();
-  const protocol = environment === "dev" || environment === "local" ? "http" : "https";
+  const protocol = environment === "dev" ? "http" : "https";
   const host = environment === "prod" || environment === "production"
     ? "gateway.lotus"
     : `gateway.${environment}.lotus`;
-  return `${protocol}://${host}`;
+  return assertCanonicalGatewayBaseUrl(`${protocol}://${host}`);
 }
 
 export function resolveBffProxyBaseUrl(): string {

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -6,6 +6,7 @@ import {
   WorkbenchPerformanceHorizonComparison,
   WorkbenchRiskConcentrationResponse,
   WorkbenchRiskDrawdownResponse,
+  WorkbenchRiskRollingResponse,
   WorkbenchRiskSummaryResponse,
   WorkbenchPerformanceWorkspaceDetails,
   WorkbenchPerformanceWorkspaceSummary,
@@ -461,6 +462,35 @@ export async function getWorkbenchRiskDrawdownClient(
   return await fetchWorkbenchJson<WorkbenchRiskDrawdownResponse>(
     buildWorkbenchUrl("client", `/workbench/${portfolioId}/risk/drawdown`, query),
     "workbench risk drawdown"
+  );
+}
+
+export async function getWorkbenchRiskRollingClient(
+  portfolioId: string,
+  params: {
+    period: string;
+    detailBasis: string;
+    benchmark?: string;
+    asOfDate?: string;
+    reportingCurrency?: string;
+    includeTimeSeries?: boolean;
+  }
+): Promise<WorkbenchRiskRollingResponse> {
+  const query = new URLSearchParams(
+    buildRiskWorkspaceQuery({
+      period: params.period,
+      detailBasis: params.detailBasis,
+      benchmark: params.benchmark,
+      asOfDate: params.asOfDate,
+      reportingCurrency: params.reportingCurrency,
+    })
+  );
+  if (params.includeTimeSeries) {
+    query.set("include_time_series", "true");
+  }
+  return await fetchWorkbenchJson<WorkbenchRiskRollingResponse>(
+    buildWorkbenchUrl("client", `/workbench/${portfolioId}/risk/rolling`, query),
+    "workbench risk rolling"
   );
 }
 

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -4,6 +4,8 @@ import {
   WorkbenchPerformanceAttributionTrend,
   WorkbenchOverview,
   WorkbenchPerformanceHorizonComparison,
+  WorkbenchRiskConcentrationResponse,
+  WorkbenchRiskSummaryResponse,
   WorkbenchPerformanceWorkspaceDetails,
   WorkbenchPerformanceWorkspaceSummary,
   WorkbenchPortfolio360,
@@ -355,6 +357,80 @@ export async function getWorkbenchPerformanceAdvisorBriefClient(
     `/workbench/${portfolioId}/performance/advisor-brief`,
     "performance advisor brief",
     buildPerformanceWorkspaceQuery(params)
+  );
+}
+
+function buildRiskWorkspaceQuery(params: {
+  period: string;
+  detailBasis?: string;
+  benchmark?: string;
+  asOfDate?: string;
+  reportingCurrency?: string;
+}): string {
+  const query = new URLSearchParams();
+  query.set("period", params.period);
+  if (params.detailBasis) {
+    query.set("detail_basis", params.detailBasis);
+  }
+  if (params.benchmark) {
+    query.set("benchmark_code", params.benchmark);
+  }
+  if (params.asOfDate) {
+    query.set("as_of_date", params.asOfDate);
+  }
+  if (params.reportingCurrency) {
+    query.set("reporting_currency", params.reportingCurrency);
+  }
+  return query.toString();
+}
+
+function buildRiskWorkspaceUrl(
+  portfolioId: string,
+  pathSuffix: "/risk/summary" | "/risk/concentration",
+  params: {
+    period: string;
+    detailBasis?: string;
+    benchmark?: string;
+    asOfDate?: string;
+    reportingCurrency?: string;
+  },
+  target: WorkbenchRequestTarget
+): string {
+  return buildWorkbenchUrl(
+    target,
+    `/workbench/${portfolioId}${pathSuffix}`,
+    buildRiskWorkspaceQuery(params)
+  );
+}
+
+export async function getWorkbenchRiskSummaryClient(
+  portfolioId: string,
+  params: {
+    period: string;
+    detailBasis: string;
+    benchmark?: string;
+    asOfDate?: string;
+    reportingCurrency?: string;
+  }
+): Promise<WorkbenchRiskSummaryResponse> {
+  return await fetchWorkbenchJson<WorkbenchRiskSummaryResponse>(
+    buildRiskWorkspaceUrl(portfolioId, "/risk/summary", params, "client"),
+    "workbench risk summary"
+  );
+}
+
+export async function getWorkbenchRiskConcentrationClient(
+  portfolioId: string,
+  params: {
+    period: string;
+    benchmark?: string;
+    asOfDate?: string;
+    reportingCurrency?: string;
+  }
+): Promise<WorkbenchRiskConcentrationResponse> {
+  return await fetchWorkbenchJson<WorkbenchRiskConcentrationResponse>(
+    buildRiskWorkspaceUrl(portfolioId, "/risk/concentration", params, "client"),
+    "workbench risk concentration"
   );
 }
 

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -5,6 +5,7 @@ import {
   WorkbenchOverview,
   WorkbenchPerformanceHorizonComparison,
   WorkbenchRiskConcentrationResponse,
+  WorkbenchRiskDrawdownResponse,
   WorkbenchRiskSummaryResponse,
   WorkbenchPerformanceWorkspaceDetails,
   WorkbenchPerformanceWorkspaceSummary,
@@ -386,7 +387,7 @@ function buildRiskWorkspaceQuery(params: {
 
 function buildRiskWorkspaceUrl(
   portfolioId: string,
-  pathSuffix: "/risk/summary" | "/risk/concentration",
+  pathSuffix: "/risk/summary" | "/risk/concentration" | "/risk/drawdown",
   params: {
     period: string;
     detailBasis?: string;
@@ -431,6 +432,35 @@ export async function getWorkbenchRiskConcentrationClient(
   return await fetchWorkbenchJson<WorkbenchRiskConcentrationResponse>(
     buildRiskWorkspaceUrl(portfolioId, "/risk/concentration", params, "client"),
     "workbench risk concentration"
+  );
+}
+
+export async function getWorkbenchRiskDrawdownClient(
+  portfolioId: string,
+  params: {
+    period: string;
+    detailBasis: string;
+    benchmark?: string;
+    asOfDate?: string;
+    reportingCurrency?: string;
+    includeUnderwaterSeries?: boolean;
+  }
+): Promise<WorkbenchRiskDrawdownResponse> {
+  const query = new URLSearchParams(
+    buildRiskWorkspaceQuery({
+      period: params.period,
+      detailBasis: params.detailBasis,
+      benchmark: params.benchmark,
+      asOfDate: params.asOfDate,
+      reportingCurrency: params.reportingCurrency,
+    })
+  );
+  if (params.includeUnderwaterSeries) {
+    query.set("include_underwater_series", "true");
+  }
+  return await fetchWorkbenchJson<WorkbenchRiskDrawdownResponse>(
+    buildWorkbenchUrl("client", `/workbench/${portfolioId}/risk/drawdown`, query),
+    "workbench risk drawdown"
   );
 }
 

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -6,6 +6,7 @@ import {
   WorkbenchPerformanceHorizonComparison,
   WorkbenchRiskConcentrationResponse,
   WorkbenchRiskDrawdownResponse,
+  WorkbenchRiskAttributionResponse,
   WorkbenchRiskRollingResponse,
   WorkbenchRiskSummaryResponse,
   WorkbenchPerformanceWorkspaceDetails,
@@ -388,7 +389,11 @@ function buildRiskWorkspaceQuery(params: {
 
 function buildRiskWorkspaceUrl(
   portfolioId: string,
-  pathSuffix: "/risk/summary" | "/risk/concentration" | "/risk/drawdown",
+  pathSuffix:
+    | "/risk/summary"
+    | "/risk/concentration"
+    | "/risk/drawdown"
+    | "/risk/attribution",
   params: {
     period: string;
     detailBasis?: string;
@@ -491,6 +496,35 @@ export async function getWorkbenchRiskRollingClient(
   return await fetchWorkbenchJson<WorkbenchRiskRollingResponse>(
     buildWorkbenchUrl("client", `/workbench/${portfolioId}/risk/rolling`, query),
     "workbench risk rolling"
+  );
+}
+
+export async function getWorkbenchRiskAttributionClient(
+  portfolioId: string,
+  params: {
+    period: string;
+    detailBasis: string;
+    benchmark?: string;
+    asOfDate?: string;
+    reportingCurrency?: string;
+    attributionType: string;
+    groupingDimension: string;
+  }
+): Promise<WorkbenchRiskAttributionResponse> {
+  const query = new URLSearchParams(
+    buildRiskWorkspaceQuery({
+      period: params.period,
+      detailBasis: params.detailBasis,
+      benchmark: params.benchmark,
+      asOfDate: params.asOfDate,
+      reportingCurrency: params.reportingCurrency,
+    })
+  );
+  query.set("attribution_type", params.attributionType);
+  query.set("grouping_dimension", params.groupingDimension);
+  return await fetchWorkbenchJson<WorkbenchRiskAttributionResponse>(
+    buildWorkbenchUrl("client", `/workbench/${portfolioId}/risk/attribution`, query),
+    "workbench risk attribution"
   );
 }
 

--- a/src/features/workbench/components/decision-readiness-panel.tsx
+++ b/src/features/workbench/components/decision-readiness-panel.tsx
@@ -1,4 +1,4 @@
-import { MetricRow, SectionBlock, SemanticBadge, Text } from "@/design-system";
+import { ActionLink, MetricRow, SectionBlock, SemanticBadge, Text } from "@/design-system";
 
 type Props = {
   hasValuationData: boolean;
@@ -7,29 +7,15 @@ type Props = {
   hasActiveSandbox: boolean;
   warningCount: number;
   failureCount: number;
-  hhiProposed: number | null;
+  riskWorkspaceHref: string;
 };
 
 function statusLabel(ready: boolean): string {
   return ready ? "READY" : "PENDING";
 }
 
-function concentrationSignal(hhiProposed: number | null): string {
-  if (hhiProposed === null) {
-    return "UNAVAILABLE";
-  }
-  if (hhiProposed >= 0.25) {
-    return "HIGH";
-  }
-  if (hhiProposed >= 0.15) {
-    return "MEDIUM";
-  }
-  return "LOW";
-}
-
 export default function DecisionReadinessPanel(props: Props) {
   const dataIntegrityReady = props.warningCount === 0 && props.failureCount === 0;
-  const riskSignal = concentrationSignal(props.hhiProposed);
   const readinessTone = (value: string) =>
     value === "READY" || value === "LOW"
       ? "success"
@@ -48,8 +34,8 @@ export default function DecisionReadinessPanel(props: Props) {
       <MetricRow label="Sandbox Session" value={<SemanticBadge tone={readinessTone(statusLabel(props.hasActiveSandbox))}>{statusLabel(props.hasActiveSandbox)}</SemanticBadge>} />
       <MetricRow label="Data Integrity" value={<SemanticBadge tone={readinessTone(dataIntegrityReady ? "READY" : "ATTENTION")}>{dataIntegrityReady ? "READY" : "ATTENTION"}</SemanticBadge>} />
       <MetricRow
-        label="Concentration Risk"
-        value={<SemanticBadge tone={readinessTone(riskSignal)}>{riskSignal}</SemanticBadge>}
+        label="Risk Workspace"
+        value={<ActionLink href={props.riskWorkspaceHref}>Open Risk</ActionLink>}
       />
     </SectionBlock>
   );

--- a/src/features/workbench/components/decision-readiness-panel.tsx
+++ b/src/features/workbench/components/decision-readiness-panel.tsx
@@ -16,7 +16,7 @@ function statusLabel(ready: boolean): string {
 
 function concentrationSignal(hhiProposed: number | null): string {
   if (hhiProposed === null) {
-    return "UNKNOWN";
+    return "UNAVAILABLE";
   }
   if (hhiProposed >= 0.25) {
     return "HIGH";
@@ -31,7 +31,11 @@ export default function DecisionReadinessPanel(props: Props) {
   const dataIntegrityReady = props.warningCount === 0 && props.failureCount === 0;
   const riskSignal = concentrationSignal(props.hhiProposed);
   const readinessTone = (value: string) =>
-    value === "READY" || value === "LOW" ? "success" : value === "ATTENTION" || value === "MEDIUM" ? "warn" : "danger";
+    value === "READY" || value === "LOW"
+      ? "success"
+      : value === "ATTENTION" || value === "MEDIUM" || value === "UNAVAILABLE"
+        ? "warn"
+        : "danger";
 
   return (
     <SectionBlock title="Decision Readiness">
@@ -43,7 +47,10 @@ export default function DecisionReadinessPanel(props: Props) {
       <MetricRow label="Reporting Coverage" value={<SemanticBadge tone={readinessTone(statusLabel(props.hasReporting))}>{statusLabel(props.hasReporting)}</SemanticBadge>} />
       <MetricRow label="Sandbox Session" value={<SemanticBadge tone={readinessTone(statusLabel(props.hasActiveSandbox))}>{statusLabel(props.hasActiveSandbox)}</SemanticBadge>} />
       <MetricRow label="Data Integrity" value={<SemanticBadge tone={readinessTone(dataIntegrityReady ? "READY" : "ATTENTION")}>{dataIntegrityReady ? "READY" : "ATTENTION"}</SemanticBadge>} />
-      <MetricRow label="Concentration Signal (HHI)" value={<SemanticBadge tone={readinessTone(riskSignal)}>{riskSignal}</SemanticBadge>} />
+      <MetricRow
+        label="Concentration Risk"
+        value={<SemanticBadge tone={readinessTone(riskSignal)}>{riskSignal}</SemanticBadge>}
+      />
     </SectionBlock>
   );
 }

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -525,6 +525,107 @@ export type WorkbenchPerformanceAdvisorBrief = {
   partial_failures: WorkbenchOverview["partial_failures"];
 };
 
+export type WorkbenchRiskModuleState = "ready" | "partial" | "unavailable" | "blocked";
+export type WorkbenchRiskSupportabilityState = WorkbenchRiskModuleState;
+
+export type WorkbenchRiskSupportabilityItem = {
+  key: string;
+  label: string;
+  state: WorkbenchRiskSupportabilityState;
+  reason?: string | null;
+  source_service?: string | null;
+};
+
+export type WorkbenchRiskMetric = {
+  key: string;
+  label: string;
+  value: number | null;
+  state: WorkbenchRiskModuleState;
+  reason?: string | null;
+  details?: Record<string, unknown> | null;
+};
+
+export type WorkbenchRiskSummaryResponse = {
+  correlation_id: string;
+  contract_version: "risk-workspace.v1";
+  portfolio_id: string;
+  period: string;
+  as_of_date: string;
+  benchmark_code?: string | null;
+  source_service: "lotus-risk";
+  state: WorkbenchRiskModuleState;
+  payload: {
+    periods: Array<{
+      key: string;
+      label: string;
+      start_date: string;
+      end_date: string;
+      metrics: WorkbenchRiskMetric[];
+    }>;
+  } | null;
+  supportability: WorkbenchRiskSupportabilityItem[];
+  warnings: string[];
+  partial_failures: WorkbenchOverview["partial_failures"];
+  metadata: {
+    generated_at: string;
+    input_mode: "stateful";
+    methodology_version?: string | null;
+    cache_status?: "hit" | "miss" | "bypass" | null;
+  };
+};
+
+export type WorkbenchRiskConcentrationResponse = {
+  correlation_id: string;
+  contract_version: "risk-workspace.v1";
+  portfolio_id: string;
+  period: string;
+  as_of_date: string;
+  benchmark_code?: string | null;
+  source_service: "lotus-risk";
+  state: WorkbenchRiskModuleState;
+  payload: {
+    risk_proxy: {
+      hhi_current: number;
+      hhi_proposed: number;
+      hhi_delta: number;
+    };
+    single_position_concentration: {
+      top_position_weight_current: number;
+      top_position_weight_proposed: number;
+      top_position_weight_delta: number;
+      top_n_cumulative_weight_current: number;
+      top_n_cumulative_weight_proposed: number;
+      top_n_cumulative_weight_delta: number;
+      top_n: number;
+    };
+    issuer_concentration: {
+      hhi_current: number;
+      hhi_proposed: number;
+      hhi_delta: number;
+      top_issuer_weight_current: number;
+      top_issuer_weight_proposed: number;
+      top_issuer_weight_delta: number;
+      coverage_status: string;
+      covered_position_count_current: number;
+      covered_position_count_proposed: number;
+      total_position_count_current: number;
+      total_position_count_proposed: number;
+      note?: string | null;
+    };
+    valuation_context?: Record<string, unknown> | null;
+    risk_metadata?: Record<string, unknown> | null;
+  } | null;
+  supportability: WorkbenchRiskSupportabilityItem[];
+  warnings: string[];
+  partial_failures: WorkbenchOverview["partial_failures"];
+  metadata: {
+    generated_at: string;
+    input_mode: "stateful";
+    methodology_version?: string | null;
+    cache_status?: "hit" | "miss" | "bypass" | null;
+  };
+};
+
 export type WorkbenchReportingSnapshot = {
   correlationId: string;
   contractVersion: string;

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -697,6 +697,59 @@ export type WorkbenchRiskDrawdownResponse = {
   };
 };
 
+export type WorkbenchRiskRollingMetricSummary = {
+  latest: number | null;
+  average: number | null;
+  minimum: number | null;
+  maximum: number | null;
+  p05: number | null;
+  p50: number | null;
+  p95: number | null;
+};
+
+export type WorkbenchRiskRollingMetricSeriesPoint = {
+  date: string;
+  metric_values: Record<string, number | null>;
+};
+
+export type WorkbenchRiskRollingWindowResult = {
+  window_length: number;
+  metric_summaries: Record<string, WorkbenchRiskRollingMetricSummary>;
+  metric_series?: WorkbenchRiskRollingMetricSeriesPoint[] | null;
+};
+
+export type WorkbenchRiskRollingResponse = {
+  correlation_id: string;
+  contract_version: "risk-workspace.v1";
+  portfolio_id: string;
+  period: string;
+  as_of_date: string;
+  benchmark_code?: string | null;
+  source_service: "lotus-risk";
+  state: WorkbenchRiskModuleState;
+  payload: {
+    periods: Array<{
+      key: string;
+      label: string;
+      start_date: string;
+      end_date: string;
+      series_count: number;
+      window_results: WorkbenchRiskRollingWindowResult[];
+      quality_flags: string[];
+      error?: string | null;
+    }>;
+  } | null;
+  supportability: WorkbenchRiskSupportabilityItem[];
+  warnings: string[];
+  partial_failures: WorkbenchOverview["partial_failures"];
+  metadata: {
+    generated_at: string;
+    input_mode: "stateful";
+    methodology_version?: string | null;
+    cache_status?: "hit" | "miss" | "bypass" | null;
+  };
+};
+
 export type WorkbenchReportingSnapshot = {
   correlationId: string;
   contractVersion: string;

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -126,7 +126,7 @@ export type WorkbenchAnalytics = {
   active_return_pct: number | null;
   allocation_buckets: WorkbenchAnalyticsBucket[];
   top_changes: WorkbenchAnalyticsTopChange[];
-  risk_proxy: WorkbenchAnalyticsRiskProxy;
+  risk_proxy: WorkbenchAnalyticsRiskProxy | null;
   warnings: string[];
   partial_failures: WorkbenchOverview["partial_failures"];
 };

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -750,6 +750,81 @@ export type WorkbenchRiskRollingResponse = {
   };
 };
 
+export type WorkbenchRiskAttributionTypeOption = {
+  key: string;
+  label: string;
+  state: WorkbenchRiskSupportabilityState;
+  reason?: string | null;
+};
+
+export type WorkbenchRiskAttributionGroupingOption = {
+  key: string;
+  label: string;
+  state: WorkbenchRiskSupportabilityState;
+  reason?: string | null;
+  supported_attribution_types: string[];
+};
+
+export type WorkbenchRiskAttributionContributor = {
+  group_key: string;
+  group_label: string;
+  weight_average?: number | null;
+  marginal_contribution?: number | null;
+  component_contribution?: number | null;
+  percent_contribution?: number | null;
+};
+
+export type WorkbenchRiskAttributionSet = {
+  attribution_type: string;
+  metric: string;
+  grouping_dimension: string;
+  total_value?: number | null;
+  reconciled_sum?: number | null;
+  residual?: number | null;
+  contributors: WorkbenchRiskAttributionContributor[];
+  quality_flags: string[];
+};
+
+export type WorkbenchRiskAttributionPeriodResult = {
+  key: string;
+  label: string;
+  start_date: string;
+  end_date: string;
+  attribution_sets: WorkbenchRiskAttributionSet[];
+  error?: string | null;
+};
+
+export type WorkbenchRiskAttributionControls = {
+  attribution_types: WorkbenchRiskAttributionTypeOption[];
+  grouping_dimensions: WorkbenchRiskAttributionGroupingOption[];
+  selected_attribution_type: string;
+  selected_grouping_dimension: string;
+};
+
+export type WorkbenchRiskAttributionResponse = {
+  correlation_id: string;
+  contract_version: "risk-workspace.v1";
+  portfolio_id: string;
+  period: string;
+  as_of_date: string;
+  benchmark_code?: string | null;
+  source_service: "lotus-risk";
+  state: WorkbenchRiskModuleState;
+  payload: {
+    controls: WorkbenchRiskAttributionControls;
+    periods: WorkbenchRiskAttributionPeriodResult[];
+  } | null;
+  supportability: WorkbenchRiskSupportabilityItem[];
+  warnings: string[];
+  partial_failures: WorkbenchOverview["partial_failures"];
+  metadata: {
+    generated_at: string;
+    input_mode: "stateful";
+    methodology_version?: string | null;
+    cache_status?: "hit" | "miss" | "bypass" | null;
+  };
+};
+
 export type WorkbenchReportingSnapshot = {
   correlationId: string;
   contractVersion: string;

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -626,6 +626,77 @@ export type WorkbenchRiskConcentrationResponse = {
   };
 };
 
+export type WorkbenchRiskDrawdownSummary = {
+  max_drawdown: number | null;
+  max_drawdown_peak_date?: string | null;
+  max_drawdown_trough_date?: string | null;
+  max_drawdown_recovery_date?: string | null;
+  is_recovered: boolean;
+  days_to_trough?: number | null;
+  days_to_recovery?: number | null;
+  time_under_water_days: number;
+  average_drawdown?: number | null;
+  ulcer_index?: number | null;
+  drawdown_at_risk_95?: number | null;
+  conditional_drawdown_at_risk_95?: number | null;
+};
+
+export type WorkbenchRiskDrawdownEpisode = {
+  episode_id: string;
+  peak_date: string;
+  trough_date: string;
+  recovery_date?: string | null;
+  depth: number;
+  days_to_trough: number;
+  days_to_recovery?: number | null;
+  total_days: number;
+  is_recovered: boolean;
+};
+
+export type WorkbenchRiskRelativeDrawdownSummary = {
+  max_drawdown: number | null;
+  max_drawdown_peak_date?: string | null;
+  max_drawdown_trough_date?: string | null;
+};
+
+export type WorkbenchRiskUnderwaterPoint = {
+  date: string;
+  drawdown: number;
+};
+
+export type WorkbenchRiskDrawdownResponse = {
+  correlation_id: string;
+  contract_version: "risk-workspace.v1";
+  portfolio_id: string;
+  period: string;
+  as_of_date: string;
+  benchmark_code?: string | null;
+  source_service: "lotus-risk";
+  state: WorkbenchRiskModuleState;
+  payload: {
+    periods: Array<{
+      key: string;
+      label: string;
+      start_date: string;
+      end_date: string;
+      summary: WorkbenchRiskDrawdownSummary | null;
+      episodes: WorkbenchRiskDrawdownEpisode[];
+      relative_to_benchmark?: WorkbenchRiskRelativeDrawdownSummary | null;
+      underwater_series?: WorkbenchRiskUnderwaterPoint[] | null;
+      error?: string | null;
+    }>;
+  } | null;
+  supportability: WorkbenchRiskSupportabilityItem[];
+  warnings: string[];
+  partial_failures: WorkbenchOverview["partial_failures"];
+  metadata: {
+    generated_at: string;
+    input_mode: "stateful";
+    methodology_version?: string | null;
+    cache_status?: "hit" | "miss" | "bypass" | null;
+  };
+};
+
 export type WorkbenchReportingSnapshot = {
   correlationId: string;
   contractVersion: string;

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -107,12 +107,6 @@ export type WorkbenchAnalyticsTopChange = {
   direction: string;
 };
 
-export type WorkbenchAnalyticsRiskProxy = {
-  hhi_current: number;
-  hhi_proposed: number;
-  hhi_delta: number;
-};
-
 export type WorkbenchAnalytics = {
   correlation_id: string;
   contract_version: string;
@@ -126,7 +120,6 @@ export type WorkbenchAnalytics = {
   active_return_pct: number | null;
   allocation_buckets: WorkbenchAnalyticsBucket[];
   top_changes: WorkbenchAnalyticsTopChange[];
-  risk_proxy: WorkbenchAnalyticsRiskProxy | null;
   warnings: string[];
   partial_failures: WorkbenchOverview["partial_failures"];
 };

--- a/src/shell/app-registry.ts
+++ b/src/shell/app-registry.ts
@@ -3,7 +3,6 @@ export type ShellAppId =
   | "clients"
   | "portfolio"
   | "performance"
-  | "risk"
   | "reporting"
   | "operations";
 
@@ -53,15 +52,6 @@ export const SHELL_APPS: ShellApp[] = [
     matchers: ["/performance"],
     capabilityKey: "analytics_studio",
     available: true,
-  },
-  {
-    id: "risk",
-    label: "Suitability",
-    href: "/risk-and-suitability",
-    description: "Suitability review.",
-    matchers: ["/risk-and-suitability", "/risk"],
-    capabilityKey: "analytics_studio",
-    available: false,
   },
   {
     id: "reporting",

--- a/tests/fixtures/performance-workspace-server-fixtures.ts
+++ b/tests/fixtures/performance-workspace-server-fixtures.ts
@@ -14,6 +14,7 @@ import {
 import {
   buildFixtureRiskConcentration,
   buildFixtureRiskDrawdown,
+  buildFixtureRiskRolling,
   buildFixtureRiskSummary,
 } from "../../src/apps/performance/risk-workspace-view-model";
 
@@ -163,6 +164,24 @@ function buildRiskDrawdownResponse(
   });
 }
 
+function buildRiskRollingResponse(
+  portfolioId: string,
+  options?: PerformanceFixtureOptions,
+  includeTimeSeries = false
+) {
+  const scenario = options
+    ? buildBenchmarkUnassignedPerformanceScenario()
+    : buildSupportedPerformanceScenario();
+  const workspace = {
+    ...scenario.workspace,
+    portfolio_id: portfolioId,
+    portfolio: { ...scenario.workspace.portfolio, portfolio_id: portfolioId },
+  };
+  return buildFixtureRiskRolling(workspace, workspace.period, workspace.detail_basis, {
+    includeTimeSeries,
+  });
+}
+
 export function installPerformancePageFetchMock(options?: PerformanceFixtureOptions) {
   vi.stubGlobal(
     "fetch",
@@ -227,6 +246,17 @@ export function installPerformancePageFetchMock(options?: PerformanceFixtureOpti
               "DEMO_ADV_USD_001",
               options,
               url.includes("include_underwater_series=true")
+            ),
+        } as Response;
+      }
+      if (url.includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/rolling")) {
+        return {
+          ok: true,
+          json: async () =>
+            buildRiskRollingResponse(
+              "DEMO_ADV_USD_001",
+              options,
+              url.includes("include_time_series=true")
             ),
         } as Response;
       }
@@ -335,6 +365,15 @@ export function installPerformancePageFetchScenario(
             buildFixtureRiskDrawdown(workspace, workspace.period, workspace.detail_basis, {
               includeUnderwaterSeries: url.includes("include_underwater_series=true"),
               includeBenchmarkRelative: Boolean(workspace.benchmark_code),
+            }),
+        } as Response;
+      }
+      if (url.includes(`/api/bff/api/v1/workbench/${portfolioId}/risk/rolling`)) {
+        return {
+          ok: true,
+          json: async () =>
+            buildFixtureRiskRolling(workspace, workspace.period, workspace.detail_basis, {
+              includeTimeSeries: url.includes("include_time_series=true"),
             }),
         } as Response;
       }

--- a/tests/fixtures/performance-workspace-server-fixtures.ts
+++ b/tests/fixtures/performance-workspace-server-fixtures.ts
@@ -11,6 +11,10 @@ import {
   type PerformanceFixtureOptions,
   type PerformancePresentationScenario,
 } from "./performance-workspace-fixtures";
+import {
+  buildFixtureRiskConcentration,
+  buildFixtureRiskSummary,
+} from "../../src/apps/performance/risk-workspace-view-model";
 
 type InstallPerformancePageFetchScenarioOptions = {
   portfolioId?: string;
@@ -115,6 +119,30 @@ function buildAdvisorBriefResponse(portfolioId: string, benchmarkCode: string | 
   };
 }
 
+function buildRiskSummaryResponse(portfolioId: string, options?: PerformanceFixtureOptions) {
+  const scenario = options
+    ? buildBenchmarkUnassignedPerformanceScenario()
+    : buildSupportedPerformanceScenario();
+  const workspace = {
+    ...scenario.workspace,
+    portfolio_id: portfolioId,
+    portfolio: { ...scenario.workspace.portfolio, portfolio_id: portfolioId },
+  };
+  return buildFixtureRiskSummary(workspace, workspace.period, workspace.detail_basis);
+}
+
+function buildRiskConcentrationResponse(portfolioId: string, options?: PerformanceFixtureOptions) {
+  const scenario = options
+    ? buildBenchmarkUnassignedPerformanceScenario()
+    : buildSupportedPerformanceScenario();
+  const workspace = {
+    ...scenario.workspace,
+    portfolio_id: portfolioId,
+    portfolio: { ...scenario.workspace.portfolio, portfolio_id: portfolioId },
+  };
+  return buildFixtureRiskConcentration(workspace, workspace.period);
+}
+
 export function installPerformancePageFetchMock(options?: PerformanceFixtureOptions) {
   vi.stubGlobal(
     "fetch",
@@ -157,6 +185,18 @@ export function installPerformancePageFetchMock(options?: PerformanceFixtureOpti
         return {
           ok: true,
           json: async () => buildAdvisorBriefResponse("DEMO_ADV_USD_001", "BMK_GLOBAL_BALANCED_60_40"),
+        } as Response;
+      }
+      if (url.includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/summary")) {
+        return {
+          ok: true,
+          json: async () => buildRiskSummaryResponse("DEMO_ADV_USD_001", options),
+        } as Response;
+      }
+      if (url.includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/concentration")) {
+        return {
+          ok: true,
+          json: async () => buildRiskConcentrationResponse("DEMO_ADV_USD_001", options),
         } as Response;
       }
       if (url.includes("/api/v1/workbench/PF_1001/performance/summary")) {
@@ -243,6 +283,18 @@ export function installPerformancePageFetchScenario(
         return {
           ok: true,
           json: async () => buildAdvisorBriefResponse(portfolioId, workspace.benchmark_code),
+        } as Response;
+      }
+      if (url.includes(`/api/bff/api/v1/workbench/${portfolioId}/risk/summary`)) {
+        return {
+          ok: true,
+          json: async () => buildFixtureRiskSummary(workspace, workspace.period, workspace.detail_basis),
+        } as Response;
+      }
+      if (url.includes(`/api/bff/api/v1/workbench/${portfolioId}/risk/concentration`)) {
+        return {
+          ok: true,
+          json: async () => buildFixtureRiskConcentration(workspace, workspace.period),
         } as Response;
       }
       if (url.includes("/api/v1/workbench/PF_1001/performance/summary")) {

--- a/tests/fixtures/performance-workspace-server-fixtures.ts
+++ b/tests/fixtures/performance-workspace-server-fixtures.ts
@@ -12,6 +12,7 @@ import {
   type PerformancePresentationScenario,
 } from "./performance-workspace-fixtures";
 import {
+  buildFixtureRiskAttribution,
   buildFixtureRiskConcentration,
   buildFixtureRiskDrawdown,
   buildFixtureRiskRolling,
@@ -182,6 +183,26 @@ function buildRiskRollingResponse(
   });
 }
 
+function buildRiskAttributionResponse(
+  portfolioId: string,
+  options?: PerformanceFixtureOptions,
+  attributionType: "TOTAL_RISK" | "ACTIVE_RISK" = "TOTAL_RISK",
+  groupingDimension: "POSITION" | "SECTOR" | "ASSET_CLASS" | "ISSUER" = "SECTOR"
+) {
+  const scenario = options
+    ? buildBenchmarkUnassignedPerformanceScenario()
+    : buildSupportedPerformanceScenario();
+  const workspace = {
+    ...scenario.workspace,
+    portfolio_id: portfolioId,
+    portfolio: { ...scenario.workspace.portfolio, portfolio_id: portfolioId },
+  };
+  return buildFixtureRiskAttribution(workspace, workspace.period, workspace.detail_basis, {
+    attributionType,
+    groupingDimension,
+  });
+}
+
 export function installPerformancePageFetchMock(options?: PerformanceFixtureOptions) {
   vi.stubGlobal(
     "fetch",
@@ -236,6 +257,24 @@ export function installPerformancePageFetchMock(options?: PerformanceFixtureOpti
         return {
           ok: true,
           json: async () => buildRiskConcentrationResponse("DEMO_ADV_USD_001", options),
+        } as Response;
+      }
+      if (url.includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/attribution")) {
+        return {
+          ok: true,
+          json: async () =>
+            buildRiskAttributionResponse(
+              "DEMO_ADV_USD_001",
+              options,
+              url.includes("attribution_type=ACTIVE_RISK") ? "ACTIVE_RISK" : "TOTAL_RISK",
+              url.includes("grouping_dimension=ASSET_CLASS")
+                ? "ASSET_CLASS"
+                : url.includes("grouping_dimension=ISSUER")
+                  ? "ISSUER"
+                  : url.includes("grouping_dimension=POSITION")
+                    ? "POSITION"
+                    : "SECTOR"
+            ),
         } as Response;
       }
       if (url.includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/drawdown")) {
@@ -356,6 +395,24 @@ export function installPerformancePageFetchScenario(
         return {
           ok: true,
           json: async () => buildFixtureRiskConcentration(workspace, workspace.period),
+        } as Response;
+      }
+      if (url.includes(`/api/bff/api/v1/workbench/${portfolioId}/risk/attribution`)) {
+        return {
+          ok: true,
+          json: async () =>
+            buildFixtureRiskAttribution(workspace, workspace.period, workspace.detail_basis, {
+              attributionType: url.includes("attribution_type=ACTIVE_RISK")
+                ? "ACTIVE_RISK"
+                : "TOTAL_RISK",
+              groupingDimension: url.includes("grouping_dimension=ASSET_CLASS")
+                ? "ASSET_CLASS"
+                : url.includes("grouping_dimension=ISSUER")
+                  ? "ISSUER"
+                  : url.includes("grouping_dimension=POSITION")
+                    ? "POSITION"
+                    : "SECTOR",
+            }),
         } as Response;
       }
       if (url.includes(`/api/bff/api/v1/workbench/${portfolioId}/risk/drawdown`)) {

--- a/tests/fixtures/performance-workspace-server-fixtures.ts
+++ b/tests/fixtures/performance-workspace-server-fixtures.ts
@@ -13,6 +13,7 @@ import {
 } from "./performance-workspace-fixtures";
 import {
   buildFixtureRiskConcentration,
+  buildFixtureRiskDrawdown,
   buildFixtureRiskSummary,
 } from "../../src/apps/performance/risk-workspace-view-model";
 
@@ -143,6 +144,25 @@ function buildRiskConcentrationResponse(portfolioId: string, options?: Performan
   return buildFixtureRiskConcentration(workspace, workspace.period);
 }
 
+function buildRiskDrawdownResponse(
+  portfolioId: string,
+  options?: PerformanceFixtureOptions,
+  includeUnderwaterSeries = false
+) {
+  const scenario = options
+    ? buildBenchmarkUnassignedPerformanceScenario()
+    : buildSupportedPerformanceScenario();
+  const workspace = {
+    ...scenario.workspace,
+    portfolio_id: portfolioId,
+    portfolio: { ...scenario.workspace.portfolio, portfolio_id: portfolioId },
+  };
+  return buildFixtureRiskDrawdown(workspace, workspace.period, workspace.detail_basis, {
+    includeUnderwaterSeries,
+    includeBenchmarkRelative: Boolean(workspace.benchmark_code),
+  });
+}
+
 export function installPerformancePageFetchMock(options?: PerformanceFixtureOptions) {
   vi.stubGlobal(
     "fetch",
@@ -197,6 +217,17 @@ export function installPerformancePageFetchMock(options?: PerformanceFixtureOpti
         return {
           ok: true,
           json: async () => buildRiskConcentrationResponse("DEMO_ADV_USD_001", options),
+        } as Response;
+      }
+      if (url.includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/drawdown")) {
+        return {
+          ok: true,
+          json: async () =>
+            buildRiskDrawdownResponse(
+              "DEMO_ADV_USD_001",
+              options,
+              url.includes("include_underwater_series=true")
+            ),
         } as Response;
       }
       if (url.includes("/api/v1/workbench/PF_1001/performance/summary")) {
@@ -295,6 +326,16 @@ export function installPerformancePageFetchScenario(
         return {
           ok: true,
           json: async () => buildFixtureRiskConcentration(workspace, workspace.period),
+        } as Response;
+      }
+      if (url.includes(`/api/bff/api/v1/workbench/${portfolioId}/risk/drawdown`)) {
+        return {
+          ok: true,
+          json: async () =>
+            buildFixtureRiskDrawdown(workspace, workspace.period, workspace.detail_basis, {
+              includeUnderwaterSeries: url.includes("include_underwater_series=true"),
+              includeBenchmarkRelative: Boolean(workspace.benchmark_code),
+            }),
         } as Response;
       }
       if (url.includes("/api/v1/workbench/PF_1001/performance/summary")) {

--- a/tests/integration/performance-analytics-page.test.tsx
+++ b/tests/integration/performance-analytics-page.test.tsx
@@ -496,6 +496,7 @@ describe("PerformanceAnalyticsPage", () => {
     expect(screen.getByRole("heading", { name: "Stateful Risk" })).toBeInTheDocument();
     expect(screen.getByLabelText("Risk mode status")).toHaveTextContent("Stateful only");
     expect(screen.getByLabelText("Risk snapshot metric table")).toHaveTextContent("Volatility");
+    expect(screen.getByLabelText("Rolling risk summary table")).toHaveTextContent("Average");
     expect(screen.getByLabelText("Risk concentration diagnostic table")).toHaveTextContent(
       "Issuer Coverage"
     );
@@ -515,11 +516,31 @@ describe("PerformanceAnalyticsPage", () => {
       )
     ).toBe(true);
     expect(
+      fetchMock.mock.calls.some(([input]) =>
+        input.toString().includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/rolling")
+      )
+    ).toBe(true);
+    expect(
       fetchMock.mock.calls.some(([input]) => input.toString().includes("/analytics/risk/"))
     ).toBe(false);
     expect(
       fetchMock.mock.calls.some(([input]) => input.toString().includes("lotus-risk"))
     ).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand rolling series" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Rolling risk series table")).toBeInTheDocument();
+    });
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        input
+          .toString()
+          .includes(
+            "/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/rolling?period=YTD&detail_basis=NET&benchmark_code=BMK_GLOBAL_BALANCED_60_40&as_of_date=2026-02-24&reporting_currency=USD&include_time_series=true"
+          )
+      )
+    ).toBe(true);
   });
 
   it("shows a compact normalization notice when the backend adjusted unsupported controls", async () => {

--- a/tests/integration/performance-analytics-page.test.tsx
+++ b/tests/integration/performance-analytics-page.test.tsx
@@ -496,6 +496,9 @@ describe("PerformanceAnalyticsPage", () => {
     expect(screen.getByRole("heading", { name: "Stateful Risk" })).toBeInTheDocument();
     expect(screen.getByLabelText("Risk mode status")).toHaveTextContent("Stateful only");
     expect(screen.getByLabelText("Risk snapshot metric table")).toHaveTextContent("Volatility");
+    expect(screen.getByLabelText("Historical risk attribution table")).toHaveTextContent(
+      "Technology"
+    );
     expect(screen.getByLabelText("Rolling risk summary table")).toHaveTextContent("Average");
     expect(screen.getByLabelText("Risk concentration diagnostic table")).toHaveTextContent(
       "Issuer Coverage"
@@ -513,6 +516,11 @@ describe("PerformanceAnalyticsPage", () => {
         input
           .toString()
           .includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/concentration")
+      )
+    ).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        input.toString().includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/attribution")
       )
     ).toBe(true);
     expect(
@@ -541,6 +549,28 @@ describe("PerformanceAnalyticsPage", () => {
           )
       )
     ).toBe(true);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Active Risk" }));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input]) =>
+          input.toString().includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/attribution") &&
+          input.toString().includes("attribution_type=ACTIVE_RISK") &&
+          input.toString().includes("grouping_dimension=SECTOR")
+        )
+      ).toBe(true);
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Asset Class" }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input]) =>
+          input.toString().includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/attribution") &&
+          input.toString().includes("attribution_type=ACTIVE_RISK") &&
+          input.toString().includes("grouping_dimension=ASSET_CLASS")
+        )
+      ).toBe(true);
+    });
   });
 
   it("shows a compact normalization notice when the backend adjusted unsupported controls", async () => {

--- a/tests/integration/performance-analytics-page.test.tsx
+++ b/tests/integration/performance-analytics-page.test.tsx
@@ -503,6 +503,18 @@ describe("PerformanceAnalyticsPage", () => {
 
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
     expect(
+      fetchMock.mock.calls.some(([input]) =>
+        input.toString().includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/summary")
+      )
+    ).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        input
+          .toString()
+          .includes("/api/bff/api/v1/workbench/DEMO_ADV_USD_001/risk/concentration")
+      )
+    ).toBe(true);
+    expect(
       fetchMock.mock.calls.some(([input]) => input.toString().includes("/analytics/risk/"))
     ).toBe(false);
     expect(

--- a/tests/integration/performance-analytics-page.test.tsx
+++ b/tests/integration/performance-analytics-page.test.tsx
@@ -485,6 +485,31 @@ describe("PerformanceAnalyticsPage", () => {
     expect(await screen.findByRole("heading", { name: "Attribution Detail" })).toBeInTheDocument();
   });
 
+  it("shows Risk as a stateful fixture-backed mode without browser calls to raw lotus-risk APIs", async () => {
+    installPerformancePageFetchMock();
+
+    render(await PerformanceAnalyticsPage({ searchParams: Promise.resolve({}) }));
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Risk" }));
+
+    expect(await screen.findByRole("region", { name: "Risk" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Stateful Risk" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Risk mode status")).toHaveTextContent("Stateful only");
+    expect(screen.getByLabelText("Risk snapshot metric table")).toHaveTextContent("Volatility");
+    expect(screen.getByLabelText("Risk concentration diagnostic table")).toHaveTextContent(
+      "Issuer Coverage"
+    );
+    expect(screen.getByLabelText("Risk support rail")).toHaveTextContent("Risk-free series");
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(
+      fetchMock.mock.calls.some(([input]) => input.toString().includes("/analytics/risk/"))
+    ).toBe(false);
+    expect(
+      fetchMock.mock.calls.some(([input]) => input.toString().includes("lotus-risk"))
+    ).toBe(false);
+  });
+
   it("shows a compact normalization notice when the backend adjusted unsupported controls", async () => {
     installPerformancePageFetchScenario(buildNormalizedControlsPerformanceScenario());
 

--- a/tests/integration/performance-analytics-page.test.tsx
+++ b/tests/integration/performance-analytics-page.test.tsx
@@ -485,6 +485,34 @@ describe("PerformanceAnalyticsPage", () => {
     expect(await screen.findByRole("heading", { name: "Attribution Detail" })).toBeInTheDocument();
   });
 
+  it("opens Performance Risk mode from the mode query parameter and preserves it in navigation updates", async () => {
+    installPerformancePageFetchMock();
+
+    render(
+      await PerformanceAnalyticsPage({
+        searchParams: Promise.resolve({
+          portfolioId: "DEMO_ADV_USD_001",
+          mode: "risk",
+        }),
+      })
+    );
+
+    expect(await screen.findByRole("tab", { name: "Risk" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+    expect(screen.getByLabelText("Risk mode status")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Analysis" }));
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith(
+        expect.stringContaining("/performance?portfolioId=DEMO_ADV_USD_001&mode=analysis"),
+        { scroll: false }
+      );
+    });
+  });
+
   it("shows Risk as a stateful fixture-backed mode without browser calls to raw lotus-risk APIs", async () => {
     installPerformancePageFetchMock();
 
@@ -673,7 +701,7 @@ describe("PerformanceAnalyticsPage", () => {
 
       await waitFor(() => {
         expect(replaceMock).toHaveBeenCalledWith(
-          "/performance?portfolioId=DEMO_ADV_USD_001&period=YTD&detailBasis=NET&contributionDimension=asset_class&attributionDimension=asset_class&chartFrequency=monthly&benchmark=BMK_GLOBAL_BALANCED_60_40",
+          "/performance?portfolioId=DEMO_ADV_USD_001&mode=analysis&period=YTD&detailBasis=NET&contributionDimension=asset_class&attributionDimension=asset_class&chartFrequency=monthly&benchmark=BMK_GLOBAL_BALANCED_60_40",
           { scroll: false }
         );
       });

--- a/tests/integration/portfolios-page.test.tsx
+++ b/tests/integration/portfolios-page.test.tsx
@@ -263,7 +263,7 @@ describe("PortfolioFoundationPage", () => {
     expect(screen.getAllByText("cash balance service unavailable").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByRole("link", { name: /^Performance$/i })[0]).toHaveAttribute(
       "href",
-      "/ignored"
+      "/performance?portfolioId=PORT_UI_1001"
     );
     expect(screen.getByText("Review performance")).toBeInTheDocument();
     expect(
@@ -272,7 +272,7 @@ describe("PortfolioFoundationPage", () => {
     expect(screen.queryByText(/target: performance workflow for this portfolio/i)).not.toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /^Performance$/i })[1]).toHaveAttribute(
       "href",
-      "/ignored"
+      "/performance?portfolioId=PORT_UI_1001"
     );
 
     fireEvent.click(screen.getAllByRole("button", { name: /AUM/i })[0]);

--- a/tests/integration/top-nav-capabilities.test.tsx
+++ b/tests/integration/top-nav-capabilities.test.tsx
@@ -14,15 +14,13 @@ describe("TopNav", () => {
 
     const clientsDisabled = screen.getByText("Relationship Book");
     const analyticsDisabled = screen.getByText("Performance");
-    const riskDisabled = screen.getByText("Suitability");
     const reportingDisabled = screen.getByText("Reporting");
 
     expect(clientsDisabled.tagName).toBe("SPAN");
     expect(clientsDisabled).toHaveAttribute("aria-disabled", "true");
     expect(analyticsDisabled.tagName).toBe("A");
     expect(analyticsDisabled).toHaveAttribute("href", "/performance");
-    expect(riskDisabled.tagName).toBe("SPAN");
-    expect(riskDisabled).toHaveAttribute("aria-disabled", "true");
+    expect(screen.queryByText("Suitability")).not.toBeInTheDocument();
     expect(reportingDisabled.tagName).toBe("SPAN");
     expect(reportingDisabled).toHaveAttribute("aria-disabled", "true");
   });

--- a/tests/integration/workbench-page.test.tsx
+++ b/tests/integration/workbench-page.test.tsx
@@ -95,13 +95,15 @@ describe("WorkbenchPage", () => {
               active_return_pct: 0.25,
               allocation_buckets: [],
               top_changes: [],
-              risk_proxy: {
-                hhi_current: 0.11,
-                hhi_proposed: 0.18,
-                hhi_delta: 0.07,
-              },
-              warnings: [],
-              partial_failures: [],
+              risk_proxy: null,
+              warnings: ["RISK_BFF_PENDING"],
+              partial_failures: [
+                {
+                  source_service: "risk",
+                  error_code: "RISK_BFF_NOT_IMPLEMENTED",
+                  detail: "Stateful concentration risk will be restored through the Risk BFF.",
+                },
+              ],
             }),
           } as Response;
         }
@@ -134,8 +136,9 @@ describe("WorkbenchPage", () => {
 
     expect(screen.getByRole("heading", { name: /Advisor Workbench: PF_1001/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Decision Readiness/i })).toBeInTheDocument();
-    expect(screen.getByText("Concentration Signal (HHI)")).toBeInTheDocument();
-    expect(screen.getByText("MEDIUM")).toBeInTheDocument();
+    expect(screen.getByText("Concentration Risk")).toBeInTheDocument();
+    expect(screen.getByText("UNAVAILABLE")).toBeInTheDocument();
+    expect(screen.getAllByText(/RISK_BFF_NOT_IMPLEMENTED/).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Data Integrity")).toBeInTheDocument();
     expect(screen.getByText("ATTENTION")).toBeInTheDocument();
     expect(screen.getByText("Partial Data Warning")).toBeInTheDocument();

--- a/tests/integration/workbench-page.test.tsx
+++ b/tests/integration/workbench-page.test.tsx
@@ -95,7 +95,6 @@ describe("WorkbenchPage", () => {
               active_return_pct: 0.25,
               allocation_buckets: [],
               top_changes: [],
-              risk_proxy: null,
               warnings: ["RISK_BFF_PENDING"],
               partial_failures: [
                 {
@@ -136,8 +135,11 @@ describe("WorkbenchPage", () => {
 
     expect(screen.getByRole("heading", { name: /Advisor Workbench: PF_1001/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Decision Readiness/i })).toBeInTheDocument();
-    expect(screen.getByText("Concentration Risk")).toBeInTheDocument();
-    expect(screen.getByText("UNAVAILABLE")).toBeInTheDocument();
+    expect(screen.getByText("Risk Workspace")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open Risk" })).toHaveAttribute(
+      "href",
+      "/performance?portfolioId=PF_1001&mode=risk"
+    );
     expect(screen.getAllByText(/RISK_BFF_NOT_IMPLEMENTED/).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Data Integrity")).toBeInTheDocument();
     expect(screen.getByText("ATTENTION")).toBeInTheDocument();

--- a/tests/unit/decision-readiness-panel.test.tsx
+++ b/tests/unit/decision-readiness-panel.test.tsx
@@ -13,13 +13,16 @@ describe("DecisionReadinessPanel", () => {
         hasActiveSandbox
         warningCount={0}
         failureCount={0}
-        hhiProposed={0.12}
+        riskWorkspaceHref="/performance?portfolioId=PF_1001&mode=risk"
       />
     );
 
     expect(screen.getByRole("heading", { name: /Decision Readiness/i })).toBeInTheDocument();
     expect(screen.getAllByText("READY").length).toBeGreaterThanOrEqual(5);
-    expect(screen.getByText("LOW")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open Risk" })).toHaveAttribute(
+      "href",
+      "/performance?portfolioId=PF_1001&mode=risk"
+    );
   });
 
   it("shows attention states when dependencies are missing", () => {
@@ -31,12 +34,15 @@ describe("DecisionReadinessPanel", () => {
         hasActiveSandbox={false}
         warningCount={2}
         failureCount={1}
-        hhiProposed={0.3}
+        riskWorkspaceHref="/performance?portfolioId=PF_2001&mode=risk"
       />
     );
 
     expect(screen.getAllByText("PENDING").length).toBeGreaterThanOrEqual(4);
     expect(screen.getByText("ATTENTION")).toBeInTheDocument();
-    expect(screen.getByText("HIGH")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open Risk" })).toHaveAttribute(
+      "href",
+      "/performance?portfolioId=PF_2001&mode=risk"
+    );
   });
 });

--- a/tests/unit/performance-advisor-brief-view-model.test.ts
+++ b/tests/unit/performance-advisor-brief-view-model.test.ts
@@ -238,4 +238,156 @@ describe("buildPerformanceAdvisorBriefViewModel", () => {
       ])
     );
   });
+
+  it("drops risk source facts and risk drilldowns when gateway evidence is not ready", () => {
+    const scenario = buildSupportedPerformanceScenario();
+
+    const brief = buildPerformanceAdvisorBriefViewModel({
+      workspace: scenario.workspace,
+      advisorBrief: {
+        correlation_id: "corr-risk-brief",
+        contract_version: "v1",
+        portfolio_id: "PF_1001",
+        portfolio: scenario.workspace.portfolio,
+        as_of_date: scenario.workspace.as_of_date,
+        period: scenario.workspace.period,
+        report_start_date: scenario.workspace.report_start_date,
+        report_end_date: scenario.workspace.report_end_date,
+        detail_basis: "NET",
+        chart_frequency: "monthly",
+        contribution_dimension: "asset_class",
+        attribution_dimension: "asset_class",
+        benchmark_code: scenario.workspace.benchmark_code,
+        status: "ready",
+        summary: "Risk-linked advisor brief.",
+        talking_points: [
+          {
+            headline: "Portfolio concentration warrants review.",
+            detail: "Open Risk to inspect HHI and top-position concentration.",
+            tone: "warning",
+            evidence_refs: [
+              {
+                metric_label: "HHI Current",
+                metric_value: "1260",
+                source_surface: "risk.concentration",
+                target_mode: "risk",
+                route: "/performance?portfolioId=PF_1001&mode=risk",
+              },
+            ],
+          },
+        ],
+        recommended_actions: [
+          {
+            label: "Open Risk",
+            target_mode: "risk",
+            route: "/performance?portfolioId=PF_1001&mode=risk",
+          },
+        ],
+        risks_and_exceptions: [],
+        source_metrics: [
+          {
+            label: "HHI Current",
+            value: "1260",
+            support_label: "Stateful concentration",
+            target_mode: "risk",
+            route: "/performance?portfolioId=PF_1001&mode=risk",
+            state: "partial",
+          },
+        ],
+        supportability: [{ label: "Advisor Brief", value: "Ready", tone: "success" }],
+        ai_audit: { stubbed: false },
+        ai_evidence: { source_refs: ["lotus-gateway:risk:summary"] },
+        warnings: [],
+        partial_failures: [],
+      },
+      capabilities: scenario.capabilities,
+      period: scenario.workspace.period,
+      detailBasis: "NET",
+      contributionDimension: "asset_class",
+      attributionDimension: "asset_class",
+      chartFrequency: "monthly",
+      benchmark: scenario.workspace.benchmark_code ?? undefined,
+      isDetailsPending: false,
+    });
+
+    expect(brief.talkingPoints).toEqual([]);
+    expect(brief.recommendedActions.some((action) => action.targetMode === "risk")).toBe(false);
+    expect(brief.sourceMetrics.some((metric) => metric.targetMode === "risk")).toBe(false);
+  });
+
+  it("keeps risk source facts when gateway evidence is ready", () => {
+    const scenario = buildSupportedPerformanceScenario();
+
+    const brief = buildPerformanceAdvisorBriefViewModel({
+      workspace: scenario.workspace,
+      advisorBrief: {
+        correlation_id: "corr-risk-ready",
+        contract_version: "v1",
+        portfolio_id: "PF_1001",
+        portfolio: scenario.workspace.portfolio,
+        as_of_date: scenario.workspace.as_of_date,
+        period: scenario.workspace.period,
+        report_start_date: scenario.workspace.report_start_date,
+        report_end_date: scenario.workspace.report_end_date,
+        detail_basis: "NET",
+        chart_frequency: "monthly",
+        contribution_dimension: "asset_class",
+        attribution_dimension: "asset_class",
+        benchmark_code: scenario.workspace.benchmark_code,
+        status: "ready",
+        summary: "Risk-linked advisor brief.",
+        talking_points: [
+          {
+            headline: "Portfolio concentration warrants review.",
+            detail: "Open Risk to inspect HHI and top-position concentration.",
+            tone: "warning",
+            evidence_refs: [
+              {
+                metric_label: "HHI Current",
+                metric_value: "1260",
+                source_surface: "risk.concentration",
+                target_mode: "risk",
+                route: "/performance?portfolioId=PF_1001&mode=risk",
+              },
+            ],
+          },
+        ],
+        recommended_actions: [
+          {
+            label: "Open Risk",
+            target_mode: "risk",
+            route: "/performance?portfolioId=PF_1001&mode=risk",
+          },
+        ],
+        risks_and_exceptions: [],
+        source_metrics: [
+          {
+            label: "HHI Current",
+            value: "1260",
+            support_label: "Stateful concentration",
+            target_mode: "risk",
+            route: "/performance?portfolioId=PF_1001&mode=risk",
+            state: "ready",
+          },
+        ],
+        supportability: [{ label: "Advisor Brief", value: "Ready", tone: "success" }],
+        ai_audit: { stubbed: false },
+        ai_evidence: { source_refs: ["lotus-gateway:risk:concentration"] },
+        warnings: [],
+        partial_failures: [],
+      },
+      capabilities: scenario.capabilities,
+      period: scenario.workspace.period,
+      detailBasis: "NET",
+      contributionDimension: "asset_class",
+      attributionDimension: "asset_class",
+      chartFrequency: "monthly",
+      benchmark: scenario.workspace.benchmark_code ?? undefined,
+      isDetailsPending: false,
+    });
+
+    expect(brief.talkingPoints[0]?.evidenceRefs[0]?.targetMode).toBe("risk");
+    expect(brief.recommendedActions.some((action) => action.targetMode === "risk")).toBe(true);
+    expect(brief.sourceMetrics.some((metric) => metric.targetMode === "risk")).toBe(true);
+  });
 });

--- a/tests/unit/performance-risk-mode.test.tsx
+++ b/tests/unit/performance-risk-mode.test.tsx
@@ -6,11 +6,13 @@ import PerformanceRiskMode from "../../src/apps/performance/components/performan
 import {
   buildFixtureRiskConcentration,
   buildFixtureRiskDrawdown,
+  buildFixtureRiskRolling,
   buildFixtureRiskSummary,
 } from "../../src/apps/performance/risk-workspace-view-model";
 import {
   getWorkbenchRiskConcentrationClient,
   getWorkbenchRiskDrawdownClient,
+  getWorkbenchRiskRollingClient,
   getWorkbenchRiskSummaryClient,
 } from "../../src/features/workbench/api";
 import { buildBenchmarkUnassignedPerformanceScenario, buildSupportedPerformanceScenario } from "../fixtures/performance-workspace-fixtures";
@@ -19,6 +21,7 @@ vi.mock("../../src/features/workbench/api", () => ({
   getWorkbenchRiskSummaryClient: vi.fn(),
   getWorkbenchRiskConcentrationClient: vi.fn(),
   getWorkbenchRiskDrawdownClient: vi.fn(),
+  getWorkbenchRiskRollingClient: vi.fn(),
 }));
 
 function renderRiskMode(
@@ -56,6 +59,9 @@ describe("PerformanceRiskMode", () => {
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
       buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
     );
+    vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+    );
 
     renderRiskMode(scenario);
 
@@ -85,6 +91,14 @@ describe("PerformanceRiskMode", () => {
       reportingCurrency: "USD",
       includeUnderwaterSeries: false,
     });
+    expect(getWorkbenchRiskRollingClient).toHaveBeenCalledWith("PF_1001", {
+      period: "YTD",
+      detailBasis: "NET",
+      benchmark: "BMK_GLOBAL_BALANCED_60_40",
+      asOfDate: "2026-02-24",
+      reportingCurrency: "USD",
+      includeTimeSeries: false,
+    });
   });
 
   it("reuses cached live responses for the same request shape and invalidates summary only when detail basis changes", async () => {
@@ -97,6 +111,9 @@ describe("PerformanceRiskMode", () => {
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
       buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+    );
+    vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
     );
 
     const { rerender } = render(
@@ -138,6 +155,7 @@ describe("PerformanceRiskMode", () => {
     expect(getWorkbenchRiskSummaryClient).toHaveBeenCalledTimes(1);
     expect(getWorkbenchRiskConcentrationClient).toHaveBeenCalledTimes(1);
     expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledTimes(1);
+    expect(getWorkbenchRiskRollingClient).toHaveBeenCalledTimes(1);
 
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
       buildFixtureRiskSummary(scenario.workspace, "YTD", "GROSS")
@@ -162,6 +180,7 @@ describe("PerformanceRiskMode", () => {
     });
     expect(getWorkbenchRiskConcentrationClient).toHaveBeenCalledTimes(1);
     expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledTimes(2);
+    expect(getWorkbenchRiskRollingClient).toHaveBeenCalledTimes(2);
   });
 
   it("shows partial live supportability when benchmark-relative risk is unavailable", async () => {
@@ -176,6 +195,9 @@ describe("PerformanceRiskMode", () => {
       buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET", {
         includeBenchmarkRelative: false,
       })
+    );
+    vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
     );
 
     renderRiskMode(scenario);
@@ -194,6 +216,7 @@ describe("PerformanceRiskMode", () => {
       new Error("concentration down")
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockRejectedValue(new Error("drawdown down"));
+    vi.mocked(getWorkbenchRiskRollingClient).mockRejectedValue(new Error("rolling down"));
 
     renderRiskMode();
 
@@ -219,6 +242,9 @@ describe("PerformanceRiskMode", () => {
           includeUnderwaterSeries: true,
         })
       );
+    vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+    );
 
     renderRiskMode(scenario);
 
@@ -231,7 +257,7 @@ describe("PerformanceRiskMode", () => {
       includeUnderwaterSeries: false,
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Expand" }));
+    fireEvent.click(screen.getByRole("button", { name: "Expand underwater path" }));
 
     await waitFor(() => {
       expect(screen.getByLabelText("Risk underwater series table")).toBeInTheDocument();
@@ -240,6 +266,48 @@ describe("PerformanceRiskMode", () => {
     expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledTimes(2);
     expect(vi.mocked(getWorkbenchRiskDrawdownClient).mock.calls[1][1]).toMatchObject({
       includeUnderwaterSeries: true,
+    });
+  });
+
+  it("does not request rolling detail on first paint and fetches it only on expand", async () => {
+    const scenario = buildSupportedPerformanceScenario();
+    vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+    );
+    vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
+      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+    );
+    vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+    );
+    vi.mocked(getWorkbenchRiskRollingClient)
+      .mockResolvedValueOnce(buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"))
+      .mockResolvedValueOnce(
+        buildFixtureRiskRolling(scenario.workspace, "YTD", "NET", {
+          includeTimeSeries: true,
+        })
+      );
+
+    renderRiskMode(scenario);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Rolling risk summary table")).toBeInTheDocument();
+    });
+
+    expect(getWorkbenchRiskRollingClient).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getWorkbenchRiskRollingClient).mock.calls[0][1]).toMatchObject({
+      includeTimeSeries: false,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand rolling series" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Rolling risk series table")).toBeInTheDocument();
+    });
+
+    expect(getWorkbenchRiskRollingClient).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(getWorkbenchRiskRollingClient).mock.calls[1][1]).toMatchObject({
+      includeTimeSeries: true,
     });
   });
 });

--- a/tests/unit/performance-risk-mode.test.tsx
+++ b/tests/unit/performance-risk-mode.test.tsx
@@ -4,12 +4,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import PerformanceRiskMode from "../../src/apps/performance/components/performance-risk-mode";
 import {
+  buildFixtureRiskAttribution,
   buildFixtureRiskConcentration,
   buildFixtureRiskDrawdown,
   buildFixtureRiskRolling,
   buildFixtureRiskSummary,
 } from "../../src/apps/performance/risk-workspace-view-model";
 import {
+  getWorkbenchRiskAttributionClient,
   getWorkbenchRiskConcentrationClient,
   getWorkbenchRiskDrawdownClient,
   getWorkbenchRiskRollingClient,
@@ -20,6 +22,7 @@ import { buildBenchmarkUnassignedPerformanceScenario, buildSupportedPerformanceS
 vi.mock("../../src/features/workbench/api", () => ({
   getWorkbenchRiskSummaryClient: vi.fn(),
   getWorkbenchRiskConcentrationClient: vi.fn(),
+  getWorkbenchRiskAttributionClient: vi.fn(),
   getWorkbenchRiskDrawdownClient: vi.fn(),
   getWorkbenchRiskRollingClient: vi.fn(),
 }));
@@ -56,6 +59,9 @@ describe("PerformanceRiskMode", () => {
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
       buildFixtureRiskConcentration(scenario.workspace, "YTD")
     );
+    vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+    );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
       buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
     );
@@ -83,6 +89,15 @@ describe("PerformanceRiskMode", () => {
       asOfDate: "2026-02-24",
       reportingCurrency: "USD",
     });
+    expect(getWorkbenchRiskAttributionClient).toHaveBeenCalledWith("PF_1001", {
+      period: "YTD",
+      detailBasis: "NET",
+      benchmark: "BMK_GLOBAL_BALANCED_60_40",
+      asOfDate: "2026-02-24",
+      reportingCurrency: "USD",
+      attributionType: "TOTAL_RISK",
+      groupingDimension: "SECTOR",
+    });
     expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledWith("PF_1001", {
       period: "YTD",
       detailBasis: "NET",
@@ -108,6 +123,9 @@ describe("PerformanceRiskMode", () => {
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
       buildFixtureRiskConcentration(scenario.workspace, "YTD")
+    );
+    vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
       buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
@@ -154,6 +172,7 @@ describe("PerformanceRiskMode", () => {
 
     expect(getWorkbenchRiskSummaryClient).toHaveBeenCalledTimes(1);
     expect(getWorkbenchRiskConcentrationClient).toHaveBeenCalledTimes(1);
+    expect(getWorkbenchRiskAttributionClient).toHaveBeenCalledTimes(1);
     expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledTimes(1);
     expect(getWorkbenchRiskRollingClient).toHaveBeenCalledTimes(1);
 
@@ -179,6 +198,7 @@ describe("PerformanceRiskMode", () => {
       expect(getWorkbenchRiskSummaryClient).toHaveBeenCalledTimes(2);
     });
     expect(getWorkbenchRiskConcentrationClient).toHaveBeenCalledTimes(1);
+    expect(getWorkbenchRiskAttributionClient).toHaveBeenCalledTimes(2);
     expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledTimes(2);
     expect(getWorkbenchRiskRollingClient).toHaveBeenCalledTimes(2);
   });
@@ -190,6 +210,9 @@ describe("PerformanceRiskMode", () => {
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
       buildFixtureRiskConcentration(scenario.workspace, "YTD")
+    );
+    vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
       buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET", {
@@ -215,6 +238,7 @@ describe("PerformanceRiskMode", () => {
     vi.mocked(getWorkbenchRiskConcentrationClient).mockRejectedValue(
       new Error("concentration down")
     );
+    vi.mocked(getWorkbenchRiskAttributionClient).mockRejectedValue(new Error("attribution down"));
     vi.mocked(getWorkbenchRiskDrawdownClient).mockRejectedValue(new Error("drawdown down"));
     vi.mocked(getWorkbenchRiskRollingClient).mockRejectedValue(new Error("rolling down"));
 
@@ -234,6 +258,9 @@ describe("PerformanceRiskMode", () => {
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
       buildFixtureRiskConcentration(scenario.workspace, "YTD")
+    );
+    vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
     );
     vi.mocked(getWorkbenchRiskDrawdownClient)
       .mockResolvedValueOnce(buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"))
@@ -277,6 +304,9 @@ describe("PerformanceRiskMode", () => {
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
       buildFixtureRiskConcentration(scenario.workspace, "YTD")
     );
+    vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+    );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
       buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
     );
@@ -308,6 +338,72 @@ describe("PerformanceRiskMode", () => {
     expect(getWorkbenchRiskRollingClient).toHaveBeenCalledTimes(2);
     expect(vi.mocked(getWorkbenchRiskRollingClient).mock.calls[1][1]).toMatchObject({
       includeTimeSeries: true,
+    });
+  });
+
+  it("requests supported active-risk attribution directly and does not expose issuer as interactive", async () => {
+    const scenario = buildSupportedPerformanceScenario();
+    vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+    );
+    vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
+      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+    );
+    vi.mocked(getWorkbenchRiskAttributionClient).mockImplementation(async (_portfolioId, params) =>
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET", {
+        attributionType:
+          params.attributionType === "ACTIVE_RISK" ? "ACTIVE_RISK" : "TOTAL_RISK",
+        groupingDimension:
+          params.groupingDimension === "ASSET_CLASS"
+            ? "ASSET_CLASS"
+            : params.groupingDimension === "POSITION"
+              ? "POSITION"
+              : params.groupingDimension === "ISSUER"
+                ? "ISSUER"
+                : "SECTOR",
+      })
+    );
+    vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+    );
+    vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+    );
+
+    renderRiskMode(scenario);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Historical risk attribution table")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Active Risk" }));
+    await waitFor(() => {
+      expect(getWorkbenchRiskAttributionClient).toHaveBeenCalledWith("PF_1001", {
+        period: "YTD",
+        detailBasis: "NET",
+        benchmark: "BMK_GLOBAL_BALANCED_60_40",
+        asOfDate: "2026-02-24",
+        reportingCurrency: "USD",
+        attributionType: "ACTIVE_RISK",
+        groupingDimension: "SECTOR",
+      });
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Asset Class" }));
+
+    await waitFor(() => {
+      expect(getWorkbenchRiskAttributionClient).toHaveBeenCalledTimes(3);
+    });
+    expect(getWorkbenchRiskAttributionClient).toHaveBeenLastCalledWith("PF_1001", {
+      period: "YTD",
+      detailBasis: "NET",
+      benchmark: "BMK_GLOBAL_BALANCED_60_40",
+      asOfDate: "2026-02-24",
+      reportingCurrency: "USD",
+      attributionType: "ACTIVE_RISK",
+      groupingDimension: "ASSET_CLASS",
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Issuer" })).toBeDisabled();
     });
   });
 });

--- a/tests/unit/performance-risk-mode.test.tsx
+++ b/tests/unit/performance-risk-mode.test.tsx
@@ -1,18 +1,33 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import PerformanceRiskMode from "../../src/apps/performance/components/performance-risk-mode";
-import { buildSupportedPerformanceScenario } from "../fixtures/performance-workspace-fixtures";
+import {
+  buildFixtureRiskConcentration,
+  buildFixtureRiskSummary,
+} from "../../src/apps/performance/risk-workspace-view-model";
+import {
+  getWorkbenchRiskConcentrationClient,
+  getWorkbenchRiskSummaryClient,
+} from "../../src/features/workbench/api";
+import { buildBenchmarkUnassignedPerformanceScenario, buildSupportedPerformanceScenario } from "../fixtures/performance-workspace-fixtures";
 
-function renderRiskMode(options: { isDetailsPending?: boolean } = {}) {
-  const scenario = buildSupportedPerformanceScenario();
+vi.mock("../../src/features/workbench/api", () => ({
+  getWorkbenchRiskSummaryClient: vi.fn(),
+  getWorkbenchRiskConcentrationClient: vi.fn(),
+}));
+
+function renderRiskMode(
+  scenario = buildSupportedPerformanceScenario(),
+  options: { detailBasis?: "NET" | "GROSS"; period?: string; isDetailsPending?: boolean } = {}
+) {
   render(
     <PerformanceRiskMode
       workspace={scenario.workspace}
       capabilities={scenario.capabilities}
-      period="YTD"
-      detailBasis="NET"
+      period={options.period ?? "YTD"}
+      detailBasis={options.detailBasis ?? "NET"}
       contributionDimension="asset_class"
       attributionDimension="asset_class"
       chartFrequency="monthly"
@@ -23,25 +38,144 @@ function renderRiskMode(options: { isDetailsPending?: boolean } = {}) {
 }
 
 describe("PerformanceRiskMode", () => {
-  it("renders the fixture-backed Risk shell using shared analytical sections", () => {
-    renderRiskMode();
-
-    expect(screen.getByRole("region", { name: "Risk" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Stateful Risk" })).toBeInTheDocument();
-    expect(screen.getByLabelText("Risk mode status")).toHaveTextContent("Stateful only");
-    expect(screen.getByLabelText("Risk context")).toHaveTextContent("Portfolio");
-    expect(screen.getByLabelText("Risk snapshot headline metrics")).toHaveTextContent("Volatility");
-    expect(screen.getByLabelText("Risk snapshot metric table")).toHaveTextContent("Tracking Error");
-    expect(screen.getByLabelText("Risk concentration headline metrics")).toHaveTextContent("Top Issuer");
-    expect(screen.getByLabelText("Risk support rail")).toHaveTextContent("Issuer enrichment");
-    expect(screen.getByLabelText("Risk provenance")).toHaveTextContent("risk-workspace.v1");
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
-  it("shows a controlled loading state instead of fixture metrics while details are pending", () => {
-    renderRiskMode({ isDetailsPending: true });
+  it("fetches live Gateway-backed risk summary and concentration contracts", async () => {
+    const scenario = buildSupportedPerformanceScenario();
+    vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+    );
+    vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
+      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+    );
+
+    renderRiskMode(scenario);
 
     expect(screen.getByText("Loading stateful risk")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Risk snapshot metric table")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Risk snapshot metric table")).toHaveTextContent("Volatility");
+    });
+
+    expect(getWorkbenchRiskSummaryClient).toHaveBeenCalledWith("PF_1001", {
+      period: "YTD",
+      detailBasis: "NET",
+      benchmark: "BMK_GLOBAL_BALANCED_60_40",
+      asOfDate: "2026-02-24",
+      reportingCurrency: "USD",
+    });
+    expect(getWorkbenchRiskConcentrationClient).toHaveBeenCalledWith("PF_1001", {
+      period: "YTD",
+      benchmark: "BMK_GLOBAL_BALANCED_60_40",
+      asOfDate: "2026-02-24",
+      reportingCurrency: "USD",
+    });
+  });
+
+  it("reuses cached live responses for the same request shape and invalidates summary only when detail basis changes", async () => {
+    const scenario = buildSupportedPerformanceScenario();
+    vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+    );
+    vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
+      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+    );
+
+    const { rerender } = render(
+      <PerformanceRiskMode
+        workspace={scenario.workspace}
+        capabilities={scenario.capabilities}
+        period="YTD"
+        detailBasis="NET"
+        contributionDimension="asset_class"
+        attributionDimension="asset_class"
+        chartFrequency="monthly"
+        isUpdating={false}
+        isDetailsPending={false}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Risk snapshot metric table")).toBeInTheDocument();
+    });
+
+    rerender(
+      <PerformanceRiskMode
+        workspace={scenario.workspace}
+        capabilities={scenario.capabilities}
+        period="YTD"
+        detailBasis="NET"
+        contributionDimension="asset_class"
+        attributionDimension="asset_class"
+        chartFrequency="monthly"
+        isUpdating={false}
+        isDetailsPending={false}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Risk concentration diagnostic table")).toBeInTheDocument();
+    });
+
+    expect(getWorkbenchRiskSummaryClient).toHaveBeenCalledTimes(1);
+    expect(getWorkbenchRiskConcentrationClient).toHaveBeenCalledTimes(1);
+
+    vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "GROSS")
+    );
+
+    rerender(
+      <PerformanceRiskMode
+        workspace={scenario.workspace}
+        capabilities={scenario.capabilities}
+        period="YTD"
+        detailBasis="GROSS"
+        contributionDimension="asset_class"
+        attributionDimension="asset_class"
+        chartFrequency="monthly"
+        isUpdating={false}
+        isDetailsPending={false}
+      />
+    );
+
+    await waitFor(() => {
+      expect(getWorkbenchRiskSummaryClient).toHaveBeenCalledTimes(2);
+    });
+    expect(getWorkbenchRiskConcentrationClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows partial live supportability when benchmark-relative risk is unavailable", async () => {
+    const scenario = buildBenchmarkUnassignedPerformanceScenario();
+    vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+    );
+    vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
+      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+    );
+
+    renderRiskMode(scenario);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Risk support rail")).toHaveTextContent("Benchmark returns");
+    });
+    expect(screen.getByLabelText("Risk support rail")).toHaveTextContent(
+      "Benchmark-relative risk requires benchmark context."
+    );
+  });
+
+  it("renders controlled unavailable states when both live BFF requests fail", async () => {
+    vi.mocked(getWorkbenchRiskSummaryClient).mockRejectedValue(new Error("summary down"));
+    vi.mocked(getWorkbenchRiskConcentrationClient).mockRejectedValue(
+      new Error("concentration down")
+    );
+
+    renderRiskMode();
+
+    await waitFor(() => {
+      expect(screen.getByText("Risk unavailable")).toBeInTheDocument();
+    });
     expect(screen.getByLabelText("Risk provenance")).toHaveTextContent("Stateful only");
+    expect(screen.queryByLabelText("Risk snapshot metric table")).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/performance-risk-mode.test.tsx
+++ b/tests/unit/performance-risk-mode.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import PerformanceRiskMode from "../../src/apps/performance/components/performance-risk-mode";
+import { buildSupportedPerformanceScenario } from "../fixtures/performance-workspace-fixtures";
+
+function renderRiskMode(options: { isDetailsPending?: boolean } = {}) {
+  const scenario = buildSupportedPerformanceScenario();
+  render(
+    <PerformanceRiskMode
+      workspace={scenario.workspace}
+      capabilities={scenario.capabilities}
+      period="YTD"
+      detailBasis="NET"
+      contributionDimension="asset_class"
+      attributionDimension="asset_class"
+      chartFrequency="monthly"
+      isUpdating={false}
+      isDetailsPending={options.isDetailsPending ?? false}
+    />
+  );
+}
+
+describe("PerformanceRiskMode", () => {
+  it("renders the fixture-backed Risk shell using shared analytical sections", () => {
+    renderRiskMode();
+
+    expect(screen.getByRole("region", { name: "Risk" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Stateful Risk" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Risk mode status")).toHaveTextContent("Stateful only");
+    expect(screen.getByLabelText("Risk context")).toHaveTextContent("Portfolio");
+    expect(screen.getByLabelText("Risk snapshot headline metrics")).toHaveTextContent("Volatility");
+    expect(screen.getByLabelText("Risk snapshot metric table")).toHaveTextContent("Tracking Error");
+    expect(screen.getByLabelText("Risk concentration headline metrics")).toHaveTextContent("Top Issuer");
+    expect(screen.getByLabelText("Risk support rail")).toHaveTextContent("Issuer enrichment");
+    expect(screen.getByLabelText("Risk provenance")).toHaveTextContent("risk-workspace.v1");
+  });
+
+  it("shows a controlled loading state instead of fixture metrics while details are pending", () => {
+    renderRiskMode({ isDetailsPending: true });
+
+    expect(screen.getByText("Loading stateful risk")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Risk snapshot metric table")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Risk provenance")).toHaveTextContent("Stateful only");
+  });
+});

--- a/tests/unit/performance-risk-mode.test.tsx
+++ b/tests/unit/performance-risk-mode.test.tsx
@@ -1,14 +1,16 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import PerformanceRiskMode from "../../src/apps/performance/components/performance-risk-mode";
 import {
   buildFixtureRiskConcentration,
+  buildFixtureRiskDrawdown,
   buildFixtureRiskSummary,
 } from "../../src/apps/performance/risk-workspace-view-model";
 import {
   getWorkbenchRiskConcentrationClient,
+  getWorkbenchRiskDrawdownClient,
   getWorkbenchRiskSummaryClient,
 } from "../../src/features/workbench/api";
 import { buildBenchmarkUnassignedPerformanceScenario, buildSupportedPerformanceScenario } from "../fixtures/performance-workspace-fixtures";
@@ -16,6 +18,7 @@ import { buildBenchmarkUnassignedPerformanceScenario, buildSupportedPerformanceS
 vi.mock("../../src/features/workbench/api", () => ({
   getWorkbenchRiskSummaryClient: vi.fn(),
   getWorkbenchRiskConcentrationClient: vi.fn(),
+  getWorkbenchRiskDrawdownClient: vi.fn(),
 }));
 
 function renderRiskMode(
@@ -50,6 +53,9 @@ describe("PerformanceRiskMode", () => {
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
       buildFixtureRiskConcentration(scenario.workspace, "YTD")
     );
+    vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+    );
 
     renderRiskMode(scenario);
 
@@ -71,6 +77,14 @@ describe("PerformanceRiskMode", () => {
       asOfDate: "2026-02-24",
       reportingCurrency: "USD",
     });
+    expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledWith("PF_1001", {
+      period: "YTD",
+      detailBasis: "NET",
+      benchmark: "BMK_GLOBAL_BALANCED_60_40",
+      asOfDate: "2026-02-24",
+      reportingCurrency: "USD",
+      includeUnderwaterSeries: false,
+    });
   });
 
   it("reuses cached live responses for the same request shape and invalidates summary only when detail basis changes", async () => {
@@ -80,6 +94,9 @@ describe("PerformanceRiskMode", () => {
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
       buildFixtureRiskConcentration(scenario.workspace, "YTD")
+    );
+    vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
     );
 
     const { rerender } = render(
@@ -120,6 +137,7 @@ describe("PerformanceRiskMode", () => {
 
     expect(getWorkbenchRiskSummaryClient).toHaveBeenCalledTimes(1);
     expect(getWorkbenchRiskConcentrationClient).toHaveBeenCalledTimes(1);
+    expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledTimes(1);
 
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
       buildFixtureRiskSummary(scenario.workspace, "YTD", "GROSS")
@@ -143,6 +161,7 @@ describe("PerformanceRiskMode", () => {
       expect(getWorkbenchRiskSummaryClient).toHaveBeenCalledTimes(2);
     });
     expect(getWorkbenchRiskConcentrationClient).toHaveBeenCalledTimes(1);
+    expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledTimes(2);
   });
 
   it("shows partial live supportability when benchmark-relative risk is unavailable", async () => {
@@ -152,6 +171,11 @@ describe("PerformanceRiskMode", () => {
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
       buildFixtureRiskConcentration(scenario.workspace, "YTD")
+    );
+    vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET", {
+        includeBenchmarkRelative: false,
+      })
     );
 
     renderRiskMode(scenario);
@@ -169,6 +193,7 @@ describe("PerformanceRiskMode", () => {
     vi.mocked(getWorkbenchRiskConcentrationClient).mockRejectedValue(
       new Error("concentration down")
     );
+    vi.mocked(getWorkbenchRiskDrawdownClient).mockRejectedValue(new Error("drawdown down"));
 
     renderRiskMode();
 
@@ -177,5 +202,44 @@ describe("PerformanceRiskMode", () => {
     });
     expect(screen.getByLabelText("Risk provenance")).toHaveTextContent("Stateful only");
     expect(screen.queryByLabelText("Risk snapshot metric table")).not.toBeInTheDocument();
+  });
+
+  it("does not request underwater detail on first paint and fetches it only on expand", async () => {
+    const scenario = buildSupportedPerformanceScenario();
+    vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+    );
+    vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
+      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+    );
+    vi.mocked(getWorkbenchRiskDrawdownClient)
+      .mockResolvedValueOnce(buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"))
+      .mockResolvedValueOnce(
+        buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET", {
+          includeUnderwaterSeries: true,
+        })
+      );
+
+    renderRiskMode(scenario);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Risk drawdown episode table")).toBeInTheDocument();
+    });
+
+    expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getWorkbenchRiskDrawdownClient).mock.calls[0][1]).toMatchObject({
+      includeUnderwaterSeries: false,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Risk underwater series table")).toBeInTheDocument();
+    });
+
+    expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(getWorkbenchRiskDrawdownClient).mock.calls[1][1]).toMatchObject({
+      includeUnderwaterSeries: true,
+    });
   });
 });

--- a/tests/unit/performance-risk-view-model.test.ts
+++ b/tests/unit/performance-risk-view-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildFixtureRiskAttribution,
   buildFixtureRiskConcentration,
   buildFixtureRiskDrawdown,
   buildFixtureRiskRolling,
@@ -19,6 +20,7 @@ describe("buildPerformanceRiskViewModel", () => {
       detailBasis: "NET",
       riskSummary: buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
       riskConcentration: buildFixtureRiskConcentration(scenario.workspace, "YTD"),
+      riskAttribution: buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET"),
       riskDrawdown: buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
       riskRolling: buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     });
@@ -46,6 +48,9 @@ describe("buildPerformanceRiskViewModel", () => {
       "summary:risk_free_series",
       "concentration:portfolio_positions",
       "concentration:issuer_enrichment",
+      "attribution:portfolio_returns",
+      "attribution:exposure_history",
+      "attribution:benchmark_exposure_context",
       "drawdown:portfolio_returns",
       "drawdown:benchmark_relative_drawdown",
       "drawdown:underwater_series",
@@ -76,6 +81,10 @@ describe("buildPerformanceRiskViewModel", () => {
     expect(viewModel.rollingWindows[0]?.headlineMetrics.map((metric) => metric.label)).toContain(
       "Volatility"
     );
+    expect(viewModel.attributionControls?.selectedAttributionType).toBe("TOTAL_RISK");
+    expect(viewModel.attributionRows[0]).toMatchObject({
+      group: "Technology",
+    });
     expect(viewModel.rollingQualityFlags).toContain(
       "metric:ROLLING_BETA:benchmark_variance_zero"
     );
@@ -90,6 +99,10 @@ describe("buildPerformanceRiskViewModel", () => {
       detailBasis: "NET",
       riskSummary: buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
       riskConcentration: buildFixtureRiskConcentration(scenario.workspace, "YTD"),
+      riskAttribution: buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET", {
+        attributionType: "ACTIVE_RISK",
+        groupingDimension: "SECTOR",
+      }),
       riskDrawdown: buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET", {
         includeBenchmarkRelative: false,
       }),
@@ -106,6 +119,10 @@ describe("buildPerformanceRiskViewModel", () => {
     expect(viewModel.drawdownRelativeMetric).toMatchObject({
       value: "N/A",
       support: "Benchmark-relative drawdown requires benchmark context.",
+    });
+    expect(viewModel.attributionControls?.attributionTypes[1]).toMatchObject({
+      key: "ACTIVE_RISK",
+      disabled: true,
     });
   });
 
@@ -161,6 +178,10 @@ describe("buildPerformanceRiskViewModel", () => {
       detailBasis: "NET",
       riskSummary: buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
       riskConcentration: buildFixtureRiskConcentration(scenario.workspace, "YTD"),
+      riskAttribution: buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET", {
+        attributionType: "ACTIVE_RISK",
+        groupingDimension: "ISSUER",
+      }),
       riskDrawdown: buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
       riskRolling: buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
       riskRollingDetail: buildFixtureRiskRolling(scenario.workspace, "YTD", "NET", {
@@ -176,5 +197,7 @@ describe("buildPerformanceRiskViewModel", () => {
     expect(viewModel.rollingWindows[0]?.seriesRows[0]?.values.ROLLING_VOLATILITY).toMatch(
       /%$/
     );
+    expect(viewModel.attributionState).toBe("blocked");
+    expect(viewModel.attributionTotals).toBeNull();
   });
 });

--- a/tests/unit/performance-risk-view-model.test.ts
+++ b/tests/unit/performance-risk-view-model.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { buildPerformanceRiskViewModel } from "../../src/apps/performance/risk-workspace-view-model";
+import {
+  buildFixtureRiskConcentration,
+  buildFixtureRiskSummary,
+  buildPerformanceRiskViewModel,
+} from "../../src/apps/performance/risk-workspace-view-model";
 import { buildBenchmarkUnassignedPerformanceScenario, buildSupportedPerformanceScenario } from "../fixtures/performance-workspace-fixtures";
 
 describe("buildPerformanceRiskViewModel", () => {
@@ -11,6 +15,8 @@ describe("buildPerformanceRiskViewModel", () => {
       workspace: scenario.workspace,
       period: "YTD",
       detailBasis: "NET",
+      riskSummary: buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
+      riskConcentration: buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     });
 
     expect(viewModel.state).toBe("partial");
@@ -50,6 +56,8 @@ describe("buildPerformanceRiskViewModel", () => {
       workspace: scenario.workspace,
       period: "YTD",
       detailBasis: "NET",
+      riskSummary: buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
+      riskConcentration: buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     });
 
     expect(viewModel.state).toBe("partial");

--- a/tests/unit/performance-risk-view-model.test.ts
+++ b/tests/unit/performance-risk-view-model.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildFixtureRiskConcentration,
   buildFixtureRiskDrawdown,
+  buildFixtureRiskRolling,
   buildFixtureRiskSummary,
   buildPerformanceRiskViewModel,
 } from "../../src/apps/performance/risk-workspace-view-model";
@@ -19,6 +20,7 @@ describe("buildPerformanceRiskViewModel", () => {
       riskSummary: buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
       riskConcentration: buildFixtureRiskConcentration(scenario.workspace, "YTD"),
       riskDrawdown: buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
+      riskRolling: buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     });
 
     expect(viewModel.state).toBe("partial");
@@ -47,6 +49,10 @@ describe("buildPerformanceRiskViewModel", () => {
       "drawdown:portfolio_returns",
       "drawdown:benchmark_relative_drawdown",
       "drawdown:underwater_series",
+      "rolling:portfolio_returns",
+      "rolling:benchmark_returns",
+      "rolling:risk_free_series",
+      "rolling:rolling_time_series",
     ]);
     expect(viewModel.drawdownHeadlineMetrics.map((metric) => metric.label)).toEqual([
       "Max Drawdown",
@@ -64,6 +70,15 @@ describe("buildPerformanceRiskViewModel", () => {
       label: "Input Mode",
       value: "Stateful only",
     });
+    expect(viewModel.rollingWindows[0]).toMatchObject({
+      label: "21D",
+    });
+    expect(viewModel.rollingWindows[0]?.headlineMetrics.map((metric) => metric.label)).toContain(
+      "Volatility"
+    );
+    expect(viewModel.rollingQualityFlags).toContain(
+      "metric:ROLLING_BETA:benchmark_variance_zero"
+    );
   });
 
   it("does not imply benchmark-relative risk is ready when benchmark context is absent", () => {
@@ -78,6 +93,7 @@ describe("buildPerformanceRiskViewModel", () => {
       riskDrawdown: buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET", {
         includeBenchmarkRelative: false,
       }),
+      riskRolling: buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     });
 
     expect(viewModel.state).toBe("partial");
@@ -106,6 +122,7 @@ describe("buildPerformanceRiskViewModel", () => {
     expect(viewModel.state).toBe("loading");
     expect(viewModel.snapshotMetrics).toEqual([]);
     expect(viewModel.concentrationMetrics).toEqual([]);
+    expect(viewModel.rollingWindows).toEqual([]);
     expect(viewModel.supportability).toEqual([
       expect.objectContaining({ key: "risk_bff", state: "partial" }),
     ]);
@@ -124,6 +141,7 @@ describe("buildPerformanceRiskViewModel", () => {
       riskDrawdownDetail: buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET", {
         includeUnderwaterSeries: true,
       }),
+      riskRolling: buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     });
 
     expect(viewModel.underwaterDetailState).toBe("ready");
@@ -132,5 +150,31 @@ describe("buildPerformanceRiskViewModel", () => {
       date: "20 Jan 2026",
       drawdown: "-5.21%",
     });
+  });
+
+  it("only surfaces rolling series after detail-on-demand fetch returns", () => {
+    const scenario = buildSupportedPerformanceScenario();
+
+    const viewModel = buildPerformanceRiskViewModel({
+      workspace: scenario.workspace,
+      period: "YTD",
+      detailBasis: "NET",
+      riskSummary: buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
+      riskConcentration: buildFixtureRiskConcentration(scenario.workspace, "YTD"),
+      riskDrawdown: buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
+      riskRolling: buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
+      riskRollingDetail: buildFixtureRiskRolling(scenario.workspace, "YTD", "NET", {
+        includeTimeSeries: true,
+      }),
+    });
+
+    expect(viewModel.rollingDetailState).toBe("ready");
+    expect(viewModel.rollingWindows[0]?.seriesRows).toHaveLength(3);
+    expect(viewModel.rollingWindows[0]?.seriesRows[0]).toMatchObject({
+      date: "15 Mar 2026",
+    });
+    expect(viewModel.rollingWindows[0]?.seriesRows[0]?.values.ROLLING_VOLATILITY).toMatch(
+      /%$/
+    );
   });
 });

--- a/tests/unit/performance-risk-view-model.test.ts
+++ b/tests/unit/performance-risk-view-model.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPerformanceRiskViewModel } from "../../src/apps/performance/risk-workspace-view-model";
+import { buildBenchmarkUnassignedPerformanceScenario, buildSupportedPerformanceScenario } from "../fixtures/performance-workspace-fixtures";
+
+describe("buildPerformanceRiskViewModel", () => {
+  it("builds a stateful contract-shaped risk view model with supportability evidence", () => {
+    const scenario = buildSupportedPerformanceScenario();
+
+    const viewModel = buildPerformanceRiskViewModel({
+      workspace: scenario.workspace,
+      period: "YTD",
+      detailBasis: "NET",
+    });
+
+    expect(viewModel.state).toBe("partial");
+    expect(viewModel.title).toBe("Stateful Risk");
+    expect(viewModel.snapshotMetrics.map((metric) => metric.label)).toEqual([
+      "Volatility",
+      "Sharpe",
+      "Sortino",
+      "Beta",
+      "Tracking Error",
+      "Information Ratio",
+      "Value at Risk",
+    ]);
+    expect(viewModel.concentrationMetrics.map((metric) => metric.label)).toEqual([
+      "HHI",
+      "Top Position",
+      "Top Issuer",
+      "Issuer Coverage",
+    ]);
+    expect(viewModel.supportability.map((item) => item.key)).toEqual([
+      "portfolio_returns",
+      "benchmark_returns",
+      "risk_free_series",
+      "portfolio_positions",
+      "issuer_enrichment",
+    ]);
+    expect(viewModel.provenance).toContainEqual({
+      label: "Input Mode",
+      value: "Stateful only",
+    });
+  });
+
+  it("does not imply benchmark-relative risk is ready when benchmark context is absent", () => {
+    const scenario = buildBenchmarkUnassignedPerformanceScenario();
+
+    const viewModel = buildPerformanceRiskViewModel({
+      workspace: scenario.workspace,
+      period: "YTD",
+      detailBasis: "NET",
+    });
+
+    expect(viewModel.state).toBe("partial");
+    expect(
+      viewModel.supportability.find((item) => item.key === "benchmark_returns")
+    ).toMatchObject({
+      state: "unavailable",
+      reason: "Benchmark-relative risk requires benchmark context.",
+    });
+  });
+
+  it("returns a loading state without fabricated metrics while details are pending", () => {
+    const scenario = buildSupportedPerformanceScenario();
+
+    const viewModel = buildPerformanceRiskViewModel({
+      workspace: scenario.workspace,
+      period: "YTD",
+      detailBasis: "NET",
+      isDetailsPending: true,
+    });
+
+    expect(viewModel.state).toBe("loading");
+    expect(viewModel.snapshotMetrics).toEqual([]);
+    expect(viewModel.concentrationMetrics).toEqual([]);
+    expect(viewModel.supportability).toEqual([
+      expect.objectContaining({ key: "risk_bff", state: "partial" }),
+    ]);
+  });
+});

--- a/tests/unit/performance-risk-view-model.test.ts
+++ b/tests/unit/performance-risk-view-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildFixtureRiskConcentration,
+  buildFixtureRiskDrawdown,
   buildFixtureRiskSummary,
   buildPerformanceRiskViewModel,
 } from "../../src/apps/performance/risk-workspace-view-model";
@@ -17,6 +18,7 @@ describe("buildPerformanceRiskViewModel", () => {
       detailBasis: "NET",
       riskSummary: buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
       riskConcentration: buildFixtureRiskConcentration(scenario.workspace, "YTD"),
+      riskDrawdown: buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
     });
 
     expect(viewModel.state).toBe("partial");
@@ -37,12 +39,27 @@ describe("buildPerformanceRiskViewModel", () => {
       "Issuer Coverage",
     ]);
     expect(viewModel.supportability.map((item) => item.key)).toEqual([
-      "portfolio_returns",
-      "benchmark_returns",
-      "risk_free_series",
-      "portfolio_positions",
-      "issuer_enrichment",
+      "summary:portfolio_returns",
+      "summary:benchmark_returns",
+      "summary:risk_free_series",
+      "concentration:portfolio_positions",
+      "concentration:issuer_enrichment",
+      "drawdown:portfolio_returns",
+      "drawdown:benchmark_relative_drawdown",
+      "drawdown:underwater_series",
     ]);
+    expect(viewModel.drawdownHeadlineMetrics.map((metric) => metric.label)).toEqual([
+      "Max Drawdown",
+      "Time Under Water",
+      "Ulcer Index",
+      "DaR 95",
+      "CDaR 95",
+    ]);
+    expect(viewModel.drawdownEpisodes[0]).toMatchObject({
+      episode: "DD_0001",
+      depth: "-12.45%",
+      status: "Open",
+    });
     expect(viewModel.provenance).toContainEqual({
       label: "Input Mode",
       value: "Stateful only",
@@ -58,14 +75,21 @@ describe("buildPerformanceRiskViewModel", () => {
       detailBasis: "NET",
       riskSummary: buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
       riskConcentration: buildFixtureRiskConcentration(scenario.workspace, "YTD"),
+      riskDrawdown: buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET", {
+        includeBenchmarkRelative: false,
+      }),
     });
 
     expect(viewModel.state).toBe("partial");
     expect(
-      viewModel.supportability.find((item) => item.key === "benchmark_returns")
+      viewModel.supportability.find((item) => item.key === "summary:benchmark_returns")
     ).toMatchObject({
       state: "unavailable",
       reason: "Benchmark-relative risk requires benchmark context.",
+    });
+    expect(viewModel.drawdownRelativeMetric).toMatchObject({
+      value: "N/A",
+      support: "Benchmark-relative drawdown requires benchmark context.",
     });
   });
 
@@ -85,5 +109,28 @@ describe("buildPerformanceRiskViewModel", () => {
     expect(viewModel.supportability).toEqual([
       expect.objectContaining({ key: "risk_bff", state: "partial" }),
     ]);
+  });
+
+  it("only surfaces underwater series after detail-on-demand fetch returns", () => {
+    const scenario = buildSupportedPerformanceScenario();
+
+    const viewModel = buildPerformanceRiskViewModel({
+      workspace: scenario.workspace,
+      period: "YTD",
+      detailBasis: "NET",
+      riskSummary: buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
+      riskConcentration: buildFixtureRiskConcentration(scenario.workspace, "YTD"),
+      riskDrawdown: buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
+      riskDrawdownDetail: buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET", {
+        includeUnderwaterSeries: true,
+      }),
+    });
+
+    expect(viewModel.underwaterDetailState).toBe("ready");
+    expect(viewModel.underwaterSeries).toHaveLength(3);
+    expect(viewModel.underwaterSeries[0]).toMatchObject({
+      date: "20 Jan 2026",
+      drawdown: "-5.21%",
+    });
   });
 });

--- a/tests/unit/performance-workspace-mode-switch.test.tsx
+++ b/tests/unit/performance-workspace-mode-switch.test.tsx
@@ -6,7 +6,7 @@ import PerformanceWorkspaceModeSwitch from "../../src/apps/performance/component
 import { buildPerformanceCapabilities } from "../fixtures/performance-workspace-fixtures";
 
 describe("PerformanceWorkspaceModeSwitch", () => {
-  it("renders the three workspace modes and calls onChange with the selected mode", () => {
+  it("renders the workspace modes and calls onChange with the selected mode", () => {
     const onChange = vi.fn();
 
     render(<PerformanceWorkspaceModeSwitch value="summary" onChange={onChange} />);
@@ -17,13 +17,16 @@ describe("PerformanceWorkspaceModeSwitch", () => {
     );
     expect(screen.getByRole("tab", { name: "Summary" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tab", { name: "Analysis" })).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByRole("tab", { name: "Risk" })).toHaveAttribute("aria-selected", "false");
     expect(screen.getByRole("tab", { name: "Evidence" })).toHaveAttribute("aria-selected", "false");
 
     fireEvent.click(screen.getByRole("tab", { name: "Analysis" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Risk" }));
     fireEvent.click(screen.getByRole("tab", { name: "Evidence" }));
 
     expect(onChange).toHaveBeenNthCalledWith(1, "analysis");
-    expect(onChange).toHaveBeenNthCalledWith(2, "evidence");
+    expect(onChange).toHaveBeenNthCalledWith(2, "risk");
+    expect(onChange).toHaveBeenNthCalledWith(3, "evidence");
   });
 
   it("disables unavailable modes and shows readiness status when capabilities are provided", () => {
@@ -43,6 +46,7 @@ describe("PerformanceWorkspaceModeSwitch", () => {
     );
 
     expect(screen.getByRole("tab", { name: "Analysis" })).toBeDisabled();
+    expect(screen.getByRole("tab", { name: "Risk" })).not.toBeDisabled();
     expect(screen.getByRole("tab", { name: "Evidence" })).toBeDisabled();
     expect(screen.getByRole("group", { name: "Performance mode readiness" })).toHaveTextContent(
       "Analysis unavailable"

--- a/tests/unit/performance-workspace-view.test.tsx
+++ b/tests/unit/performance-workspace-view.test.tsx
@@ -8,6 +8,7 @@ import {
   buildSupportedPerformanceScenario,
   buildUnavailableEvidencePerformanceScenario,
 } from "../fixtures/performance-workspace-fixtures";
+import type { PerformanceWorkspaceMode } from "../../src/apps/performance/components/performance-workspace-mode-switch";
 
 vi.mock("next/dynamic", () => ({
   default: (loader: () => Promise<unknown>) => {
@@ -52,19 +53,37 @@ vi.mock("../../src/apps/performance/components/performance-evidence-mode", () =>
 }));
 
 describe("PerformanceWorkspaceView", () => {
+  function renderWorkspaceView({
+    mode = "summary",
+    workspace = buildSupportedPerformanceScenario().workspace,
+  }: {
+    mode?: PerformanceWorkspaceMode;
+    workspace?: ReturnType<typeof buildSupportedPerformanceScenario>["workspace"];
+  }) {
+    function Harness() {
+      const [selectedMode, setSelectedMode] = React.useState<PerformanceWorkspaceMode>(mode);
+
+      return (
+        <PerformanceWorkspaceView
+          workspace={workspace}
+          mode={selectedMode}
+          period="YTD"
+          detailBasis="NET"
+          contributionDimension="asset_class"
+          attributionDimension="asset_class"
+          chartFrequency="monthly"
+          onModeChange={setSelectedMode}
+        />
+      );
+    }
+
+    return render(<Harness />);
+  }
+
   it("keeps summary mode as the only mounted mode on initial render", async () => {
     const scenario = buildSupportedPerformanceScenario();
 
-    render(
-      <PerformanceWorkspaceView
-        workspace={scenario.workspace}
-        period="YTD"
-        detailBasis="NET"
-        contributionDimension="asset_class"
-        attributionDimension="asset_class"
-        chartFrequency="monthly"
-      />
-    );
+    renderWorkspaceView({ workspace: scenario.workspace });
 
     expect(screen.getByRole("tab", { name: "Summary" })).toHaveClass(
       "workbench-segmented-control-button-active"
@@ -86,16 +105,7 @@ describe("PerformanceWorkspaceView", () => {
   it("passes contract-backed evidence capability into evidence mode from the shared scenario", async () => {
     const scenario = buildUnavailableEvidencePerformanceScenario();
 
-    render(
-      <PerformanceWorkspaceView
-        workspace={scenario.workspace}
-        period="YTD"
-        detailBasis="NET"
-        contributionDimension="asset_class"
-        attributionDimension="asset_class"
-        chartFrequency="monthly"
-      />
-    );
+    renderWorkspaceView({ workspace: scenario.workspace });
 
     expect(screen.getByRole("tab", { name: "Evidence" })).toBeDisabled();
     expect(screen.queryByRole("group", { name: "Performance mode readiness" })).not.toBeInTheDocument();
@@ -104,16 +114,7 @@ describe("PerformanceWorkspaceView", () => {
   it("disables unavailable evidence mode instead of mounting a dead panel", async () => {
     const scenario = buildUnavailableEvidencePerformanceScenario();
 
-    render(
-      <PerformanceWorkspaceView
-        workspace={scenario.workspace}
-        period="YTD"
-        detailBasis="NET"
-        contributionDimension="asset_class"
-        attributionDimension="asset_class"
-        chartFrequency="monthly"
-      />
-    );
+    renderWorkspaceView({ workspace: scenario.workspace });
 
     fireEvent.click(screen.getByRole("tab", { name: "Summary" }));
     expect(screen.getByRole("tab", { name: "Evidence" })).toBeDisabled();
@@ -124,16 +125,7 @@ describe("PerformanceWorkspaceView", () => {
   it("keeps analysis available when there is at least partial analytical coverage", async () => {
     const scenario = buildSupportedPerformanceScenario();
 
-    render(
-      <PerformanceWorkspaceView
-        workspace={scenario.workspace}
-        period="YTD"
-        detailBasis="NET"
-        contributionDimension="asset_class"
-        attributionDimension="asset_class"
-        chartFrequency="monthly"
-      />
-    );
+    renderWorkspaceView({ workspace: scenario.workspace });
 
     expect(screen.getByRole("tab", { name: "Analysis" })).not.toBeDisabled();
     fireEvent.click(screen.getByRole("tab", { name: "Analysis" }));
@@ -145,16 +137,7 @@ describe("PerformanceWorkspaceView", () => {
   it("shows a backend-backed control normalization notice when unsupported deep-link controls were adjusted", async () => {
     const scenario = buildNormalizedControlsPerformanceScenario();
 
-    render(
-      <PerformanceWorkspaceView
-        workspace={scenario.workspace}
-        period="YTD"
-        detailBasis="NET"
-        contributionDimension="asset_class"
-        attributionDimension="asset_class"
-        chartFrequency="monthly"
-      />
-    );
+    renderWorkspaceView({ workspace: scenario.workspace });
 
     const normalizationNotice = screen.getByRole("status", {
       name: "Performance control normalization",
@@ -172,16 +155,7 @@ describe("PerformanceWorkspaceView", () => {
   it("switches between summary, analysis, risk, and evidence modes", async () => {
     const scenario = buildSupportedPerformanceScenario();
 
-    render(
-      <PerformanceWorkspaceView
-        workspace={scenario.workspace}
-        period="YTD"
-        detailBasis="NET"
-        contributionDimension="asset_class"
-        attributionDimension="asset_class"
-        chartFrequency="monthly"
-      />
-    );
+    renderWorkspaceView({ workspace: scenario.workspace });
 
     expect(document.querySelector(".main-with-side-rail-layout.workstation-shell-main-only")).toBeTruthy();
     expect(document.querySelector(".workstation-shell-main")).toBeTruthy();

--- a/tests/unit/performance-workspace-view.test.tsx
+++ b/tests/unit/performance-workspace-view.test.tsx
@@ -32,6 +32,7 @@ vi.mock("next/dynamic", () => ({
 
 const summaryModeMock = vi.fn((_: unknown) => <div>Summary Mode Panel</div>);
 const analysisModeMock = vi.fn((_: unknown) => <div>Analysis Mode Panel</div>);
+const riskModeMock = vi.fn((_: unknown) => <div>Risk Mode Panel</div>);
 const evidenceModeMock = vi.fn((_: unknown) => <div>Evidence Mode Panel</div>);
 
 vi.mock("../../src/apps/performance/components/performance-summary-mode", () => ({
@@ -40,6 +41,10 @@ vi.mock("../../src/apps/performance/components/performance-summary-mode", () => 
 
 vi.mock("../../src/apps/performance/components/performance-analysis-mode", () => ({
   default: (props: unknown) => analysisModeMock(props),
+}));
+
+vi.mock("../../src/apps/performance/components/performance-risk-mode", () => ({
+  default: (props: unknown) => riskModeMock(props),
 }));
 
 vi.mock("../../src/apps/performance/components/performance-evidence-mode", () => ({
@@ -71,6 +76,7 @@ describe("PerformanceWorkspaceView", () => {
 
     expect(summaryModeMock).toHaveBeenCalledTimes(1);
     expect(analysisModeMock).not.toHaveBeenCalled();
+    expect(riskModeMock).not.toHaveBeenCalled();
     expect(evidenceModeMock).not.toHaveBeenCalled();
     expect(document.querySelector(".workbench-deferred-placeholder")).toBeFalsy();
     expect(screen.queryByText("Analysis Mode Panel")).not.toBeInTheDocument();
@@ -163,7 +169,7 @@ describe("PerformanceWorkspaceView", () => {
     );
   });
 
-  it("switches between summary, analysis, and evidence modes", async () => {
+  it("switches between summary, analysis, risk, and evidence modes", async () => {
     const scenario = buildSupportedPerformanceScenario();
 
     render(
@@ -202,6 +208,7 @@ describe("PerformanceWorkspaceView", () => {
       selectedBenchmarkCode: scenario.workspace.benchmark_code,
     });
     expect(screen.queryByText("Analysis Mode Panel")).not.toBeInTheDocument();
+    expect(screen.queryByText("Risk Mode Panel")).not.toBeInTheDocument();
     expect(screen.queryByText("Evidence Mode Panel")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("tab", { name: "Analysis" }));
@@ -220,10 +227,23 @@ describe("PerformanceWorkspaceView", () => {
     });
     expect(screen.queryByText("Summary Mode Panel")).not.toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("tab", { name: "Risk" }));
+    await waitFor(() => {
+      expect(screen.getByText("Risk Mode Panel")).toBeInTheDocument();
+    });
+    expect(riskModeMock).toHaveBeenCalled();
+    expect(riskModeMock.mock.calls.at(-1)?.[0]).toMatchObject({
+      workspace: scenario.workspace,
+      chartFrequency: "monthly",
+      contributionDimension: "asset_class",
+      attributionDimension: "asset_class",
+    });
+    expect(screen.queryByText("Analysis Mode Panel")).not.toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("tab", { name: "Evidence" }));
     expect(screen.getByRole("tab", { name: "Evidence" })).toBeDisabled();
     expect(screen.queryByText("Evidence Mode Panel")).not.toBeInTheDocument();
     expect(evidenceModeMock).not.toHaveBeenCalled();
-    expect(screen.getByText("Analysis Mode Panel")).toBeInTheDocument();
+    expect(screen.getByText("Risk Mode Panel")).toBeInTheDocument();
   });
 });

--- a/tests/unit/portfolio-view-model.test.ts
+++ b/tests/unit/portfolio-view-model.test.ts
@@ -455,24 +455,48 @@ describe("portfolio view model", () => {
         impact:
           "Review portfolio return, benchmark context, and contribution once the book is valued.",
         target: "Target: Performance workflow for this portfolio",
-        href: "/performance",
+        href: "/performance?portfolioId=PORT_UI_1001",
         cta_label: "Performance",
         recommended: true,
       },
       {
         sequence: 2,
-        title: "Review suitability",
+        title: "Review risk",
         impact:
           "Validate suitability, exposure, and mandate fit before the next client action.",
         target: "Target: Risk workflow for this portfolio",
-        href: "/risk",
-        cta_label: "Risk",
+        href: "/performance?portfolioId=PORT_UI_1001&mode=risk",
+        cta_label: "Open Risk",
         recommended: false,
       },
     ]);
 
     expect(buildPortfolioExceptionSummaries(workspace)).toEqual([]);
     expect(buildPortfolioInsights(workspace)).toEqual([]);
+  });
+
+  it("routes concentration insights into Performance Risk mode", () => {
+    const workspace = buildOperationalWorkspace();
+    workspace.top_positions = [
+      {
+        security_id: "EQ_1",
+        instrument_name: "Apple Inc",
+        asset_class: "Equities",
+        quantity: 10,
+        market_value_base: 250000,
+        weight_pct: 22,
+      },
+    ];
+
+    expect(buildPortfolioInsights(workspace)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "equity-concentration-high",
+          href: "/performance?portfolioId=PORT_UI_1001&mode=risk",
+          detail: expect.stringContaining("Open Risk"),
+        }),
+      ])
+    );
   });
 
   it("does not raise false funding or transaction exceptions when summary evidence exists", () => {

--- a/tests/unit/portfolio-workspace-config.test.ts
+++ b/tests/unit/portfolio-workspace-config.test.ts
@@ -14,20 +14,20 @@ describe("portfolio workspace config", () => {
       "/performance?portfolioId=PORT%201001"
     );
     expect(mapWorkflowHref("risk", "PORT_1001")).toBe(
-      "/risk-and-suitability?portfolioId=PORT_1001"
+      "/performance?portfolioId=PORT_1001&mode=risk"
     );
     expect(mapWorkflowHref("unknown", "PORT_1001")).toBe("/portfolio?portfolioId=PORT_1001");
   });
 
   it("maps workflow cues into advisor-facing action labels", () => {
     expect(getWorkflowActionLabel("performance")).toBe("Performance");
-    expect(getWorkflowActionLabel("risk")).toBe("Review Suitability");
+    expect(getWorkflowActionLabel("risk")).toBe("Open Risk");
     expect(getWorkflowActionLabel("unknown")).toBe("Performance");
   });
 
   it("maps workflow cues into concise task labels", () => {
     expect(getWorkflowTaskLabel("performance")).toBe("Review performance");
-    expect(getWorkflowTaskLabel("risk")).toBe("Review suitability");
+    expect(getWorkflowTaskLabel("risk")).toBe("Review risk");
     expect(getWorkflowTaskLabel("unknown")).toBe("Review performance");
   });
 

--- a/tests/unit/rfc0022-risk-architecture-guard.test.ts
+++ b/tests/unit/rfc0022-risk-architecture-guard.test.ts
@@ -56,4 +56,34 @@ describe("RFC-0022 risk workspace architecture guard", () => {
 
     expect(violations).toEqual([]);
   });
+
+  it("keeps the legacy workbench analytics contract free of removed risk proxy fields", () => {
+    const typesPath = path.join(repoRoot, "src/features/workbench/types.ts");
+    const typesContents = fs.readFileSync(typesPath, "utf8");
+    const workbenchAnalyticsStart = typesContents.indexOf("export type WorkbenchAnalytics = {");
+    const nextTypeStart = typesContents.indexOf("export type PerformanceComparativeSummary = {");
+    const analyticsBlock = typesContents.slice(workbenchAnalyticsStart, nextTypeStart);
+
+    const pagePath = path.join(repoRoot, "src/app/workbench/[portfolioId]/page.tsx");
+    const pageContents = fs.readFileSync(pagePath, "utf8");
+
+    const violations = [
+      analyticsBlock.includes("risk_proxy")
+        ? {
+            file: "src/features/workbench/types.ts",
+            pattern: "risk_proxy",
+            reason: "Legacy workbench analytics should not depend on the removed risk proxy field.",
+          }
+        : null,
+      pageContents.includes("risk_proxy")
+        ? {
+            file: "src/app/workbench/[portfolioId]/page.tsx",
+            pattern: "risk_proxy",
+            reason: "The legacy workbench page should not read removed risk proxy fields.",
+          }
+        : null,
+    ].filter((value): value is { file: string; pattern: string; reason: string } => value !== null);
+
+    expect(violations).toEqual([]);
+  });
 });

--- a/tests/unit/rfc0022-risk-architecture-guard.test.ts
+++ b/tests/unit/rfc0022-risk-architecture-guard.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const sourceRoot = path.join(repoRoot, "src");
+const sourceExtensions = new Set([".ts", ".tsx", ".js", ".jsx"]);
+
+function collectSourceFiles(directory: string): string[] {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(entryPath));
+      continue;
+    }
+
+    if (sourceExtensions.has(path.extname(entry.name))) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+describe("RFC-0022 risk workspace architecture guard", () => {
+  it("keeps Workbench risk integration behind Gateway-owned BFF contracts", () => {
+    const forbiddenPatterns = [
+      {
+        pattern: "/analytics/risk/",
+        reason: "Workbench must not call lotus-risk analytics routes directly.",
+      },
+      {
+        pattern: "/analytics/workbench/risk-proxy",
+        reason: "The old lotus-risk workbench risk-proxy endpoint is removed.",
+      },
+      {
+        pattern: "risk.dev.lotus",
+        reason: "Browser/runtime UI code must use the Gateway BFF, not service hostnames.",
+      },
+    ];
+
+    const violations = collectSourceFiles(sourceRoot).flatMap((filePath) => {
+      const contents = fs.readFileSync(filePath, "utf8");
+      return forbiddenPatterns
+        .filter(({ pattern }) => contents.includes(pattern))
+        .map(({ pattern, reason }) => ({
+          file: path.relative(repoRoot, filePath).replaceAll(path.sep, "/"),
+          pattern,
+          reason,
+        }));
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/service-addressing.test.ts
+++ b/tests/unit/service-addressing.test.ts
@@ -38,6 +38,14 @@ describe("service addressing", () => {
     expect(resolveGatewayBaseUrl()).toBe("https://gateway.uat.lotus");
   });
 
+  it("rejects local loopback BFF overrides", () => {
+    process.env.BFF_BASE_URL = "http://127.0.0.1:8000/";
+
+    expect(() => resolveGatewayBaseUrl()).toThrow(
+      "BFF_BASE_URL must use a canonical Lotus hostname, not local loopback"
+    );
+  });
+
   it("uses the proxy path for client-side requests", () => {
     expect(resolveBffProxyBaseUrl()).toBe("/api/bff");
     expect(resolveWorkbenchApiBase("client")).toBe("/api/bff/api/v1");

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -111,7 +111,6 @@ describe("workbench api", () => {
             active_return_pct: 0.5,
             allocation_buckets: [],
             top_changes: [],
-            risk_proxy: { hhi_current: 1500, hhi_proposed: 1600, hhi_delta: 100 },
             warnings: [],
             partial_failures: [],
           }),


### PR DESCRIPTION
## Summary
- adds RFC-0022 for a stateful-only Risk Workspace in lotus-workbench
- defines the Gateway BFF replacement for the old /analytics/workbench/risk-proxy path
- specifies modular micro-frontend-style Workbench risk panels using RFC-0021 shared primitives
- captures implementation slices, supportability gates, test strategy, and definition of done

## Notes
- RFC only; no production code changes
- lotus-risk was reviewed read-only because its current feature branch has existing uncommitted hardening work

## Validation
- documentation sanity check and RFC index update