### PR TITLE
[codex] RFC-0075 canonical Workbench validation and screenshot evidence

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -90,10 +90,10 @@ That script performs:
 1. preview the canonical hosts block from `lotus-platform`
 2. `docker compose up -d` for `lotus-core`, `lotus-performance`, `lotus-risk`, `lotus-ai`, and `lotus-advise`
 3. `docker compose up -d` for `lotus-report`
-4. canonical host-process startup for `lotus-manage` on `8001`
-5. direct ingress restart on port `80` using `lotus-platform/platform-stack/dev-ingress/Caddyfile.direct-host`
+4. direct ingress restart on port `80` using `lotus-platform/platform-stack/dev-ingress/Caddyfile.direct-host`
+5. canonical `lotus-gateway` startup on port `8111`
 6. governed `lotus-core` seed for `PB_SG_GLOBAL_BAL_001`
-7. canonical `lotus-gateway` startup on port `8111`
+7. canonical host-process startup for `lotus-manage` on `8001`
 8. canonical `lotus-workbench` startup on port `3000`
 9. end-to-end validation of canonical routes and populated UI panels
 
@@ -153,6 +153,11 @@ Machine-readable validation evidence is written to:
 ```txt
 output/playwright/live-canonical/live-validation-summary.json
 ```
+
+The validation script runs the browser validator from the `lotus-workbench` repository root so
+these artifact paths are stable even when `lotus-platform` or another orchestrator calls the
+script. Browser validation failures must fail the PowerShell command; do not treat stale summaries
+or partial screenshot output as successful evidence.
 
 ## Gateway startup rule
 

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -169,6 +169,11 @@ assert numeric ranges, contribution reconciliation, governed attribution fallbac
 observation coverage, concentration coverage, rolling-window availability, and historical risk
 attribution residuals before screenshots are accepted as demo evidence.
 
+The summary also includes `panelClassifications` for the product surfaces validated during the run.
+Panels must be classified as `ready`, `partial`, `unavailable`, or another explicit governed state.
+The validator fails if a supported panel is recorded as blank without a governed empty, partial, or
+unavailable posture.
+
 ## Gateway startup rule
 
 Canonical local Gateway startup must use:

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -131,7 +131,12 @@ Validation layers:
    - platform capabilities
    - workbench overview
    - performance summary
+   - performance details
    - risk summary
+   - risk concentration
+   - risk drawdown
+   - risk rolling
+   - risk attribution
    - advisor brief
 5. browser-level validation for populated UI on:
    - Portfolio summary
@@ -158,6 +163,11 @@ The validation script runs the browser validator from the `lotus-workbench` repo
 these artifact paths are stable even when `lotus-platform` or another orchestrator calls the
 script. Browser validation failures must fail the PowerShell command; do not treat stale summaries
 or partial screenshot output as successful evidence.
+
+The summary includes `calculationChecks` for canonical performance and risk sanity. These checks
+assert numeric ranges, contribution reconciliation, governed attribution fallback posture, risk
+observation coverage, concentration coverage, rolling-window availability, and historical risk
+attribution residuals before screenshots are accepted as demo evidence.
 
 ## Gateway startup rule
 
@@ -225,6 +235,8 @@ For `PB_SG_GLOBAL_BAL_001`, the validator confirms:
   - `Attribution Over Time` renders
   - `Attribution Detail` table is populated
   - `Performance Drivers` table is populated
+  - contribution rows reconcile to the net portfolio return
+  - attribution detail is populated or carries a governed partial fallback
 - Advisor Brief:
   - talking points render
   - source metrics render
@@ -236,6 +248,11 @@ For `PB_SG_GLOBAL_BAL_001`, the validator confirms:
   - `Rolling Risk`
   - `Historical Risk Attribution`
   - attribution table is populated
+  - summary metrics have sufficient observations and ready benchmark-relative metrics
+  - concentration has issuer coverage and top-exposure evidence
+  - drawdown has underwater-series evidence
+  - rolling risk has all configured windows and enough computable windows for the current horizon
+  - historical attribution contributors reconcile with a negligible residual
 - Evidence:
   - Evidence mode opens
   - evidence support strip or truthful degraded state renders

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -119,6 +119,13 @@ To validate an already-running stack:
 npm run live:validate
 ```
 
+To write demo screenshots to a caller-provided directory:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1 `
+  -ScreenshotDirectory C:\Users\Sandeep\AppData\Local\Temp\lotus-risk-module-shots
+```
+
 Validation layers:
 
 1. canonical hostname resolution
@@ -152,6 +159,12 @@ Screenshots are written to:
 ```txt
 output/playwright/live-canonical/
 ```
+
+When `-ScreenshotDirectory` is supplied, screenshots and the live validation summary are written to
+that directory instead. The summary records structured screenshot evidence for each capture:
+stable file name, absolute path, route, panel identifier, portfolio ID, benchmark ID, as-of date,
+and demo readiness state. The validator also writes `SHOT-INDEX.md` in the screenshot directory so
+demo reviewers can quickly identify the captured product surfaces.
 
 Machine-readable validation evidence is written to:
 

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -2,6 +2,7 @@ param(
   [string]$ProjectsRoot = "C:\\Users\\Sandeep\\projects",
   [string]$PortfolioId = "PB_SG_GLOBAL_BAL_001",
   [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40",
+  [string]$ScreenshotDirectory = "",
   [switch]$BuildImages
 )
 
@@ -98,6 +99,11 @@ if (-not (Test-HttpReady "http://127.0.0.1:3000")) {
 }
 
 Write-Host "Running canonical live validation ..."
-& (Join-Path $workbenchRepo "scripts\\live\\Validate-LotusFrontOfficeCanonical.ps1") `
-  -PortfolioId $PortfolioId `
-  -BenchmarkCode $BenchmarkCode
+$validationArguments = @{
+  PortfolioId = $PortfolioId
+  BenchmarkCode = $BenchmarkCode
+}
+if (-not [string]::IsNullOrWhiteSpace($ScreenshotDirectory)) {
+  $validationArguments.ScreenshotDirectory = $ScreenshotDirectory
+}
+& (Join-Path $workbenchRepo "scripts\\live\\Validate-LotusFrontOfficeCanonical.ps1") @validationArguments

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -76,7 +76,7 @@ Write-Host "Starting canonical Gateway on :8111 ..."
 & (Join-Path $gatewayRepo "scripts\\Start-CanonicalGateway.ps1")
 
 Write-Host "Seeding governed front-office portfolio data for $PortfolioId ..."
-Invoke-RepoCommand $coreRepo "python tools/front_office_portfolio_seed.py --portfolio-id $PortfolioId --start-date 2025-03-31 --end-date 2026-03-28 --benchmark-start-date 2025-01-06 --wait-seconds 300"
+Invoke-RepoCommand $coreRepo "python tools/front_office_portfolio_seed.py --portfolio-id $PortfolioId --start-date 2025-03-31 --end-date 2026-04-10 --benchmark-start-date 2025-01-06 --wait-seconds 300"
 
 Write-Host "Starting canonical lotus-manage on :8001 ..."
 & (Join-Path $manageRepo "scripts\\Start-CanonicalManage.ps1")

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -67,11 +67,11 @@ Write-Host "Ensuring direct ingress container is running..."
 Remove-ContainerIfPresent "lotus-direct-dev-ingress"
 docker run -d --name lotus-direct-dev-ingress -p 80:80 -v "${ingressCaddyfile}:/etc/caddy/Caddyfile" caddy:2.8.4 | Out-Null
 
-Write-Host "Seeding governed front-office portfolio data for $PortfolioId ..."
-Invoke-RepoCommand $coreRepo "python tools/front_office_portfolio_seed.py --portfolio-id $PortfolioId --start-date 2025-03-31 --end-date 2026-03-28 --benchmark-start-date 2025-01-06 --wait-seconds 300"
-
 Write-Host "Starting canonical Gateway on :8111 ..."
 & (Join-Path $gatewayRepo "scripts\\Start-CanonicalGateway.ps1")
+
+Write-Host "Seeding governed front-office portfolio data for $PortfolioId ..."
+Invoke-RepoCommand $coreRepo "python tools/front_office_portfolio_seed.py --portfolio-id $PortfolioId --start-date 2025-03-31 --end-date 2026-03-28 --benchmark-start-date 2025-01-06 --wait-seconds 300"
 
 Write-Host "Starting canonical lotus-manage on :8001 ..."
 & (Join-Path $manageRepo "scripts\\Start-CanonicalManage.ps1")

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -1,7 +1,8 @@
 param(
   [string]$ProjectsRoot = "C:\\Users\\Sandeep\\projects",
   [string]$PortfolioId = "PB_SG_GLOBAL_BAL_001",
-  [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40"
+  [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40",
+  [switch]$BuildImages
 )
 
 $ErrorActionPreference = "Stop"
@@ -56,12 +57,16 @@ Write-Host "Previewing managed canonical hosts block from lotus-platform ..."
 Invoke-RepoCommand $platformRepo "powershell -ExecutionPolicy Bypass -File automation\\Sync-Dev-Ingress-Hosts.ps1"
 
 Write-Host "Starting Docker-backed upstream services..."
-Invoke-RepoCommand $coreRepo "docker compose up -d"
-Invoke-RepoCommand $performanceRepo "docker compose up -d"
-Invoke-RepoCommand $riskRepo "docker compose up -d"
-Invoke-RepoCommand $aiRepo "docker compose up -d"
-Invoke-RepoCommand $adviseRepo "docker compose up -d"
-Invoke-RepoCommand $reportRepo "docker compose up -d"
+$composeUpCommand = "docker compose up -d"
+if ($BuildImages) {
+  $composeUpCommand = "$composeUpCommand --build"
+}
+Invoke-RepoCommand $coreRepo $composeUpCommand
+Invoke-RepoCommand $performanceRepo $composeUpCommand
+Invoke-RepoCommand $riskRepo $composeUpCommand
+Invoke-RepoCommand $aiRepo $composeUpCommand
+Invoke-RepoCommand $adviseRepo $composeUpCommand
+Invoke-RepoCommand $reportRepo $composeUpCommand
 
 Write-Host "Ensuring direct ingress container is running..."
 Remove-ContainerIfPresent "lotus-direct-dev-ingress"

--- a/scripts/live/Stop-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Stop-LotusFrontOfficeCanonical.ps1
@@ -1,5 +1,7 @@
 param(
-  [string]$ProjectsRoot = "C:\\Users\\Sandeep\\projects"
+  [string]$ProjectsRoot = "C:\\Users\\Sandeep\\projects",
+  [switch]$RemoveVolumes,
+  [switch]$RemoveImages
 )
 
 $ErrorActionPreference = "Stop"
@@ -60,12 +62,19 @@ Write-Host "Stopping direct ingress..."
 Remove-ContainerIfPresent "lotus-direct-dev-ingress"
 
 Write-Host "Stopping Docker-backed Lotus services..."
-Invoke-RepoCommand $coreRepo "docker compose down"
-Invoke-RepoCommand $performanceRepo "docker compose down"
-Invoke-RepoCommand $riskRepo "docker compose down"
-Invoke-RepoCommand $aiRepo "docker compose down"
-Invoke-RepoCommand $adviseRepo "docker compose down"
-Invoke-RepoCommand $manageRepo "docker compose down"
-Invoke-RepoCommand $reportRepo "docker compose down"
+$downCommand = "docker compose down --remove-orphans"
+if ($RemoveVolumes) {
+  $downCommand = "$downCommand -v"
+}
+if ($RemoveImages) {
+  $downCommand = "$downCommand --rmi local"
+}
+Invoke-RepoCommand $coreRepo $downCommand
+Invoke-RepoCommand $performanceRepo $downCommand
+Invoke-RepoCommand $riskRepo $downCommand
+Invoke-RepoCommand $aiRepo $downCommand
+Invoke-RepoCommand $adviseRepo $downCommand
+Invoke-RepoCommand $manageRepo $downCommand
+Invoke-RepoCommand $reportRepo $downCommand
 
 Write-Host "Canonical front-office local runtime stopped."

--- a/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
@@ -2,7 +2,8 @@ param(
   [string]$PortfolioId = "PB_SG_GLOBAL_BAL_001",
   [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40",
   [string]$WorkbenchBaseUrl = "http://workbench.dev.lotus",
-  [string]$GatewayBaseUrl = "http://gateway.dev.lotus"
+  [string]$GatewayBaseUrl = "http://gateway.dev.lotus",
+  [string]$ScreenshotDirectory = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -67,11 +68,22 @@ Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/advisor
 
 Push-Location $repoRoot
 try {
-  node "$repoRoot\\scripts\\live\\validate-canonical-workbench-live.mjs" `
-    --portfolio-id "$PortfolioId" `
-    --benchmark-code "$BenchmarkCode" `
-    --workbench-base-url "$WorkbenchBaseUrl" `
-    --gateway-base-url "$GatewayBaseUrl"
+  $validatorArguments = @(
+    "$repoRoot\\scripts\\live\\validate-canonical-workbench-live.mjs",
+    "--portfolio-id",
+    $PortfolioId,
+    "--benchmark-code",
+    $BenchmarkCode,
+    "--workbench-base-url",
+    $WorkbenchBaseUrl,
+    "--gateway-base-url",
+    $GatewayBaseUrl
+  )
+  if (-not [string]::IsNullOrWhiteSpace($ScreenshotDirectory)) {
+    $validatorArguments += @("--output-dir", $ScreenshotDirectory)
+  }
+
+  & node @validatorArguments
 
   if ($LASTEXITCODE -ne 0) {
     throw "Canonical Workbench browser validation failed with exit code $LASTEXITCODE."

--- a/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
@@ -65,8 +65,17 @@ Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/summary
 Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/risk/summary?period=YTD&detail_basis=NET&benchmark_code=$BenchmarkCode" "Gateway risk summary"
 Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "Gateway advisor brief"
 
-node "$repoRoot\\scripts\\live\\validate-canonical-workbench-live.mjs" `
-  --portfolio-id "$PortfolioId" `
-  --benchmark-code "$BenchmarkCode" `
-  --workbench-base-url "$WorkbenchBaseUrl" `
-  --gateway-base-url "$GatewayBaseUrl"
+Push-Location $repoRoot
+try {
+  node "$repoRoot\\scripts\\live\\validate-canonical-workbench-live.mjs" `
+    --portfolio-id "$PortfolioId" `
+    --benchmark-code "$BenchmarkCode" `
+    --workbench-base-url "$WorkbenchBaseUrl" `
+    --gateway-base-url "$GatewayBaseUrl"
+
+  if ($LASTEXITCODE -ne 0) {
+    throw "Canonical Workbench browser validation failed with exit code $LASTEXITCODE."
+  }
+} finally {
+  Pop-Location
+}

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -31,7 +31,9 @@ const outputDir = path.resolve(
   args.get("output-dir") ?? "output/playwright/live-canonical"
 );
 const summaryPath = path.join(outputDir, "live-validation-summary.json");
+const shotIndexPath = path.join(outputDir, "SHOT-INDEX.md");
 const timeoutMs = Number(args.get("timeout-ms") ?? "60000");
+const canonicalAsOfDate = args.get("as-of-date") ?? "2026-04-10";
 
 const summary = {
   generatedAt: new Date().toISOString(),
@@ -417,14 +419,46 @@ function assertRiskCalculationSanity(riskSummary, concentration, drawdown, rolli
   });
 }
 
-async function screenshot(page, name) {
+async function screenshot(page, name, metadata) {
   const target = path.join(outputDir, name);
   await page.screenshot({ path: target, fullPage: true });
-  summary.screenshots.push(name);
+  summary.screenshots.push({
+    name,
+    path: target,
+    route: metadata.route,
+    panel: metadata.panel,
+    portfolioId,
+    benchmarkCode,
+    asOfDate: canonicalAsOfDate,
+    state: metadata.state ?? "demo_ready",
+  });
 }
 
 async function writeSummary() {
   await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+}
+
+async function writeShotIndex() {
+  const lines = [
+    "# Lotus Canonical Front-Office Screenshots",
+    "",
+    `- Generated: ${summary.generatedAt}`,
+    `- Portfolio: ${portfolioId}`,
+    `- Benchmark: ${benchmarkCode}`,
+    `- As of: ${canonicalAsOfDate}`,
+    `- Validation summary: ${summaryPath}`,
+    "",
+    "## Captures",
+    "",
+  ];
+
+  for (const screenshotEvidence of summary.screenshots) {
+    lines.push(
+      `- ${screenshotEvidence.name} - ${screenshotEvidence.panel} - ${screenshotEvidence.route} - ${screenshotEvidence.state}`
+    );
+  }
+
+  await fs.writeFile(shotIndexPath, `${lines.join("\n")}\n`, "utf8");
 }
 
 async function run() {
@@ -603,7 +637,10 @@ async function run() {
     await expect(page.getByRole("img", { name: "Allocation donut chart" })).toBeVisible({
       timeout: timeoutMs,
     });
-    await screenshot(page, "portfolio-summary-live.png");
+    await screenshot(page, "portfolio-summary-live.png", {
+      route: `/portfolio?portfolioId=${portfolioId}`,
+      panel: "portfolio.summary",
+    });
 
     await page.getByRole("tab", { name: "Detailed" }).click();
     await expect(page.getByRole("tab", { name: "Detailed", exact: true, selected: true })).toBeVisible({
@@ -619,7 +656,10 @@ async function run() {
     await expect(page.getByLabel("Projected cashflow summary")).toBeVisible({
       timeout: timeoutMs,
     });
-    await screenshot(page, "portfolio-detailed-live.png");
+    await screenshot(page, "portfolio-detailed-live.png", {
+      route: `/portfolio?portfolioId=${portfolioId}&tab=detailed`,
+      panel: "portfolio.detailed",
+    });
 
     await page.goto(`${workbenchBaseUrl}/performance?portfolioId=${portfolioId}`, {
       waitUntil: "networkidle",
@@ -642,7 +682,10 @@ async function run() {
       4,
       "Return path observation table"
     );
-    await screenshot(page, "performance-summary-live.png");
+    await screenshot(page, "performance-summary-live.png", {
+      route: `/performance?portfolioId=${portfolioId}`,
+      panel: "performance.summary",
+    });
 
     await page.goto(
       `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=analysis&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
@@ -670,7 +713,10 @@ async function run() {
       1,
       "Contribution detail table"
     );
-    await screenshot(page, "performance-analysis-live.png");
+    await screenshot(page, "performance-analysis-live.png", {
+      route: `/performance?portfolioId=${portfolioId}&mode=analysis`,
+      panel: "performance.analysis",
+    });
 
     await page.goto(
       `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=advisor&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
@@ -697,7 +743,10 @@ async function run() {
       kind: "buttons",
       buttonCount: sourceMetricButtons,
     });
-    await screenshot(page, "performance-advisor-brief-live.png");
+    await screenshot(page, "performance-advisor-brief-live.png", {
+      route: `/performance?portfolioId=${portfolioId}&mode=advisor`,
+      panel: "performance.advisor_brief",
+    });
 
     await page.goto(
       `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
@@ -726,7 +775,10 @@ async function run() {
       5,
       "Historical risk attribution table"
     );
-    await screenshot(page, "performance-risk-live.png");
+    await screenshot(page, "performance-risk-live.png", {
+      route: `/performance?portfolioId=${portfolioId}&mode=risk`,
+      panel: "performance.risk",
+    });
 
     await page.goto(
       `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=evidence&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
@@ -748,12 +800,17 @@ async function run() {
       });
       summary.uiChecks.push({ description: "Evidence support status", kind: "status-strip", state: "degraded" });
     }
-    await screenshot(page, "performance-evidence-live.png");
+    await screenshot(page, "performance-evidence-live.png", {
+      route: `/performance?portfolioId=${portfolioId}&mode=evidence`,
+      panel: "performance.evidence",
+      state: "truthfully_degraded",
+    });
   } finally {
     await browser.close();
   }
 
   await writeSummary();
+  await writeShotIndex();
   console.log(`Live canonical Workbench validation passed for ${portfolioId}. Screenshots: ${outputDir}`);
 }
 

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -43,6 +43,7 @@ const summary = {
   apiChecks: [],
   uiChecks: [],
   calculationChecks: [],
+  panelClassifications: [],
   screenshots: [],
 };
 
@@ -175,6 +176,23 @@ function recordCalculationCheck(description, evidence) {
   summary.calculationChecks.push({ description, ...evidence });
 }
 
+function recordPanelClassification(panel, state, owner, evidence) {
+  summary.panelClassifications.push({ panel, state, owner, ...evidence });
+}
+
+function assertNoUnsupportedBlankPanels() {
+  const unsupportedBlankPanels = summary.panelClassifications.filter(
+    (panel) => panel.state === "supported_blank"
+  );
+  if (unsupportedBlankPanels.length > 0) {
+    throw new Error(
+      `Unsupported blank panels found: ${unsupportedBlankPanels
+        .map((panel) => panel.panel)
+        .join(", ")}.`
+    );
+  }
+}
+
 function assertPerformanceCalculationSanity(performanceSummary, performanceDetails) {
   const netPerformance = performanceSummary?.net_performance ?? {};
   const overview = performanceSummary?.overview ?? {};
@@ -246,6 +264,31 @@ function assertPerformanceCalculationSanity(performanceSummary, performanceDetai
     attributionState: attributionCapability.state,
     attributionRows,
   });
+
+  recordPanelClassification("performance.summary", "ready", "lotus-gateway", {
+    returnPathRows: performanceDetails.net_chart.length,
+  });
+  recordPanelClassification("performance.analysis.contribution", "ready", "lotus-gateway", {
+    contributionRows: contributionRows.length,
+  });
+  recordPanelClassification(
+    "performance.analysis.attribution",
+    attributionFallback ? "partial" : "ready",
+    "lotus-gateway",
+    {
+      attributionState: attributionCapability.state,
+      attributionRows,
+      fallbackAvailable: attributionCapability.fallback_available === true,
+    }
+  );
+  recordPanelClassification(
+    "performance.evidence",
+    performanceSummary?.capabilities?.evidence?.state ?? "unknown",
+    "lotus-gateway",
+    {
+      reason: performanceSummary?.capabilities?.evidence?.reason ?? null,
+    }
+  );
 }
 
 function assertRiskCalculationSanity(riskSummary, concentration, drawdown, rolling, attribution) {
@@ -354,6 +397,23 @@ function assertRiskCalculationSanity(riskSummary, concentration, drawdown, rolli
     rollingWindowResultCount: rollingWindows.length,
     rollingWindowsWithLatestVolatility,
     attributionContributorCount: contributors.length,
+  });
+
+  recordPanelClassification("risk.snapshot", "ready", "lotus-risk", {
+    readyMetricCount: readyMetrics.length,
+  });
+  recordPanelClassification("risk.concentration", "ready", "lotus-risk", {
+    issuerCoverageRatio: concentrationPayload.issuer_concentration?.coverage_ratio_current,
+  });
+  recordPanelClassification("risk.drawdown", "ready", "lotus-risk", {
+    underwaterSeriesRows: drawdownPeriod.underwater_series.length,
+  });
+  recordPanelClassification("risk.rolling", "ready", "lotus-risk", {
+    windowCount: rollingPeriod.window_count_emitted,
+    computableWindows: rollingWindowsWithLatestVolatility,
+  });
+  recordPanelClassification("risk.historical_attribution", "ready", "lotus-risk", {
+    contributorRows: contributors.length,
   });
 }
 
@@ -495,6 +555,16 @@ async function run() {
   if (gatewayOverview?.portfolio?.portfolio_id !== portfolioId) {
     throw new Error("Gateway workbench overview returned no portfolio payload.");
   }
+  recordPanelClassification("portfolio.summary", "ready", "lotus-gateway", {
+    portfolioId,
+  });
+  recordPanelClassification("portfolio.detailed", "ready", "lotus-gateway", {
+    portfolioId,
+  });
+  recordPanelClassification("performance.advisor_brief", "ready", "lotus-gateway", {
+    sourceMetricMinimum: 3,
+  });
+  assertNoUnsupportedBlankPanels();
 
   const portfolioShell = await fetchText(
     `${workbenchBaseUrl}/portfolio?portfolioId=${portfolioId}`,

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -42,6 +42,7 @@ const summary = {
   dns: [],
   apiChecks: [],
   uiChecks: [],
+  calculationChecks: [],
   screenshots: [],
 };
 
@@ -142,6 +143,220 @@ async function assertRegionHasButtons(locator, minimumButtons, description) {
   summary.uiChecks.push({ description, kind: "buttons", buttonCount: count });
 }
 
+function assertFiniteNumber(value, description) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${description} expected a finite number but received ${String(value)}.`);
+  }
+  return value;
+}
+
+function assertNumberInRange(value, minimum, maximum, description) {
+  const numericValue = assertFiniteNumber(value, description);
+  if (numericValue < minimum || numericValue > maximum) {
+    throw new Error(
+      `${description} expected ${minimum} <= value <= ${maximum} but received ${numericValue}.`
+    );
+  }
+  return numericValue;
+}
+
+function assertArrayHasLength(value, minimumLength, description) {
+  if (!Array.isArray(value) || value.length < minimumLength) {
+    throw new Error(
+      `${description} expected at least ${minimumLength} rows but found ${
+        Array.isArray(value) ? value.length : "non-array"
+      }.`
+    );
+  }
+  return value;
+}
+
+function recordCalculationCheck(description, evidence) {
+  summary.calculationChecks.push({ description, ...evidence });
+}
+
+function assertPerformanceCalculationSanity(performanceSummary, performanceDetails) {
+  const netPerformance = performanceSummary?.net_performance ?? {};
+  const overview = performanceSummary?.overview ?? {};
+  const contributionLevel = performanceDetails?.contribution?.levels?.[0];
+  const attributionCapability = performanceDetails?.capabilities?.attribution_detail ?? {};
+  const attributionLevel = performanceDetails?.attribution?.levels?.[0];
+
+  const portfolioReturn = assertNumberInRange(
+    netPerformance.portfolio_return_pct,
+    -100,
+    200,
+    "Net portfolio return"
+  );
+  const benchmarkReturn = assertNumberInRange(
+    netPerformance.benchmark_return_pct,
+    -100,
+    100,
+    "Benchmark return"
+  );
+  const activeReturn = assertNumberInRange(
+    netPerformance.active_return_pct,
+    -200,
+    200,
+    "Active return"
+  );
+  const activeDifference = Math.abs(activeReturn - (portfolioReturn - benchmarkReturn));
+  if (activeDifference > 0.01) {
+    throw new Error(
+      `Active return is not reconciled: active=${activeReturn}, portfolio=${portfolioReturn}, benchmark=${benchmarkReturn}.`
+    );
+  }
+
+  assertNumberInRange(overview.market_value_base, 1, 100_000_000, "Portfolio market value");
+  assertNumberInRange(overview.cash_weight_pct, -5, 100, "Cash weight");
+  assertNumberInRange(overview.position_count, 10, 100, "Position count");
+  assertArrayHasLength(performanceDetails?.net_chart, 4, "Performance return path observations");
+  const contributionRows = assertArrayHasLength(
+    contributionLevel?.rows,
+    4,
+    "Performance contribution rows"
+  );
+  const contributionTotal = assertFiniteNumber(
+    contributionLevel.total_contribution_pct,
+    "Contribution total"
+  );
+  if (Math.abs(contributionTotal - portfolioReturn) > 0.02) {
+    throw new Error(
+      `Contribution total does not reconcile with net portfolio return: contribution=${contributionTotal}, return=${portfolioReturn}.`
+    );
+  }
+
+  const attributionRows = Array.isArray(attributionLevel?.rows) ? attributionLevel.rows.length : 0;
+  const attributionFallback =
+    attributionCapability.state === "partial" && attributionCapability.fallback_available === true;
+  if (attributionCapability.state === "supported" && attributionRows < 1) {
+    throw new Error("Attribution detail is supported but returned no rows.");
+  }
+  if (!attributionFallback && attributionCapability.state !== "supported") {
+    throw new Error(
+      `Attribution detail is ${String(attributionCapability.state)} without a governed fallback.`
+    );
+  }
+
+  recordCalculationCheck("Performance calculation sanity", {
+    portfolioReturnPct: portfolioReturn,
+    benchmarkReturnPct: benchmarkReturn,
+    activeReturnPct: activeReturn,
+    contributionRows: contributionRows.length,
+    attributionState: attributionCapability.state,
+    attributionRows,
+  });
+}
+
+function assertRiskCalculationSanity(riskSummary, concentration, drawdown, rolling, attribution) {
+  const riskPeriod = assertArrayHasLength(riskSummary?.payload?.periods, 1, "Risk periods")[0];
+  const metrics = assertArrayHasLength(riskPeriod.metrics, 6, "Risk summary metrics");
+  const readyMetrics = metrics.filter((metric) => metric?.state === "ready");
+  if (readyMetrics.length < 6) {
+    throw new Error(`Risk summary expected at least 6 ready metrics but found ${readyMetrics.length}.`);
+  }
+  assertNumberInRange(riskPeriod.portfolio_observation_count, 60, 400, "Risk observations");
+  assertNumberInRange(
+    riskPeriod.aligned_benchmark_observation_count,
+    60,
+    400,
+    "Aligned benchmark observations"
+  );
+  if (riskPeriod.benchmark_context?.aligned !== true) {
+    throw new Error("Risk benchmark context is not aligned.");
+  }
+
+  const concentrationPayload = concentration?.payload ?? {};
+  assertNumberInRange(
+    concentrationPayload.portfolio_concentration?.hhi_current,
+    1,
+    10_000,
+    "Portfolio concentration HHI"
+  );
+  assertNumberInRange(
+    concentrationPayload.issuer_concentration?.coverage_ratio_current,
+    0.95,
+    1,
+    "Issuer concentration coverage ratio"
+  );
+  assertNumberInRange(
+    concentrationPayload.single_position_concentration?.top_n_cumulative_weight_current,
+    0.5,
+    1.01,
+    "Top positions cumulative weight"
+  );
+
+  const drawdownPeriod = assertArrayHasLength(drawdown?.payload?.periods, 1, "Drawdown periods")[0];
+  assertNumberInRange(
+    drawdownPeriod.portfolio_observation_count,
+    60,
+    400,
+    "Drawdown observation count"
+  );
+  assertNumberInRange(
+    drawdownPeriod.relative_to_benchmark?.time_under_water_days,
+    1,
+    366,
+    "Relative drawdown time under water"
+  );
+  assertArrayHasLength(drawdownPeriod.underwater_series, 60, "Drawdown underwater series");
+
+  const rollingPeriod = assertArrayHasLength(rolling?.payload?.periods, 1, "Rolling risk periods")[0];
+  assertNumberInRange(rollingPeriod.window_count_emitted, 4, 4, "Rolling risk window count");
+  const rollingWindows = assertArrayHasLength(
+    rollingPeriod.window_results,
+    4,
+    "Rolling risk window results"
+  );
+  let rollingWindowsWithLatestVolatility = 0;
+  for (const windowResult of rollingPeriod.window_results) {
+    const volatility = windowResult?.metric_summaries?.ROLLING_VOLATILITY;
+    if (!volatility || typeof volatility !== "object") {
+      throw new Error(
+        `Rolling risk window ${String(windowResult?.window_length)} has no volatility summary.`
+      );
+    }
+    if (typeof volatility.latest === "number") {
+      rollingWindowsWithLatestVolatility += 1;
+    }
+  }
+  if (rollingWindowsWithLatestVolatility < 2) {
+    throw new Error(
+      `Rolling risk expected at least 2 computable windows but found ${rollingWindowsWithLatestVolatility}.`
+    );
+  }
+
+  const attributionPeriod = assertArrayHasLength(
+    attribution?.payload?.periods,
+    1,
+    "Historical risk attribution periods"
+  )[0];
+  const attributionSet = assertArrayHasLength(
+    attributionPeriod.attribution_sets,
+    1,
+    "Historical risk attribution sets"
+  )[0];
+  const contributors = assertArrayHasLength(
+    attributionSet.contributors,
+    5,
+    "Historical risk attribution contributors"
+  );
+  const residual = assertFiniteNumber(attributionSet.residual, "Historical risk residual");
+  if (Math.abs(residual) > 0.000001) {
+    throw new Error(`Historical risk attribution residual is too high: ${residual}.`);
+  }
+
+  recordCalculationCheck("Risk calculation sanity", {
+    readyMetricCount: readyMetrics.length,
+    observationCount: riskPeriod.portfolio_observation_count,
+    concentrationHhi: concentrationPayload.portfolio_concentration?.hhi_current,
+    rollingWindowCount: rollingPeriod.window_count_emitted,
+    rollingWindowResultCount: rollingWindows.length,
+    rollingWindowsWithLatestVolatility,
+    attributionContributorCount: contributors.length,
+  });
+}
+
 async function screenshot(page, name) {
   const target = path.join(outputDir, name);
   await page.screenshot({ path: target, fullPage: true });
@@ -189,6 +404,14 @@ async function run() {
     throw new Error("Performance summary returned no portfolio payload.");
   }
 
+  const performanceDetails = await fetchJson(
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/details?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}`,
+    "Performance details"
+  );
+  if (!performanceDetails?.portfolio_id) {
+    throw new Error("Performance details returned no portfolio payload.");
+  }
+
   const riskSummary = await fetchJson(
     `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/summary?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}`,
     "Risk summary"
@@ -196,6 +419,41 @@ async function run() {
   if (!riskSummary?.portfolio_id) {
     throw new Error("Risk summary returned no portfolio payload.");
   }
+
+  const riskConcentration = await fetchJson(
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/concentration?period=YTD&benchmark_code=${benchmarkCode}`,
+    "Risk concentration"
+  );
+  const riskDrawdown = await fetchJson(
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/drawdown?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&include_underwater_series=true`,
+    "Risk drawdown"
+  );
+  const riskRolling = await fetchJson(
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/rolling?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&include_time_series=true`,
+    "Risk rolling"
+  );
+  const riskAttribution = await fetchJson(
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/attribution?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&attribution_type=total_risk&grouping_dimension=sector`,
+    "Risk attribution"
+  );
+  for (const [description, payload] of [
+    ["Risk concentration", riskConcentration],
+    ["Risk drawdown", riskDrawdown],
+    ["Risk rolling", riskRolling],
+    ["Risk attribution", riskAttribution],
+  ]) {
+    if (payload?.state !== "ready") {
+      throw new Error(`${description} returned non-ready state: ${String(payload?.state)}.`);
+    }
+  }
+  assertPerformanceCalculationSanity(performanceSummary, performanceDetails);
+  assertRiskCalculationSanity(
+    riskSummary,
+    riskConcentration,
+    riskDrawdown,
+    riskRolling,
+    riskAttribution
+  );
 
   const advisorBrief = await fetchJson(
     `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}`,

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("canonical live validation script", () => {
+  it("propagates browser validation failures to the caller", () => {
+    const script = readFileSync(
+      join(process.cwd(), "scripts", "live", "Validate-LotusFrontOfficeCanonical.ps1"),
+      "utf8"
+    );
+
+    expect(script).toContain('node "$repoRoot\\\\scripts\\\\live\\\\validate-canonical-workbench-live.mjs"');
+    expect(script).toContain("Push-Location $repoRoot");
+    expect(script).toContain("Pop-Location");
+    expect(script).toContain("if ($LASTEXITCODE -ne 0)");
+    expect(script).toContain("Canonical Workbench browser validation failed");
+  });
+
+  it("documents stable live-validation artifact ownership", () => {
+    const runbook = readFileSync(
+      join(process.cwd(), "docs", "operations", "canonical-front-office-local-runtime.md"),
+      "utf8"
+    );
+
+    expect(runbook).toContain("runs the browser validator from the `lotus-workbench` repository root");
+    expect(runbook).toContain("Browser validation failures must fail the PowerShell command");
+    expect(runbook).toContain("stale summaries");
+  });
+});

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -54,4 +54,20 @@ describe("canonical live validation script", () => {
     expect(script).toContain("Contribution total does not reconcile with net portfolio return");
     expect(script).toContain("Historical risk attribution residual is too high");
   });
+
+  it("records explicit panel support classifications for demo evidence", () => {
+    const script = readFileSync(
+      join(process.cwd(), "scripts", "live", "validate-canonical-workbench-live.mjs"),
+      "utf8"
+    );
+
+    expect(script).toContain("panelClassifications");
+    expect(script).toContain("recordPanelClassification");
+    expect(script).toContain("assertNoUnsupportedBlankPanels");
+    expect(script).toContain("portfolio.summary");
+    expect(script).toContain("performance.analysis.attribution");
+    expect(script).toContain("performance.evidence");
+    expect(script).toContain("risk.historical_attribution");
+    expect(script).toContain("supported_blank");
+  });
 });

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -8,11 +8,15 @@ describe("canonical live validation script", () => {
       "utf8"
     );
 
-    expect(script).toContain('node "$repoRoot\\\\scripts\\\\live\\\\validate-canonical-workbench-live.mjs"');
+    expect(script).toContain("$validatorArguments = @(");
+    expect(script).toContain('"$repoRoot\\\\scripts\\\\live\\\\validate-canonical-workbench-live.mjs"');
+    expect(script).toContain("& node @validatorArguments");
     expect(script).toContain("Push-Location $repoRoot");
     expect(script).toContain("Pop-Location");
     expect(script).toContain("if ($LASTEXITCODE -ne 0)");
     expect(script).toContain("Canonical Workbench browser validation failed");
+    expect(script).toContain("[string]$ScreenshotDirectory");
+    expect(script).toContain('"--output-dir"');
   });
 
   it("documents stable live-validation artifact ownership", () => {
@@ -35,6 +39,8 @@ describe("canonical live validation script", () => {
     expect(script).toContain("--portfolio-id $PortfolioId");
     expect(script).toContain("--end-date 2026-04-10");
     expect(script).toContain("--benchmark-start-date 2025-01-06");
+    expect(script).toContain("[string]$ScreenshotDirectory");
+    expect(script).toContain("ScreenshotDirectory = $ScreenshotDirectory");
   });
 
   it("asserts canonical performance and risk calculation sanity", () => {
@@ -69,5 +75,30 @@ describe("canonical live validation script", () => {
     expect(script).toContain("performance.evidence");
     expect(script).toContain("risk.historical_attribution");
     expect(script).toContain("supported_blank");
+  });
+
+  it("records demo screenshot evidence with stable names, routes, and absolute paths", () => {
+    const script = readFileSync(
+      join(process.cwd(), "scripts", "live", "validate-canonical-workbench-live.mjs"),
+      "utf8"
+    );
+    const runbook = readFileSync(
+      join(process.cwd(), "docs", "operations", "canonical-front-office-local-runtime.md"),
+      "utf8"
+    );
+
+    expect(script).toContain("canonicalAsOfDate");
+    expect(script).toContain("portfolio-summary-live.png");
+    expect(script).toContain("performance-risk-live.png");
+    expect(script).toContain("performance-evidence-live.png");
+    expect(script).toContain("route: `/performance?portfolioId=${portfolioId}&mode=risk`");
+    expect(script).toContain("panel: \"performance.risk\"");
+    expect(script).toContain("state: \"truthfully_degraded\"");
+    expect(script).toContain("path: target");
+    expect(script).toContain("SHOT-INDEX.md");
+    expect(script).toContain("writeShotIndex");
+    expect(runbook).toContain("ScreenshotDirectory");
+    expect(runbook).toContain("structured screenshot evidence");
+    expect(runbook).toContain("SHOT-INDEX.md");
   });
 });

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -25,4 +25,15 @@ describe("canonical live validation script", () => {
     expect(runbook).toContain("Browser validation failures must fail the PowerShell command");
     expect(runbook).toContain("stale summaries");
   });
+
+  it("starts the governed seed with the canonical RFC-0075 as-of date", () => {
+    const script = readFileSync(
+      join(process.cwd(), "scripts", "live", "Start-LotusFrontOfficeCanonical.ps1"),
+      "utf8"
+    );
+
+    expect(script).toContain("--portfolio-id $PortfolioId");
+    expect(script).toContain("--end-date 2026-04-10");
+    expect(script).toContain("--benchmark-start-date 2025-01-06");
+  });
 });

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -36,4 +36,22 @@ describe("canonical live validation script", () => {
     expect(script).toContain("--end-date 2026-04-10");
     expect(script).toContain("--benchmark-start-date 2025-01-06");
   });
+
+  it("asserts canonical performance and risk calculation sanity", () => {
+    const script = readFileSync(
+      join(process.cwd(), "scripts", "live", "validate-canonical-workbench-live.mjs"),
+      "utf8"
+    );
+
+    expect(script).toContain("calculationChecks");
+    expect(script).toContain("assertPerformanceCalculationSanity");
+    expect(script).toContain("assertRiskCalculationSanity");
+    expect(script).toContain("/performance/details?");
+    expect(script).toContain("/risk/concentration?");
+    expect(script).toContain("/risk/drawdown?");
+    expect(script).toContain("/risk/rolling?");
+    expect(script).toContain("/risk/attribution?");
+    expect(script).toContain("Contribution total does not reconcile with net portfolio return");
+    expect(script).toContain("Historical risk attribution residual is too high");
+  });
 });


### PR DESCRIPTION
## Summary
- Implements canonical Workbench live validation for RFC-0075.
- Adds calculation and panel readiness checks, structured screenshot evidence, explicit screenshot output directory support, and updated runtime documentation.

## Validation
- npx vitest run tests/unit/live-canonical-validation-script.test.ts
- node --check scripts\live\validate-canonical-workbench-live.mjs
- powershell -ExecutionPolicy Bypass -File scripts\live\Validate-LotusFrontOfficeCanonical.ps1 -ScreenshotDirectory C:\Users\Sandeep\AppData\Local\Temp\lotus-risk-module-shots
