### PR TITLE
RFC-0078 slice 1: extract validation contract layer

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -182,6 +182,11 @@ The validator also loads the governed panel registry from
 expected panel identifiers, allowed panel states, and screenshot ownership under `RFC-0077`, so
 new panel work must extend the registry instead of introducing ad hoc validator metadata.
 
+The validator implementation is intentionally modular under `scripts/live/validation/`:
+contract metadata, probe behavior, calculation sanity, browser workflows, and panel-governance
+rules are separated so future changes extend the correct boundary instead of re-growing a single
+monolithic validation script.
+
 The validation script runs the browser validator from the `lotus-workbench` repository root so
 these artifact paths are stable even when `lotus-platform` or another orchestrator calls the
 script. Browser validation failures must fail the PowerShell command; do not treat stale summaries

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -1,334 +1,43 @@
 import dns from "node:dns/promises";
-import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { chromium, expect } from "@playwright/test";
+import { resolveValidationConfig } from "./validation/args.mjs";
+import {
+  loadCanonicalContractMetadata,
+  loadWorkbenchPanelRegistryMetadata,
+} from "./validation/contract-metadata.mjs";
+import {
+  buildSummaryPaths,
+  createValidationSummary,
+  ensureDirectory,
+  writeShotIndex,
+  writeValidationSummary,
+} from "./validation/evidence-summary-writer.mjs";
 
-const DEFAULT_CANONICAL_CONTRACT = {
-  contractId: "canonical-front-office-demo-data-contract",
-  contractVersion: "1.0.0",
-  governedByRfc: "RFC-0076",
-  portfolioId: "PB_SG_GLOBAL_BAL_001",
-  benchmarkCode: "BMK_PB_GLOBAL_BALANCED_60_40",
-  canonicalAsOfDate: "2026-04-10",
-};
-
-const DEFAULT_PANEL_REGISTRY = {
-  contractId: "workbench-panel-registry",
-  contractVersion: "1.0.0",
-  governedByRfc: "RFC-0077",
-  canonicalDataContract: "canonical-front-office-demo-data-contract",
-  sourcePath: "deterministic-fallback",
-  panels: [
-    {
-      panelId: "portfolio.summary",
-      owningService: "lotus-gateway",
-      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/overview",
-      requiredSupportState: "ready",
-      route: "/portfolio?portfolioId={portfolioId}",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "portfolio-summary-live.png",
-      knownLimitations: [],
-      ownerFollowUpRfc: null,
-    },
-    {
-      panelId: "portfolio.detailed",
-      owningService: "lotus-gateway",
-      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/overview",
-      requiredSupportState: "ready",
-      route: "/portfolio?portfolioId={portfolioId}&tab=detailed",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "portfolio-detailed-live.png",
-      knownLimitations: [],
-      ownerFollowUpRfc: null,
-    },
-    {
-      panelId: "performance.summary",
-      owningService: "lotus-performance",
-      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/performance/summary",
-      requiredSupportState: "ready",
-      route: "/performance?portfolioId={portfolioId}",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "performance-summary-live.png",
-      knownLimitations: [],
-      ownerFollowUpRfc: null,
-    },
-    {
-      panelId: "performance.analysis.contribution",
-      owningService: "lotus-performance",
-      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/performance/details",
-      requiredSupportState: "ready",
-      route: "/performance?portfolioId={portfolioId}&mode=analysis&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "performance-analysis-live.png",
-      knownLimitations: [],
-      ownerFollowUpRfc: null,
-    },
-    {
-      panelId: "performance.analysis.attribution",
-      owningService: "lotus-performance",
-      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/performance/details",
-      requiredSupportState: "partial",
-      route: "/performance?portfolioId={portfolioId}&mode=analysis&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "performance-analysis-live.png",
-      knownLimitations: [
-        "benchmark-relative attribution may remain partial until full source-backed detail is available",
-      ],
-      ownerFollowUpRfc: null,
-    },
-    {
-      panelId: "performance.advisor_brief",
-      owningService: "lotus-performance",
-      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/performance/advisor-brief",
-      requiredSupportState: "ready",
-      route: "/performance?portfolioId={portfolioId}&mode=advisor&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "performance-advisor-brief-live.png",
-      knownLimitations: [],
-      ownerFollowUpRfc: null,
-    },
-    {
-      panelId: "performance.risk.snapshot",
-      owningService: "lotus-risk",
-      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/risk/summary",
-      requiredSupportState: "ready",
-      route: "/performance?portfolioId={portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "performance-risk-live.png",
-      knownLimitations: [],
-      ownerFollowUpRfc: null,
-    },
-    {
-      panelId: "performance.risk.drawdown",
-      owningService: "lotus-risk",
-      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/risk/drawdown",
-      requiredSupportState: "ready",
-      route: "/performance?portfolioId={portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "performance-risk-live.png",
-      knownLimitations: [],
-      ownerFollowUpRfc: null,
-    },
-    {
-      panelId: "performance.risk.concentration",
-      owningService: "lotus-risk",
-      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/risk/concentration",
-      requiredSupportState: "ready",
-      route: "/performance?portfolioId={portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "performance-risk-live.png",
-      knownLimitations: [],
-      ownerFollowUpRfc: null,
-    },
-    {
-      panelId: "performance.risk.rolling",
-      owningService: "lotus-risk",
-      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/risk/rolling",
-      requiredSupportState: "ready",
-      route: "/performance?portfolioId={portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "performance-risk-live.png",
-      knownLimitations: [],
-      ownerFollowUpRfc: null,
-    },
-    {
-      panelId: "performance.risk.historical_attribution",
-      owningService: "lotus-risk",
-      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/risk/attribution",
-      requiredSupportState: "ready",
-      route: "/performance?portfolioId={portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "performance-risk-live.png",
-      knownLimitations: [],
-      ownerFollowUpRfc: null,
-    },
-    {
-      panelId: "performance.evidence",
-      owningService: "lotus-gateway",
-      gatewayEndpoint: null,
-      requiredSupportState: "unavailable",
-      route: "/performance?portfolioId={portfolioId}&mode=evidence&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
-      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
-      screenshotName: "performance-evidence-live.png",
-      knownLimitations: ["full evidence and lineage support is deferred pending RFC-0079"],
-      ownerFollowUpRfc: "RFC-0079",
-    },
-  ],
-};
-
-function parseArgs(argv) {
-  const args = new Map();
-  for (let index = 0; index < argv.length; index += 1) {
-    const token = argv[index];
-    if (!token.startsWith("--")) continue;
-    const key = token.slice(2);
-    const next = argv[index + 1];
-    if (!next || next.startsWith("--")) {
-      args.set(key, "true");
-      continue;
-    }
-    args.set(key, next);
-    index += 1;
-  }
-  return args;
-}
-
-const args = parseArgs(process.argv.slice(2));
-const portfolioId = args.get("portfolio-id") ?? "PB_SG_GLOBAL_BAL_001";
-const benchmarkCode = args.get("benchmark-code") ?? "BMK_PB_GLOBAL_BALANCED_60_40";
-const workbenchBaseUrl = (args.get("workbench-base-url") ?? "http://workbench.dev.lotus").replace(/\/+$/, "");
-const gatewayBaseUrl = (args.get("gateway-base-url") ?? "http://gateway.dev.lotus").replace(/\/+$/, "");
-const outputDir = path.resolve(
-  process.cwd(),
-  args.get("output-dir") ?? "output/playwright/live-canonical"
-);
-const summaryPath = path.join(outputDir, "live-validation-summary.json");
-const shotIndexPath = path.join(outputDir, "SHOT-INDEX.md");
-const timeoutMs = Number(args.get("timeout-ms") ?? "60000");
-const canonicalAsOfDate = args.get("as-of-date") ?? "2026-04-10";
+const {
+  portfolioId,
+  benchmarkCode,
+  workbenchBaseUrl,
+  gatewayBaseUrl,
+  outputDir,
+  timeoutMs,
+  canonicalAsOfDate,
+} = resolveValidationConfig(process.argv.slice(2));
+const { summaryPath, shotIndexPath } = buildSummaryPaths(outputDir);
 const canonicalContract = await loadCanonicalContractMetadata();
 const panelRegistry = await loadWorkbenchPanelRegistryMetadata();
 const panelRegistryById = new Map(panelRegistry.panels.map((panel) => [panel.panelId, panel]));
 
-const summary = {
+const summary = createValidationSummary({
   generatedAt: new Date().toISOString(),
   portfolioId,
   benchmarkCode,
   canonicalContract,
-  panelRegistry: {
-    contractId: panelRegistry.contractId,
-    contractVersion: panelRegistry.contractVersion,
-    governedByRfc: panelRegistry.governedByRfc,
-    canonicalDataContract: panelRegistry.canonicalDataContract,
-    sourcePath: panelRegistry.sourcePath,
-  },
   workbenchBaseUrl,
   gatewayBaseUrl,
-  dns: [],
-  apiChecks: [],
-  uiChecks: [],
-  calculationChecks: [],
-  panelClassifications: [],
-  supportabilityChecks: [],
-  screenshots: [],
-};
-
-async function loadCanonicalContractMetadata() {
-  const candidatePaths = [
-    process.env.LOTUS_PLATFORM_REPO
-      ? path.resolve(
-          process.env.LOTUS_PLATFORM_REPO,
-          "context",
-          "contracts",
-          "canonical-front-office-demo-data-contract.json"
-        )
-      : null,
-    path.resolve(
-      process.cwd(),
-      "..",
-      "lotus-platform",
-      "context",
-      "contracts",
-      "canonical-front-office-demo-data-contract.json"
-    ),
-  ].filter(Boolean);
-
-  for (const candidatePath of candidatePaths) {
-    try {
-      const raw = await fs.readFile(candidatePath, "utf8");
-      const payload = JSON.parse(raw);
-      return {
-        contractId: payload.contract_id ?? DEFAULT_CANONICAL_CONTRACT.contractId,
-        contractVersion: payload.contract_version ?? DEFAULT_CANONICAL_CONTRACT.contractVersion,
-        governedByRfc: payload.governed_by_rfc ?? DEFAULT_CANONICAL_CONTRACT.governedByRfc,
-        portfolioId: payload.portfolio?.portfolio_id ?? DEFAULT_CANONICAL_CONTRACT.portfolioId,
-        benchmarkCode:
-          payload.benchmark?.benchmark_id ?? DEFAULT_CANONICAL_CONTRACT.benchmarkCode,
-        canonicalAsOfDate:
-          payload.date_policy?.canonical_as_of_date ??
-          DEFAULT_CANONICAL_CONTRACT.canonicalAsOfDate,
-        sourcePath: candidatePath,
-      };
-    } catch (error) {
-      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
-        continue;
-      }
-      throw new Error(
-        `Unable to load governed canonical contract metadata from ${candidatePath}: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-    }
-  }
-
-  return {
-    ...DEFAULT_CANONICAL_CONTRACT,
-    sourcePath: "deterministic-fallback",
-  };
-}
-
-async function loadWorkbenchPanelRegistryMetadata() {
-  const candidatePaths = [
-    process.env.LOTUS_PLATFORM_REPO
-      ? path.resolve(
-          process.env.LOTUS_PLATFORM_REPO,
-          "context",
-          "contracts",
-          "workbench-panel-registry.json"
-        )
-      : null,
-    path.resolve(
-      process.cwd(),
-      "..",
-      "lotus-platform",
-      "context",
-      "contracts",
-      "workbench-panel-registry.json"
-    ),
-  ].filter(Boolean);
-
-  for (const candidatePath of candidatePaths) {
-    try {
-      const raw = await fs.readFile(candidatePath, "utf8");
-      const payload = JSON.parse(raw);
-      return {
-        contractId: payload.contract_id ?? DEFAULT_PANEL_REGISTRY.contractId,
-        contractVersion: payload.contract_version ?? DEFAULT_PANEL_REGISTRY.contractVersion,
-        governedByRfc: payload.governed_by_rfc ?? DEFAULT_PANEL_REGISTRY.governedByRfc,
-        canonicalDataContract:
-          payload.canonical_data_contract ?? DEFAULT_PANEL_REGISTRY.canonicalDataContract,
-        sourcePath: candidatePath,
-        panels: (payload.panels ?? []).map((panel) => ({
-          panelId: panel.panel_id,
-          owningService: panel.owning_service,
-          gatewayEndpoint: panel.gateway_endpoint,
-          requiredSupportState: panel.required_support_state,
-          route: panel.route,
-          allowedStates: panel.allowed_states ?? [],
-          screenshotName: panel.screenshot_policy?.screenshot_name ?? null,
-          knownLimitations: panel.known_limitations ?? [],
-          ownerFollowUpRfc: panel.owner_follow_up_rfc ?? null,
-        })),
-      };
-    } catch (error) {
-      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
-        continue;
-      }
-      throw new Error(
-        `Unable to load governed panel registry metadata from ${candidatePath}: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-    }
-  }
-
-  return DEFAULT_PANEL_REGISTRY;
-}
-
-async function ensureDirectory(target) {
-  await fs.mkdir(target, { recursive: true });
-}
+  panelRegistry,
+});
 
 async function checkDns(hostname, required = true) {
   try {
@@ -773,35 +482,6 @@ async function screenshotRegisteredPanel(page, panelId, metadata = {}) {
   });
 }
 
-async function writeSummary() {
-  await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
-}
-
-async function writeShotIndex() {
-  const lines = [
-    "# Lotus Canonical Front-Office Screenshots",
-    "",
-    `- Generated: ${summary.generatedAt}`,
-    `- Contract: ${summary.canonicalContract.contractId} ${summary.canonicalContract.contractVersion}`,
-    `- Governed by: ${summary.canonicalContract.governedByRfc}`,
-    `- Portfolio: ${portfolioId}`,
-    `- Benchmark: ${benchmarkCode}`,
-    `- As of: ${canonicalAsOfDate}`,
-    `- Validation summary: ${summaryPath}`,
-    "",
-    "## Captures",
-    "",
-  ];
-
-  for (const screenshotEvidence of summary.screenshots) {
-    lines.push(
-      `- ${screenshotEvidence.name} - ${screenshotEvidence.panel} - ${screenshotEvidence.route} - ${screenshotEvidence.state}`
-    );
-  }
-
-  await fs.writeFile(shotIndexPath, `${lines.join("\n")}\n`, "utf8");
-}
-
 async function run() {
   await ensureDirectory(outputDir);
 
@@ -1131,8 +811,8 @@ async function run() {
     await browser.close();
   }
 
-  await writeSummary();
-  await writeShotIndex();
+  await writeValidationSummary(summaryPath, summary);
+  await writeShotIndex(shotIndexPath, summary, summaryPath);
   console.log(`Live canonical Workbench validation passed for ${portfolioId}. Screenshots: ${outputDir}`);
 }
 

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -1,4 +1,3 @@
-import dns from "node:dns/promises";
 import path from "node:path";
 import process from "node:process";
 import { chromium, expect } from "@playwright/test";
@@ -14,6 +13,7 @@ import {
   writeShotIndex,
   writeValidationSummary,
 } from "./validation/evidence-summary-writer.mjs";
+import { checkDns, fetchJson, fetchText } from "./validation/probes.mjs";
 
 const {
   portfolioId,
@@ -38,72 +38,6 @@ const summary = createValidationSummary({
   gatewayBaseUrl,
   panelRegistry,
 });
-
-async function checkDns(hostname, required = true) {
-  try {
-    const resolution = await dns.lookup(hostname);
-    const result = { hostname, ok: true, address: resolution.address, required };
-    summary.dns.push(result);
-    return result;
-  } catch (error) {
-    const result = {
-      hostname,
-      ok: false,
-      required,
-      warning: `Optional canonical host '${hostname}' is not resolvable: ${error.message}`,
-    };
-    summary.dns.push(result);
-    if (required) {
-      throw new Error(
-        `Canonical host '${hostname}' is not resolvable. Update your hosts/DNS mapping before running the live validation again.`
-      );
-    }
-    return result;
-  }
-}
-
-async function fetchJson(url, description) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetch(url, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`${description} failed (${response.status}) at ${url}`);
-    }
-    const body = await response.text();
-    if (!body.trim()) {
-      throw new Error(`${description} returned HTTP ${response.status} with an empty body at ${url}`);
-    }
-    let payload;
-    try {
-      payload = JSON.parse(body);
-    } catch (error) {
-      throw new Error(
-        `${description} returned non-JSON content at ${url}: ${error instanceof Error ? error.message : String(error)}`
-      );
-    }
-    summary.apiChecks.push({ description, url, status: response.status, kind: "json" });
-    return payload;
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-async function fetchText(url, description) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetch(url, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`${description} failed (${response.status}) at ${url}`);
-    }
-    const payload = await response.text();
-    summary.apiChecks.push({ description, url, status: response.status, kind: "text" });
-    return payload;
-  } finally {
-    clearTimeout(timer);
-  }
-}
 
 async function assertListHasItems(locator, description) {
   await expect(locator).toBeVisible({ timeout: timeoutMs });
@@ -486,17 +420,17 @@ async function run() {
   await ensureDirectory(outputDir);
 
   const dnsChecks = await Promise.all([
-    checkDns("workbench.dev.lotus"),
-    checkDns("gateway.dev.lotus"),
-    checkDns("core-query.dev.lotus"),
-    checkDns("core-control.dev.lotus"),
-    checkDns("core-ingestion.dev.lotus"),
-    checkDns("performance.dev.lotus"),
-    checkDns("risk.dev.lotus"),
-    checkDns("advise.dev.lotus"),
-    checkDns("manage.dev.lotus"),
-    checkDns("report.dev.lotus"),
-    checkDns("ai.dev.lotus", false),
+    checkDns(summary, "workbench.dev.lotus"),
+    checkDns(summary, "gateway.dev.lotus"),
+    checkDns(summary, "core-query.dev.lotus"),
+    checkDns(summary, "core-control.dev.lotus"),
+    checkDns(summary, "core-ingestion.dev.lotus"),
+    checkDns(summary, "performance.dev.lotus"),
+    checkDns(summary, "risk.dev.lotus"),
+    checkDns(summary, "advise.dev.lotus"),
+    checkDns(summary, "manage.dev.lotus"),
+    checkDns(summary, "report.dev.lotus"),
+    checkDns(summary, "ai.dev.lotus", { required: false }),
   ]);
 
   dnsChecks
@@ -504,52 +438,68 @@ async function run() {
     .forEach((item) => console.warn(item.warning));
 
   const foundationWorkspace = await fetchJson(
+    summary,
     `${gatewayBaseUrl}/api/v1/foundation/portfolios/${portfolioId}/workspace`,
-    "Foundation workspace"
+    "Foundation workspace",
+    timeoutMs
   );
   if (foundationWorkspace?.portfolio?.portfolio_id !== portfolioId) {
     throw new Error(`Foundation workspace did not resolve ${portfolioId}.`);
   }
 
   const performanceSummary = await fetchJson(
+    summary,
     `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}`,
-    "Performance summary"
+    "Performance summary",
+    timeoutMs
   );
   if (!performanceSummary?.portfolio_id) {
     throw new Error("Performance summary returned no portfolio payload.");
   }
 
   const performanceDetails = await fetchJson(
+    summary,
     `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/details?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}`,
-    "Performance details"
+    "Performance details",
+    timeoutMs
   );
   if (!performanceDetails?.portfolio_id) {
     throw new Error("Performance details returned no portfolio payload.");
   }
 
   const riskSummary = await fetchJson(
+    summary,
     `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/summary?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}`,
-    "Risk summary"
+    "Risk summary",
+    timeoutMs
   );
   if (!riskSummary?.portfolio_id) {
     throw new Error("Risk summary returned no portfolio payload.");
   }
 
   const riskConcentration = await fetchJson(
+    summary,
     `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/concentration?period=YTD&benchmark_code=${benchmarkCode}`,
-    "Risk concentration"
+    "Risk concentration",
+    timeoutMs
   );
   const riskDrawdown = await fetchJson(
+    summary,
     `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/drawdown?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&include_underwater_series=true`,
-    "Risk drawdown"
+    "Risk drawdown",
+    timeoutMs
   );
   const riskRolling = await fetchJson(
+    summary,
     `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/rolling?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&include_time_series=true`,
-    "Risk rolling"
+    "Risk rolling",
+    timeoutMs
   );
   const riskAttribution = await fetchJson(
+    summary,
     `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/attribution?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&attribution_type=total_risk&grouping_dimension=sector`,
-    "Risk attribution"
+    "Risk attribution",
+    timeoutMs
   );
   for (const [description, payload] of [
     ["Risk concentration", riskConcentration],
@@ -571,32 +521,40 @@ async function run() {
   );
 
   const advisorBrief = await fetchJson(
+    summary,
     `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}`,
-    "Advisor brief"
+    "Advisor brief",
+    timeoutMs
   );
   if (!advisorBrief?.summary) {
     throw new Error("Advisor brief returned no summary.");
   }
 
   const manageCapabilities = await fetchJson(
+    summary,
     "http://manage.dev.lotus/integration/capabilities?consumer_system=lotus-gateway&tenant_id=default",
-    "lotus-manage integration capabilities"
+    "lotus-manage integration capabilities",
+    timeoutMs
   );
   if (!Array.isArray(manageCapabilities?.features) || manageCapabilities.features.length < 1) {
     throw new Error("lotus-manage integration capabilities returned no feature flags.");
   }
 
   const reportCapabilities = await fetchJson(
+    summary,
     "http://report.dev.lotus/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default",
-    "lotus-report integration capabilities"
+    "lotus-report integration capabilities",
+    timeoutMs
   );
   if (!Array.isArray(reportCapabilities?.features) || reportCapabilities.features.length < 1) {
     throw new Error("lotus-report integration capabilities returned no feature flags.");
   }
 
   const gatewayCapabilities = await fetchJson(
+    summary,
     `${gatewayBaseUrl}/api/v1/platform/capabilities`,
-    "Gateway platform capabilities"
+    "Gateway platform capabilities",
+    timeoutMs
   );
   const gatewayManageFeatures = gatewayCapabilities?.data?.sources?.lotus_manage?.features;
   if (!Array.isArray(gatewayManageFeatures) || gatewayManageFeatures.length < 1) {
@@ -604,8 +562,10 @@ async function run() {
   }
 
   const gatewayOverview = await fetchJson(
+    summary,
     `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/overview`,
-    "Gateway workbench overview"
+    "Gateway workbench overview",
+    timeoutMs
   );
   if (gatewayOverview?.portfolio?.portfolio_id !== portfolioId) {
     throw new Error("Gateway workbench overview returned no portfolio payload.");
@@ -623,16 +583,20 @@ async function run() {
   assertPanelSupportabilityAlignment();
 
   const portfolioShell = await fetchText(
+    summary,
     `${workbenchBaseUrl}/portfolio?portfolioId=${portfolioId}`,
-    "Workbench portfolio route"
+    "Workbench portfolio route",
+    timeoutMs
   );
   if (!portfolioShell.includes("Portfolio")) {
     throw new Error("Workbench portfolio route did not render the Portfolio shell.");
   }
 
   const performanceShell = await fetchText(
+    summary,
     `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}`,
-    "Workbench performance route"
+    "Workbench performance route",
+    timeoutMs
   );
   if (!performanceShell.includes("Performance")) {
     throw new Error("Workbench performance route did not render the Performance shell.");

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -26,6 +26,7 @@ import {
   validatePortfolioPanels,
   validateRiskPanel,
 } from "./validation/browser-workflows.mjs";
+import { createPanelGovernance } from "./validation/panel-governance.mjs";
 
 const {
   portfolioId,
@@ -39,7 +40,6 @@ const {
 const { summaryPath, shotIndexPath } = buildSummaryPaths(outputDir);
 const canonicalContract = await loadCanonicalContractMetadata();
 const panelRegistry = await loadWorkbenchPanelRegistryMetadata();
-const panelRegistryById = new Map(panelRegistry.panels.map((panel) => [panel.panelId, panel]));
 
 const summary = createValidationSummary({
   generatedAt: new Date().toISOString(),
@@ -50,77 +50,7 @@ const summary = createValidationSummary({
   gatewayBaseUrl,
   panelRegistry,
 });
-
-function recordSupportabilityCheck(panel, evidence) {
-  summary.supportabilityChecks.push({ panel, ...evidence });
-}
-
-function recordPanelClassification(panel, state, owner, evidence) {
-  const panelSpec = panelRegistryById.get(panel);
-  if (!panelSpec) {
-    throw new Error(`Panel classification '${panel}' is not present in the governed panel registry.`);
-  }
-  if (!panelSpec.allowedStates.includes(state)) {
-    throw new Error(
-      `Panel classification '${panel}' used unsupported state '${state}'. Allowed states: ${panelSpec.allowedStates.join(", ")}.`
-    );
-  }
-  summary.panelClassifications.push({ panel, state, owner, ...evidence });
-}
-
-function assertNoUnsupportedBlankPanels() {
-  const unsupportedBlankPanels = summary.panelClassifications.filter(
-    (panel) => panel.state === "supported_blank"
-  );
-  if (unsupportedBlankPanels.length > 0) {
-    throw new Error(
-      `Unsupported blank panels found: ${unsupportedBlankPanels
-        .map((panel) => panel.panel)
-        .join(", ")}.`
-    );
-  }
-}
-
-function assertPanelSupportabilityAlignment() {
-  const classifiedPanels = new Set(summary.panelClassifications.map((panel) => panel.panel));
-
-  for (const panelSpec of panelRegistry.panels) {
-    if (!classifiedPanels.has(panelSpec.panelId)) {
-      throw new Error(`Governed panel '${panelSpec.panelId}' was not classified during validation.`);
-    }
-  }
-
-  for (const panel of summary.panelClassifications) {
-    const panelSpec = panelRegistryById.get(panel.panel);
-    if (panel.owner !== panelSpec.owningService) {
-      throw new Error(
-        `Panel '${panel.panel}' reported owner '${panel.owner}' but registry owner is '${panelSpec.owningService}'.`
-      );
-    }
-    if (panel.state !== panelSpec.requiredSupportState) {
-      throw new Error(
-        `Panel '${panel.panel}' reported state '${panel.state}' but registry requires '${panelSpec.requiredSupportState}'.`
-      );
-    }
-    if (
-      (panel.state === "partial" || panel.state === "unavailable") &&
-      !panel.reason &&
-      panelSpec.knownLimitations.length < 1 &&
-      !panelSpec.ownerFollowUpRfc
-    ) {
-      throw new Error(
-        `Panel '${panel.panel}' is ${panel.state} without a governed reason, limitation, or follow-up RFC.`
-      );
-    }
-    recordSupportabilityCheck(panel.panel, {
-      owner: panel.owner,
-      state: panel.state,
-      requiredSupportState: panelSpec.requiredSupportState,
-      gatewayEndpoint: panelSpec.gatewayEndpoint,
-      ownerFollowUpRfc: panelSpec.ownerFollowUpRfc,
-    });
-  }
-}
+const panelGovernance = createPanelGovernance(summary, panelRegistry);
 
 async function run() {
   await ensureDirectory(outputDir);
@@ -221,7 +151,7 @@ async function run() {
     summary,
     performanceSummary,
     performanceDetails,
-    recordPanelClassification,
+    recordPanelClassification: panelGovernance.recordPanelClassification,
   });
   assertRiskCalculationSanity({
     summary,
@@ -230,7 +160,7 @@ async function run() {
     drawdown: riskDrawdown,
     rolling: riskRolling,
     attribution: riskAttribution,
-    recordPanelClassification,
+    recordPanelClassification: panelGovernance.recordPanelClassification,
   });
 
   const advisorBrief = await fetchJson(
@@ -283,17 +213,17 @@ async function run() {
   if (gatewayOverview?.portfolio?.portfolio_id !== portfolioId) {
     throw new Error("Gateway workbench overview returned no portfolio payload.");
   }
-  recordPanelClassification("portfolio.summary", "ready", "lotus-gateway", {
+  panelGovernance.recordPanelClassification("portfolio.summary", "ready", "lotus-gateway", {
     portfolioId,
   });
-  recordPanelClassification("portfolio.detailed", "ready", "lotus-gateway", {
+  panelGovernance.recordPanelClassification("portfolio.detailed", "ready", "lotus-gateway", {
     portfolioId,
   });
-  recordPanelClassification("performance.advisor_brief", "ready", "lotus-performance", {
+  panelGovernance.recordPanelClassification("performance.advisor_brief", "ready", "lotus-performance", {
     sourceMetricMinimum: 3,
   });
-  assertNoUnsupportedBlankPanels();
-  assertPanelSupportabilityAlignment();
+  panelGovernance.assertNoUnsupportedBlankPanels();
+  panelGovernance.assertPanelSupportabilityAlignment();
 
   const portfolioShell = await fetchText(
     summary,
@@ -324,7 +254,7 @@ async function run() {
     benchmarkCode,
     canonicalAsOfDate,
     timeoutMs,
-    panelRegistryById,
+    panelRegistryById: panelGovernance.panelRegistryById,
   });
 
   try {

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -14,6 +14,10 @@ import {
   writeValidationSummary,
 } from "./validation/evidence-summary-writer.mjs";
 import { checkDns, fetchJson, fetchText } from "./validation/probes.mjs";
+import {
+  assertPerformanceCalculationSanity,
+  assertRiskCalculationSanity,
+} from "./validation/calculation-sanity.mjs";
 
 const {
   portfolioId,
@@ -55,38 +59,6 @@ async function assertTableHasRows(locator, minimumRows, description) {
     throw new Error(`${description} expected at least ${minimumRows} body rows but found ${count}.`);
   }
   summary.uiChecks.push({ description, kind: "table", rowCount: count });
-}
-
-function assertFiniteNumber(value, description) {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    throw new Error(`${description} expected a finite number but received ${String(value)}.`);
-  }
-  return value;
-}
-
-function assertNumberInRange(value, minimum, maximum, description) {
-  const numericValue = assertFiniteNumber(value, description);
-  if (numericValue < minimum || numericValue > maximum) {
-    throw new Error(
-      `${description} expected ${minimum} <= value <= ${maximum} but received ${numericValue}.`
-    );
-  }
-  return numericValue;
-}
-
-function assertArrayHasLength(value, minimumLength, description) {
-  if (!Array.isArray(value) || value.length < minimumLength) {
-    throw new Error(
-      `${description} expected at least ${minimumLength} rows but found ${
-        Array.isArray(value) ? value.length : "non-array"
-      }.`
-    );
-  }
-  return value;
-}
-
-function recordCalculationCheck(description, evidence) {
-  summary.calculationChecks.push({ description, ...evidence });
 }
 
 function recordSupportabilityCheck(panel, evidence) {
@@ -158,226 +130,6 @@ function assertPanelSupportabilityAlignment() {
       ownerFollowUpRfc: panelSpec.ownerFollowUpRfc,
     });
   }
-}
-
-function assertPerformanceCalculationSanity(performanceSummary, performanceDetails) {
-  const netPerformance = performanceSummary?.net_performance ?? {};
-  const overview = performanceSummary?.overview ?? {};
-  const contributionLevel = performanceDetails?.contribution?.levels?.[0];
-  const attributionCapability = performanceDetails?.capabilities?.attribution_detail ?? {};
-  const attributionLevel = performanceDetails?.attribution?.levels?.[0];
-
-  const portfolioReturn = assertNumberInRange(
-    netPerformance.portfolio_return_pct,
-    -100,
-    200,
-    "Net portfolio return"
-  );
-  const benchmarkReturn = assertNumberInRange(
-    netPerformance.benchmark_return_pct,
-    -100,
-    100,
-    "Benchmark return"
-  );
-  const activeReturn = assertNumberInRange(
-    netPerformance.active_return_pct,
-    -200,
-    200,
-    "Active return"
-  );
-  const activeDifference = Math.abs(activeReturn - (portfolioReturn - benchmarkReturn));
-  if (activeDifference > 0.01) {
-    throw new Error(
-      `Active return is not reconciled: active=${activeReturn}, portfolio=${portfolioReturn}, benchmark=${benchmarkReturn}.`
-    );
-  }
-
-  assertNumberInRange(overview.market_value_base, 1, 100_000_000, "Portfolio market value");
-  assertNumberInRange(overview.cash_weight_pct, -5, 100, "Cash weight");
-  assertNumberInRange(overview.position_count, 10, 100, "Position count");
-  assertArrayHasLength(performanceDetails?.net_chart, 4, "Performance return path observations");
-  const contributionRows = assertArrayHasLength(
-    contributionLevel?.rows,
-    4,
-    "Performance contribution rows"
-  );
-  const contributionTotal = assertFiniteNumber(
-    contributionLevel.total_contribution_pct,
-    "Contribution total"
-  );
-  if (Math.abs(contributionTotal - portfolioReturn) > 0.02) {
-    throw new Error(
-      `Contribution total does not reconcile with net portfolio return: contribution=${contributionTotal}, return=${portfolioReturn}.`
-    );
-  }
-
-  const attributionRows = Array.isArray(attributionLevel?.rows) ? attributionLevel.rows.length : 0;
-  const attributionFallback =
-    attributionCapability.state === "partial" && attributionCapability.fallback_available === true;
-  if (attributionCapability.state === "supported" && attributionRows < 1) {
-    throw new Error("Attribution detail is supported but returned no rows.");
-  }
-  if (!attributionFallback && attributionCapability.state !== "supported") {
-    throw new Error(
-      `Attribution detail is ${String(attributionCapability.state)} without a governed fallback.`
-    );
-  }
-
-  recordCalculationCheck("Performance calculation sanity", {
-    portfolioReturnPct: portfolioReturn,
-    benchmarkReturnPct: benchmarkReturn,
-    activeReturnPct: activeReturn,
-    contributionRows: contributionRows.length,
-    attributionState: attributionCapability.state,
-    attributionRows,
-  });
-
-  recordPanelClassification("performance.summary", "ready", "lotus-performance", {
-    returnPathRows: performanceDetails.net_chart.length,
-  });
-  recordPanelClassification("performance.analysis.contribution", "ready", "lotus-performance", {
-    contributionRows: contributionRows.length,
-  });
-  recordPanelClassification(
-    "performance.analysis.attribution",
-    attributionFallback ? "partial" : "ready",
-    "lotus-performance",
-    {
-      attributionState: attributionCapability.state,
-      attributionRows,
-      fallbackAvailable: attributionCapability.fallback_available === true,
-    }
-  );
-  const evidenceState = performanceSummary?.capabilities?.evidence?.state ?? "unavailable";
-  recordPanelClassification("performance.evidence", evidenceState, "lotus-gateway", {
-    reason: performanceSummary?.capabilities?.evidence?.reason ?? null,
-  });
-}
-
-function assertRiskCalculationSanity(riskSummary, concentration, drawdown, rolling, attribution) {
-  const riskPeriod = assertArrayHasLength(riskSummary?.payload?.periods, 1, "Risk periods")[0];
-  const metrics = assertArrayHasLength(riskPeriod.metrics, 6, "Risk summary metrics");
-  const readyMetrics = metrics.filter((metric) => metric?.state === "ready");
-  if (readyMetrics.length < 6) {
-    throw new Error(`Risk summary expected at least 6 ready metrics but found ${readyMetrics.length}.`);
-  }
-  assertNumberInRange(riskPeriod.portfolio_observation_count, 60, 400, "Risk observations");
-  assertNumberInRange(
-    riskPeriod.aligned_benchmark_observation_count,
-    60,
-    400,
-    "Aligned benchmark observations"
-  );
-  if (riskPeriod.benchmark_context?.aligned !== true) {
-    throw new Error("Risk benchmark context is not aligned.");
-  }
-
-  const concentrationPayload = concentration?.payload ?? {};
-  assertNumberInRange(
-    concentrationPayload.portfolio_concentration?.hhi_current,
-    1,
-    10_000,
-    "Portfolio concentration HHI"
-  );
-  assertNumberInRange(
-    concentrationPayload.issuer_concentration?.coverage_ratio_current,
-    0.95,
-    1,
-    "Issuer concentration coverage ratio"
-  );
-  assertNumberInRange(
-    concentrationPayload.single_position_concentration?.top_n_cumulative_weight_current,
-    0.5,
-    1.01,
-    "Top positions cumulative weight"
-  );
-
-  const drawdownPeriod = assertArrayHasLength(drawdown?.payload?.periods, 1, "Drawdown periods")[0];
-  assertNumberInRange(
-    drawdownPeriod.portfolio_observation_count,
-    60,
-    400,
-    "Drawdown observation count"
-  );
-  assertNumberInRange(
-    drawdownPeriod.relative_to_benchmark?.time_under_water_days,
-    1,
-    366,
-    "Relative drawdown time under water"
-  );
-  assertArrayHasLength(drawdownPeriod.underwater_series, 60, "Drawdown underwater series");
-
-  const rollingPeriod = assertArrayHasLength(rolling?.payload?.periods, 1, "Rolling risk periods")[0];
-  assertNumberInRange(rollingPeriod.window_count_emitted, 4, 4, "Rolling risk window count");
-  const rollingWindows = assertArrayHasLength(
-    rollingPeriod.window_results,
-    4,
-    "Rolling risk window results"
-  );
-  let rollingWindowsWithLatestVolatility = 0;
-  for (const windowResult of rollingPeriod.window_results) {
-    const volatility = windowResult?.metric_summaries?.ROLLING_VOLATILITY;
-    if (!volatility || typeof volatility !== "object") {
-      throw new Error(
-        `Rolling risk window ${String(windowResult?.window_length)} has no volatility summary.`
-      );
-    }
-    if (typeof volatility.latest === "number") {
-      rollingWindowsWithLatestVolatility += 1;
-    }
-  }
-  if (rollingWindowsWithLatestVolatility < 2) {
-    throw new Error(
-      `Rolling risk expected at least 2 computable windows but found ${rollingWindowsWithLatestVolatility}.`
-    );
-  }
-
-  const attributionPeriod = assertArrayHasLength(
-    attribution?.payload?.periods,
-    1,
-    "Historical risk attribution periods"
-  )[0];
-  const attributionSet = assertArrayHasLength(
-    attributionPeriod.attribution_sets,
-    1,
-    "Historical risk attribution sets"
-  )[0];
-  const contributors = assertArrayHasLength(
-    attributionSet.contributors,
-    5,
-    "Historical risk attribution contributors"
-  );
-  const residual = assertFiniteNumber(attributionSet.residual, "Historical risk residual");
-  if (Math.abs(residual) > 0.000001) {
-    throw new Error(`Historical risk attribution residual is too high: ${residual}.`);
-  }
-
-  recordCalculationCheck("Risk calculation sanity", {
-    readyMetricCount: readyMetrics.length,
-    observationCount: riskPeriod.portfolio_observation_count,
-    concentrationHhi: concentrationPayload.portfolio_concentration?.hhi_current,
-    rollingWindowCount: rollingPeriod.window_count_emitted,
-    rollingWindowResultCount: rollingWindows.length,
-    rollingWindowsWithLatestVolatility,
-    attributionContributorCount: contributors.length,
-  });
-
-  recordPanelClassification("performance.risk.snapshot", "ready", "lotus-risk", {
-    readyMetricCount: readyMetrics.length,
-  });
-  recordPanelClassification("performance.risk.concentration", "ready", "lotus-risk", {
-    issuerCoverageRatio: concentrationPayload.issuer_concentration?.coverage_ratio_current,
-  });
-  recordPanelClassification("performance.risk.drawdown", "ready", "lotus-risk", {
-    underwaterSeriesRows: drawdownPeriod.underwater_series.length,
-  });
-  recordPanelClassification("performance.risk.rolling", "ready", "lotus-risk", {
-    windowCount: rollingPeriod.window_count_emitted,
-    computableWindows: rollingWindowsWithLatestVolatility,
-  });
-  recordPanelClassification("performance.risk.historical_attribution", "ready", "lotus-risk", {
-    contributorRows: contributors.length,
-  });
 }
 
 async function screenshot(page, name, metadata) {
@@ -511,14 +263,21 @@ async function run() {
       throw new Error(`${description} returned non-ready state: ${String(payload?.state)}.`);
     }
   }
-  assertPerformanceCalculationSanity(performanceSummary, performanceDetails);
-  assertRiskCalculationSanity(
+  assertPerformanceCalculationSanity({
+    summary,
+    performanceSummary,
+    performanceDetails,
+    recordPanelClassification,
+  });
+  assertRiskCalculationSanity({
+    summary,
     riskSummary,
-    riskConcentration,
-    riskDrawdown,
-    riskRolling,
-    riskAttribution
-  );
+    concentration: riskConcentration,
+    drawdown: riskDrawdown,
+    rolling: riskRolling,
+    attribution: riskAttribution,
+    recordPanelClassification,
+  });
 
   const advisorBrief = await fetchJson(
     summary,

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -1,4 +1,3 @@
-import path from "node:path";
 import process from "node:process";
 import { chromium, expect } from "@playwright/test";
 import { resolveValidationConfig } from "./validation/args.mjs";
@@ -18,6 +17,15 @@ import {
   assertPerformanceCalculationSanity,
   assertRiskCalculationSanity,
 } from "./validation/calculation-sanity.mjs";
+import {
+  createBrowserValidationHelpers,
+  validateAdvisorBriefPanel,
+  validateEvidencePanel,
+  validatePerformanceAnalysisPanel,
+  validatePerformanceSummaryPanel,
+  validatePortfolioPanels,
+  validateRiskPanel,
+} from "./validation/browser-workflows.mjs";
 
 const {
   portfolioId,
@@ -42,24 +50,6 @@ const summary = createValidationSummary({
   gatewayBaseUrl,
   panelRegistry,
 });
-
-async function assertListHasItems(locator, description) {
-  await expect(locator).toBeVisible({ timeout: timeoutMs });
-  const count = await locator.locator('[role="listitem"]').count();
-  if (count < 1) {
-    throw new Error(`${description} is visible but empty.`);
-  }
-  summary.uiChecks.push({ description, kind: "list", itemCount: count });
-}
-
-async function assertTableHasRows(locator, minimumRows, description) {
-  await expect(locator).toBeVisible({ timeout: timeoutMs });
-  const count = await locator.locator("tbody tr").count();
-  if (count < minimumRows) {
-    throw new Error(`${description} expected at least ${minimumRows} body rows but found ${count}.`);
-  }
-  summary.uiChecks.push({ description, kind: "table", rowCount: count });
-}
 
 function recordSupportabilityCheck(panel, evidence) {
   summary.supportabilityChecks.push({ panel, ...evidence });
@@ -130,42 +120,6 @@ function assertPanelSupportabilityAlignment() {
       ownerFollowUpRfc: panelSpec.ownerFollowUpRfc,
     });
   }
-}
-
-async function screenshot(page, name, metadata) {
-  const target = path.join(outputDir, name);
-  await page.screenshot({ path: target, fullPage: true });
-  summary.screenshots.push({
-    name,
-    path: target,
-    route: metadata.route,
-    panel: metadata.panel,
-    portfolioId,
-    benchmarkCode,
-    asOfDate: canonicalAsOfDate,
-    state: metadata.state ?? "demo_ready",
-  });
-}
-
-function resolveRegistryRoute(routeTemplate) {
-  return routeTemplate
-    .replaceAll("{portfolioId}", portfolioId)
-    .replaceAll("{benchmarkCode}", benchmarkCode);
-}
-
-async function screenshotRegisteredPanel(page, panelId, metadata = {}) {
-  const panelSpec = panelRegistryById.get(panelId);
-  if (!panelSpec) {
-    throw new Error(`Screenshot requested for unregistered panel '${panelId}'.`);
-  }
-  if (!panelSpec.screenshotName) {
-    throw new Error(`Panel '${panelId}' has no governed screenshot name.`);
-  }
-  await screenshot(page, panelSpec.screenshotName, {
-    route: metadata.route ?? resolveRegistryRoute(panelSpec.route),
-    panel: panelId,
-    state: metadata.state,
-  });
 }
 
 async function run() {
@@ -363,172 +317,62 @@ async function run() {
 
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage({ viewport: { width: 1600, height: 1200 } });
+  const browserHelpers = createBrowserValidationHelpers({
+    outputDir,
+    summary,
+    portfolioId,
+    benchmarkCode,
+    canonicalAsOfDate,
+    timeoutMs,
+    panelRegistryById,
+  });
 
   try {
-    await page.goto(`${workbenchBaseUrl}/portfolio?portfolioId=${portfolioId}`, {
-      waitUntil: "networkidle",
-      timeout: timeoutMs,
+    await validatePortfolioPanels(page, {
+      workbenchBaseUrl,
+      portfolioId,
+      timeoutMs,
+      assertListHasItems: browserHelpers.assertListHasItems,
+      screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });
-    await expect(page.getByRole("heading", { name: "Portfolio", exact: true })).toBeVisible({
-      timeout: timeoutMs,
+    await validatePerformanceSummaryPanel(page, {
+      workbenchBaseUrl,
+      portfolioId,
+      timeoutMs,
+      assertTableHasRows: browserHelpers.assertTableHasRows,
+      screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });
-    await expect(page.getByRole("heading", { name: portfolioId, exact: true })).toBeVisible({
-      timeout: timeoutMs,
+    await validatePerformanceAnalysisPanel(page, {
+      workbenchBaseUrl,
+      portfolioId,
+      benchmarkCode,
+      timeoutMs,
+      assertTableHasRows: browserHelpers.assertTableHasRows,
+      screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });
-    await expect(page.getByRole("heading", { name: "Portfolio Allocation" })).toBeVisible({
-      timeout: timeoutMs,
+    await validateAdvisorBriefPanel(page, {
+      summary,
+      workbenchBaseUrl,
+      portfolioId,
+      benchmarkCode,
+      timeoutMs,
+      screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });
-    await assertListHasItems(page.getByRole("list", { name: "Top holdings chart" }), "Top holdings chart");
-    await expect(page.getByRole("img", { name: "Allocation donut chart" })).toBeVisible({
-      timeout: timeoutMs,
+    await validateRiskPanel(page, {
+      workbenchBaseUrl,
+      portfolioId,
+      benchmarkCode,
+      timeoutMs,
+      assertTableHasRows: browserHelpers.assertTableHasRows,
+      screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });
-    await screenshotRegisteredPanel(page, "portfolio.summary");
-
-    await page.getByRole("tab", { name: "Detailed" }).click();
-    await expect(page.getByRole("tab", { name: "Detailed", exact: true, selected: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Transactions" })).toBeVisible({ timeout: timeoutMs });
-    await expect(page.getByRole("heading", { name: "Projected Cashflow" })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByLabel("Portfolio transactions grid")).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByLabel("Projected cashflow summary")).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await screenshotRegisteredPanel(page, "portfolio.detailed");
-
-    await page.goto(`${workbenchBaseUrl}/performance?portfolioId=${portfolioId}`, {
-      waitUntil: "networkidle",
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Performance", exact: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("tab", { name: "Summary", exact: true, selected: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Net Return Path" })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Performance Drivers" })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await assertTableHasRows(
-      page.getByRole("table", { name: "Return path observation table" }),
-      4,
-      "Return path observation table"
-    );
-    await screenshotRegisteredPanel(page, "performance.summary");
-
-    await page.goto(
-      `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=analysis&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
-      { waitUntil: "networkidle", timeout: timeoutMs }
-    );
-    await expect(page.getByRole("tab", { name: "Analysis", exact: true, selected: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Attribution Over Time" })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Attribution Detail" })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Performance Drivers" })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await assertTableHasRows(
-      page.getByRole("table", { name: /attribution/i }).first(),
-      1,
-      "Attribution detail table"
-    );
-    await assertTableHasRows(
-      page.getByRole("table", { name: /contribution/i }).first(),
-      1,
-      "Contribution detail table"
-    );
-    await screenshotRegisteredPanel(page, "performance.analysis.contribution");
-
-    await page.goto(
-      `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=advisor&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
-      { waitUntil: "networkidle", timeout: timeoutMs }
-    );
-    await expect(page.getByRole("tab", { name: "Advisor Brief", exact: true, selected: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Performance Advisor Brief" })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Client Talking Points" })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Source Metrics" })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    const sourceMetricButtons = await page.getByRole("region", { name: "Source Metrics" }).getByRole("button").count();
-    if (sourceMetricButtons < 3) {
-      throw new Error(`Advisor brief source metrics expected at least 3 metric buttons but found ${sourceMetricButtons}.`);
-    }
-    summary.uiChecks.push({
-      description: "Advisor brief source metrics",
-      kind: "buttons",
-      buttonCount: sourceMetricButtons,
-    });
-    await screenshotRegisteredPanel(page, "performance.advisor_brief");
-
-    await page.goto(
-      `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
-      { waitUntil: "networkidle", timeout: timeoutMs }
-    );
-    await expect(page.getByRole("tab", { name: "Risk", exact: true, selected: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Risk Snapshot", exact: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Drawdown", exact: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Concentration", exact: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Rolling Risk", exact: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Historical Risk Attribution", exact: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await assertTableHasRows(
-      page.getByRole("table", { name: "Historical risk attribution table" }),
-      5,
-      "Historical risk attribution table"
-    );
-    await screenshotRegisteredPanel(page, "performance.risk.snapshot");
-
-    await page.goto(
-      `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=evidence&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
-      { waitUntil: "networkidle", timeout: timeoutMs }
-    );
-    await expect(page.getByRole("tab", { name: "Evidence", exact: true, selected: true })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    await expect(page.getByRole("heading", { name: "Evidence and Calculation Context" })).toBeVisible({
-      timeout: timeoutMs,
-    });
-    const evidenceStatusStrip = page.getByLabel("Evidence support status");
-    if (await evidenceStatusStrip.count()) {
-      await expect(evidenceStatusStrip).toBeVisible({ timeout: timeoutMs });
-      summary.uiChecks.push({ description: "Evidence support status", kind: "status-strip", state: "supported" });
-    } else {
-      await expect(page.getByText(/Evidence (partially available|unavailable)/)).toBeVisible({
-        timeout: timeoutMs,
-      });
-      summary.uiChecks.push({ description: "Evidence support status", kind: "status-strip", state: "degraded" });
-    }
-    await screenshotRegisteredPanel(page, "performance.evidence", {
-      state: "truthfully_degraded",
+    await validateEvidencePanel(page, {
+      summary,
+      workbenchBaseUrl,
+      portfolioId,
+      benchmarkCode,
+      timeoutMs,
+      screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });
   } finally {
     await browser.close();

--- a/scripts/live/validation/args.d.mts
+++ b/scripts/live/validation/args.d.mts
@@ -1,0 +1,5 @@
+import type { ValidationConfig } from "./shared-types";
+
+export function parseArgs(argv: string[]): Map<string, string>;
+
+export function resolveValidationConfig(argv: string[], cwd?: string): ValidationConfig;

--- a/scripts/live/validation/args.mjs
+++ b/scripts/live/validation/args.mjs
@@ -1,0 +1,36 @@
+import path from "node:path";
+
+export function parseArgs(argv) {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      args.set(key, "true");
+      continue;
+    }
+    args.set(key, next);
+    index += 1;
+  }
+  return args;
+}
+
+export function resolveValidationConfig(argv, cwd = process.cwd()) {
+  const args = parseArgs(argv);
+
+  return {
+    args,
+    portfolioId: args.get("portfolio-id") ?? "PB_SG_GLOBAL_BAL_001",
+    benchmarkCode: args.get("benchmark-code") ?? "BMK_PB_GLOBAL_BALANCED_60_40",
+    workbenchBaseUrl: (args.get("workbench-base-url") ?? "http://workbench.dev.lotus").replace(
+      /\/+$/,
+      ""
+    ),
+    gatewayBaseUrl: (args.get("gateway-base-url") ?? "http://gateway.dev.lotus").replace(/\/+$/, ""),
+    outputDir: path.resolve(cwd, args.get("output-dir") ?? "output/playwright/live-canonical"),
+    timeoutMs: Number(args.get("timeout-ms") ?? "60000"),
+    canonicalAsOfDate: args.get("as-of-date") ?? "2026-04-10",
+  };
+}

--- a/scripts/live/validation/browser-workflows.d.mts
+++ b/scripts/live/validation/browser-workflows.d.mts
@@ -1,0 +1,41 @@
+import type {
+  BrowserValidationHelpers,
+  BrowserValidationPage,
+  PanelRegistryEntry,
+  ValidationSummary,
+} from "./shared-types";
+
+export function createBrowserValidationHelpers(input: {
+  outputDir: string;
+  summary: ValidationSummary;
+  portfolioId: string;
+  benchmarkCode: string;
+  canonicalAsOfDate: string;
+  timeoutMs: number;
+  panelRegistryById: Map<string, Pick<PanelRegistryEntry, "screenshotName" | "route">>;
+}): BrowserValidationHelpers;
+
+export function validatePortfolioPanels(
+  page: BrowserValidationPage,
+  options: Record<string, unknown>
+): Promise<void>;
+export function validatePerformanceSummaryPanel(
+  page: BrowserValidationPage,
+  options: Record<string, unknown>
+): Promise<void>;
+export function validatePerformanceAnalysisPanel(
+  page: BrowserValidationPage,
+  options: Record<string, unknown>
+): Promise<void>;
+export function validateAdvisorBriefPanel(
+  page: BrowserValidationPage,
+  options: Record<string, unknown>
+): Promise<void>;
+export function validateRiskPanel(
+  page: BrowserValidationPage,
+  options: Record<string, unknown>
+): Promise<void>;
+export function validateEvidencePanel(
+  page: BrowserValidationPage,
+  options: Record<string, unknown>
+): Promise<void>;

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -1,0 +1,322 @@
+import path from "node:path";
+import { expect } from "@playwright/test";
+
+export function createBrowserValidationHelpers({
+  outputDir,
+  summary,
+  portfolioId,
+  benchmarkCode,
+  canonicalAsOfDate,
+  timeoutMs,
+  panelRegistryById,
+}) {
+  async function assertListHasItems(locator, description) {
+    await expect(locator).toBeVisible({ timeout: timeoutMs });
+    const count = await locator.locator('[role="listitem"]').count();
+    if (count < 1) {
+      throw new Error(`${description} is visible but empty.`);
+    }
+    summary.uiChecks.push({ description, kind: "list", itemCount: count });
+  }
+
+  async function assertTableHasRows(locator, minimumRows, description) {
+    await expect(locator).toBeVisible({ timeout: timeoutMs });
+    const count = await locator.locator("tbody tr").count();
+    if (count < minimumRows) {
+      throw new Error(`${description} expected at least ${minimumRows} body rows but found ${count}.`);
+    }
+    summary.uiChecks.push({ description, kind: "table", rowCount: count });
+  }
+
+  async function screenshot(page, name, metadata) {
+    const target = path.join(outputDir, name);
+    await page.screenshot({ path: target, fullPage: true });
+    summary.screenshots.push({
+      name,
+      path: target,
+      route: metadata.route,
+      panel: metadata.panel,
+      portfolioId,
+      benchmarkCode,
+      asOfDate: canonicalAsOfDate,
+      state: metadata.state ?? "demo_ready",
+    });
+  }
+
+  function resolveRegistryRoute(routeTemplate) {
+    return routeTemplate
+      .replaceAll("{portfolioId}", portfolioId)
+      .replaceAll("{benchmarkCode}", benchmarkCode);
+  }
+
+  async function screenshotRegisteredPanel(page, panelId, metadata = {}) {
+    const panelSpec = panelRegistryById.get(panelId);
+    if (!panelSpec) {
+      throw new Error(`Screenshot requested for unregistered panel '${panelId}'.`);
+    }
+    if (!panelSpec.screenshotName) {
+      throw new Error(`Panel '${panelId}' has no governed screenshot name.`);
+    }
+    await screenshot(page, panelSpec.screenshotName, {
+      route: metadata.route ?? resolveRegistryRoute(panelSpec.route),
+      panel: panelId,
+      state: metadata.state,
+    });
+  }
+
+  return {
+    assertListHasItems,
+    assertTableHasRows,
+    screenshotRegisteredPanel,
+    resolveRegistryRoute,
+  };
+}
+
+export async function validatePortfolioPanels(
+  page,
+  {
+    workbenchBaseUrl,
+    portfolioId,
+    timeoutMs,
+    assertListHasItems,
+    screenshotRegisteredPanel,
+  }
+) {
+  await page.goto(`${workbenchBaseUrl}/portfolio?portfolioId=${portfolioId}`, {
+    waitUntil: "networkidle",
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Portfolio", exact: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: portfolioId, exact: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Portfolio Allocation" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await assertListHasItems(page.getByRole("list", { name: "Top holdings chart" }), "Top holdings chart");
+  await expect(page.getByRole("img", { name: "Allocation donut chart" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await screenshotRegisteredPanel(page, "portfolio.summary");
+
+  await page.getByRole("tab", { name: "Detailed" }).click();
+  await expect(page.getByRole("tab", { name: "Detailed", exact: true, selected: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Transactions" })).toBeVisible({ timeout: timeoutMs });
+  await expect(page.getByRole("heading", { name: "Projected Cashflow" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByLabel("Portfolio transactions grid")).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByLabel("Projected cashflow summary")).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await screenshotRegisteredPanel(page, "portfolio.detailed");
+}
+
+export async function validatePerformanceSummaryPanel(
+  page,
+  {
+    workbenchBaseUrl,
+    portfolioId,
+    timeoutMs,
+    assertTableHasRows,
+    screenshotRegisteredPanel,
+  }
+) {
+  await page.goto(`${workbenchBaseUrl}/performance?portfolioId=${portfolioId}`, {
+    waitUntil: "networkidle",
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Performance", exact: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("tab", { name: "Summary", exact: true, selected: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Net Return Path" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Performance Drivers" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await assertTableHasRows(
+    page.getByRole("table", { name: "Return path observation table" }),
+    4,
+    "Return path observation table"
+  );
+  await screenshotRegisteredPanel(page, "performance.summary");
+}
+
+export async function validatePerformanceAnalysisPanel(
+  page,
+  {
+    workbenchBaseUrl,
+    portfolioId,
+    benchmarkCode,
+    timeoutMs,
+    assertTableHasRows,
+    screenshotRegisteredPanel,
+  }
+) {
+  await page.goto(
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=analysis&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
+    { waitUntil: "networkidle", timeout: timeoutMs }
+  );
+  await expect(page.getByRole("tab", { name: "Analysis", exact: true, selected: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Attribution Over Time" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Attribution Detail" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Performance Drivers" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await assertTableHasRows(
+    page.getByRole("table", { name: /attribution/i }).first(),
+    1,
+    "Attribution detail table"
+  );
+  await assertTableHasRows(
+    page.getByRole("table", { name: /contribution/i }).first(),
+    1,
+    "Contribution detail table"
+  );
+  await screenshotRegisteredPanel(page, "performance.analysis.contribution");
+}
+
+export async function validateAdvisorBriefPanel(
+  page,
+  {
+    summary,
+    workbenchBaseUrl,
+    portfolioId,
+    benchmarkCode,
+    timeoutMs,
+    screenshotRegisteredPanel,
+  }
+) {
+  await page.goto(
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=advisor&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
+    { waitUntil: "networkidle", timeout: timeoutMs }
+  );
+  await expect(page.getByRole("tab", { name: "Advisor Brief", exact: true, selected: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Performance Advisor Brief" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Client Talking Points" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Source Metrics" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  const sourceMetricButtons = await page
+    .getByRole("region", { name: "Source Metrics" })
+    .getByRole("button")
+    .count();
+  if (sourceMetricButtons < 3) {
+    throw new Error(
+      `Advisor brief source metrics expected at least 3 metric buttons but found ${sourceMetricButtons}.`
+    );
+  }
+  summary.uiChecks.push({
+    description: "Advisor brief source metrics",
+    kind: "buttons",
+    buttonCount: sourceMetricButtons,
+  });
+  await screenshotRegisteredPanel(page, "performance.advisor_brief");
+}
+
+export async function validateRiskPanel(
+  page,
+  {
+    workbenchBaseUrl,
+    portfolioId,
+    benchmarkCode,
+    timeoutMs,
+    assertTableHasRows,
+    screenshotRegisteredPanel,
+  }
+) {
+  await page.goto(
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
+    { waitUntil: "networkidle", timeout: timeoutMs }
+  );
+  await expect(page.getByRole("tab", { name: "Risk", exact: true, selected: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Risk Snapshot", exact: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Drawdown", exact: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Concentration", exact: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Rolling Risk", exact: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Historical Risk Attribution", exact: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await assertTableHasRows(
+    page.getByRole("table", { name: "Historical risk attribution table" }),
+    5,
+    "Historical risk attribution table"
+  );
+  await screenshotRegisteredPanel(page, "performance.risk.snapshot");
+}
+
+export async function validateEvidencePanel(
+  page,
+  {
+    summary,
+    workbenchBaseUrl,
+    portfolioId,
+    benchmarkCode,
+    timeoutMs,
+    screenshotRegisteredPanel,
+  }
+) {
+  await page.goto(
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=evidence&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
+    { waitUntil: "networkidle", timeout: timeoutMs }
+  );
+  await expect(page.getByRole("tab", { name: "Evidence", exact: true, selected: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Evidence and Calculation Context" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  const evidenceStatusStrip = page.getByLabel("Evidence support status");
+  if (await evidenceStatusStrip.count()) {
+    await expect(evidenceStatusStrip).toBeVisible({ timeout: timeoutMs });
+    summary.uiChecks.push({
+      description: "Evidence support status",
+      kind: "status-strip",
+      state: "supported",
+    });
+  } else {
+    await expect(page.getByText(/Evidence (partially available|unavailable)/)).toBeVisible({
+      timeout: timeoutMs,
+    });
+    summary.uiChecks.push({
+      description: "Evidence support status",
+      kind: "status-strip",
+      state: "degraded",
+    });
+  }
+  await screenshotRegisteredPanel(page, "performance.evidence", {
+    state: "truthfully_degraded",
+  });
+}

--- a/scripts/live/validation/calculation-sanity.d.mts
+++ b/scripts/live/validation/calculation-sanity.d.mts
@@ -1,0 +1,28 @@
+import type { ValidationPanelState, ValidationSummary } from "./shared-types";
+
+export function assertPerformanceCalculationSanity(input: {
+  summary: ValidationSummary;
+  performanceSummary: Record<string, unknown>;
+  performanceDetails: Record<string, unknown>;
+  recordPanelClassification(
+    panel: string,
+    state: ValidationPanelState,
+    owner: string,
+    evidence: Record<string, unknown>
+  ): void;
+}): void;
+
+export function assertRiskCalculationSanity(input: {
+  summary: ValidationSummary;
+  riskSummary: Record<string, unknown>;
+  concentration: Record<string, unknown>;
+  drawdown: Record<string, unknown>;
+  rolling: Record<string, unknown>;
+  attribution: Record<string, unknown>;
+  recordPanelClassification(
+    panel: string,
+    state: ValidationPanelState,
+    owner: string,
+    evidence: Record<string, unknown>
+  ): void;
+}): void;

--- a/scripts/live/validation/calculation-sanity.mjs
+++ b/scripts/live/validation/calculation-sanity.mjs
@@ -1,0 +1,264 @@
+function assertFiniteNumber(value, description) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${description} expected a finite number but received ${String(value)}.`);
+  }
+  return value;
+}
+
+function assertNumberInRange(value, minimum, maximum, description) {
+  const numericValue = assertFiniteNumber(value, description);
+  if (numericValue < minimum || numericValue > maximum) {
+    throw new Error(
+      `${description} expected ${minimum} <= value <= ${maximum} but received ${numericValue}.`
+    );
+  }
+  return numericValue;
+}
+
+function assertArrayHasLength(value, minimumLength, description) {
+  if (!Array.isArray(value) || value.length < minimumLength) {
+    throw new Error(
+      `${description} expected at least ${minimumLength} rows but found ${
+        Array.isArray(value) ? value.length : "non-array"
+      }.`
+    );
+  }
+  return value;
+}
+
+function recordCalculationCheck(summary, description, evidence) {
+  summary.calculationChecks.push({ description, ...evidence });
+}
+
+export function assertPerformanceCalculationSanity({
+  summary,
+  performanceSummary,
+  performanceDetails,
+  recordPanelClassification,
+}) {
+  const netPerformance = performanceSummary?.net_performance ?? {};
+  const overview = performanceSummary?.overview ?? {};
+  const contributionLevel = performanceDetails?.contribution?.levels?.[0];
+  const attributionCapability = performanceDetails?.capabilities?.attribution_detail ?? {};
+  const attributionLevel = performanceDetails?.attribution?.levels?.[0];
+
+  const portfolioReturn = assertNumberInRange(
+    netPerformance.portfolio_return_pct,
+    -100,
+    200,
+    "Net portfolio return"
+  );
+  const benchmarkReturn = assertNumberInRange(
+    netPerformance.benchmark_return_pct,
+    -100,
+    100,
+    "Benchmark return"
+  );
+  const activeReturn = assertNumberInRange(
+    netPerformance.active_return_pct,
+    -200,
+    200,
+    "Active return"
+  );
+  const activeDifference = Math.abs(activeReturn - (portfolioReturn - benchmarkReturn));
+  if (activeDifference > 0.01) {
+    throw new Error(
+      `Active return is not reconciled: active=${activeReturn}, portfolio=${portfolioReturn}, benchmark=${benchmarkReturn}.`
+    );
+  }
+
+  assertNumberInRange(overview.market_value_base, 1, 100_000_000, "Portfolio market value");
+  assertNumberInRange(overview.cash_weight_pct, -5, 100, "Cash weight");
+  assertNumberInRange(overview.position_count, 10, 100, "Position count");
+  assertArrayHasLength(performanceDetails?.net_chart, 4, "Performance return path observations");
+  const contributionRows = assertArrayHasLength(
+    contributionLevel?.rows,
+    4,
+    "Performance contribution rows"
+  );
+  const contributionTotal = assertFiniteNumber(
+    contributionLevel.total_contribution_pct,
+    "Contribution total"
+  );
+  if (Math.abs(contributionTotal - portfolioReturn) > 0.02) {
+    throw new Error(
+      `Contribution total does not reconcile with net portfolio return: contribution=${contributionTotal}, return=${portfolioReturn}.`
+    );
+  }
+
+  const attributionRows = Array.isArray(attributionLevel?.rows) ? attributionLevel.rows.length : 0;
+  const attributionFallback =
+    attributionCapability.state === "partial" && attributionCapability.fallback_available === true;
+  if (attributionCapability.state === "supported" && attributionRows < 1) {
+    throw new Error("Attribution detail is supported but returned no rows.");
+  }
+  if (!attributionFallback && attributionCapability.state !== "supported") {
+    throw new Error(
+      `Attribution detail is ${String(attributionCapability.state)} without a governed fallback.`
+    );
+  }
+
+  recordCalculationCheck(summary, "Performance calculation sanity", {
+    portfolioReturnPct: portfolioReturn,
+    benchmarkReturnPct: benchmarkReturn,
+    activeReturnPct: activeReturn,
+    contributionRows: contributionRows.length,
+    attributionState: attributionCapability.state,
+    attributionRows,
+  });
+
+  recordPanelClassification("performance.summary", "ready", "lotus-performance", {
+    returnPathRows: performanceDetails.net_chart.length,
+  });
+  recordPanelClassification("performance.analysis.contribution", "ready", "lotus-performance", {
+    contributionRows: contributionRows.length,
+  });
+  recordPanelClassification(
+    "performance.analysis.attribution",
+    attributionFallback ? "partial" : "ready",
+    "lotus-performance",
+    {
+      attributionState: attributionCapability.state,
+      attributionRows,
+      fallbackAvailable: attributionCapability.fallback_available === true,
+    }
+  );
+  const evidenceState = performanceSummary?.capabilities?.evidence?.state ?? "unavailable";
+  recordPanelClassification("performance.evidence", evidenceState, "lotus-gateway", {
+    reason: performanceSummary?.capabilities?.evidence?.reason ?? null,
+  });
+}
+
+export function assertRiskCalculationSanity({
+  summary,
+  riskSummary,
+  concentration,
+  drawdown,
+  rolling,
+  attribution,
+  recordPanelClassification,
+}) {
+  const riskPeriod = assertArrayHasLength(riskSummary?.payload?.periods, 1, "Risk periods")[0];
+  const metrics = assertArrayHasLength(riskPeriod.metrics, 6, "Risk summary metrics");
+  const readyMetrics = metrics.filter((metric) => metric?.state === "ready");
+  if (readyMetrics.length < 6) {
+    throw new Error(`Risk summary expected at least 6 ready metrics but found ${readyMetrics.length}.`);
+  }
+  assertNumberInRange(riskPeriod.portfolio_observation_count, 60, 400, "Risk observations");
+  assertNumberInRange(
+    riskPeriod.aligned_benchmark_observation_count,
+    60,
+    400,
+    "Aligned benchmark observations"
+  );
+  if (riskPeriod.benchmark_context?.aligned !== true) {
+    throw new Error("Risk benchmark context is not aligned.");
+  }
+
+  const concentrationPayload = concentration?.payload ?? {};
+  assertNumberInRange(
+    concentrationPayload.portfolio_concentration?.hhi_current,
+    1,
+    10_000,
+    "Portfolio concentration HHI"
+  );
+  assertNumberInRange(
+    concentrationPayload.issuer_concentration?.coverage_ratio_current,
+    0.95,
+    1,
+    "Issuer concentration coverage ratio"
+  );
+  assertNumberInRange(
+    concentrationPayload.single_position_concentration?.top_n_cumulative_weight_current,
+    0.5,
+    1.01,
+    "Top positions cumulative weight"
+  );
+
+  const drawdownPeriod = assertArrayHasLength(drawdown?.payload?.periods, 1, "Drawdown periods")[0];
+  assertNumberInRange(
+    drawdownPeriod.portfolio_observation_count,
+    60,
+    400,
+    "Drawdown observation count"
+  );
+  assertNumberInRange(
+    drawdownPeriod.relative_to_benchmark?.time_under_water_days,
+    1,
+    366,
+    "Relative drawdown time under water"
+  );
+  assertArrayHasLength(drawdownPeriod.underwater_series, 60, "Drawdown underwater series");
+
+  const rollingPeriod = assertArrayHasLength(rolling?.payload?.periods, 1, "Rolling risk periods")[0];
+  assertNumberInRange(rollingPeriod.window_count_emitted, 4, 4, "Rolling risk window count");
+  const rollingWindows = assertArrayHasLength(
+    rollingPeriod.window_results,
+    4,
+    "Rolling risk window results"
+  );
+  let rollingWindowsWithLatestVolatility = 0;
+  for (const windowResult of rollingPeriod.window_results) {
+    const volatility = windowResult?.metric_summaries?.ROLLING_VOLATILITY;
+    if (!volatility || typeof volatility !== "object") {
+      throw new Error(
+        `Rolling risk window ${String(windowResult?.window_length)} has no volatility summary.`
+      );
+    }
+    if (typeof volatility.latest === "number") {
+      rollingWindowsWithLatestVolatility += 1;
+    }
+  }
+  if (rollingWindowsWithLatestVolatility < 2) {
+    throw new Error(
+      `Rolling risk expected at least 2 computable windows but found ${rollingWindowsWithLatestVolatility}.`
+    );
+  }
+
+  const attributionPeriod = assertArrayHasLength(
+    attribution?.payload?.periods,
+    1,
+    "Historical risk attribution periods"
+  )[0];
+  const attributionSet = assertArrayHasLength(
+    attributionPeriod.attribution_sets,
+    1,
+    "Historical risk attribution sets"
+  )[0];
+  const contributors = assertArrayHasLength(
+    attributionSet.contributors,
+    5,
+    "Historical risk attribution contributors"
+  );
+  const residual = assertFiniteNumber(attributionSet.residual, "Historical risk residual");
+  if (Math.abs(residual) > 0.000001) {
+    throw new Error(`Historical risk attribution residual is too high: ${residual}.`);
+  }
+
+  recordCalculationCheck(summary, "Risk calculation sanity", {
+    readyMetricCount: readyMetrics.length,
+    observationCount: riskPeriod.portfolio_observation_count,
+    concentrationHhi: concentrationPayload.portfolio_concentration?.hhi_current,
+    rollingWindowCount: rollingPeriod.window_count_emitted,
+    rollingWindowResultCount: rollingWindows.length,
+    rollingWindowsWithLatestVolatility,
+    attributionContributorCount: contributors.length,
+  });
+
+  recordPanelClassification("performance.risk.snapshot", "ready", "lotus-risk", {
+    readyMetricCount: readyMetrics.length,
+  });
+  recordPanelClassification("performance.risk.concentration", "ready", "lotus-risk", {
+    issuerCoverageRatio: concentrationPayload.issuer_concentration?.coverage_ratio_current,
+  });
+  recordPanelClassification("performance.risk.drawdown", "ready", "lotus-risk", {
+    underwaterSeriesRows: drawdownPeriod.underwater_series.length,
+  });
+  recordPanelClassification("performance.risk.rolling", "ready", "lotus-risk", {
+    windowCount: rollingPeriod.window_count_emitted,
+    computableWindows: rollingWindowsWithLatestVolatility,
+  });
+  recordPanelClassification("performance.risk.historical_attribution", "ready", "lotus-risk", {
+    contributorRows: contributors.length,
+  });
+}

--- a/scripts/live/validation/contract-metadata.d.mts
+++ b/scripts/live/validation/contract-metadata.d.mts
@@ -1,0 +1,7 @@
+import type { CanonicalContractMetadata, PanelRegistryMetadata } from "./shared-types";
+
+export const DEFAULT_CANONICAL_CONTRACT: CanonicalContractMetadata;
+export const DEFAULT_PANEL_REGISTRY: PanelRegistryMetadata;
+
+export function loadCanonicalContractMetadata(cwd?: string): Promise<CanonicalContractMetadata>;
+export function loadWorkbenchPanelRegistryMetadata(cwd?: string): Promise<PanelRegistryMetadata>;

--- a/scripts/live/validation/contract-metadata.mjs
+++ b/scripts/live/validation/contract-metadata.mjs
@@ -1,0 +1,267 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export const DEFAULT_CANONICAL_CONTRACT = {
+  contractId: "canonical-front-office-demo-data-contract",
+  contractVersion: "1.0.0",
+  governedByRfc: "RFC-0076",
+  portfolioId: "PB_SG_GLOBAL_BAL_001",
+  benchmarkCode: "BMK_PB_GLOBAL_BALANCED_60_40",
+  canonicalAsOfDate: "2026-04-10",
+};
+
+export const DEFAULT_PANEL_REGISTRY = {
+  contractId: "workbench-panel-registry",
+  contractVersion: "1.0.0",
+  governedByRfc: "RFC-0077",
+  canonicalDataContract: "canonical-front-office-demo-data-contract",
+  sourcePath: "deterministic-fallback",
+  panels: [
+    {
+      panelId: "portfolio.summary",
+      owningService: "lotus-gateway",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/overview",
+      requiredSupportState: "ready",
+      route: "/portfolio?portfolioId={portfolioId}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "portfolio-summary-live.png",
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "portfolio.detailed",
+      owningService: "lotus-gateway",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/overview",
+      requiredSupportState: "ready",
+      route: "/portfolio?portfolioId={portfolioId}&tab=detailed",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "portfolio-detailed-live.png",
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "performance.summary",
+      owningService: "lotus-performance",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/performance/summary",
+      requiredSupportState: "ready",
+      route: "/performance?portfolioId={portfolioId}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "performance-summary-live.png",
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "performance.analysis.contribution",
+      owningService: "lotus-performance",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/performance/details",
+      requiredSupportState: "ready",
+      route: "/performance?portfolioId={portfolioId}&mode=analysis&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "performance-analysis-live.png",
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "performance.analysis.attribution",
+      owningService: "lotus-performance",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/performance/details",
+      requiredSupportState: "partial",
+      route: "/performance?portfolioId={portfolioId}&mode=analysis&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "performance-analysis-live.png",
+      knownLimitations: [
+        "benchmark-relative attribution may remain partial until full source-backed detail is available",
+      ],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "performance.advisor_brief",
+      owningService: "lotus-performance",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/performance/advisor-brief",
+      requiredSupportState: "ready",
+      route: "/performance?portfolioId={portfolioId}&mode=advisor&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "performance-advisor-brief-live.png",
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "performance.risk.snapshot",
+      owningService: "lotus-risk",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/risk/summary",
+      requiredSupportState: "ready",
+      route: "/performance?portfolioId={portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "performance-risk-live.png",
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "performance.risk.drawdown",
+      owningService: "lotus-risk",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/risk/drawdown",
+      requiredSupportState: "ready",
+      route: "/performance?portfolioId={portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "performance-risk-live.png",
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "performance.risk.concentration",
+      owningService: "lotus-risk",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/risk/concentration",
+      requiredSupportState: "ready",
+      route: "/performance?portfolioId={portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "performance-risk-live.png",
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "performance.risk.rolling",
+      owningService: "lotus-risk",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/risk/rolling",
+      requiredSupportState: "ready",
+      route: "/performance?portfolioId={portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "performance-risk-live.png",
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "performance.risk.historical_attribution",
+      owningService: "lotus-risk",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/risk/attribution",
+      requiredSupportState: "ready",
+      route: "/performance?portfolioId={portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "performance-risk-live.png",
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "performance.evidence",
+      owningService: "lotus-gateway",
+      gatewayEndpoint: null,
+      requiredSupportState: "unavailable",
+      route: "/performance?portfolioId={portfolioId}&mode=evidence&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "performance-evidence-live.png",
+      knownLimitations: ["full evidence and lineage support is deferred pending RFC-0079"],
+      ownerFollowUpRfc: "RFC-0079",
+    },
+  ],
+};
+
+export async function loadCanonicalContractMetadata(cwd = process.cwd()) {
+  const candidatePaths = [
+    process.env.LOTUS_PLATFORM_REPO
+      ? path.resolve(
+          process.env.LOTUS_PLATFORM_REPO,
+          "context",
+          "contracts",
+          "canonical-front-office-demo-data-contract.json"
+        )
+      : null,
+    path.resolve(
+      cwd,
+      "..",
+      "lotus-platform",
+      "context",
+      "contracts",
+      "canonical-front-office-demo-data-contract.json"
+    ),
+  ].filter(Boolean);
+
+  for (const candidatePath of candidatePaths) {
+    try {
+      const raw = await fs.readFile(candidatePath, "utf8");
+      const payload = JSON.parse(raw);
+      return {
+        contractId: payload.contract_id ?? DEFAULT_CANONICAL_CONTRACT.contractId,
+        contractVersion: payload.contract_version ?? DEFAULT_CANONICAL_CONTRACT.contractVersion,
+        governedByRfc: payload.governed_by_rfc ?? DEFAULT_CANONICAL_CONTRACT.governedByRfc,
+        portfolioId: payload.portfolio?.portfolio_id ?? DEFAULT_CANONICAL_CONTRACT.portfolioId,
+        benchmarkCode:
+          payload.benchmark?.benchmark_id ?? DEFAULT_CANONICAL_CONTRACT.benchmarkCode,
+        canonicalAsOfDate:
+          payload.date_policy?.canonical_as_of_date ??
+          DEFAULT_CANONICAL_CONTRACT.canonicalAsOfDate,
+        sourcePath: candidatePath,
+      };
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        continue;
+      }
+      throw new Error(
+        `Unable to load governed canonical contract metadata from ${candidatePath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  return {
+    ...DEFAULT_CANONICAL_CONTRACT,
+    sourcePath: "deterministic-fallback",
+  };
+}
+
+export async function loadWorkbenchPanelRegistryMetadata(cwd = process.cwd()) {
+  const candidatePaths = [
+    process.env.LOTUS_PLATFORM_REPO
+      ? path.resolve(
+          process.env.LOTUS_PLATFORM_REPO,
+          "context",
+          "contracts",
+          "workbench-panel-registry.json"
+        )
+      : null,
+    path.resolve(
+      cwd,
+      "..",
+      "lotus-platform",
+      "context",
+      "contracts",
+      "workbench-panel-registry.json"
+    ),
+  ].filter(Boolean);
+
+  for (const candidatePath of candidatePaths) {
+    try {
+      const raw = await fs.readFile(candidatePath, "utf8");
+      const payload = JSON.parse(raw);
+      return {
+        contractId: payload.contract_id ?? DEFAULT_PANEL_REGISTRY.contractId,
+        contractVersion: payload.contract_version ?? DEFAULT_PANEL_REGISTRY.contractVersion,
+        governedByRfc: payload.governed_by_rfc ?? DEFAULT_PANEL_REGISTRY.governedByRfc,
+        canonicalDataContract:
+          payload.canonical_data_contract ?? DEFAULT_PANEL_REGISTRY.canonicalDataContract,
+        sourcePath: candidatePath,
+        panels: (payload.panels ?? []).map((panel) => ({
+          panelId: panel.panel_id,
+          owningService: panel.owning_service,
+          gatewayEndpoint: panel.gateway_endpoint,
+          requiredSupportState: panel.required_support_state,
+          route: panel.route,
+          allowedStates: panel.allowed_states ?? [],
+          screenshotName: panel.screenshot_policy?.screenshot_name ?? null,
+          knownLimitations: panel.known_limitations ?? [],
+          ownerFollowUpRfc: panel.owner_follow_up_rfc ?? null,
+        })),
+      };
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        continue;
+      }
+      throw new Error(
+        `Unable to load governed panel registry metadata from ${candidatePath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  return DEFAULT_PANEL_REGISTRY;
+}

--- a/scripts/live/validation/evidence-summary-writer.d.mts
+++ b/scripts/live/validation/evidence-summary-writer.d.mts
@@ -1,0 +1,43 @@
+import type {
+  CanonicalContractMetadata,
+  PanelRegistryMetadata,
+  ValidationSummary,
+} from "./shared-types";
+
+export type InitializedValidationSummary = ValidationSummary & {
+  dns: Array<Record<string, unknown>>;
+  apiChecks: Array<Record<string, unknown>>;
+  uiChecks: Array<Record<string, unknown>>;
+  calculationChecks: Array<Record<string, unknown>>;
+  panelClassifications: Array<Record<string, unknown>>;
+  supportabilityChecks: Array<Record<string, unknown>>;
+  screenshots: Array<Record<string, unknown>>;
+};
+
+export function createValidationSummary(input: {
+  generatedAt?: string;
+  portfolioId: string;
+  benchmarkCode: string;
+  canonicalContract: CanonicalContractMetadata;
+  panelRegistry: PanelRegistryMetadata;
+  workbenchBaseUrl: string;
+  gatewayBaseUrl: string;
+}): InitializedValidationSummary;
+
+export function ensureDirectory(target: string): Promise<void>;
+
+export function buildSummaryPaths(outputDir: string): {
+  summaryPath: string;
+  shotIndexPath: string;
+};
+
+export function writeValidationSummary(
+  summaryPath: string,
+  summary: ValidationSummary
+): Promise<void>;
+
+export function writeShotIndex(
+  shotIndexPath: string,
+  summary: ValidationSummary,
+  validationSummaryPath: string
+): Promise<void>;

--- a/scripts/live/validation/evidence-summary-writer.mjs
+++ b/scripts/live/validation/evidence-summary-writer.mjs
@@ -1,0 +1,75 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export function createValidationSummary({
+  generatedAt = new Date().toISOString(),
+  portfolioId,
+  benchmarkCode,
+  canonicalContract,
+  panelRegistry,
+  workbenchBaseUrl,
+  gatewayBaseUrl,
+}) {
+  return {
+    generatedAt,
+    portfolioId,
+    benchmarkCode,
+    canonicalContract,
+    panelRegistry: {
+      contractId: panelRegistry.contractId,
+      contractVersion: panelRegistry.contractVersion,
+      governedByRfc: panelRegistry.governedByRfc,
+      canonicalDataContract: panelRegistry.canonicalDataContract,
+      sourcePath: panelRegistry.sourcePath,
+    },
+    workbenchBaseUrl,
+    gatewayBaseUrl,
+    dns: [],
+    apiChecks: [],
+    uiChecks: [],
+    calculationChecks: [],
+    panelClassifications: [],
+    supportabilityChecks: [],
+    screenshots: [],
+  };
+}
+
+export async function ensureDirectory(target) {
+  await fs.mkdir(target, { recursive: true });
+}
+
+export function buildSummaryPaths(outputDir) {
+  return {
+    summaryPath: path.join(outputDir, "live-validation-summary.json"),
+    shotIndexPath: path.join(outputDir, "SHOT-INDEX.md"),
+  };
+}
+
+export async function writeValidationSummary(summaryPath, summary) {
+  await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+}
+
+export async function writeShotIndex(shotIndexPath, summary, validationSummaryPath) {
+  const lines = [
+    "# Lotus Canonical Front-Office Screenshots",
+    "",
+    `- Generated: ${summary.generatedAt}`,
+    `- Contract: ${summary.canonicalContract.contractId} ${summary.canonicalContract.contractVersion}`,
+    `- Governed by: ${summary.canonicalContract.governedByRfc}`,
+    `- Portfolio: ${summary.portfolioId}`,
+    `- Benchmark: ${summary.benchmarkCode}`,
+    `- As of: ${summary.screenshots[0]?.asOfDate ?? summary.canonicalContract.canonicalAsOfDate ?? "unknown"}`,
+    `- Validation summary: ${validationSummaryPath}`,
+    "",
+    "## Captures",
+    "",
+  ];
+
+  for (const screenshotEvidence of summary.screenshots) {
+    lines.push(
+      `- ${screenshotEvidence.name} - ${screenshotEvidence.panel} - ${screenshotEvidence.route} - ${screenshotEvidence.state}`
+    );
+  }
+
+  await fs.writeFile(shotIndexPath, `${lines.join("\n")}\n`, "utf8");
+}

--- a/scripts/live/validation/panel-governance.d.mts
+++ b/scripts/live/validation/panel-governance.d.mts
@@ -1,0 +1,29 @@
+import type {
+  ValidationPanelState,
+  ValidationSummary,
+} from "./shared-types";
+
+export function createPanelGovernance(
+  summary: ValidationSummary,
+  panelRegistry: {
+    panels: Array<{
+      panelId: string;
+      owningService: string;
+      gatewayEndpoint: string | null;
+      requiredSupportState: ValidationPanelState;
+      allowedStates: ValidationPanelState[];
+      knownLimitations: string[];
+      ownerFollowUpRfc: string | null;
+    }>;
+  }
+): {
+  panelRegistryById: Map<string, Record<string, unknown>>;
+  recordPanelClassification(
+    panel: string,
+    state: ValidationPanelState,
+    owner: string,
+    evidence: Record<string, unknown>
+  ): void;
+  assertNoUnsupportedBlankPanels(): void;
+  assertPanelSupportabilityAlignment(): void;
+};

--- a/scripts/live/validation/panel-governance.mjs
+++ b/scripts/live/validation/panel-governance.mjs
@@ -1,0 +1,81 @@
+export function createPanelGovernance(summary, panelRegistry) {
+  const panelRegistryById = new Map(panelRegistry.panels.map((panel) => [panel.panelId, panel]));
+
+  function recordSupportabilityCheck(panel, evidence) {
+    summary.supportabilityChecks.push({ panel, ...evidence });
+  }
+
+  function recordPanelClassification(panel, state, owner, evidence) {
+    const panelSpec = panelRegistryById.get(panel);
+    if (!panelSpec) {
+      throw new Error(`Panel classification '${panel}' is not present in the governed panel registry.`);
+    }
+    if (!panelSpec.allowedStates.includes(state)) {
+      throw new Error(
+        `Panel classification '${panel}' used unsupported state '${state}'. Allowed states: ${panelSpec.allowedStates.join(", ")}.`
+      );
+    }
+    summary.panelClassifications.push({ panel, state, owner, ...evidence });
+  }
+
+  function assertNoUnsupportedBlankPanels() {
+    const unsupportedBlankPanels = summary.panelClassifications.filter(
+      (panel) => panel.state === "supported_blank"
+    );
+    if (unsupportedBlankPanels.length > 0) {
+      throw new Error(
+        `Unsupported blank panels found: ${unsupportedBlankPanels
+          .map((panel) => panel.panel)
+          .join(", ")}.`
+      );
+    }
+  }
+
+  function assertPanelSupportabilityAlignment() {
+    const classifiedPanels = new Set(summary.panelClassifications.map((panel) => panel.panel));
+
+    for (const panelSpec of panelRegistry.panels) {
+      if (!classifiedPanels.has(panelSpec.panelId)) {
+        throw new Error(`Governed panel '${panelSpec.panelId}' was not classified during validation.`);
+      }
+    }
+
+    for (const panel of summary.panelClassifications) {
+      const panelSpec = panelRegistryById.get(panel.panel);
+      if (panel.owner !== panelSpec.owningService) {
+        throw new Error(
+          `Panel '${panel.panel}' reported owner '${panel.owner}' but registry owner is '${panelSpec.owningService}'.`
+        );
+      }
+      if (panel.state !== panelSpec.requiredSupportState) {
+        throw new Error(
+          `Panel '${panel.panel}' reported state '${panel.state}' but registry requires '${panelSpec.requiredSupportState}'.`
+        );
+      }
+      if (
+        (panel.state === "partial" || panel.state === "unavailable") &&
+        !panel.reason &&
+        panelSpec.knownLimitations.length < 1 &&
+        !panelSpec.ownerFollowUpRfc
+      ) {
+        throw new Error(
+          `Panel '${panel.panel}' is ${panel.state} without a governed reason, limitation, or follow-up RFC.`
+        );
+      }
+      recordSupportabilityCheck(panel.panel, {
+        owner: panel.owner,
+        state: panel.state,
+        requiredSupportState: panelSpec.requiredSupportState,
+        gatewayEndpoint: panelSpec.gatewayEndpoint,
+        ownerFollowUpRfc: panelSpec.ownerFollowUpRfc,
+      });
+    }
+  }
+
+  return {
+    panelRegistryById,
+    recordPanelClassification,
+    assertNoUnsupportedBlankPanels,
+    assertPanelSupportabilityAlignment,
+  };
+}

--- a/scripts/live/validation/probes.d.mts
+++ b/scripts/live/validation/probes.d.mts
@@ -1,0 +1,26 @@
+import type { ValidationSummary } from "./shared-types";
+
+export function checkDns(
+  summary: ValidationSummary,
+  hostname: string,
+  options?: {
+    required?: boolean;
+    lookup?: (hostname: string) => Promise<{ address: string }>;
+  }
+): Promise<Record<string, unknown>>;
+
+export function fetchJson<T = unknown>(
+  summary: ValidationSummary,
+  url: string,
+  description: string,
+  timeoutMs: number,
+  fetchImpl?: (input: string, init?: Record<string, unknown>) => Promise<Response>
+): Promise<T>;
+
+export function fetchText(
+  summary: ValidationSummary,
+  url: string,
+  description: string,
+  timeoutMs: number,
+  fetchImpl?: (input: string, init?: Record<string, unknown>) => Promise<Response>
+): Promise<string>;

--- a/scripts/live/validation/probes.mjs
+++ b/scripts/live/validation/probes.mjs
@@ -1,0 +1,83 @@
+import dns from "node:dns/promises";
+
+export async function checkDns(summary, hostname, { required = true, lookup = dns.lookup } = {}) {
+  try {
+    const resolution = await lookup(hostname);
+    const result = { hostname, ok: true, address: resolution.address, required };
+    summary.dns.push(result);
+    return result;
+  } catch (error) {
+    const result = {
+      hostname,
+      ok: false,
+      required,
+      warning: `Optional canonical host '${hostname}' is not resolvable: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+    summary.dns.push(result);
+    if (required) {
+      throw new Error(
+        `Canonical host '${hostname}' is not resolvable. Update your hosts/DNS mapping before running the live validation again.`
+      );
+    }
+    return result;
+  }
+}
+
+export async function fetchJson(
+  summary,
+  url,
+  description,
+  timeoutMs,
+  fetchImpl = globalThis.fetch
+) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`${description} failed (${response.status}) at ${url}`);
+    }
+    const body = await response.text();
+    if (!body.trim()) {
+      throw new Error(`${description} returned HTTP ${response.status} with an empty body at ${url}`);
+    }
+    let payload;
+    try {
+      payload = JSON.parse(body);
+    } catch (error) {
+      throw new Error(
+        `${description} returned non-JSON content at ${url}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+    summary.apiChecks.push({ description, url, status: response.status, kind: "json" });
+    return payload;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchText(
+  summary,
+  url,
+  description,
+  timeoutMs,
+  fetchImpl = globalThis.fetch
+) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`${description} failed (${response.status}) at ${url}`);
+    }
+    const payload = await response.text();
+    summary.apiChecks.push({ description, url, status: response.status, kind: "text" });
+    return payload;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/scripts/live/validation/shared-types.d.ts
+++ b/scripts/live/validation/shared-types.d.ts
@@ -1,0 +1,92 @@
+export type ValidationPanelState =
+  | "ready"
+  | "loading"
+  | "empty"
+  | "partial"
+  | "unavailable"
+  | "error"
+  | "supported_blank";
+
+export interface ValidationConfig {
+  args: Map<string, string>;
+  portfolioId: string;
+  benchmarkCode: string;
+  workbenchBaseUrl: string;
+  gatewayBaseUrl: string;
+  outputDir: string;
+  timeoutMs: number;
+  canonicalAsOfDate: string;
+}
+
+export interface CanonicalContractMetadata {
+  contractId: string;
+  contractVersion: string;
+  governedByRfc: string;
+  portfolioId: string;
+  benchmarkCode: string;
+  canonicalAsOfDate: string;
+  sourcePath?: string;
+}
+
+export interface PanelRegistryEntry {
+  panelId: string;
+  owningService: string;
+  gatewayEndpoint: string | null;
+  requiredSupportState: ValidationPanelState;
+  route: string;
+  allowedStates: ValidationPanelState[];
+  screenshotName: string | null;
+  knownLimitations: string[];
+  ownerFollowUpRfc: string | null;
+}
+
+export interface PanelRegistryMetadata {
+  contractId: string;
+  contractVersion: string;
+  governedByRfc: string;
+  canonicalDataContract: string;
+  sourcePath: string;
+  panels: PanelRegistryEntry[];
+}
+
+export interface ValidationSummary {
+  generatedAt?: string;
+  portfolioId?: string;
+  benchmarkCode?: string;
+  canonicalContract?: CanonicalContractMetadata;
+  panelRegistry?: {
+    contractId: string;
+    contractVersion: string;
+    governedByRfc: string;
+    canonicalDataContract: string;
+    sourcePath: string;
+  };
+  workbenchBaseUrl?: string;
+  gatewayBaseUrl?: string;
+  dns?: Array<Record<string, unknown>>;
+  apiChecks?: Array<Record<string, unknown>>;
+  uiChecks?: Array<Record<string, unknown>>;
+  calculationChecks?: Array<Record<string, unknown>>;
+  panelClassifications?: Array<Record<string, unknown>>;
+  supportabilityChecks?: Array<Record<string, unknown>>;
+  screenshots?: Array<Record<string, unknown>>;
+}
+
+export interface BrowserValidationPage {
+  screenshot(options: { path: string; fullPage: boolean }): Promise<void>;
+  goto?(url: string, options?: Record<string, unknown>): Promise<void>;
+  getByRole?(role: string, options?: Record<string, unknown>): unknown;
+  getByLabel?(label: string, options?: Record<string, unknown>): unknown;
+  getByText?(text: string | RegExp, options?: Record<string, unknown>): unknown;
+}
+
+export interface BrowserValidationHelpers {
+  assertListHasItems(locator: unknown, description: string): Promise<void>;
+  assertTableHasRows(locator: unknown, minimumRows: number, description: string): Promise<void>;
+  screenshotRegisteredPanel(
+    page: BrowserValidationPage,
+    panelId: string,
+    metadata?: { route?: string; state?: string }
+  ): Promise<void>;
+  resolveRegistryRoute(routeTemplate: string): string;
+}

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -99,6 +99,10 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validation", "contract-metadata.mjs"),
       "utf8"
     );
+    const panelGovernanceModule = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "panel-governance.mjs"),
+      "utf8"
+    );
     const runbook = readFileSync(
       join(process.cwd(), "docs", "operations", "canonical-front-office-local-runtime.md"),
       "utf8"
@@ -106,12 +110,12 @@ describe("canonical live validation script", () => {
 
     expect(script).toContain('from "./validation/contract-metadata.mjs"');
     expect(script).toContain("loadWorkbenchPanelRegistryMetadata");
-    expect(script).toContain("panelRegistryById");
+    expect(panelGovernanceModule).toContain("panelRegistryById");
     expect(contractModule).toContain("DEFAULT_PANEL_REGISTRY");
     expect(contractModule).toContain("workbench-panel-registry.json");
     expect(contractModule).toContain("requiredSupportState");
     expect(contractModule).toContain("owningService");
-    expect(script).toContain("Panel classification");
+    expect(panelGovernanceModule).toContain("Panel classification");
     expect(contractModule).toContain("allowedStates");
     expect(script).not.toContain("assertRegionHasButtons");
     expect(runbook).toContain("RFC-0077");
@@ -127,13 +131,18 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validation", "calculation-sanity.mjs"),
       "utf8"
     );
+    const panelGovernanceModule = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "panel-governance.mjs"),
+      "utf8"
+    );
 
-    expect(script).toContain("supportabilityChecks");
-    expect(script).toContain("assertPanelSupportabilityAlignment");
-    expect(script).toContain("reported owner");
-    expect(script).toContain("registry owner");
-    expect(script).toContain("requiredSupportState");
-    expect(script).toContain("ownerFollowUpRfc");
+    expect(panelGovernanceModule).toContain("supportabilityChecks");
+    expect(script).toContain("createPanelGovernance");
+    expect(panelGovernanceModule).toContain("assertPanelSupportabilityAlignment");
+    expect(panelGovernanceModule).toContain("reported owner");
+    expect(panelGovernanceModule).toContain("registry owner");
+    expect(panelGovernanceModule).toContain("requiredSupportState");
+    expect(panelGovernanceModule).toContain("ownerFollowUpRfc");
     expect(script).toContain("lotus-performance");
     expect(calculationModule).toContain("performance.evidence");
   });
@@ -147,16 +156,21 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validation", "calculation-sanity.mjs"),
       "utf8"
     );
+    const panelGovernanceModule = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "panel-governance.mjs"),
+      "utf8"
+    );
 
-    expect(script).toContain("panelClassifications");
-    expect(script).toContain("recordPanelClassification");
-    expect(script).toContain("assertNoUnsupportedBlankPanels");
+    expect(panelGovernanceModule).toContain("panelClassifications");
+    expect(script).toContain("createPanelGovernance");
+    expect(panelGovernanceModule).toContain("recordPanelClassification");
+    expect(panelGovernanceModule).toContain("assertNoUnsupportedBlankPanels");
     expect(script).toContain("portfolio.summary");
     expect(calculationModule).toContain("performance.analysis.attribution");
     expect(calculationModule).toContain("performance.evidence");
     expect(calculationModule).toContain("performance.risk.historical_attribution");
     expect(calculationModule).toContain("performance.risk.snapshot");
-    expect(script).toContain("supported_blank");
+    expect(panelGovernanceModule).toContain("supported_blank");
   });
 
   it("records demo screenshot evidence with registry-governed names, routes, and absolute paths", () => {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -48,8 +48,11 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validate-canonical-workbench-live.mjs"),
       "utf8"
     );
+    const calculationModule = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "calculation-sanity.mjs"),
+      "utf8"
+    );
 
-    expect(script).toContain("calculationChecks");
     expect(script).toContain("assertPerformanceCalculationSanity");
     expect(script).toContain("assertRiskCalculationSanity");
     expect(script).toContain("/performance/details?");
@@ -57,8 +60,9 @@ describe("canonical live validation script", () => {
     expect(script).toContain("/risk/drawdown?");
     expect(script).toContain("/risk/rolling?");
     expect(script).toContain("/risk/attribution?");
-    expect(script).toContain("Contribution total does not reconcile with net portfolio return");
-    expect(script).toContain("Historical risk attribution residual is too high");
+    expect(calculationModule).toContain("calculationChecks");
+    expect(calculationModule).toContain("Contribution total does not reconcile with net portfolio return");
+    expect(calculationModule).toContain("Historical risk attribution residual is too high");
   });
 
   it("surfaces governed canonical contract metadata in live validation evidence", () => {
@@ -135,15 +139,19 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validate-canonical-workbench-live.mjs"),
       "utf8"
     );
+    const calculationModule = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "calculation-sanity.mjs"),
+      "utf8"
+    );
 
     expect(script).toContain("panelClassifications");
     expect(script).toContain("recordPanelClassification");
     expect(script).toContain("assertNoUnsupportedBlankPanels");
     expect(script).toContain("portfolio.summary");
-    expect(script).toContain("performance.analysis.attribution");
-    expect(script).toContain("performance.evidence");
-    expect(script).toContain("performance.risk.historical_attribution");
-    expect(script).toContain("performance.risk.snapshot");
+    expect(calculationModule).toContain("performance.analysis.attribution");
+    expect(calculationModule).toContain("performance.evidence");
+    expect(calculationModule).toContain("performance.risk.historical_attribution");
+    expect(calculationModule).toContain("performance.risk.snapshot");
     expect(script).toContain("supported_blank");
   });
 

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -66,17 +66,22 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validate-canonical-workbench-live.mjs"),
       "utf8"
     );
+    const contractModule = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "contract-metadata.mjs"),
+      "utf8"
+    );
     const runbook = readFileSync(
       join(process.cwd(), "docs", "operations", "canonical-front-office-local-runtime.md"),
       "utf8"
     );
 
-    expect(script).toContain("DEFAULT_CANONICAL_CONTRACT");
+    expect(script).toContain('from "./validation/contract-metadata.mjs"');
     expect(script).toContain("loadCanonicalContractMetadata");
-    expect(script).toContain("canonical-front-office-demo-data-contract.json");
-    expect(script).toContain("LOTUS_PLATFORM_REPO");
     expect(script).toContain("canonicalContract");
-    expect(script).toContain('sourcePath: "deterministic-fallback"');
+    expect(contractModule).toContain("DEFAULT_CANONICAL_CONTRACT");
+    expect(contractModule).toContain("canonical-front-office-demo-data-contract.json");
+    expect(contractModule).toContain("LOTUS_PLATFORM_REPO");
+    expect(contractModule).toContain('sourcePath: "deterministic-fallback"');
     expect(runbook).toContain("contract identity and version");
     expect(runbook).toContain("RFC-0076");
   });
@@ -86,19 +91,24 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validate-canonical-workbench-live.mjs"),
       "utf8"
     );
+    const contractModule = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "contract-metadata.mjs"),
+      "utf8"
+    );
     const runbook = readFileSync(
       join(process.cwd(), "docs", "operations", "canonical-front-office-local-runtime.md"),
       "utf8"
     );
 
-    expect(script).toContain("DEFAULT_PANEL_REGISTRY");
+    expect(script).toContain('from "./validation/contract-metadata.mjs"');
     expect(script).toContain("loadWorkbenchPanelRegistryMetadata");
-    expect(script).toContain("workbench-panel-registry.json");
     expect(script).toContain("panelRegistryById");
-    expect(script).toContain("requiredSupportState");
-    expect(script).toContain("owningService");
+    expect(contractModule).toContain("DEFAULT_PANEL_REGISTRY");
+    expect(contractModule).toContain("workbench-panel-registry.json");
+    expect(contractModule).toContain("requiredSupportState");
+    expect(contractModule).toContain("owningService");
     expect(script).toContain("Panel classification");
-    expect(script).toContain("allowedStates");
+    expect(contractModule).toContain("allowedStates");
     expect(script).not.toContain("assertRegionHasButtons");
     expect(runbook).toContain("RFC-0077");
     expect(runbook).toContain("panel registry");
@@ -142,6 +152,14 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validate-canonical-workbench-live.mjs"),
       "utf8"
     );
+    const contractModule = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "contract-metadata.mjs"),
+      "utf8"
+    );
+    const evidenceWriter = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "evidence-summary-writer.mjs"),
+      "utf8"
+    );
     const runbook = readFileSync(
       join(process.cwd(), "docs", "operations", "canonical-front-office-local-runtime.md"),
       "utf8"
@@ -150,12 +168,12 @@ describe("canonical live validation script", () => {
     expect(script).toContain("canonicalAsOfDate");
     expect(script).toContain("screenshotRegisteredPanel");
     expect(script).toContain("resolveRegistryRoute");
-    expect(script).toContain("panelId: \"performance.risk.snapshot\"");
-    expect(script).toContain("screenshotName: \"performance-risk-live.png\"");
+    expect(contractModule).toContain('panelId: "performance.risk.snapshot"');
+    expect(contractModule).toContain('screenshotName: "performance-risk-live.png"');
     expect(script).toContain("panel: panelId");
     expect(script).toContain("state: \"truthfully_degraded\"");
     expect(script).toContain("path: target");
-    expect(script).toContain("SHOT-INDEX.md");
+    expect(evidenceWriter).toContain("SHOT-INDEX.md");
     expect(script).toContain("writeShotIndex");
     expect(runbook).toContain("ScreenshotDirectory");
     expect(runbook).toContain("structured screenshot evidence");

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -123,6 +123,10 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validate-canonical-workbench-live.mjs"),
       "utf8"
     );
+    const calculationModule = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "calculation-sanity.mjs"),
+      "utf8"
+    );
 
     expect(script).toContain("supportabilityChecks");
     expect(script).toContain("assertPanelSupportabilityAlignment");
@@ -131,7 +135,7 @@ describe("canonical live validation script", () => {
     expect(script).toContain("requiredSupportState");
     expect(script).toContain("ownerFollowUpRfc");
     expect(script).toContain("lotus-performance");
-    expect(script).toContain("performance.evidence");
+    expect(calculationModule).toContain("performance.evidence");
   });
 
   it("records explicit panel support classifications for demo evidence", () => {
@@ -168,19 +172,24 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validation", "evidence-summary-writer.mjs"),
       "utf8"
     );
+    const browserWorkflowModule = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "browser-workflows.mjs"),
+      "utf8"
+    );
     const runbook = readFileSync(
       join(process.cwd(), "docs", "operations", "canonical-front-office-local-runtime.md"),
       "utf8"
     );
 
     expect(script).toContain("canonicalAsOfDate");
-    expect(script).toContain("screenshotRegisteredPanel");
-    expect(script).toContain("resolveRegistryRoute");
+    expect(script).toContain("createBrowserValidationHelpers");
+    expect(browserWorkflowModule).toContain("screenshotRegisteredPanel");
+    expect(browserWorkflowModule).toContain("resolveRegistryRoute");
     expect(contractModule).toContain('panelId: "performance.risk.snapshot"');
     expect(contractModule).toContain('screenshotName: "performance-risk-live.png"');
-    expect(script).toContain("panel: panelId");
-    expect(script).toContain("state: \"truthfully_degraded\"");
-    expect(script).toContain("path: target");
+    expect(browserWorkflowModule).toContain("panel: panelId");
+    expect(browserWorkflowModule).toContain('state: "truthfully_degraded"');
+    expect(browserWorkflowModule).toContain("path: target");
     expect(evidenceWriter).toContain("SHOT-INDEX.md");
     expect(script).toContain("writeShotIndex");
     expect(runbook).toContain("ScreenshotDirectory");

--- a/tests/unit/live-validation-browser-workflows.test.ts
+++ b/tests/unit/live-validation-browser-workflows.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createBrowserValidationHelpers } from "../../scripts/live/validation/browser-workflows.mjs";
+
+describe("live validation browser workflow helpers", () => {
+  it("resolves governed routes and records screenshot evidence with absolute paths", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lotus-browser-workflow-"));
+    const screenshotCalls: Array<{ path: string; fullPage: boolean }> = [];
+    const summary = {
+      uiChecks: [],
+      screenshots: [],
+    };
+    const panelRegistryById = new Map([
+      [
+        "performance.risk.snapshot",
+        {
+          screenshotName: "performance-risk-live.png",
+          route: "/performance?portfolioId={portfolioId}&mode=risk&benchmark={benchmarkCode}",
+        },
+      ],
+    ]);
+
+    try {
+      const helpers = createBrowserValidationHelpers({
+        outputDir: tempDir,
+        summary,
+        portfolioId: "PB_SG_GLOBAL_BAL_001",
+        benchmarkCode: "BMK_PB_GLOBAL_BALANCED_60_40",
+        canonicalAsOfDate: "2026-04-10",
+        timeoutMs: 60000,
+        panelRegistryById,
+      });
+
+      expect(
+        helpers.resolveRegistryRoute(
+          "/performance?portfolioId={portfolioId}&mode=risk&benchmark={benchmarkCode}"
+        )
+      ).toBe(
+        "/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk&benchmark=BMK_PB_GLOBAL_BALANCED_60_40"
+      );
+
+      await helpers.screenshotRegisteredPanel(
+        {
+          screenshot: async ({ path, fullPage }: { path: string; fullPage: boolean }) => {
+            screenshotCalls.push({ path, fullPage });
+          },
+        },
+        "performance.risk.snapshot"
+      );
+
+      expect(screenshotCalls).toEqual([
+        {
+          path: join(tempDir, "performance-risk-live.png"),
+          fullPage: true,
+        },
+      ]);
+      expect(summary.screenshots).toEqual([
+        expect.objectContaining({
+          name: "performance-risk-live.png",
+          panel: "performance.risk.snapshot",
+          route: "/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk&benchmark=BMK_PB_GLOBAL_BALANCED_60_40",
+          portfolioId: "PB_SG_GLOBAL_BAL_001",
+          benchmarkCode: "BMK_PB_GLOBAL_BALANCED_60_40",
+          asOfDate: "2026-04-10",
+          state: "demo_ready",
+        }),
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/live-validation-calculation-sanity.test.ts
+++ b/tests/unit/live-validation-calculation-sanity.test.ts
@@ -1,0 +1,277 @@
+import {
+  assertPerformanceCalculationSanity,
+  assertRiskCalculationSanity,
+} from "../../scripts/live/validation/calculation-sanity.mjs";
+
+function createSummary() {
+  return {
+    calculationChecks: [],
+    panelClassifications: [],
+  };
+}
+
+function createClassifier(summary: ReturnType<typeof createSummary>) {
+  return (panel: string, state: string, owner: string, evidence: Record<string, unknown>) => {
+    summary.panelClassifications.push({ panel, state, owner, ...evidence });
+  };
+}
+
+describe("live validation calculation sanity helpers", () => {
+  it("accepts reconciled performance payloads and records governed panel classifications", () => {
+    const summary = createSummary();
+
+    assertPerformanceCalculationSanity({
+      summary,
+      recordPanelClassification: createClassifier(summary),
+      performanceSummary: {
+        net_performance: {
+          portfolio_return_pct: 9.33,
+          benchmark_return_pct: 6.52,
+          active_return_pct: 2.81,
+        },
+        overview: {
+          market_value_base: 1_500_000,
+          cash_weight_pct: 12.4,
+          position_count: 18,
+        },
+        capabilities: {
+          evidence: {
+            state: "unavailable",
+            reason: "gateway contract pending",
+          },
+        },
+      },
+      performanceDetails: {
+        net_chart: [{}, {}, {}, {}],
+        contribution: {
+          levels: [
+            {
+              rows: [{}, {}, {}, {}],
+              total_contribution_pct: 9.33,
+            },
+          ],
+        },
+        capabilities: {
+          attribution_detail: {
+            state: "partial",
+            fallback_available: true,
+          },
+        },
+        attribution: {
+          levels: [
+            {
+              rows: [],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(summary.calculationChecks).toHaveLength(1);
+    expect(summary.panelClassifications).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ panel: "performance.summary", state: "ready" }),
+        expect.objectContaining({
+          panel: "performance.analysis.attribution",
+          state: "partial",
+        }),
+        expect.objectContaining({ panel: "performance.evidence", state: "unavailable" }),
+      ])
+    );
+  });
+
+  it("fails performance attribution when governed fallback is missing", () => {
+    const summary = createSummary();
+
+    expect(() =>
+      assertPerformanceCalculationSanity({
+        summary,
+        recordPanelClassification: createClassifier(summary),
+        performanceSummary: {
+          net_performance: {
+            portfolio_return_pct: 9.33,
+            benchmark_return_pct: 6.52,
+            active_return_pct: 2.81,
+          },
+          overview: {
+            market_value_base: 1_500_000,
+            cash_weight_pct: 12.4,
+            position_count: 18,
+          },
+        },
+        performanceDetails: {
+          net_chart: [{}, {}, {}, {}],
+          contribution: {
+            levels: [
+              {
+                rows: [{}, {}, {}, {}],
+                total_contribution_pct: 9.33,
+              },
+            ],
+          },
+          capabilities: {
+            attribution_detail: {
+              state: "partial",
+              fallback_available: false,
+            },
+          },
+          attribution: {
+            levels: [{ rows: [] }],
+          },
+        },
+      })
+    ).toThrow("Attribution detail is partial without a governed fallback.");
+  });
+
+  it("accepts ready risk payloads and records all risk panel classifications", () => {
+    const summary = createSummary();
+
+    assertRiskCalculationSanity({
+      summary,
+      recordPanelClassification: createClassifier(summary),
+      riskSummary: {
+        payload: {
+          periods: [
+            {
+              metrics: Array.from({ length: 6 }, () => ({ state: "ready" })),
+              portfolio_observation_count: 120,
+              aligned_benchmark_observation_count: 120,
+              benchmark_context: { aligned: true },
+            },
+          ],
+        },
+      },
+      concentration: {
+        payload: {
+          portfolio_concentration: { hhi_current: 1356 },
+          issuer_concentration: { coverage_ratio_current: 0.99 },
+          single_position_concentration: { top_n_cumulative_weight_current: 0.992 },
+        },
+      },
+      drawdown: {
+        payload: {
+          periods: [
+            {
+              portfolio_observation_count: 120,
+              relative_to_benchmark: { time_under_water_days: 81 },
+              underwater_series: Array.from({ length: 60 }, () => ({})),
+            },
+          ],
+        },
+      },
+      rolling: {
+        payload: {
+          periods: [
+            {
+              window_count_emitted: 4,
+              window_results: [
+                { window_length: 21, metric_summaries: { ROLLING_VOLATILITY: { latest: 0.02 } } },
+                { window_length: 63, metric_summaries: { ROLLING_VOLATILITY: { latest: 0.04 } } },
+                { window_length: 126, metric_summaries: { ROLLING_VOLATILITY: {} } },
+                { window_length: 252, metric_summaries: { ROLLING_VOLATILITY: {} } },
+              ],
+            },
+          ],
+        },
+      },
+      attribution: {
+        payload: {
+          periods: [
+            {
+              attribution_sets: [
+                {
+                  contributors: [{}, {}, {}, {}, {}],
+                  residual: 0,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(summary.calculationChecks).toHaveLength(1);
+    expect(summary.panelClassifications).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ panel: "performance.risk.snapshot", state: "ready" }),
+        expect.objectContaining({ panel: "performance.risk.concentration", state: "ready" }),
+        expect.objectContaining({ panel: "performance.risk.drawdown", state: "ready" }),
+        expect.objectContaining({ panel: "performance.risk.rolling", state: "ready" }),
+        expect.objectContaining({
+          panel: "performance.risk.historical_attribution",
+          state: "ready",
+        }),
+      ])
+    );
+  });
+
+  it("fails risk attribution when the residual breaches the governed tolerance", () => {
+    const summary = createSummary();
+
+    expect(() =>
+      assertRiskCalculationSanity({
+        summary,
+        recordPanelClassification: createClassifier(summary),
+        riskSummary: {
+          payload: {
+            periods: [
+              {
+                metrics: Array.from({ length: 6 }, () => ({ state: "ready" })),
+                portfolio_observation_count: 120,
+                aligned_benchmark_observation_count: 120,
+                benchmark_context: { aligned: true },
+              },
+            ],
+          },
+        },
+        concentration: {
+          payload: {
+            portfolio_concentration: { hhi_current: 1356 },
+            issuer_concentration: { coverage_ratio_current: 0.99 },
+            single_position_concentration: { top_n_cumulative_weight_current: 0.992 },
+          },
+        },
+        drawdown: {
+          payload: {
+            periods: [
+              {
+                portfolio_observation_count: 120,
+                relative_to_benchmark: { time_under_water_days: 81 },
+                underwater_series: Array.from({ length: 60 }, () => ({})),
+              },
+            ],
+          },
+        },
+        rolling: {
+          payload: {
+            periods: [
+              {
+                window_count_emitted: 4,
+                window_results: [
+                  { window_length: 21, metric_summaries: { ROLLING_VOLATILITY: { latest: 0.02 } } },
+                  { window_length: 63, metric_summaries: { ROLLING_VOLATILITY: { latest: 0.04 } } },
+                  { window_length: 126, metric_summaries: { ROLLING_VOLATILITY: {} } },
+                  { window_length: 252, metric_summaries: { ROLLING_VOLATILITY: {} } },
+                ],
+              },
+            ],
+          },
+        },
+        attribution: {
+          payload: {
+            periods: [
+              {
+                attribution_sets: [
+                  {
+                    contributors: [{}, {}, {}, {}, {}],
+                    residual: 0.1,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      })
+    ).toThrow("Historical risk attribution residual is too high: 0.1.");
+  });
+});

--- a/tests/unit/live-validation-calculation-sanity.test.ts
+++ b/tests/unit/live-validation-calculation-sanity.test.ts
@@ -3,14 +3,19 @@ import {
   assertRiskCalculationSanity,
 } from "../../scripts/live/validation/calculation-sanity.mjs";
 
-function createSummary() {
+type TestValidationSummary = {
+  calculationChecks: Array<Record<string, unknown>>;
+  panelClassifications: Array<Record<string, unknown>>;
+};
+
+function createSummary(): TestValidationSummary {
   return {
     calculationChecks: [],
     panelClassifications: [],
   };
 }
 
-function createClassifier(summary: ReturnType<typeof createSummary>) {
+function createClassifier(summary: TestValidationSummary) {
   return (panel: string, state: string, owner: string, evidence: Record<string, unknown>) => {
     summary.panelClassifications.push({ panel, state, owner, ...evidence });
   };

--- a/tests/unit/live-validation-contract-modules.test.ts
+++ b/tests/unit/live-validation-contract-modules.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveValidationConfig } from "../../scripts/live/validation/args.mjs";
+import {
+  DEFAULT_CANONICAL_CONTRACT,
+  DEFAULT_PANEL_REGISTRY,
+} from "../../scripts/live/validation/contract-metadata.mjs";
+import {
+  buildSummaryPaths,
+  createValidationSummary,
+  ensureDirectory,
+  writeShotIndex,
+  writeValidationSummary,
+} from "../../scripts/live/validation/evidence-summary-writer.mjs";
+
+describe("live validation contract modules", () => {
+  it("resolves canonical defaults and normalizes trailing slashes", () => {
+    const config = resolveValidationConfig(
+      [
+        "--workbench-base-url",
+        "http://workbench.dev.lotus///",
+        "--gateway-base-url",
+        "http://gateway.dev.lotus//",
+        "--timeout-ms",
+        "45000",
+      ],
+      "C:\\lotus-workbench"
+    );
+
+    expect(config.portfolioId).toBe("PB_SG_GLOBAL_BAL_001");
+    expect(config.benchmarkCode).toBe("BMK_PB_GLOBAL_BALANCED_60_40");
+    expect(config.workbenchBaseUrl).toBe("http://workbench.dev.lotus");
+    expect(config.gatewayBaseUrl).toBe("http://gateway.dev.lotus");
+    expect(config.timeoutMs).toBe(45000);
+    expect(config.outputDir).toContain("output");
+    expect(config.outputDir).toContain("live-canonical");
+  });
+
+  it("builds governed summary evidence with registry metadata and writable artifacts", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lotus-validation-"));
+
+    try {
+      const { summaryPath, shotIndexPath } = buildSummaryPaths(tempDir);
+      const summary = createValidationSummary({
+        generatedAt: "2026-04-11T00:00:00.000Z",
+        portfolioId: DEFAULT_CANONICAL_CONTRACT.portfolioId,
+        benchmarkCode: DEFAULT_CANONICAL_CONTRACT.benchmarkCode,
+        canonicalContract: {
+          ...DEFAULT_CANONICAL_CONTRACT,
+          sourcePath: "deterministic-fallback",
+        },
+        panelRegistry: DEFAULT_PANEL_REGISTRY,
+        workbenchBaseUrl: "http://workbench.dev.lotus",
+        gatewayBaseUrl: "http://gateway.dev.lotus",
+      });
+
+      summary.screenshots.push({
+        name: "performance-risk-live.png",
+        path: join(tempDir, "performance-risk-live.png"),
+        route: "/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk",
+        panel: "performance.risk.snapshot",
+        portfolioId: DEFAULT_CANONICAL_CONTRACT.portfolioId,
+        benchmarkCode: DEFAULT_CANONICAL_CONTRACT.benchmarkCode,
+        asOfDate: DEFAULT_CANONICAL_CONTRACT.canonicalAsOfDate,
+        state: "demo_ready",
+      });
+
+      await ensureDirectory(tempDir);
+      await writeValidationSummary(summaryPath, summary);
+      await writeShotIndex(shotIndexPath, summary, summaryPath);
+
+      const persistedSummary = JSON.parse(readFileSync(summaryPath, "utf8"));
+      const shotIndex = readFileSync(shotIndexPath, "utf8");
+
+      expect(persistedSummary.panelRegistry.contractId).toBe("workbench-panel-registry");
+      expect(persistedSummary.panelRegistry.governedByRfc).toBe("RFC-0077");
+      expect(persistedSummary.canonicalContract.contractId).toBe(
+        "canonical-front-office-demo-data-contract"
+      );
+      expect(shotIndex).toContain("performance-risk-live.png");
+      expect(shotIndex).toContain("performance.risk.snapshot");
+      expect(shotIndex).toContain(summaryPath);
+      expect(shotIndex).toContain("2026-04-10");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/live-validation-panel-governance.test.ts
+++ b/tests/unit/live-validation-panel-governance.test.ts
@@ -1,0 +1,94 @@
+import { createPanelGovernance } from "../../scripts/live/validation/panel-governance.mjs";
+
+function createSummary() {
+  return {
+    panelClassifications: [],
+    supportabilityChecks: [],
+  };
+}
+
+const registry = {
+  panels: [
+    {
+      panelId: "portfolio.summary",
+      owningService: "lotus-gateway",
+      gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/overview",
+      requiredSupportState: "ready",
+      allowedStates: ["ready", "partial", "unavailable", "supported_blank"],
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
+      panelId: "performance.evidence",
+      owningService: "lotus-gateway",
+      gatewayEndpoint: null,
+      requiredSupportState: "unavailable",
+      allowedStates: ["ready", "partial", "unavailable", "supported_blank"],
+      knownLimitations: ["deferred to RFC-0079"],
+      ownerFollowUpRfc: "RFC-0079",
+    },
+  ],
+};
+
+describe("live validation panel governance", () => {
+  it("records classifications and supportability checks for governed panels", () => {
+    const summary = createSummary();
+    const governance = createPanelGovernance(summary, registry);
+
+    governance.recordPanelClassification("portfolio.summary", "ready", "lotus-gateway", {
+      portfolioId: "PB_SG_GLOBAL_BAL_001",
+    });
+    governance.recordPanelClassification("performance.evidence", "unavailable", "lotus-gateway", {
+      reason: "gateway contract pending",
+    });
+
+    governance.assertNoUnsupportedBlankPanels();
+    governance.assertPanelSupportabilityAlignment();
+
+    expect(summary.panelClassifications).toHaveLength(2);
+    expect(summary.supportabilityChecks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          panel: "portfolio.summary",
+          state: "ready",
+          requiredSupportState: "ready",
+        }),
+        expect.objectContaining({
+          panel: "performance.evidence",
+          state: "unavailable",
+          ownerFollowUpRfc: "RFC-0079",
+        }),
+      ])
+    );
+  });
+
+  it("fails unsupported blank panels explicitly", () => {
+    const summary = createSummary();
+    const governance = createPanelGovernance(summary, registry);
+
+    governance.recordPanelClassification("portfolio.summary", "supported_blank", "lotus-gateway", {
+      reason: "unexpected blank",
+    });
+    governance.recordPanelClassification("performance.evidence", "unavailable", "lotus-gateway", {
+      reason: "gateway contract pending",
+    });
+
+    expect(() => governance.assertNoUnsupportedBlankPanels()).toThrow(
+      "Unsupported blank panels found: portfolio.summary."
+    );
+  });
+
+  it("fails owner drift against the registry", () => {
+    const summary = createSummary();
+    const governance = createPanelGovernance(summary, registry);
+
+    governance.recordPanelClassification("portfolio.summary", "ready", "lotus-performance", {
+      portfolioId: "PB_SG_GLOBAL_BAL_001",
+    });
+    governance.recordPanelClassification("performance.evidence", "unavailable", "lotus-gateway", {
+      reason: "gateway contract pending",
+    });
+
+    expect(() => governance.assertPanelSupportabilityAlignment()).toThrow("registry owner");
+  });
+});

--- a/tests/unit/live-validation-panel-governance.test.ts
+++ b/tests/unit/live-validation-panel-governance.test.ts
@@ -1,4 +1,5 @@
 import { createPanelGovernance } from "../../scripts/live/validation/panel-governance.mjs";
+import type { ValidationPanelState } from "../../scripts/live/validation/shared-types";
 
 function createSummary() {
   return {
@@ -7,7 +8,19 @@ function createSummary() {
   };
 }
 
-const registry = {
+type TestRegistry = {
+  panels: Array<{
+    panelId: string;
+    owningService: string;
+    gatewayEndpoint: string | null;
+    requiredSupportState: ValidationPanelState;
+    allowedStates: ValidationPanelState[];
+    knownLimitations: string[];
+    ownerFollowUpRfc: string | null;
+  }>;
+};
+
+const registry: TestRegistry = {
   panels: [
     {
       panelId: "portfolio.summary",

--- a/tests/unit/live-validation-probes.test.ts
+++ b/tests/unit/live-validation-probes.test.ts
@@ -1,0 +1,94 @@
+import { checkDns, fetchJson, fetchText } from "../../scripts/live/validation/probes.mjs";
+
+function createSummary() {
+  return {
+    dns: [],
+    apiChecks: [],
+  };
+}
+
+describe("live validation probe helpers", () => {
+  it("records optional DNS failures without aborting validation", async () => {
+    const summary = createSummary();
+
+    const result = await checkDns(summary, "ai.dev.lotus", {
+      required: false,
+      lookup: async () => {
+        throw new Error("getaddrinfo ENOTFOUND ai.dev.lotus");
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.required).toBe(false);
+    expect(result.warning).toContain("Optional canonical host 'ai.dev.lotus'");
+    expect(summary.dns).toHaveLength(1);
+  });
+
+  it("fails required DNS resolution with a governed operator message", async () => {
+    const summary = createSummary();
+
+    await expect(
+      checkDns(summary, "gateway.dev.lotus", {
+        lookup: async () => {
+          throw new Error("getaddrinfo ENOTFOUND gateway.dev.lotus");
+        },
+      })
+    ).rejects.toThrow(
+      "Canonical host 'gateway.dev.lotus' is not resolvable. Update your hosts/DNS mapping before running the live validation again."
+    );
+  });
+
+  it("records successful JSON and text probes in the summary", async () => {
+    const summary = createSummary();
+
+    const jsonPayload = await fetchJson(
+      summary,
+      "http://gateway.dev.lotus/api/v1/example",
+      "Example JSON",
+      1000,
+      async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+    );
+    const textPayload = await fetchText(
+      summary,
+      "http://workbench.dev.lotus/example",
+      "Example text",
+      1000,
+      async () => new Response("Portfolio", { status: 200 })
+    );
+
+    expect(jsonPayload).toEqual({ ok: true });
+    expect(textPayload).toBe("Portfolio");
+    expect(summary.apiChecks).toEqual([
+      {
+        description: "Example JSON",
+        url: "http://gateway.dev.lotus/api/v1/example",
+        status: 200,
+        kind: "json",
+      },
+      {
+        description: "Example text",
+        url: "http://workbench.dev.lotus/example",
+        status: 200,
+        kind: "text",
+      },
+    ]);
+  });
+
+  it("fails non-JSON gateway responses with a high-signal error", async () => {
+    const summary = createSummary();
+
+    await expect(
+      fetchJson(
+        summary,
+        "http://gateway.dev.lotus/api/v1/example",
+        "Example JSON",
+        1000,
+        async () => new Response("not-json", { status: 200 })
+      )
+    ).rejects.toThrow("Example JSON returned non-JSON content");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
   },
   "include": [
     "next-env.d.ts",
+    "**/*.d.ts",
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts"


### PR DESCRIPTION
## Summary
- extract shared validation config, contract metadata, and evidence writing modules from the monolithic live validator
- remove duplicated bootstrap helpers from the canonical validation entrypoint while keeping operator commands stable
- add focused module-level tests and keep RFC-0078 slice evidence/governance in lotus-platform

## Testing
- npm test -- --runInBand tests/unit/live-canonical-validation-script.test.ts tests/unit/live-validation-contract-modules.test.ts
