### PR TITLE
Split canonical stack startup from validation

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -77,7 +77,7 @@ Workbench local environment:
 BFF_BASE_URL=http://gateway.dev.lotus
 ```
 
-## One-command bring-up
+## Canonical bring-up
 
 From `lotus-workbench`:
 
@@ -95,7 +95,22 @@ That script performs:
 6. governed `lotus-core` seed for `PB_SG_GLOBAL_BAL_001`
 7. canonical host-process startup for `lotus-manage` on `8001`
 8. canonical `lotus-workbench` startup on port `3000`
-9. end-to-end validation of canonical routes and populated UI panels
+
+The command exits after the stack is usable. It does not block on browser validation.
+
+Use this path when you want to bring the product up quickly, inspect it manually, or restart the
+runtime without waiting for the full validation lane to finish.
+
+## Canonical bring-up with validation
+
+From `lotus-workbench`:
+
+```powershell
+npm run live:stack:up:validate
+```
+
+This runs the same bring-up flow and then executes the end-to-end validation lane once the stack
+is live.
 
 ## One-command teardown
 
@@ -111,13 +126,16 @@ That script:
 2. removes direct ingress if it is present
 3. runs `docker compose down` for `lotus-core`, `lotus-performance`, `lotus-risk`, `lotus-ai`, `lotus-advise`, `lotus-manage`, and `lotus-report`
 
-## One-command validation
+## Canonical validation
 
-To validate an already-running stack:
+To validate an already-running canonical stack:
 
 ```powershell
 npm run live:validate
 ```
+
+This is the preferred operator path after `npm run live:stack:up` because it keeps service startup
+separate from readiness, browser, and screenshot evidence gathering.
 
 To write demo screenshots to a caller-provided directory:
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "playwright test",
     "live:stack:down": "powershell -ExecutionPolicy Bypass -File scripts/live/Stop-LotusFrontOfficeCanonical.ps1",
     "live:stack:up": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1",
+    "live:stack:up:validate": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -RunValidation",
     "live:validate": "powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1",
     "live:validate:ui": "node scripts/live/validate-canonical-workbench-live.mjs",
     "auto:pulse": "powershell -ExecutionPolicy Bypass -File scripts/automation/Platform-Pulse.ps1",

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -3,7 +3,8 @@ param(
   [string]$PortfolioId = "PB_SG_GLOBAL_BAL_001",
   [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40",
   [string]$ScreenshotDirectory = "",
-  [switch]$BuildImages
+  [switch]$BuildImages,
+  [switch]$RunValidation
 )
 
 $ErrorActionPreference = "Stop"
@@ -96,6 +97,21 @@ if (-not (Test-HttpReady "http://127.0.0.1:3000")) {
   Start-Sleep -Seconds 10
 } else {
   Write-Host "Workbench already responding on :3000"
+}
+
+if (-not $RunValidation) {
+  if (-not [string]::IsNullOrWhiteSpace($ScreenshotDirectory)) {
+    Write-Warning "ScreenshotDirectory is ignored unless -RunValidation is also supplied."
+  }
+
+  Write-Host ""
+  Write-Host "Canonical front-office stack is up."
+  Write-Host "  Workbench: http://workbench.dev.lotus"
+  Write-Host "  Gateway:   http://gateway.dev.lotus"
+  Write-Host "  Manage:    http://manage.dev.lotus"
+  Write-Host ""
+  Write-Host "Run 'npm run live:validate' from lotus-workbench when you want end-to-end validation."
+  return
 }
 
 Write-Host "Running canonical live validation ..."


### PR DESCRIPTION
## Summary
- split canonical runtime startup from end-to-end validation
- add an explicit `live:stack:up:validate` path for the combined flow
- update the canonical runtime runbook to reflect the new operator workflow

## Validation
- PowerShell parse check for `scripts/live/Start-LotusFrontOfficeCanonical.ps1`
- `package.json` parse check
- `git diff --check`