### PR TITLE
docs: standardize lotus-workbench readme and wiki

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+# Lotus Agent Operating Contract
+
+This is the governed operating contract for Lotus agent work.
+
+Repo-root `AGENTS.md` files across Lotus repositories and the deployed local `AGENTS.md` should
+remain synchronized copies of this file.
+
+Use `automation/Sync-AgentOperatingContract.ps1` to synchronize or verify that deployed copy.
+
+## Mandatory Reading Order
+
+Before doing substantial work, load context in this order:
+
+1. `AGENTS.md`
+2. `lotus-platform/context/LOTUS-QUICKSTART-CONTEXT.md`
+3. `lotus-platform/context/LOTUS-ENGINEERING-CONTEXT.md`
+4. the target repository's `REPOSITORY-ENGINEERING-CONTEXT.md`
+5. `lotus-platform/context/CONTEXT-REFERENCE-MAP.md`
+6. `lotus-platform/context/PROCEDURAL-MEMORY-INDEX.md` when the task is primarily about how work should be executed
+
+Use the smallest correct working set. Do not load broad context blindly if the task is narrow.
+
+## Mandatory Operating Rules
+
+Always:
+
+1. reduce complexity where possible,
+2. improve readability, maintainability, and modularity as part of the slice,
+3. make code and test improvements that materially improve reliability and maintainability,
+4. update documentation when platform or repository truth changes,
+5. leave the codebase cleaner than you found it,
+6. write meaningful, high-value tests and avoid superficial coverage,
+7. keep commits small, meaningful, and truthful,
+8. remove dead code, duplicate logic, and stale non-standard handling when encountered,
+9. ensure every UI feature is genuinely backed by supported backend functionality.
+
+## Delivery Posture
+
+Operate as a banking-grade engineer, not a generic coding assistant.
+
+That means:
+
+1. prefer truthful implementation over cosmetic output,
+2. prefer reusable patterns over local hacks,
+3. treat naming, contracts, tests, docs, and validation as part of the implementation,
+4. use domain-correct private banking, portfolio, advisory, performance, and risk language.
+
+## Skills, Automation, And Async Execution
+
+When the task matches an available Lotus skill, use it.
+
+Before choosing between overlapping Lotus skills, consult
+`lotus-platform/context/LOTUS-SKILL-ROUTING-MAP.md`.
+
+Prefer:
+
+1. standards, validators, and runbooks before inventing a new pattern,
+2. repo-native commands before ad hoc command sequences,
+3. targeted local checks for quick proof,
+4. GitHub-backed heavy execution for expensive full validation,
+5. async monitoring and fix-forward work rather than blocking on long reruns.
+
+When a task is explicitly about canonical populated Workbench surfaces, demo screenshots, or
+`PB_SG_GLOBAL_BAL_001`, choose `lotus-front-office-runtime` first and use broader QA or delivery
+skills only as supporting guidance.
+
+## Front-Office Runtime Routing Rule
+
+When the task is about:
+
+1. local front-office runtime bring-up,
+2. populated Workbench screens,
+3. panel validation,
+4. demo screenshots,
+5. canonical UI proof,
+
+use the governed `lotus-workbench` runtime and validation flow first:
+
+1. `lotus-workbench/docs/operations/canonical-front-office-local-runtime.md`
+2. `npm run live:stack:up`
+3. `npm run live:validate`
+4. `npm run live:stack:down`
+5. `lotus-platform/automation/Invoke-Canonical-FrontOffice-QA.ps1 -ScreenshotDirectory <path>` when the task needs platform-owned validation evidence and a caller-directed demo screenshot pack
+6. `lotus-platform/context/contracts/canonical-front-office-demo-data-contract.json`
+7. `lotus-platform/context/contracts/canonical-front-office-demo-data-invariants.json`
+
+Use `PB_SG_GLOBAL_BAL_001` as the governed seeded front-office portfolio unless the task explicitly requires another dataset.
+
+Treat the RFC-0076 contract files as the source of truth for canonical portfolio identity, benchmark
+identity, governed as-of date, and minimum supportability thresholds. Runtime evidence should carry
+contract provenance instead of relying on implicit repo convention.
+
+Do not treat `lotus-platform/platform-stack` as the canonical front-office product bring-up path. It owns shared ingress and infrastructure support, not the full governed product-surface flow.
+
+Do not capture or share demo-ready screenshots before canonical API, calculation, and panel validation pass. If a pre-validation capture is necessary for diagnosis, label it with a `diagnostic-` prefix and keep it separate from demo evidence.
+
+## Context Maintenance Rule
+
+Keep the context system up to date as Lotus changes.
+
+Update the relevant context artifacts when:
+
+1. platform architecture changes,
+2. repository responsibilities change,
+3. canonical commands or validation flows change,
+4. CI or governance expectations change,
+5. a repeatable pattern should become durable guidance,
+6. domain vocabulary or operating assumptions materially change.
+
+If the change is platform-wide:
+
+1. update the central context system in `lotus-platform/context/`.
+2. update `LOTUS-SKILL-ROUTING-MAP.md` if task routing expectations changed.
+
+If the change is repository-local:
+
+1. update that repository's `REPOSITORY-ENGINEERING-CONTEXT.md`.
+
+If both changed:
+
+1. update both in the same slice.
+
+## Cross-Links
+
+Central context system:
+
+1. `<lotus-platform>/context/LOTUS-QUICKSTART-CONTEXT.md`
+2. `<lotus-platform>/context/LOTUS-ENGINEERING-CONTEXT.md`
+3. `<lotus-platform>/context/CONTEXT-REFERENCE-MAP.md`
+4. `<lotus-platform>/context/PROCEDURAL-MEMORY-INDEX.md`
+5. `<lotus-platform>/context/LOTUS-SKILL-ROUTING-MAP.md`
+6. `<lotus-platform>/context/lotus-context-manifest.json`
+7. `<lotus-platform>/context/platform-engineering-ledger.md`
+8. `<lotus-platform>/context/recent-architectural-decisions-digest.md`
+9. `<lotus-platform>/docs/onboarding/LOTUS-DEVELOPER-ONBOARDING.md`
+10. `<lotus-platform>/docs/onboarding/LOTUS-AGENT-RAMP-UP.md`
+
+Repository-local context:
+
+1. `REPOSITORY-ENGINEERING-CONTEXT.md` in the repository you are changing
+
+When the central contract changes, keep both this source file and the deployed `AGENTS.md` synchronized.

--- a/README.md
+++ b/README.md
@@ -1,213 +1,243 @@
 # lotus-workbench
 
-Unified product workspace for the Lotus ecosystem, evolving from proposal-first slices into a
-world-class multi-application operating surface for portfolio, analytics, risk, proposal,
-management, and reporting workflows.
+Primary product UI for the Lotus ecosystem, consumed through `lotus-gateway`.
 
-## Contribution Standards
+Repository-local engineering context:
+[REPOSITORY-ENGINEERING-CONTEXT.md](REPOSITORY-ENGINEERING-CONTEXT.md)
 
-- Contribution process: `CONTRIBUTING.md`
-- Repository-local engineering context: `REPOSITORY-ENGINEERING-CONTEXT.md`
-- Docs-with-code standard: `docs/documentation/implementation-documentation-standard.md`
-- PR checklist template: `.github/pull_request_template.md`
-- Platform-wide architecture governance source: `https://github.com/sgajbi/lotus-platform`
+Product architecture blueprint:
+[docs/documentation/product-architecture-blueprint.md](docs/documentation/product-architecture-blueprint.md)
 
-## Standard Frontend Stack
+Canonical front-office local runtime:
+[docs/operations/canonical-front-office-local-runtime.md](docs/operations/canonical-front-office-local-runtime.md)
 
-- Next.js (App Router)
-- React + TypeScript
-- TanStack Query
-- MUI
-- AG Grid
-- ECharts
-- React Hook Form
-- Zod
+## Purpose And Scope
 
-## Architecture Direction
+`lotus-workbench` owns the user-facing product experience for Lotus.
 
-- Product architecture blueprint:
-  `docs/documentation/product-architecture-blueprint.md`
-- Platform-wide architecture governance source:
-  `https://github.com/sgajbi/lotus-platform`
-- Current RFC history:
-  `docs/rfcs/README.md`
+It is responsible for:
 
-## Design System Foundation
+- coherent front-office user experience
+- truthful summary-first workflows
+- detail-on-demand product modules
+- rendering gateway-backed data in a banking-grade product surface
+- canonical local runtime and browser validation for supported product flows
 
-- Shared frontend primitives live in `src/design-system/`
-- Shared shell composition lives in `src/shell/`
-- New product surfaces should prefer design-system primitives over page-local structural markup
-- The current reference implementation is the `Portfolio` surface under `src/apps/portfolio/`
+It does not own portfolio, performance, risk, advisory, reporting, or AI business truth. Those stay
+behind governed backend contracts, primarily `lotus-gateway`.
 
-## App Package Direction
+## Ownership And Boundaries
 
-- `src/app/` owns route mounting only
-- `src/apps/home/` owns the home entry redirect
-- `src/apps/portfolio/` owns the portfolio workspace
-- `src/apps/performance/` owns the performance entry behavior
-- `src/apps/recommendations/` owns the recommendations entry behavior
+`lotus-workbench` is the primary product client in the Lotus ecosystem.
 
-## Quickstart
+It depends on:
+
+- `lotus-gateway`
+  primary backend contract for product flows
+- canonical `*.dev.lotus` runtime and ingress
+  governed local validation and screenshot posture
+- repo-local design-system and shell primitives
+  shared presentation and interaction foundations
+
+Boundary rules that matter:
+
+1. supported UI states must be backed by supported gateway behavior
+2. direct raw service consumption is not the default pattern
+3. presentation can prioritize and frame data, but domain authority stays upstream
+4. visual polish must not introduce fake data, duplicate meaning, or unsupported workflow states
+
+## Current Operational Posture
+
+1. `Portfolio` and `Performance` are the most mature live workflows.
+2. `lotus-workbench` uses `lotus-gateway` as its primary backend contract.
+3. Canonical local product proof uses the governed front-office runtime and seeded portfolio
+   `PB_SG_GLOBAL_BAL_001`.
+4. Recommendations and proposals routes still exist as compatibility paths, but they are no longer
+   the primary supported front-office app surfaces.
+
+## Architecture At A Glance
+
+Route mounting comes from `src/app/`, while app-local ownership lives under `src/apps/`.
+
+Current main surfaces:
+
+- `portfolio`
+  `/portfolio`, `/portfolios`, `/intake`
+- `performance`
+  `/performance` with performance, risk, advisor-brief, and evidence modes
+- `workbench`
+  `/workbench/*` compatibility and portfolio-linked workspace entry
+- `api/bff`
+  internal Next.js proxy bridge to `lotus-gateway`
+
+Current compatibility redirects:
+
+- `/recommendations`
+  redirects to supported active surfaces
+- `/proposals`, `/proposals/simulate`, `/proposals/[proposalId]`
+  compatibility routes, not primary active shell apps
+
+Key code areas:
+
+- `src/app/`
+  Next.js app-router entrypoints and route mounting
+- `src/apps/portfolio/`
+  portfolio workspace
+- `src/apps/performance/`
+  performance and risk product surfaces
+- `src/apps/recommendations/`
+  current compatibility redirect behavior for legacy recommendation entry
+- `src/design-system/`
+  shared UI primitives and tokens
+- `src/shell/`
+  app shell, navigation, and app registry
+- `tests/`
+  unit, integration, and Playwright smoke coverage
+
+## Repository Layout
+
+- `src/app/`
+  route entries, layouts, and the `/api/bff` gateway proxy bridge
+- `src/apps/`
+  app-local product surfaces
+- `src/design-system/`
+  shared tokens, components, and data-display primitives
+- `src/shell/`
+  navigation, app registry, and shared shell structure
+- `src/features/`
+  reusable feature-specific API and view-model logic
+- `docs/`
+  product architecture, operations, automation, demo, and review guidance
+- `wiki/`
+  canonical authored source for GitHub wiki publication
+
+## Quick Start
+
+Install dependencies:
 
 ```bash
-npm install
-npm run dev
+make install
 ```
 
-Open `http://workbench.dev.lotus`.
+Local development server:
 
-Preferred local entry points follow the RFC-0071 service identity model:
+```bash
+make run
+```
 
-- Workbench: `http://workbench.dev.lotus`
-- Gateway: `http://gateway.dev.lotus`
+Canonical local identities:
 
-Set `BFF_BASE_URL` to the environment-scoped gateway URL, for example `http://gateway.dev.lotus`.
+- product UI: `http://workbench.dev.lotus`
+- gateway: `http://gateway.dev.lotus`
 
-Canonical local runtime and live validation:
+Set:
 
-- Runbook: `docs/operations/canonical-front-office-local-runtime.md`
-- Manage the canonical `*.dev.lotus` hosts block from `lotus-platform` with
-  `automation/Sync-Dev-Ingress-Hosts.ps1`
-- Bring up the full front-office stack and validate it:
+```txt
+BFF_BASE_URL=http://gateway.dev.lotus
+```
+
+Canonical front-office runtime:
 
 ```bash
 npm run live:stack:up
-```
-
-- Bring the canonical stack down cleanly:
-
-```bash
-npm run live:stack:down
-```
-
-- Validate an already-running canonical stack:
-
-```bash
 npm run live:validate
 ```
 
-The live validator writes browser screenshots and a machine-readable validation artifact to:
+Quick local browser-facing path:
 
 ```txt
-output/playwright/live-canonical/
+http://workbench.dev.lotus/portfolio
+http://workbench.dev.lotus/performance
 ```
 
-## Quality Gate
+## Common Commands
 
-Frontend changes are expected to pass a hard CI gate before merge.
+- `make install`
+  install dependencies
+- `make lint`
+  lint the Next.js app
+- `make typecheck`
+  TypeScript typecheck
+- `make test-coverage`
+  Vitest coverage-backed unit and integration gate
+- `make test-e2e`
+  Playwright smoke validation
+- `make check`
+  local feature-lane parity: lint, typecheck, coverage, build
+- `make ci-local-docker`
+  Docker parity check
+- `npm run live:stack:up`
+  canonical front-office stack bring-up
+- `npm run live:validate`
+  canonical front-office validation against the running stack
 
-Lane model:
+## Validation And CI Lanes
 
-- `Remote Feature Lane`: lint, typecheck, and fast `npm run test`
-- `Pull Request Merge Gate`: lint, typecheck, coverage, build, Playwright smoke, Docker validation, and local Docker parity
-- `Main Releasability Gate`: reruns the PR-grade gate on `main` with retained artifacts
+`lotus-workbench` follows the Lotus multi-lane model:
 
-Required layers:
+1. `Remote Feature Lane`
+2. `Pull Request Merge Gate`
+3. `Main Releasability Gate`
 
-- unit and integration tests through Vitest coverage
-- Playwright smoke checks against a built Next.js app
-- lint, typecheck, and production build validation
+Repo-native gate mapping:
 
-Current enforced coverage thresholds in `vitest.config.ts`:
+- `make check`
+  lint, typecheck, coverage-backed tests, build
+- `make test-e2e`
+  Playwright smoke
+- `make ci-local-docker`
+  Docker parity
+- `npm run live:validate`
+  canonical integrated product validation when cross-app flows change
 
-- lines: `86`
-- statements: `86`
-- functions: `70`
-- branches: `74`
+## Product Contract Notes
 
-Coverage is enforced against the real application surface, not a hand-picked subset. The Vitest
-coverage include set spans:
+Important current product and route truths:
 
-- `src/app/**/*.ts`
-- `src/app/**/*.tsx`
-- `src/apps/**/*.ts`
-- `src/apps/**/*.tsx`
-- `src/design-system/**/*.ts`
-- `src/design-system/**/*.tsx`
-- `src/features/**/*.ts`
-- `src/features/**/*.tsx`
-- `src/shell/**/*.ts`
-- `src/shell/**/*.tsx`
+1. the active front-office surfaces are `Portfolio` and `Performance`
+2. `Risk` is currently served through the `Performance` route via mode-based behavior, not as a
+   separate top-level route
+3. `/recommendations` and `/proposals*` remain compatibility routes and should not be documented as
+   the main supported shell paths
+4. the internal `/api/bff/*` route proxies to `lotus-gateway` and preserves gateway-first
+   integration posture
 
-This is a temporary baseline for the broadened real-app surface. Future refactors are expected to
-raise it from here, not narrow the protected surface.
+Copy-paste route and runtime examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 
-Local commands:
+## Integration Boundaries
 
-```bash
-make test-coverage
-make test-e2e
-make check
-```
+- primary backend contract:
+  `lotus-gateway`
+- canonical local runtime:
+  `*.dev.lotus` direct ingress and governed seeded data
+- contract rule:
+  workbench should consume gateway-shaped product contracts instead of recreating backend semantics
+  in the browser
 
-CI must pass before merge.
+## Operations And Runtime Posture
 
-## Live Performance Demo
+- use `workbench.dev.lotus` and `gateway.dev.lotus` for canonical local product proof
+- use `npm run live:stack:up` and `npm run live:validate` for governed integrated validation
+- use seeded portfolio `PB_SG_GLOBAL_BAL_001` unless the slice explicitly targets another dataset
+- keep demo screenshots separate from diagnostic captures until canonical validation passes
 
-The current flagship demo path is the benchmark-aware performance workstation:
+## Documentation Map
 
-- UI: `http://workbench.dev.lotus/performance`
-- Gateway: `http://gateway.dev.lotus`
-- Required upstreams:
-  - `lotus-core` query: `http://core-query.dev.lotus`
-  - `lotus-core` control plane: `http://core-control.dev.lotus`
-  - `lotus-core` ingestion: `http://core-ingestion.dev.lotus`
-  - `lotus-performance`: `http://performance.dev.lotus`
-  - `lotus-ai`: `http://ai.dev.lotus`
+- product architecture:
+  [docs/documentation/product-architecture-blueprint.md](docs/documentation/product-architecture-blueprint.md)
+- canonical local runtime:
+  [docs/operations/canonical-front-office-local-runtime.md](docs/operations/canonical-front-office-local-runtime.md)
+- demo guidance:
+  [docs/demo/README.md](docs/demo/README.md)
+- architecture review ledger:
+  [docs/architecture/CODEBASE-REVIEW-LEDGER.md](docs/architecture/CODEBASE-REVIEW-LEDGER.md)
+- RFC inventory:
+  [docs/rfcs/README.md](docs/rfcs/README.md)
+- wiki home:
+  [wiki/Home.md](wiki/Home.md)
 
-Flagship seeded mandate and benchmarks:
+## Wiki Source
 
-- portfolio: `PB_SG_GLOBAL_BAL_001`
-- assigned benchmark: `BMK_PB_GLOBAL_BALANCED_60_40` (`Private Banking Global Balanced 60/40`)
-- alternate benchmark: `BMK_GLOBAL_BALANCED_60_40` (`Global Balanced 60/40`)
-
-Expected live behavior:
-
-- the `Performance` route first paints benchmark-aware summary context immediately
-- the chart stage supports horizon, explicit dates, basis, frequency, and benchmark switching
-- the lower analytical canvas refreshes independently for heavy analytical modules
-- the multi-horizon comparison module shows `MTD`, `QTD`, `YTD`, and `1Y`
-- attribution-over-time, contribution, and relative segment analytics use real gateway data
-- `Advisor Brief` is a third Performance mode that fetches a source-grounded brief from Gateway,
-  shows evidence-backed talking points and drill-down actions, and degrades to truthful partial
-  or unavailable states when `lotus-ai` or source analytics are not ready
-
-## Current Routes
-
-- `/portfolio` - primary portfolio review surface for holdings, allocation, readiness, and next actions
-- `/performance` - front-office entry route for performance review
-- `/recommendations` - front-office entry route for investment recommendations
-- `/proposals/simulate` - recommendation drafting flow
-- `/proposals` - recommendation workspace list
-- `/proposals/[proposalId]` - recommendation detail with submit/approval/consent actions and workflow timeline
-- `/workbench/[portfolioId]` - legacy operational console compatibility route
-
-These routes are the current implementation baseline, not the final product topology. The target
-future direction is an app-shell model documented in
-`docs/documentation/product-architecture-blueprint.md`.
-
-## Docker
-
-```bash
-make docker-up
-make docker-down
-
-make ci-local-docker
-make ci-local-docker-down
-```
-
-## Demo Pack
-
-- `docs/demo/README.md`
-- `docs/demo/scripts/demo-ui-approval-chain.md`
-
-## Automation
-
-- Automation runbook: `docs/automation/Automation-Ecosystem.md`
-- One-shot pulse (sync + PR monitor): `npm run auto:pulse`
-- Sync all repositories: `npm run auto:sync`
-- Monitor open PRs (`author:@me`): `npm run auto:pr`
-- Continuous agent loop with status feed: `npm run auto:agent`
-- Single agent iteration: `npm run auto:agent:once`
-- Targeted lotus-core refresh: `npm run auto:refresh:pas -- query_service demo_data_loader`
-
+Repository-authored wiki pages live under [wiki/](wiki). If the GitHub wiki is published later,
+keep `wiki/` as the canonical source and treat any separate `*.wiki.git` clone as publication
+plumbing only.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Boundary rules that matter:
    `PB_SG_GLOBAL_BAL_001`.
 4. Recommendations and proposals routes still exist as compatibility paths, but they are no longer
    the primary supported front-office app surfaces.
+5. Top-level shell navigation is capability-gated: `Portfolio`, `Performance`, and `Risk` are
+   active, while `Proposal` and `Advisory` remain disabled in the current normalized shell
+   bootstrap contract.
+6. Canonical review-ready browser evidence comes from `npm run live:validate` artifacts under
+   `output/playwright/live-canonical/`, not from ad hoc localhost screenshots.
 
 ## Architecture At A Glance
 
@@ -69,6 +74,13 @@ Current main surfaces:
   `/workbench/*` compatibility and portfolio-linked workspace entry
 - `api/bff`
   internal Next.js proxy bridge to `lotus-gateway`
+
+Current shell navigation truth:
+
+- active:
+  `Portfolio`, `Performance`, `Risk`
+- currently disabled by capability posture:
+  `Proposal`, `Advisory`
 
 Current compatibility redirects:
 
@@ -148,6 +160,7 @@ Quick local browser-facing path:
 ```txt
 http://workbench.dev.lotus/portfolio
 http://workbench.dev.lotus/performance
+http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk
 ```
 
 ## Common Commands
@@ -201,6 +214,10 @@ Important current product and route truths:
    the main supported shell paths
 4. the internal `/api/bff/*` route proxies to `lotus-gateway` and preserves gateway-first
    integration posture
+5. shell navigation availability is contract-driven and currently exposes disabled `Proposal` and
+   `Advisory` items rather than live product routes
+6. evidence-oriented performance views must be documented truthfully as runtime-governed product
+   behavior, not as a promise of separate unsupported backend ownership inside Workbench
 
 Copy-paste route and runtime examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 
@@ -220,6 +237,9 @@ Copy-paste route and runtime examples live in [wiki/API-Surface.md](wiki/API-Sur
 - use `npm run live:stack:up` and `npm run live:validate` for governed integrated validation
 - use seeded portfolio `PB_SG_GLOBAL_BAL_001` unless the slice explicitly targets another dataset
 - keep demo screenshots separate from diagnostic captures until canonical validation passes
+- canonical live validation artifacts are written under `output/playwright/live-canonical/`
+- use `output/playwright/live-canonical/live-validation-summary.json` as the structured evidence
+  record for review and troubleshooting
 
 ## Documentation Map
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -60,6 +60,8 @@ Primary areas:
    Shared shell composition and application framing.
 7. `tests/`
    Unit, integration, and Playwright smoke coverage.
+8. `wiki/`
+   canonical authored source for GitHub wiki publication and operator-facing Workbench summaries.
 
 ## Runtime And Integration Boundaries
 
@@ -111,7 +113,9 @@ Important validation expectations:
 1. unit and integration behavior is validated through Vitest coverage,
 2. browser smoke is validated through Playwright,
 3. Docker and build validation remain part of the merge gate,
-4. canonical live validation matters when a change affects integrated product flows.
+4. canonical live validation matters when a change affects integrated product flows,
+5. README and wiki updates should keep active product-surface truth explicit, especially when
+   legacy compatibility routes still exist beside the supported Portfolio and Performance paths.
 
 ### Visual Review Gate
 
@@ -145,7 +149,9 @@ Most relevant current governance:
 1. this repository evolves quickly, so stale UX assumptions and stale E2E expectations are a recurring drift risk,
 2. design-system and shell primitives should be preferred over page-local hacks,
 3. premium banking-grade UI in Lotus means clarity, density, trust, and backend truth over decorative novelty,
-4. when a screen changes materially, tests and docs should be updated in the same slice.
+4. when a screen changes materially, tests and docs should be updated in the same slice,
+5. repo-local `wiki/` content should summarize supported product surfaces, canonical runtime flow,
+   and legacy route posture without duplicating the full `docs/` tree.
 
 ## Context Maintenance Rule
 
@@ -155,7 +161,8 @@ Update this document when:
 2. repo-native commands or CI expectations change,
 3. the gateway-first integration model changes,
 4. dominant design-system or shell patterns change,
-5. current product-surface maturity or rollout posture materially changes.
+5. current product-surface maturity or rollout posture materially changes,
+6. active versus legacy route posture changes.
 
 ## Cross-Links
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -115,7 +115,12 @@ Important validation expectations:
 3. Docker and build validation remain part of the merge gate,
 4. canonical live validation matters when a change affects integrated product flows,
 5. README and wiki updates should keep active product-surface truth explicit, especially when
-   legacy compatibility routes still exist beside the supported Portfolio and Performance paths.
+   legacy compatibility routes still exist beside the supported Portfolio and Performance paths,
+6. product docs should distinguish active shell navigation from disabled or compatibility-only
+   routes when the shell bootstrap contract does not treat every historical route as supported,
+7. route-file existence alone is not enough for documentation truth; use shell registry,
+   capabilities tests, redirect behavior, and canonical runtime guidance before describing a surface
+   as supported.
 
 ### Visual Review Gate
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -1,0 +1,54 @@
+# API Surface
+
+## Product routes
+
+- `/portfolio`
+- `/portfolios`
+- `/intake`
+- `/performance`
+- `/workbench`
+- `/workbench/{portfolioId}`
+- `/api/bff/*`
+
+## Compatibility routes
+
+- `/recommendations`
+  redirects to supported active surfaces
+- `/proposals`
+- `/proposals/simulate`
+- `/proposals/{proposalId}`
+  compatibility redirects, not primary shell apps
+
+## Current contract notes
+
+- risk is currently served through `/performance` route mode selection, not a separate top-level URL
+- internal browser-to-gateway traffic can flow through `/api/bff/*`
+- canonical product proof should use `workbench.dev.lotus`, not ad hoc localhost URLs
+
+## Route examples
+
+Portfolio:
+
+```txt
+http://workbench.dev.lotus/portfolio
+```
+
+Performance:
+
+```txt
+http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001
+```
+
+Performance risk mode:
+
+```txt
+http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk
+```
+
+Compatibility recommendation redirect:
+
+```txt
+http://workbench.dev.lotus/recommendations?portfolioId=PB_SG_GLOBAL_BAL_001
+```
+
+These examples are here to keep the active-versus-legacy route posture explicit.

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -10,6 +10,16 @@
 - `/workbench/{portfolioId}`
 - `/api/bff/*`
 
+## Capability-gated shell navigation
+
+- active product entries:
+  `Portfolio`, `Performance`, `Risk`
+- disabled entries in the current normalized shell bootstrap contract:
+  `Proposal`, `Advisory`
+
+Treat the active shell contract as the source of truth for supported front-office navigation. Do not
+promote dormant labels into product ownership just because historical route files still exist.
+
 ## Compatibility routes
 
 - `/recommendations`
@@ -24,6 +34,10 @@
 - risk is currently served through `/performance` route mode selection, not a separate top-level URL
 - internal browser-to-gateway traffic can flow through `/api/bff/*`
 - canonical product proof should use `workbench.dev.lotus`, not ad hoc localhost URLs
+- shell navigation support is narrower than the historical route set: `Proposal` and `Advisory`
+  are currently disabled even though compatibility routes still exist
+- canonical evidence should be taken from `output/playwright/live-canonical/` after
+  `npm run live:validate`
 
 ## Route examples
 
@@ -45,10 +59,25 @@ Performance risk mode:
 http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk
 ```
 
+Capability-gated navigation truth:
+
+```txt
+Active: Portfolio, Performance, Risk
+Disabled: Proposal, Advisory
+```
+
 Compatibility recommendation redirect:
 
 ```txt
 http://workbench.dev.lotus/recommendations?portfolioId=PB_SG_GLOBAL_BAL_001
 ```
 
-These examples are here to keep the active-versus-legacy route posture explicit.
+Compatibility proposal redirect posture:
+
+```txt
+/proposals -> /portfolio
+/proposals/{proposalId} -> /portfolio
+/proposals/simulate?portfolioId=PB_SG_GLOBAL_BAL_001 -> /performance?portfolioId=PB_SG_GLOBAL_BAL_001
+```
+
+These examples keep the active-versus-legacy route posture explicit.

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,28 @@
+# Architecture
+
+## Runtime model
+
+- Next.js App Router application
+- app-route mounting under `src/app/`
+- app-local product ownership under `src/apps/`
+- shared primitives under `src/design-system/`
+- shell composition under `src/shell/`
+- internal `/api/bff/*` proxy bridge to `lotus-gateway`
+
+## Product-surface map
+
+- `Portfolio`
+  primary holdings, allocation, readiness, and next-actions experience
+- `Performance`
+  benchmark-aware performance, analysis, advisor brief, evidence, and risk modes
+- `Workbench`
+  compatibility workspace entry and portfolio-linked operational route
+- legacy compatibility surfaces
+  recommendations and proposals redirects
+
+## Boundary notes
+
+1. workbench consumes gateway-shaped contracts
+2. domain truth stays upstream
+3. shell and design-system primitives should be preferred over page-local hacks
+4. legacy compatibility routes should not be documented as the main active topology

--- a/wiki/Development-Workflow.md
+++ b/wiki/Development-Workflow.md
@@ -1,0 +1,23 @@
+# Development Workflow
+
+## Branching and slice model
+
+- branch from `main`
+- keep one branch per RFC or documentation slice
+- use PR-first delivery
+
+## Repo-native commands
+
+- `make lint`
+- `make typecheck`
+- `make test-coverage`
+- `make test-e2e`
+- `make check`
+- `make ci-local-docker`
+
+## Documentation workflow
+
+- keep `README.md` as the front door for supported product truth
+- keep `wiki/` as the authored wiki source
+- route runtime and route examples into the wiki
+- keep deep product-architecture and runtime details in `docs/`

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,48 @@
+# Getting Started
+
+## Install
+
+```bash
+make install
+```
+
+## Local development
+
+```bash
+make run
+```
+
+## Canonical local runtime
+
+```bash
+npm run live:stack:up
+npm run live:validate
+```
+
+Canonical identities:
+
+- workbench: `http://workbench.dev.lotus`
+- gateway: `http://gateway.dev.lotus`
+
+Required environment posture:
+
+```txt
+BFF_BASE_URL=http://gateway.dev.lotus
+```
+
+## First checks
+
+```txt
+http://workbench.dev.lotus/portfolio
+http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001
+```
+
+If the product loads against localhost but not the canonical hostnames, fix the governed hosts and
+runtime flow before debugging UI components.
+
+## First docs to read
+
+- [README.md](../README.md)
+- [REPOSITORY-ENGINEERING-CONTEXT.md](../REPOSITORY-ENGINEERING-CONTEXT.md)
+- [docs/operations/canonical-front-office-local-runtime.md](../docs/operations/canonical-front-office-local-runtime.md)
+- [docs/documentation/product-architecture-blueprint.md](../docs/documentation/product-architecture-blueprint.md)

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -35,6 +35,7 @@ BFF_BASE_URL=http://gateway.dev.lotus
 ```txt
 http://workbench.dev.lotus/portfolio
 http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001
+http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk
 ```
 
 If the product loads against localhost but not the canonical hostnames, fix the governed hosts and

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -16,6 +16,7 @@
 - primary product client for Lotus
 - Portfolio and Performance are the most mature active front-office surfaces
 - recommendations and proposals remain compatibility routes, not the main supported shell apps
+- shell navigation currently treats `Proposal` and `Advisory` as disabled capability-gated entries
 
 ## Most important commands
 
@@ -24,6 +25,13 @@
 - `make test-e2e`
 - `npm run live:stack:up`
 - `npm run live:validate`
+
+## Review evidence
+
+- canonical validation output:
+  `output/playwright/live-canonical/`
+- governed seeded portfolio:
+  `PB_SG_GLOBAL_BAL_001`
 
 ## Navigation
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,41 @@
+# lotus-workbench wiki
+
+`lotus-workbench` is the primary product UI for Lotus.
+
+## Start here
+
+- Repo entrypoint: [README.md](../README.md)
+- Repo context: [REPOSITORY-ENGINEERING-CONTEXT.md](../REPOSITORY-ENGINEERING-CONTEXT.md)
+- Product architecture blueprint:
+  [docs/documentation/product-architecture-blueprint.md](../docs/documentation/product-architecture-blueprint.md)
+- Canonical local runtime:
+  [docs/operations/canonical-front-office-local-runtime.md](../docs/operations/canonical-front-office-local-runtime.md)
+
+## Current phase
+
+- primary product client for Lotus
+- Portfolio and Performance are the most mature active front-office surfaces
+- recommendations and proposals remain compatibility routes, not the main supported shell apps
+
+## Most important commands
+
+- `make install`
+- `make check`
+- `make test-e2e`
+- `npm run live:stack:up`
+- `npm run live:validate`
+
+## Navigation
+
+- [Overview](Overview)
+- [Architecture](Architecture)
+- [API Surface](API-Surface)
+- [Getting Started](Getting-Started)
+- [Development Workflow](Development-Workflow)
+- [Validation and CI](Validation-and-CI)
+- [Operations Runbook](Operations-Runbook)
+- [Integrations](Integrations)
+- [Security and Governance](Security-and-Governance)
+- [RFC Index](RFC-Index)
+- [Roadmap](Roadmap)
+- [Troubleshooting](Troubleshooting)

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -1,0 +1,31 @@
+# Integrations
+
+## Primary backend posture
+
+- `lotus-gateway`
+  primary backend contract for product flows
+
+## Canonical local runtime participants
+
+- `lotus-core`
+- `lotus-performance`
+- `lotus-risk`
+- `lotus-ai`
+- `lotus-advise`
+- `lotus-manage`
+- `lotus-report`
+- `lotus-gateway`
+- `lotus-workbench`
+
+## Canonical local identities
+
+- workbench:
+  `http://workbench.dev.lotus`
+- gateway:
+  `http://gateway.dev.lotus`
+
+## Contract notes
+
+1. gateway-first integration is the default
+2. `/api/bff/*` is an internal bridge, not a second product API authority
+3. canonical front-office validation depends on governed `*.dev.lotus` routing and seeded data

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -29,3 +29,5 @@
 1. gateway-first integration is the default
 2. `/api/bff/*` is an internal bridge, not a second product API authority
 3. canonical front-office validation depends on governed `*.dev.lotus` routing and seeded data
+4. shell navigation supportability is informed by gateway-backed capability posture rather than by
+   the mere existence of historical routes

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -1,0 +1,29 @@
+# Operations Runbook
+
+## Important operational checks
+
+- use `workbench.dev.lotus` and `gateway.dev.lotus` for canonical product proof
+- use seeded portfolio `PB_SG_GLOBAL_BAL_001` unless the slice explicitly targets another dataset
+- keep diagnostic screenshots separate from final demo evidence
+- validate the canonical stack before treating screenshots as review-ready
+
+## Practical runtime flow
+
+```powershell
+npm run live:stack:up
+npm run live:validate
+npm run live:stack:down
+```
+
+## Browser-facing probes
+
+```txt
+http://workbench.dev.lotus/portfolio
+http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001
+http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk
+```
+
+## Key references
+
+- [docs/operations/canonical-front-office-local-runtime.md](../docs/operations/canonical-front-office-local-runtime.md)
+- [docs/demo/README.md](../docs/demo/README.md)

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -6,6 +6,8 @@
 - use seeded portfolio `PB_SG_GLOBAL_BAL_001` unless the slice explicitly targets another dataset
 - keep diagnostic screenshots separate from final demo evidence
 - validate the canonical stack before treating screenshots as review-ready
+- treat capability-disabled shell entries as contract truth, not as something to work around in
+  demo documentation
 
 ## Practical runtime flow
 
@@ -22,6 +24,20 @@ http://workbench.dev.lotus/portfolio
 http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001
 http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk
 ```
+
+## Output paths
+
+- screenshots and summary:
+  `output/playwright/live-canonical/`
+- machine-readable summary:
+  `output/playwright/live-canonical/live-validation-summary.json`
+
+## Review-ready evidence
+
+- use canonical validated captures for demos, PR review, and operator handoff
+- keep pre-validation captures clearly labeled as diagnostic artifacts only
+- when a route exists but is capability-disabled, capture the supported active path instead of the
+  dormant compatibility page
 
 ## Key references
 

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -1,0 +1,28 @@
+# Overview
+
+## Business role
+
+`lotus-workbench` is the primary front-office product UI for Lotus. It presents gateway-backed
+portfolio, performance, risk, advisory-brief, and evidence workflows in one governed shell.
+
+## Ownership boundaries
+
+This repo owns:
+
+1. user-facing product workflows
+2. shell and design-system presentation behavior
+3. truthful summary-first interaction patterns
+4. canonical front-office browser validation
+
+This repo does not own:
+
+1. domain data truth
+2. gateway or direct backend contract ownership
+3. analytics, risk, reporting, or AI methodology
+
+## Current posture
+
+- gateway-first product client
+- Portfolio and Performance are the active front-office paths
+- risk is served through Performance route modes
+- recommendations and proposals remain compatibility entrypoints rather than active shell apps

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -26,3 +26,5 @@ This repo does not own:
 - Portfolio and Performance are the active front-office paths
 - risk is served through Performance route modes
 - recommendations and proposals remain compatibility entrypoints rather than active shell apps
+- shell navigation currently exposes disabled `Proposal` and `Advisory` items through normalized
+  capability posture rather than treating them as active supported apps

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -1,0 +1,18 @@
+# RFC Index
+
+## Most relevant local RFCs
+
+- RFC-0070
+  product-experience ownership and quality standard
+- RFC-0071
+  canonical service identity and ingress posture
+- RFC-0072
+  CI and validation governance
+- RFC-0073
+  context and agent guidance system
+
+## Local references
+
+- [docs/rfcs/README.md](../docs/rfcs/README.md)
+- [docs/documentation/product-architecture-blueprint.md](../docs/documentation/product-architecture-blueprint.md)
+- [docs/operations/canonical-front-office-local-runtime.md](../docs/operations/canonical-front-office-local-runtime.md)

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -1,0 +1,17 @@
+# Roadmap
+
+## Current phase
+
+- active premium front-office product client
+- Portfolio and Performance are the strongest current app surfaces
+
+## Intentional limitations
+
+- some historical compatibility routes still exist
+- workbench topology is still converging toward the target shell and app map
+
+## Next priorities
+
+1. keep strengthening Portfolio and Performance truth and density
+2. preserve gateway-first integration discipline
+3. continue aligning route ownership to the product architecture blueprint

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -23,3 +23,5 @@
 - keep active product-surface truth explicit
 - treat Portfolio and Performance as the supported front-office paths
 - document compatibility redirects without presenting them as active product ownership
+- distinguish disabled shell entries from active apps when capability posture says they are not
+  supported yet

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -1,0 +1,25 @@
+# Security and Governance
+
+## Current governance
+
+- RFC-0070
+  gold-standard product experience foundation and ownership model
+- RFC-0071
+  environment-scoped service identity and ingress governance
+- RFC-0072
+  multi-lane CI and release governance
+- RFC-0073
+  context and agent guidance system
+
+## Repo-specific guardrails
+
+- gateway-first product integration
+- canonical seeded-data runtime validation
+- Playwright browser smoke and coverage-backed tests
+- no unsupported UI states or fabricated data
+
+## Operational discipline
+
+- keep active product-surface truth explicit
+- treat Portfolio and Performance as the supported front-office paths
+- document compatibility redirects without presenting them as active product ownership

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -4,6 +4,8 @@
 
 - if the UI looks right on localhost but breaks on canonical hosts, fix the runtime and host mapping first
 - if a route appears active in old docs, verify whether it is now a compatibility redirect
+- if `Proposal` or `Advisory` appear unavailable, check shell capabilities before treating that as
+  a regression
 - if a screen looks populated but canonical validation fails, treat it as diagnostic evidence only
 - if product data looks wrong, inspect gateway responses before adjusting frontend presentation
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,21 @@
+# Troubleshooting
+
+## Common checks
+
+- if the UI looks right on localhost but breaks on canonical hosts, fix the runtime and host mapping first
+- if a route appears active in old docs, verify whether it is now a compatibility redirect
+- if a screen looks populated but canonical validation fails, treat it as diagnostic evidence only
+- if product data looks wrong, inspect gateway responses before adjusting frontend presentation
+
+## Useful commands
+
+```bash
+make check
+make test-e2e
+npm run live:validate
+```
+
+## References
+
+- [docs/operations/canonical-front-office-local-runtime.md](../docs/operations/canonical-front-office-local-runtime.md)
+- [docs/architecture/CODEBASE-REVIEW-LEDGER.md](../docs/architecture/CODEBASE-REVIEW-LEDGER.md)

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -25,3 +25,18 @@
 - browser smoke for supported front-office flows
 - Docker parity for production-like runtime assumptions
 - canonical seeded-data validation for integrated product proof
+
+## Evidence posture
+
+- canonical browser validation writes screenshots and structured summary output under
+  `output/playwright/live-canonical/`
+- final visual review should use canonical validated captures, not pre-validation diagnostics
+
+## Canonical live validation coverage
+
+The governed front-office validation flow checks the seeded `PB_SG_GLOBAL_BAL_001` runtime across:
+
+- portfolio summary and detailed surfaces
+- performance summary and analysis surfaces
+- advisor-brief and risk modes inside the performance experience
+- evidence-oriented product validation paths that are part of the current governed runtime

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -1,0 +1,27 @@
+# Validation and CI
+
+## Lane model
+
+`lotus-workbench` uses:
+
+1. `Remote Feature Lane`
+2. `Pull Request Merge Gate`
+3. `Main Releasability Gate`
+
+## Local command mapping
+
+- `make check`
+  lint, typecheck, coverage-backed test gate, build
+- `make test-e2e`
+  Playwright smoke validation
+- `make ci-local-docker`
+  Docker parity
+- `npm run live:validate`
+  canonical integrated product validation
+
+## What the gates protect
+
+- real app-surface coverage across the active product paths
+- browser smoke for supported front-office flows
+- Docker parity for production-like runtime assumptions
+- canonical seeded-data validation for integrated product proof

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,19 @@
+[Home](Home)
+
+### Orientation
+- [Overview](Overview)
+- [Architecture](Architecture)
+- [API Surface](API-Surface)
+- [Getting Started](Getting-Started)
+
+### Delivery
+- [Development Workflow](Development-Workflow)
+- [Validation and CI](Validation-and-CI)
+- [Operations Runbook](Operations-Runbook)
+- [Troubleshooting](Troubleshooting)
+
+### Boundaries
+- [Integrations](Integrations)
+- [Security and Governance](Security-and-Governance)
+- [RFC Index](RFC-Index)
+- [Roadmap](Roadmap)


### PR DESCRIPTION
## Summary
- add the repo-root `AGENTS.md` operating contract
- rewrite the README into a product-UI front door with gateway-first boundaries, canonical runtime guidance, and active-versus-legacy route truth
- add authored wiki source pages for product surfaces, route examples, setup, validation, operations, integrations, governance, RFCs, troubleshooting, and roadmap
- update `REPOSITORY-ENGINEERING-CONTEXT.md` so future agents keep supported surface truth explicit and avoid overstating legacy compatibility routes

## Validation
- `npx vitest run tests/unit/app-route-entrypoints.test.tsx tests/unit/app-route-wrappers.test.tsx tests/unit/service-addressing.test.ts tests/unit/shell-app-registry.test.ts`