### PR TITLE
RFC-0033 advisor brief workflow-pack posture consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ Boundary rules that matter:
 2. `lotus-workbench` uses `lotus-gateway` as its primary backend contract.
 3. Canonical local product proof uses the governed front-office runtime and seeded portfolio
    `PB_SG_GLOBAL_BAL_001`.
-4. Recommendations and proposals routes still exist as compatibility paths, but they are no longer
+4. `Data Products` is available at `/data-products` for gateway-backed catalog, dependency, and
+   live trust discovery.
+5. Recommendations and proposals routes still exist as compatibility paths, but they are no longer
    the primary supported front-office app surfaces.
-5. Top-level shell navigation is capability-gated: `Portfolio`, `Performance`, and `Risk` are
+6. Top-level shell navigation is capability-gated: `Portfolio`, `Performance`, and `Risk` are
    active, while `Proposal` and `Advisory` remain disabled in the current normalized shell
    bootstrap contract.
-6. Canonical review-ready browser evidence comes from `npm run live:validate` artifacts under
+7. Canonical review-ready browser evidence comes from `npm run live:validate` artifacts under
    `output/playwright/live-canonical/`, not from ad hoc localhost screenshots.
 
 ## Architecture At A Glance
@@ -72,6 +74,8 @@ Current main surfaces:
   `/performance` with performance, risk, advisor-brief, and evidence modes
 - `workbench`
   `/workbench/*` compatibility and portfolio-linked workspace entry
+- `data-products`
+  `/data-products` self-serve catalog, dependency, and live trust discovery through gateway
 - `api/bff`
   internal Next.js proxy bridge to `lotus-gateway`
 
@@ -161,6 +165,7 @@ Quick local browser-facing path:
 http://workbench.dev.lotus/portfolio
 http://workbench.dev.lotus/performance
 http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk
+http://workbench.dev.lotus/data-products
 ```
 
 ## Common Commands
@@ -214,9 +219,11 @@ Important current product and route truths:
    the main supported shell paths
 4. the internal `/api/bff/*` route proxies to `lotus-gateway` and preserves gateway-first
    integration posture
-5. shell navigation availability is contract-driven and currently exposes disabled `Proposal` and
+5. `/data-products` consumes only gateway domain-product discovery and trust-certification
+   endpoints; it must not read platform files directly or fabricate trust posture
+6. shell navigation availability is contract-driven and currently exposes disabled `Proposal` and
    `Advisory` items rather than live product routes
-6. evidence-oriented performance views must be documented truthfully as runtime-governed product
+7. evidence-oriented performance views must be documented truthfully as runtime-governed product
    behavior, not as a promise of separate unsupported backend ownership inside Workbench
 
 Copy-paste route and runtime examples live in [wiki/API-Surface.md](wiki/API-Surface.md).

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -40,7 +40,9 @@ Current repository posture:
 1. the platform is converging on a premium private-banking product experience standard,
 2. `lotus-workbench` uses `lotus-gateway` as its primary backend contract,
 3. the `Portfolio` and `Performance` surfaces are the most mature live workflows,
-4. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
+4. `/data-products` provides self-serve gateway-backed domain-product catalog, dependency, and
+   live trust discovery for RFC-0088,
+5. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map
 
@@ -76,7 +78,9 @@ Boundary rules:
 1. UI features must be backed by supported gateway functionality,
 2. direct raw service consumption is not the default pattern,
 3. presentation logic may shape or prioritize information, but domain authority stays upstream,
-4. visual polish should not introduce fake data, duplicated meaning, or unsupported workflow states.
+4. visual polish should not introduce fake data, duplicated meaning, or unsupported workflow states,
+5. domain-product discovery UI must consume gateway domain-product APIs only and must render
+   unavailable, stale, partial, blocked, and error trust states truthfully.
 
 ## Repo-Native Commands
 
@@ -168,6 +172,7 @@ Update this document when:
 4. dominant design-system or shell patterns change,
 5. current product-surface maturity or rollout posture materially changes,
 6. active versus legacy route posture changes.
+7. domain-product discovery route, gateway endpoint usage, or trust-state rendering changes.
 
 ## Cross-Links
 

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -168,6 +168,7 @@ Validation layers:
    - risk rolling
    - risk attribution
    - advisor brief
+   - advisor-brief workflow-pack review actions for `ACCEPT`, `REVISE`, and `SUPERSEDE`
 5. browser-level validation for populated UI on:
    - Portfolio summary
    - Portfolio detailed
@@ -188,6 +189,11 @@ that directory instead. The summary records structured screenshot evidence for e
 stable file name, absolute path, route, panel identifier, portfolio ID, benchmark ID, as-of date,
 and demo readiness state. The validator also writes `SHOT-INDEX.md` in the screenshot directory so
 demo reviewers can quickly identify the captured product surfaces.
+
+The machine-readable summary also records `workflowPackChecks` for the advisor-brief live path.
+Those checks prove initial workflow-pack run visibility plus bounded `ACCEPT`, `REVISE`, and
+`SUPERSEDE` review transitions with replacement lineage through the live
+`lotus-workbench` -> `lotus-gateway` -> `lotus-ai` contract chain.
 
 Machine-readable validation evidence is written to:
 
@@ -297,6 +303,8 @@ For `PB_SG_GLOBAL_BAL_001`, the validator confirms:
   - talking points render
   - source metrics render
   - source evidence actions render
+  - the Workbench `Accept Brief` action records a bounded review transition through the live
+    gateway and lotus-ai path
 - Risk:
   - `Risk Snapshot`
   - `Drawdown`

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -97,9 +97,14 @@ That script performs:
 8. canonical `lotus-workbench` startup on port `3000`
 
 The command exits after the stack is usable. It does not block on browser validation.
+Non-zero seed or upstream startup failures must fail the PowerShell command; a partial bring-up is
+not considered success.
 
 Use this path when you want to bring the product up quickly, inspect it manually, or restart the
 runtime without waiting for the full validation lane to finish.
+
+The canonical bring-up script also accepts `-SeedWaitSeconds` when the governed seed needs a longer
+drain window than the default `900` seconds.
 
 ## Canonical bring-up with validation
 

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -3,6 +3,7 @@ param(
   [string]$PortfolioId = "PB_SG_GLOBAL_BAL_001",
   [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40",
   [string]$ScreenshotDirectory = "",
+  [int]$SeedWaitSeconds = 900,
   [switch]$BuildImages,
   [switch]$RunValidation
 )
@@ -29,7 +30,11 @@ function Invoke-RepoCommand {
 
   Push-Location $RepoPath
   try {
+    $global:LASTEXITCODE = 0
     Invoke-Expression $Command
+    if ($LASTEXITCODE -ne 0) {
+      throw "Command failed with exit code $LASTEXITCODE in '$RepoPath': $Command"
+    }
   } finally {
     Pop-Location
   }
@@ -76,12 +81,18 @@ docker run -d --name lotus-direct-dev-ingress -p 80:80 -v "${ingressCaddyfile}:/
 
 Write-Host "Starting canonical Gateway on :8111 ..."
 & (Join-Path $gatewayRepo "scripts\\Start-CanonicalGateway.ps1")
+if ($LASTEXITCODE -ne 0) {
+  throw "Canonical Gateway startup failed with exit code $LASTEXITCODE."
+}
 
 Write-Host "Seeding governed front-office portfolio data for $PortfolioId ..."
-Invoke-RepoCommand $coreRepo "python tools/front_office_portfolio_seed.py --portfolio-id $PortfolioId --start-date 2025-03-31 --end-date 2026-04-10 --benchmark-start-date 2025-01-06 --wait-seconds 300"
+Invoke-RepoCommand $coreRepo "python tools/front_office_portfolio_seed.py --portfolio-id $PortfolioId --start-date 2025-03-31 --end-date 2026-04-10 --benchmark-start-date 2025-01-06 --wait-seconds $SeedWaitSeconds"
 
 Write-Host "Starting canonical lotus-manage on :8001 ..."
 & (Join-Path $manageRepo "scripts\\Start-CanonicalManage.ps1")
+if ($LASTEXITCODE -ne 0) {
+  throw "Canonical lotus-manage startup failed with exit code $LASTEXITCODE."
+}
 
 if (-not (Test-HttpReady "http://127.0.0.1:3000")) {
   Write-Host "Starting Workbench dev server on :3000 ..."

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -12,7 +12,7 @@ import {
   writeShotIndex,
   writeValidationSummary,
 } from "./validation/evidence-summary-writer.mjs";
-import { checkDns, fetchJson, fetchText } from "./validation/probes.mjs";
+import { checkDns, fetchJson, fetchText, postJson } from "./validation/probes.mjs";
 import {
   assertPerformanceCalculationSanity,
   assertRiskCalculationSanity,
@@ -27,6 +27,7 @@ import {
   validateRiskPanel,
 } from "./validation/browser-workflows.mjs";
 import { createPanelGovernance } from "./validation/panel-governance.mjs";
+import { validateAdvisorBriefWorkflowPackReviewChain } from "./validation/workflow-pack-proof.mjs";
 
 const {
   portfolioId,
@@ -172,6 +173,27 @@ async function run() {
   if (!advisorBrief?.summary) {
     throw new Error("Advisor brief returned no summary.");
   }
+  if (!advisorBrief?.workflow_pack_run?.run_id) {
+    throw new Error("Advisor brief returned no workflow-pack run identity.");
+  }
+  summary.workflowPackChecks.push({
+    actionType: "INITIAL_VISIBLE",
+    route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}`,
+    sourceRunId: advisorBrief.workflow_pack_run.run_id,
+    resultReviewState: advisorBrief.workflow_pack_run.review_state,
+    resultSupportabilityStatus: advisorBrief.workflow_pack_run.supportability_status,
+  });
+
+  await validateAdvisorBriefWorkflowPackReviewChain({
+    summary,
+    gatewayBaseUrl,
+    portfolioId,
+    benchmarkCode,
+    canonicalAsOfDate,
+    timeoutMs,
+    fetchJson,
+    postJson,
+  });
 
   const manageCapabilities = await fetchJson(
     summary,
@@ -287,6 +309,7 @@ async function run() {
       benchmarkCode,
       timeoutMs,
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
+      performAcceptReviewActionProof: true,
     });
     await validateRiskPanel(page, {
       workbenchBaseUrl,

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -215,6 +215,7 @@ export async function validateAdvisorBriefPanel(
     benchmarkCode,
     timeoutMs,
     screenshotRegisteredPanel,
+    performAcceptReviewActionProof = false,
   }
 ) {
   await page.goto(
@@ -246,6 +247,27 @@ export async function validateAdvisorBriefPanel(
     buttonCount: sourceMetricButtons,
   });
   await screenshotRegisteredPanel(page, "performance.advisor_brief");
+
+  if (performAcceptReviewActionProof) {
+    const reviewRegion = page.getByLabel("Advisor brief review actions");
+    await expect(reviewRegion).toBeVisible({ timeout: timeoutMs });
+    await reviewRegion.getByLabel("Reviewed by").fill("live.validator.ui");
+    await reviewRegion
+      .getByLabel("Review reason")
+      .fill("Live canonical validator proving the Workbench ACCEPT review path.");
+    await reviewRegion.getByRole("button", { name: "Accept Brief" }).click();
+    await expect(
+      page.getByText("Run is supportable through the current bounded workflow-pack ledger posture.")
+    ).toBeVisible({ timeout: timeoutMs });
+    await expect(page.getByText("AI Review")).toBeVisible({ timeout: timeoutMs });
+    await expect(page.getByText("ACCEPTED")).toBeVisible({ timeout: timeoutMs });
+    summary.uiChecks.push({
+      description: "Advisor brief ACCEPT review action",
+      kind: "workflow-pack-review-action",
+      actionType: "ACCEPT",
+      state: "accepted",
+    });
+  }
 }
 
 export async function validateRiskPanel(

--- a/scripts/live/validation/contract-metadata.mjs
+++ b/scripts/live/validation/contract-metadata.mjs
@@ -144,7 +144,7 @@ export const DEFAULT_PANEL_REGISTRY = {
       panelId: "performance.evidence",
       owningService: "lotus-gateway",
       gatewayEndpoint: null,
-      requiredSupportState: "unavailable",
+      requiredSupportState: "partial",
       route: "/performance?portfolioId={portfolioId}&mode=evidence&period=YTD&detailBasis=NET&benchmark={benchmarkCode}",
       allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
       screenshotName: "performance-evidence-live.png",

--- a/scripts/live/validation/evidence-summary-writer.mjs
+++ b/scripts/live/validation/evidence-summary-writer.mjs
@@ -26,6 +26,7 @@ export function createValidationSummary({
     gatewayBaseUrl,
     dns: [],
     apiChecks: [],
+    workflowPackChecks: [],
     uiChecks: [],
     calculationChecks: [],
     panelClassifications: [],

--- a/scripts/live/validation/probes.mjs
+++ b/scripts/live/validation/probes.mjs
@@ -32,20 +32,60 @@ export async function fetchJson(
   timeoutMs,
   fetchImpl = globalThis.fetch
 ) {
+  return await sendJson(summary, url, description, timeoutMs, {
+    fetchImpl,
+  });
+}
+
+export async function postJson(
+  summary,
+  url,
+  description,
+  timeoutMs,
+  body,
+  fetchImpl = globalThis.fetch
+) {
+  return await sendJson(summary, url, description, timeoutMs, {
+    method: "POST",
+    body,
+    fetchImpl,
+  });
+}
+
+export async function sendJson(
+  summary,
+  url,
+  description,
+  timeoutMs,
+  { method = "GET", body: requestBody, headers = {}, fetchImpl = globalThis.fetch } = {}
+) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetchImpl(url, { signal: controller.signal });
+    const response = await fetchImpl(url, {
+      method,
+      signal: controller.signal,
+      headers:
+        requestBody === undefined
+          ? headers
+          : {
+              "Content-Type": "application/json",
+              ...headers,
+            },
+      body: requestBody === undefined ? undefined : JSON.stringify(requestBody),
+    });
     if (!response.ok) {
-      throw new Error(`${description} failed (${response.status}) at ${url}`);
+      const errorBody = await response.text();
+      const detail = errorBody.trim() ? `: ${errorBody.trim()}` : "";
+      throw new Error(`${description} failed (${response.status}) at ${url}${detail}`);
     }
-    const body = await response.text();
-    if (!body.trim()) {
+    const responseBody = await response.text();
+    if (!responseBody.trim()) {
       throw new Error(`${description} returned HTTP ${response.status} with an empty body at ${url}`);
     }
     let payload;
     try {
-      payload = JSON.parse(body);
+      payload = JSON.parse(responseBody);
     } catch (error) {
       throw new Error(
         `${description} returned non-JSON content at ${url}: ${
@@ -53,7 +93,13 @@ export async function fetchJson(
         }`
       );
     }
-    summary.apiChecks.push({ description, url, status: response.status, kind: "json" });
+    summary.apiChecks.push({
+      description,
+      url,
+      status: response.status,
+      kind: "json",
+      method,
+    });
     return payload;
   } finally {
     clearTimeout(timer);
@@ -75,7 +121,7 @@ export async function fetchText(
       throw new Error(`${description} failed (${response.status}) at ${url}`);
     }
     const payload = await response.text();
-    summary.apiChecks.push({ description, url, status: response.status, kind: "text" });
+    summary.apiChecks.push({ description, url, status: response.status, kind: "text", method: "GET" });
     return payload;
   } finally {
     clearTimeout(timer);

--- a/scripts/live/validation/workflow-pack-proof.mjs
+++ b/scripts/live/validation/workflow-pack-proof.mjs
@@ -1,0 +1,230 @@
+function buildAdvisorBriefWorkspaceQuery(params) {
+  const query = new URLSearchParams();
+  query.set("period", params.period);
+  query.set("chart_frequency", params.chartFrequency ?? "monthly");
+  query.set("contribution_dimension", params.contributionDimension ?? "asset_class");
+  query.set("attribution_dimension", params.attributionDimension ?? "asset_class");
+  query.set("detail_basis", params.detailBasis);
+  query.set("benchmark_code", params.benchmarkCode);
+  if (params.reportStartDate) {
+    query.set("report_start_date", params.reportStartDate);
+  }
+  if (params.reportEndDate) {
+    query.set("report_end_date", params.reportEndDate);
+  }
+  return query.toString();
+}
+
+function recordWorkflowPackCheck(summary, payload) {
+  summary.workflowPackChecks.push(payload);
+}
+
+function assertWorkflowPackRunPresence(payload, description) {
+  const run = payload?.workflow_pack_run;
+  if (!run?.run_id) {
+    throw new Error(`${description} returned no workflow-pack run identity.`);
+  }
+  return run;
+}
+
+function assertReplacementLineagePosture(payload, expectedReviewState, replacementRunId) {
+  const run = assertWorkflowPackRunPresence(
+    payload,
+    `Advisor brief ${expectedReviewState} review action`
+  );
+  if (run.review_state !== expectedReviewState) {
+    throw new Error(
+      `Advisor brief ${expectedReviewState} review action returned review state '${String(
+        run.review_state
+      )}' instead of '${expectedReviewState}'.`
+    );
+  }
+  if (run.supportability_status !== "HISTORICAL") {
+    throw new Error(
+      `Advisor brief ${expectedReviewState} review action returned supportability '${String(
+        run.supportability_status
+      )}' instead of 'HISTORICAL'.`
+    );
+  }
+  if (run.superseded !== true) {
+    throw new Error(
+      `Advisor brief ${expectedReviewState} review action did not mark the run as historical.`
+    );
+  }
+  if (run.replacement_run_id !== replacementRunId) {
+    throw new Error(
+      `Advisor brief ${expectedReviewState} review action returned replacement_run_id '${String(
+        run.replacement_run_id
+      )}' instead of '${replacementRunId}'.`
+    );
+  }
+  return run;
+}
+
+export async function validateAdvisorBriefWorkflowPackReviewChain({
+  summary,
+  gatewayBaseUrl,
+  portfolioId,
+  benchmarkCode,
+  canonicalAsOfDate,
+  timeoutMs,
+  fetchJson,
+  postJson,
+}) {
+  const acceptQuery = buildAdvisorBriefWorkspaceQuery({
+    period: "YTD",
+    detailBasis: "NET",
+    benchmarkCode,
+  });
+  const acceptedBrief = await postJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${acceptQuery}`,
+    "Advisor brief ACCEPT review action",
+    timeoutMs,
+    {
+      action_type: "ACCEPT",
+      reviewed_by: "live.validator.accept",
+      reason: "Live canonical validator proving bounded ACCEPT review posture.",
+    }
+  );
+  const acceptedRun = assertWorkflowPackRunPresence(acceptedBrief, "Advisor brief ACCEPT review action");
+  if (acceptedRun.review_state !== "ACCEPTED") {
+    throw new Error(
+      `Advisor brief ACCEPT review action returned review state '${String(
+        acceptedRun.review_state
+      )}' instead of 'ACCEPTED'.`
+    );
+  }
+  if (acceptedRun.supportability_status !== "READY") {
+    throw new Error(
+      `Advisor brief ACCEPT review action returned supportability '${String(
+        acceptedRun.supportability_status
+      )}' instead of 'READY'.`
+    );
+  }
+  recordWorkflowPackCheck(summary, {
+    actionType: "ACCEPT",
+    route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${acceptQuery}`,
+    sourceRunId: acceptedRun.run_id,
+    resultReviewState: acceptedRun.review_state,
+    resultSupportabilityStatus: acceptedRun.supportability_status,
+  });
+
+  const supersedeOriginalQuery = buildAdvisorBriefWorkspaceQuery({
+    period: "EXPLICIT",
+    detailBasis: "NET",
+    benchmarkCode,
+    reportStartDate: "2026-01-01",
+    reportEndDate: canonicalAsOfDate,
+  });
+  const supersedeReplacementQuery = buildAdvisorBriefWorkspaceQuery({
+    period: "EXPLICIT",
+    detailBasis: "GROSS",
+    benchmarkCode,
+    reportStartDate: "2026-01-01",
+    reportEndDate: canonicalAsOfDate,
+  });
+  const supersedeOriginal = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief?${supersedeOriginalQuery}`,
+    "Advisor brief supersede source run",
+    timeoutMs
+  );
+  const supersedeReplacement = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief?${supersedeReplacementQuery}`,
+    "Advisor brief supersede replacement run",
+    timeoutMs
+  );
+  const supersedeSourceRun = assertWorkflowPackRunPresence(
+    supersedeOriginal,
+    "Advisor brief supersede source run"
+  );
+  const supersedeReplacementRun = assertWorkflowPackRunPresence(
+    supersedeReplacement,
+    "Advisor brief supersede replacement run"
+  );
+  const supersededBrief = await postJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${supersedeOriginalQuery}`,
+    "Advisor brief SUPERSEDE review action",
+    timeoutMs,
+    {
+      action_type: "SUPERSEDE",
+      reviewed_by: "live.validator.supersede",
+      reason: "Live canonical validator proving bounded SUPERSEDE replacement lineage.",
+      replacement_run_id: supersedeReplacementRun.run_id,
+    }
+  );
+  const supersededRun = assertReplacementLineagePosture(
+    supersededBrief,
+    "SUPERSEDED",
+    supersedeReplacementRun.run_id
+  );
+  recordWorkflowPackCheck(summary, {
+    actionType: "SUPERSEDE",
+    route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${supersedeOriginalQuery}`,
+    sourceRunId: supersedeSourceRun.run_id,
+    replacementRunId: supersedeReplacementRun.run_id,
+    resultReviewState: supersededRun.review_state,
+    resultSupportabilityStatus: supersededRun.supportability_status,
+  });
+
+  const reviseOriginalQuery = buildAdvisorBriefWorkspaceQuery({
+    period: "YTD",
+    detailBasis: "GROSS",
+    benchmarkCode,
+  });
+  const reviseReplacementQuery = buildAdvisorBriefWorkspaceQuery({
+    period: "EXPLICIT",
+    detailBasis: "NET",
+    benchmarkCode,
+    reportStartDate: "2026-02-01",
+    reportEndDate: canonicalAsOfDate,
+  });
+  const reviseOriginal = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief?${reviseOriginalQuery}`,
+    "Advisor brief revise source run",
+    timeoutMs
+  );
+  const reviseReplacement = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief?${reviseReplacementQuery}`,
+    "Advisor brief revise replacement run",
+    timeoutMs
+  );
+  const reviseSourceRun = assertWorkflowPackRunPresence(
+    reviseOriginal,
+    "Advisor brief revise source run"
+  );
+  const reviseReplacementRun = assertWorkflowPackRunPresence(
+    reviseReplacement,
+    "Advisor brief revise replacement run"
+  );
+  const revisedBrief = await postJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${reviseOriginalQuery}`,
+    "Advisor brief REVISE review action",
+    timeoutMs,
+    {
+      action_type: "REVISE",
+      reviewed_by: "live.validator.revise",
+      reason: "Live canonical validator proving bounded REVISE replacement lineage.",
+      replacement_run_id: reviseReplacementRun.run_id,
+    }
+  );
+  const revisedRun = assertReplacementLineagePosture(
+    revisedBrief,
+    "REVISED",
+    reviseReplacementRun.run_id
+  );
+  recordWorkflowPackCheck(summary, {
+    actionType: "REVISE",
+    route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${reviseOriginalQuery}`,
+    sourceRunId: reviseSourceRun.run_id,
+    replacementRunId: reviseReplacementRun.run_id,
+    resultReviewState: revisedRun.review_state,
+    resultSupportabilityStatus: revisedRun.supportability_status,
+  });
+}

--- a/src/app/data-products/page.tsx
+++ b/src/app/data-products/page.tsx
@@ -1,0 +1,5 @@
+import DomainProductDiscoveryClient from "@/features/domain-products/domain-product-discovery-client";
+
+export default function DataProductsPage() {
+  return <DomainProductDiscoveryClient />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9230,6 +9230,155 @@ a:hover {
   border-top: 1px solid rgba(23, 32, 43, 0.08);
 }
 
+.domain-products-page {
+  --domain-products-panel-radius: 8px;
+}
+
+.domain-products-overview,
+.domain-products-grid,
+.domain-products-dependencies,
+.domain-products-graph,
+.domain-products-issues {
+  display: grid;
+  gap: 12px;
+}
+
+.domain-products-overview {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.domain-products-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.domain-products-graph {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.domain-products-summary-tile,
+.domain-products-card,
+.domain-products-row,
+.domain-products-state,
+.domain-products-loading {
+  border: 1px solid var(--border);
+  border-radius: var(--domain-products-panel-radius);
+  background: var(--surface-primary);
+}
+
+.domain-products-summary-tile {
+  display: grid;
+  gap: 6px;
+  min-height: 92px;
+  padding: 16px;
+  align-content: center;
+}
+
+.domain-products-summary-tile strong {
+  font-size: var(--type-metric-l-size);
+  line-height: var(--type-metric-l-line-height);
+  font-variant-numeric: var(--type-financial-numeric);
+}
+
+.domain-products-card {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+  padding: 18px;
+}
+
+.domain-products-card-header,
+.domain-products-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.domain-products-card-header {
+  align-items: flex-start;
+}
+
+.domain-products-card-header h2 {
+  margin: 4px 0;
+  color: var(--text);
+  font-size: var(--type-panel-title-size);
+  line-height: var(--type-panel-title-line-height);
+}
+
+.domain-products-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.domain-products-facts div {
+  min-width: 0;
+}
+
+.domain-products-facts dt {
+  color: var(--text-muted);
+  font-size: var(--type-label-size);
+  font-weight: var(--type-label-weight);
+  line-height: var(--type-label-line-height);
+}
+
+.domain-products-facts dd {
+  margin: 4px 0 0;
+  color: var(--text);
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-line-height);
+  overflow-wrap: anywhere;
+}
+
+.domain-products-row {
+  align-items: center;
+  padding: 14px 16px;
+}
+
+.domain-products-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+}
+
+.domain-products-state,
+.domain-products-loading {
+  padding: 16px;
+  color: var(--text);
+}
+
+.domain-products-state-warn {
+  border-color: var(--warn-border);
+  background: var(--warn-bg);
+  color: var(--warn-text);
+}
+
+.domain-products-state-danger {
+  border-color: var(--danger);
+  background: var(--status-danger-bg);
+  color: var(--danger);
+}
+
+@media (max-width: 960px) {
+  .domain-products-overview,
+  .domain-products-grid,
+  .domain-products-graph {
+    grid-template-columns: 1fr;
+  }
+
+  .domain-products-card-header,
+  .domain-products-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .domain-products-chip-row {
+    justify-content: flex-start;
+  }
+}
+
 .performance-advisor-brief-supportability-identity {
   display: grid;
   gap: 0.18rem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9230,6 +9230,18 @@ a:hover {
   border-top: 1px solid rgba(23, 32, 43, 0.08);
 }
 
+.performance-advisor-brief-supportability-identity {
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+}
+
+.performance-advisor-brief-supportability-detail {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
 .performance-advisor-brief-supportability-notes {
   display: grid;
   gap: 0.45rem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9310,6 +9310,30 @@ a:hover {
   line-height: 1.4;
 }
 
+.performance-advisor-brief-review-actions {
+  display: grid;
+  gap: 0.75rem;
+  padding-top: 0.35rem;
+}
+
+.performance-advisor-brief-review-actions-copy {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.performance-advisor-brief-review-field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.performance-advisor-brief-review-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
 .performance-advisor-brief-empty-note {
   padding: 0.95rem 1rem;
   background: rgba(248, 250, 252, 0.9);

--- a/src/apps/performance/advisor-brief/advisor-brief-view-model-types.ts
+++ b/src/apps/performance/advisor-brief/advisor-brief-view-model-types.ts
@@ -42,6 +42,7 @@ export type PerformanceAdvisorBriefSupportabilityItem = {
   label: string;
   value: string;
   tone: "success" | "warn" | "danger";
+  detail?: string | null;
 };
 
 export type PerformanceAdvisorBriefAudit = {

--- a/src/apps/performance/advisor-brief/build-gateway-advisor-brief-view-model.ts
+++ b/src/apps/performance/advisor-brief/build-gateway-advisor-brief-view-model.ts
@@ -51,12 +51,7 @@ export function buildGatewayAdvisorBriefViewModel(
       hasBackedRiskEvidence,
     }),
     supportability: normalizeGatewaySupportability(advisorBrief),
-    reviewNotes: Array.from(
-      new Set([
-        ...advisorBrief.partial_failures.map((failure) => failure.detail),
-        ...advisorBrief.warnings,
-      ])
-    ),
+    reviewNotes: buildGatewayReviewNotes(advisorBrief),
     audit: {
       taskId: advisorBrief.ai_audit.task_id ?? "explain.v1",
       outputLabel: advisorBrief.ai_audit.output_label ?? "EXPLANATION_ONLY",
@@ -76,17 +71,21 @@ export function buildGatewayAdvisorBriefViewModel(
 }
 
 function resolveAdvisorBriefSourceRefs(advisorBrief: WorkbenchPerformanceAdvisorBrief) {
+  const workflowPackRunRef = advisorBrief.workflow_pack_run
+    ? [`lotus-ai:workflow-pack-run:${advisorBrief.workflow_pack_run.run_id}`]
+    : [];
   const aiEvidenceRefs = advisorBrief.ai_evidence.source_refs ?? [];
   if (aiEvidenceRefs.length > 0) {
-    return aiEvidenceRefs;
+    return Array.from(new Set([...aiEvidenceRefs, ...workflowPackRunRef]));
   }
 
   const aiAuditRefs = advisorBrief.ai_audit.source_refs ?? [];
   if (aiAuditRefs.length > 0) {
-    return aiAuditRefs;
+    return Array.from(new Set([...aiAuditRefs, ...workflowPackRunRef]));
   }
 
   return [
+    ...workflowPackRunRef,
     `lotus-gateway:workbench:${advisorBrief.portfolio_id}:performance-advisor-brief:${advisorBrief.period}`,
   ];
 }
@@ -94,7 +93,7 @@ function resolveAdvisorBriefSourceRefs(advisorBrief: WorkbenchPerformanceAdvisor
 function normalizeGatewaySupportability(
   advisorBrief: WorkbenchPerformanceAdvisorBrief
 ): PerformanceAdvisorBriefViewModel["supportability"] {
-  return advisorBrief.supportability.map((item) => {
+  const normalizedItems = advisorBrief.supportability.map((item) => {
     if (item.label.trim().toLowerCase() === "advisor brief") {
       const normalizedValue =
         advisorBrief.status === "ready"
@@ -116,6 +115,50 @@ function normalizeGatewaySupportability(
       tone: normalizeSupportabilityTone(item.tone, item.value),
     };
   });
+
+  if (!advisorBrief.workflow_pack_run) {
+    return normalizedItems;
+  }
+
+  return [
+    ...normalizedItems,
+    {
+      label: "AI Run",
+      value: normalizeWorkflowPackRuntimeValue(advisorBrief.workflow_pack_run.runtime_state),
+      tone: normalizeWorkflowPackRuntimeTone(advisorBrief.workflow_pack_run.runtime_state),
+    },
+    {
+      label: "AI Review",
+      value: normalizeWorkflowPackReviewValue(advisorBrief.workflow_pack_run.review_state),
+      tone: normalizeWorkflowPackReviewTone(advisorBrief.workflow_pack_run),
+    },
+  ];
+}
+
+function buildGatewayReviewNotes(advisorBrief: WorkbenchPerformanceAdvisorBrief): string[] {
+  const workflowPackRun = advisorBrief.workflow_pack_run;
+  const workflowPackNotes = workflowPackRun
+    ? [
+        workflowPackRun.current_summary_note,
+        ...workflowPackRun.findings.map((finding) => {
+          const severityPrefix = finding.severity.replaceAll("_", " ");
+          return `${severityPrefix}: ${finding.summary}`;
+        }),
+        workflowPackRun.replacement_run_id
+          ? `Superseded by workflow-pack run ${workflowPackRun.replacement_run_id}.`
+          : null,
+      ]
+    : [];
+
+  return Array.from(
+    new Set(
+      [
+        ...advisorBrief.partial_failures.map((failure) => failure.detail),
+        ...advisorBrief.warnings,
+        ...workflowPackNotes,
+      ].filter((note): note is string => Boolean(note))
+    )
+  );
 }
 
 function normalizeGatewaySourceMetrics({
@@ -249,6 +292,47 @@ function normalizeSupportabilityTone(
     return "warn";
   }
   return "danger";
+}
+
+function normalizeWorkflowPackRuntimeValue(runtimeState: string): string {
+  return runtimeState.replaceAll("_", " ");
+}
+
+function normalizeWorkflowPackReviewValue(reviewState: string): string {
+  return reviewState.replaceAll("_", " ");
+}
+
+function normalizeWorkflowPackRuntimeTone(
+  runtimeState: string
+): "success" | "warn" | "danger" {
+  switch (runtimeState) {
+    case "COMPLETED":
+      return "success";
+    case "FAILED":
+    case "ABANDONED":
+      return "danger";
+    default:
+      return "warn";
+  }
+}
+
+function normalizeWorkflowPackReviewTone(
+  workflowPackRun: NonNullable<WorkbenchPerformanceAdvisorBrief["workflow_pack_run"]>
+): "success" | "warn" | "danger" {
+  if (
+    workflowPackRun.review_state === "REJECTED" ||
+    workflowPackRun.review_state === "ABANDONED" ||
+    workflowPackRun.supportability_status === "FAILED"
+  ) {
+    return "danger";
+  }
+  if (
+    workflowPackRun.review_state === "ACCEPTED" ||
+    workflowPackRun.supportability_status === "READY"
+  ) {
+    return "success";
+  }
+  return "warn";
 }
 
 function normalizeAdvisorTargetMode(targetMode: string): PerformanceWorkspaceMode {

--- a/src/apps/performance/advisor-brief/build-gateway-advisor-brief-view-model.ts
+++ b/src/apps/performance/advisor-brief/build-gateway-advisor-brief-view-model.ts
@@ -315,11 +315,13 @@ function buildWorkflowPackRunDetail(
 function buildWorkflowPackReviewDetail(
   workflowPackRun: NonNullable<WorkbenchPerformanceAdvisorBrief["workflow_pack_run"]>
 ): string {
-  const detailParts = [
-    `Supportability ${normalizeWorkflowPackReviewValue(workflowPackRun.supportability_status)}`,
-  ];
-  if (workflowPackRun.superseded && workflowPackRun.replacement_run_id) {
-    detailParts.push(`Superseded by ${workflowPackRun.replacement_run_id}`);
+  const detailParts = [`Supportability ${normalizeWorkflowPackReviewValue(workflowPackRun.supportability_status)}`];
+  if (workflowPackRun.superseded) {
+    detailParts.push(
+      workflowPackRun.replacement_run_id
+        ? `Superseded by ${workflowPackRun.replacement_run_id}`
+        : "Superseded"
+    );
   }
   return detailParts.join(" • ");
 }
@@ -341,6 +343,9 @@ function normalizeWorkflowPackRuntimeTone(
 function normalizeWorkflowPackReviewTone(
   workflowPackRun: NonNullable<WorkbenchPerformanceAdvisorBrief["workflow_pack_run"]>
 ): "success" | "warn" | "danger" {
+  if (workflowPackRun.superseded) {
+    return "warn";
+  }
   if (
     workflowPackRun.review_state === "REJECTED" ||
     workflowPackRun.review_state === "ABANDONED" ||

--- a/src/apps/performance/advisor-brief/build-gateway-advisor-brief-view-model.ts
+++ b/src/apps/performance/advisor-brief/build-gateway-advisor-brief-view-model.ts
@@ -126,11 +126,13 @@ function normalizeGatewaySupportability(
       label: "AI Run",
       value: normalizeWorkflowPackRuntimeValue(advisorBrief.workflow_pack_run.runtime_state),
       tone: normalizeWorkflowPackRuntimeTone(advisorBrief.workflow_pack_run.runtime_state),
+      detail: buildWorkflowPackRunDetail(advisorBrief.workflow_pack_run),
     },
     {
       label: "AI Review",
       value: normalizeWorkflowPackReviewValue(advisorBrief.workflow_pack_run.review_state),
       tone: normalizeWorkflowPackReviewTone(advisorBrief.workflow_pack_run),
+      detail: buildWorkflowPackReviewDetail(advisorBrief.workflow_pack_run),
     },
   ];
 }
@@ -300,6 +302,26 @@ function normalizeWorkflowPackRuntimeValue(runtimeState: string): string {
 
 function normalizeWorkflowPackReviewValue(reviewState: string): string {
   return reviewState.replaceAll("_", " ");
+}
+
+function buildWorkflowPackRunDetail(
+  workflowPackRun: NonNullable<WorkbenchPerformanceAdvisorBrief["workflow_pack_run"]>
+): string {
+  return [workflowPackRun.run_id, `Authority ${workflowPackRun.workflow_authority_owner}`].join(
+    " • "
+  );
+}
+
+function buildWorkflowPackReviewDetail(
+  workflowPackRun: NonNullable<WorkbenchPerformanceAdvisorBrief["workflow_pack_run"]>
+): string {
+  const detailParts = [
+    `Supportability ${normalizeWorkflowPackReviewValue(workflowPackRun.supportability_status)}`,
+  ];
+  if (workflowPackRun.superseded && workflowPackRun.replacement_run_id) {
+    detailParts.push(`Superseded by ${workflowPackRun.replacement_run_id}`);
+  }
+  return detailParts.join(" • ");
 }
 
 function normalizeWorkflowPackRuntimeTone(

--- a/src/apps/performance/components/advisor-brief/lotus-supportability-panel.tsx
+++ b/src/apps/performance/components/advisor-brief/lotus-supportability-panel.tsx
@@ -5,9 +5,11 @@ import PerformanceWorkspaceSection from "../performance-workspace-section";
 export default function LotusSupportabilityPanel({
   items,
   reviewNotes,
+  reviewActionForm,
 }: {
   items: PerformanceAdvisorBriefSupportabilityItem[];
   reviewNotes: string[];
+  reviewActionForm?: React.ReactNode;
 }) {
   const readyCount = items.filter((item) => item.tone === "success").length;
   const reviewItems = items.filter((item) => item.tone !== "success");
@@ -55,6 +57,7 @@ export default function LotusSupportabilityPanel({
           ))}
         </div>
       ) : null}
+      {reviewActionForm}
     </PerformanceWorkspaceSection>
   );
 }

--- a/src/apps/performance/components/advisor-brief/lotus-supportability-panel.tsx
+++ b/src/apps/performance/components/advisor-brief/lotus-supportability-panel.tsx
@@ -2,6 +2,10 @@ import type { PerformanceAdvisorBriefSupportabilityItem } from "../../advisor-br
 import PerformanceSupportabilitySummary from "../performance-supportability-summary";
 import PerformanceWorkspaceSection from "../performance-workspace-section";
 
+function isWorkflowPackStateItem(item: PerformanceAdvisorBriefSupportabilityItem): boolean {
+  return item.label === "AI Run" || item.label === "AI Review";
+}
+
 export default function LotusSupportabilityPanel({
   items,
   reviewNotes,
@@ -12,7 +16,12 @@ export default function LotusSupportabilityPanel({
   reviewActionForm?: React.ReactNode;
 }) {
   const readyCount = items.filter((item) => item.tone === "success").length;
-  const reviewItems = items.filter((item) => item.tone !== "success");
+  const workflowPackStateItems = items.filter(isWorkflowPackStateItem);
+  const reviewItems = items.filter(
+    (item) => item.tone !== "success" && !isWorkflowPackStateItem(item)
+  );
+  const hasVisibleSupportabilityItems =
+    workflowPackStateItems.length > 0 || reviewItems.length > 0;
 
   return (
     <PerformanceWorkspaceSection
@@ -29,20 +38,45 @@ export default function LotusSupportabilityPanel({
           { label: "Review items", value: reviewItems.length + reviewNotes.length },
         ]}
       />
-      {reviewItems.length ? (
-        <div className="performance-advisor-brief-supportability-grid">
-          {reviewItems.map((item) => (
-            <div key={item.label} className="performance-advisor-brief-supportability-row">
-              <span className="performance-advisor-brief-supportability-label">{item.label}</span>
-              <span
-                className={`performance-advisor-brief-supportability-state performance-advisor-brief-supportability-state-${item.tone}`}
-              >
-                <span aria-hidden="true" className="performance-advisor-brief-supportability-dot" />
-                {item.value}
-              </span>
+      {hasVisibleSupportabilityItems ? (
+        <>
+          {workflowPackStateItems.length ? (
+            <div className="performance-advisor-brief-supportability-grid">
+              {workflowPackStateItems.map((item) => (
+                <div key={item.label} className="performance-advisor-brief-supportability-row">
+                  <span className="performance-advisor-brief-supportability-label">{item.label}</span>
+                  <span
+                    className={`performance-advisor-brief-supportability-state performance-advisor-brief-supportability-state-${item.tone}`}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="performance-advisor-brief-supportability-dot"
+                    />
+                    {item.value}
+                  </span>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+          ) : null}
+          {reviewItems.length ? (
+            <div className="performance-advisor-brief-supportability-grid">
+              {reviewItems.map((item) => (
+                <div key={item.label} className="performance-advisor-brief-supportability-row">
+                  <span className="performance-advisor-brief-supportability-label">{item.label}</span>
+                  <span
+                    className={`performance-advisor-brief-supportability-state performance-advisor-brief-supportability-state-${item.tone}`}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="performance-advisor-brief-supportability-dot"
+                    />
+                    {item.value}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </>
       ) : (
         <div className="performance-advisor-brief-supportability-all-ready">
           All current brief dependencies are ready for the selected context.

--- a/src/apps/performance/components/advisor-brief/lotus-supportability-panel.tsx
+++ b/src/apps/performance/components/advisor-brief/lotus-supportability-panel.tsx
@@ -44,7 +44,14 @@ export default function LotusSupportabilityPanel({
             <div className="performance-advisor-brief-supportability-grid">
               {workflowPackStateItems.map((item) => (
                 <div key={item.label} className="performance-advisor-brief-supportability-row">
-                  <span className="performance-advisor-brief-supportability-label">{item.label}</span>
+                  <div className="performance-advisor-brief-supportability-identity">
+                    <span className="performance-advisor-brief-supportability-label">{item.label}</span>
+                    {item.detail ? (
+                      <span className="performance-advisor-brief-supportability-detail">
+                        {item.detail}
+                      </span>
+                    ) : null}
+                  </div>
                   <span
                     className={`performance-advisor-brief-supportability-state performance-advisor-brief-supportability-state-${item.tone}`}
                   >
@@ -62,7 +69,14 @@ export default function LotusSupportabilityPanel({
             <div className="performance-advisor-brief-supportability-grid">
               {reviewItems.map((item) => (
                 <div key={item.label} className="performance-advisor-brief-supportability-row">
-                  <span className="performance-advisor-brief-supportability-label">{item.label}</span>
+                  <div className="performance-advisor-brief-supportability-identity">
+                    <span className="performance-advisor-brief-supportability-label">{item.label}</span>
+                    {item.detail ? (
+                      <span className="performance-advisor-brief-supportability-detail">
+                        {item.detail}
+                      </span>
+                    ) : null}
+                  </div>
                   <span
                     className={`performance-advisor-brief-supportability-state performance-advisor-brief-supportability-state-${item.tone}`}
                   >

--- a/src/apps/performance/components/performance-advisor-brief-mode.tsx
+++ b/src/apps/performance/components/performance-advisor-brief-mode.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useState } from "react";
+
+import { ActionButton } from "@/design-system";
 import { getPerformanceWorkspaceModeDefinition } from "../performance-workspace-modes";
 import { buildPerformanceAdvisorBriefViewModel } from "../advisor-brief-view-model";
 import { usePerformanceAdvisorBrief } from "../use-performance-advisor-brief";
@@ -19,6 +22,7 @@ import PerformanceWorkspaceStageSurface, {
 } from "./performance-workspace-stage-surface";
 import PerformanceWorkspaceSection from "./performance-workspace-section";
 import type { PerformanceAdvisorBriefModeProps } from "./performance-workspace-types";
+import type { WorkbenchAdvisorBriefWorkflowPackRunReviewActionType } from "@/features/workbench/types";
 
 export default function PerformanceAdvisorBriefMode({
   workspace,
@@ -39,7 +43,17 @@ export default function PerformanceAdvisorBriefMode({
     detailBasis,
     benchmark,
   });
-  const { advisorBrief, advisorBriefUnavailable, isLoading, refresh } = usePerformanceAdvisorBrief({
+  const [reviewedBy, setReviewedBy] = useState("");
+  const [reviewReason, setReviewReason] = useState("");
+  const {
+    advisorBrief,
+    advisorBriefUnavailable,
+    isLoading,
+    isApplyingReviewAction,
+    reviewActionError,
+    applyReviewAction,
+    refresh,
+  } = usePerformanceAdvisorBrief({
     request: {
       portfolioId: workspace.portfolio.portfolio_id,
       period,
@@ -125,6 +139,87 @@ export default function PerformanceAdvisorBriefMode({
       ),
     },
   ] as const;
+  const workflowPackRun = advisorBrief?.workflow_pack_run ?? null;
+  const reviewActionAllowed =
+    workflowPackRun !== null && workflowPackRun.allowed_review_actions.length > 0;
+  const canSubmitReviewAction =
+    reviewActionAllowed &&
+    reviewedBy.trim().length > 0 &&
+    reviewReason.trim().length > 0 &&
+    !isApplyingReviewAction;
+
+  async function handleReviewAction(
+    actionType: WorkbenchAdvisorBriefWorkflowPackRunReviewActionType
+  ) {
+    if (!canSubmitReviewAction) {
+      return;
+    }
+    try {
+      await applyReviewAction({
+        action_type: actionType,
+        reviewed_by: reviewedBy.trim(),
+        reason: reviewReason.trim(),
+      });
+      setReviewReason("");
+    } catch {
+      // The hook already exposes a user-facing error note for the supportability rail.
+    }
+  }
+
+  const reviewActionForm =
+    reviewActionAllowed && workflowPackRun ? (
+      <div
+        className="performance-advisor-brief-review-actions"
+        aria-label="Advisor brief review actions"
+      >
+        <p className="performance-advisor-brief-review-actions-copy">
+          Record one bounded review transition through the gateway contract. Reviewer identity and
+          rationale are required because the downstream lotus-ai ledger is actor-attributed.
+        </p>
+        <label className="performance-advisor-brief-review-field">
+          <span className="performance-advisor-brief-supportability-label">Reviewed by</span>
+          <input
+            className="input"
+            value={reviewedBy}
+            onChange={(event) => setReviewedBy(event.target.value)}
+            placeholder="advisor_1"
+            autoComplete="off"
+          />
+        </label>
+        <label className="performance-advisor-brief-review-field">
+          <span className="performance-advisor-brief-supportability-label">Review reason</span>
+          <textarea
+            className="textarea"
+            value={reviewReason}
+            onChange={(event) => setReviewReason(event.target.value)}
+            placeholder="Explain why this bounded review action is appropriate for downstream use."
+            rows={3}
+          />
+        </label>
+        <div className="performance-advisor-brief-review-action-row">
+          {workflowPackRun.allowed_review_actions.map((actionType) => (
+            <ActionButton
+              key={actionType}
+              priority={actionType === "ACCEPT" ? "primary" : "secondary"}
+              disabled={!canSubmitReviewAction}
+              onClick={() => void handleReviewAction(actionType)}
+            >
+              {getReviewActionLabel(actionType, isApplyingReviewAction)}
+            </ActionButton>
+          ))}
+        </div>
+        {reviewActionError ? (
+          <div className="performance-advisor-brief-supportability-note">{reviewActionError}</div>
+        ) : null}
+      </div>
+    ) : reviewActionError ? (
+      <div
+        className="performance-advisor-brief-review-actions"
+        aria-label="Advisor brief review actions"
+      >
+        <div className="performance-advisor-brief-supportability-note">{reviewActionError}</div>
+      </div>
+    ) : null;
 
   return (
     <PerformanceWorkspaceStageSurface
@@ -163,10 +258,37 @@ export default function PerformanceAdvisorBriefMode({
             aria-label="Advisor brief source metrics"
           >
             <LotusMetricPanel metrics={brief.sourceMetrics} onSelectMode={onSelectMode} />
-            <LotusSupportabilityPanel items={brief.supportability} reviewNotes={brief.reviewNotes} />
+            <LotusSupportabilityPanel
+              items={brief.supportability}
+              reviewNotes={brief.reviewNotes}
+              reviewActionForm={reviewActionForm}
+            />
             <LotusAuditStrip audit={brief.audit} />
           </aside>
         </div>
     </PerformanceWorkspaceStageSurface>
   );
+}
+
+function getReviewActionLabel(
+  actionType: WorkbenchAdvisorBriefWorkflowPackRunReviewActionType,
+  isApplyingReviewAction: boolean
+): string {
+  if (isApplyingReviewAction) {
+    return "Recording...";
+  }
+  switch (actionType) {
+    case "ACCEPT":
+      return "Accept Brief";
+    case "REJECT":
+      return "Reject Brief";
+    case "REVISE":
+      return "Request Revision";
+    case "SUPERSEDE":
+      return "Mark Superseded";
+    case "ABANDON":
+      return "Abandon Brief";
+    default:
+      return actionType;
+  }
 }

--- a/src/apps/performance/components/performance-advisor-brief-mode.tsx
+++ b/src/apps/performance/components/performance-advisor-brief-mode.tsx
@@ -45,6 +45,7 @@ export default function PerformanceAdvisorBriefMode({
   });
   const [reviewedBy, setReviewedBy] = useState("");
   const [reviewReason, setReviewReason] = useState("");
+  const [replacementRunId, setReplacementRunId] = useState("");
   const {
     advisorBrief,
     advisorBriefUnavailable,
@@ -142,16 +143,31 @@ export default function PerformanceAdvisorBriefMode({
   const workflowPackRun = advisorBrief?.workflow_pack_run ?? null;
   const reviewActionAllowed =
     workflowPackRun !== null && workflowPackRun.allowed_review_actions.length > 0;
-  const canSubmitReviewAction =
-    reviewActionAllowed &&
-    reviewedBy.trim().length > 0 &&
-    reviewReason.trim().length > 0 &&
-    !isApplyingReviewAction;
+  const supportsReplacementRunId =
+    workflowPackRun !== null &&
+    workflowPackRun.allowed_review_actions.some(requiresReplacementRunId);
+
+  function canSubmitReviewAction(
+    actionType: WorkbenchAdvisorBriefWorkflowPackRunReviewActionType
+  ): boolean {
+    if (
+      !reviewActionAllowed ||
+      reviewedBy.trim().length === 0 ||
+      reviewReason.trim().length === 0 ||
+      isApplyingReviewAction
+    ) {
+      return false;
+    }
+    if (requiresReplacementRunId(actionType) && replacementRunId.trim().length === 0) {
+      return false;
+    }
+    return true;
+  }
 
   async function handleReviewAction(
     actionType: WorkbenchAdvisorBriefWorkflowPackRunReviewActionType
   ) {
-    if (!canSubmitReviewAction) {
+    if (!canSubmitReviewAction(actionType)) {
       return;
     }
     try {
@@ -159,8 +175,12 @@ export default function PerformanceAdvisorBriefMode({
         action_type: actionType,
         reviewed_by: reviewedBy.trim(),
         reason: reviewReason.trim(),
+        replacement_run_id: requiresReplacementRunId(actionType)
+          ? replacementRunId.trim()
+          : undefined,
       });
       setReviewReason("");
+      setReplacementRunId("");
     } catch {
       // The hook already exposes a user-facing error note for the supportability rail.
     }
@@ -196,12 +216,31 @@ export default function PerformanceAdvisorBriefMode({
             rows={3}
           />
         </label>
+        {supportsReplacementRunId ? (
+          <label className="performance-advisor-brief-review-field">
+            <span className="performance-advisor-brief-supportability-label">
+              Replacement run id
+            </span>
+            <input
+              className="input"
+              aria-label="Replacement run id"
+              value={replacementRunId}
+              onChange={(event) => setReplacementRunId(event.target.value)}
+              placeholder="packrun_advisor_brief_req-2"
+              autoComplete="off"
+            />
+            <span className="performance-advisor-brief-supportability-note">
+              Required only for revision or supersede transitions so bounded lineage stays
+              reconstructable.
+            </span>
+          </label>
+        ) : null}
         <div className="performance-advisor-brief-review-action-row">
           {workflowPackRun.allowed_review_actions.map((actionType) => (
             <ActionButton
               key={actionType}
               priority={actionType === "ACCEPT" ? "primary" : "secondary"}
-              disabled={!canSubmitReviewAction}
+              disabled={!canSubmitReviewAction(actionType)}
               onClick={() => void handleReviewAction(actionType)}
             >
               {getReviewActionLabel(actionType, isApplyingReviewAction)}
@@ -291,4 +330,10 @@ function getReviewActionLabel(
     default:
       return actionType;
   }
+}
+
+function requiresReplacementRunId(
+  actionType: WorkbenchAdvisorBriefWorkflowPackRunReviewActionType
+): boolean {
+  return actionType === "REVISE" || actionType === "SUPERSEDE";
 }

--- a/src/apps/performance/use-performance-advisor-brief.ts
+++ b/src/apps/performance/use-performance-advisor-brief.ts
@@ -2,8 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { getWorkbenchPerformanceAdvisorBriefClient } from "@/features/workbench/api";
-import type { WorkbenchPerformanceAdvisorBrief } from "@/features/workbench/types";
+import {
+  getWorkbenchPerformanceAdvisorBriefClient,
+  postWorkbenchPerformanceAdvisorBriefReviewActionClient,
+} from "@/features/workbench/api";
+import type {
+  WorkbenchAdvisorBriefWorkflowPackRunReviewActionRequest,
+  WorkbenchPerformanceAdvisorBrief,
+} from "@/features/workbench/types";
 
 type PerformanceAdvisorBriefRequest = {
   portfolioId: string;
@@ -37,6 +43,8 @@ export function usePerformanceAdvisorBrief({
   const [advisorBrief, setAdvisorBrief] = useState<WorkbenchPerformanceAdvisorBrief | null>(null);
   const [advisorBriefUnavailable, setAdvisorBriefUnavailable] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [isApplyingReviewAction, setIsApplyingReviewAction] = useState(false);
+  const [reviewActionError, setReviewActionError] = useState<string | null>(null);
   const [refreshSequence, setRefreshSequence] = useState(0);
   const requestSequenceRef = useRef(0);
   const cacheRef = useRef<Map<string, WorkbenchPerformanceAdvisorBrief>>(new Map());
@@ -72,6 +80,7 @@ export function usePerformanceAdvisorBrief({
     const cachedResponse = cacheRef.current.get(requestKey) ?? null;
     setAdvisorBrief(cachedResponse);
     setAdvisorBriefUnavailable(false);
+    setReviewActionError(null);
 
     if (cachedResponse) {
       setIsLoading(false);
@@ -129,10 +138,61 @@ export function usePerformanceAdvisorBrief({
     setRefreshSequence((current) => current + 1);
   }, []);
 
+  const applyReviewAction = useCallback(
+    async (payload: WorkbenchAdvisorBriefWorkflowPackRunReviewActionRequest) => {
+      setIsApplyingReviewAction(true);
+      setReviewActionError(null);
+
+      try {
+        const response = await postWorkbenchPerformanceAdvisorBriefReviewActionClient(
+          portfolioId,
+          {
+            period,
+            chartFrequency,
+            contributionDimension,
+            attributionDimension,
+            detailBasis,
+            benchmark: benchmark ?? undefined,
+            reportStartDate,
+            reportEndDate,
+          },
+          payload
+        );
+
+        cacheRef.current.set(requestKey, response);
+        setAdvisorBrief(response);
+        setAdvisorBriefUnavailable(false);
+        return response;
+      } catch (error) {
+        setReviewActionError(
+          "Gateway could not record the bounded review action. Refresh the brief and try again."
+        );
+        throw error;
+      } finally {
+        setIsApplyingReviewAction(false);
+      }
+    },
+    [
+      attributionDimension,
+      benchmark,
+      chartFrequency,
+      contributionDimension,
+      detailBasis,
+      period,
+      portfolioId,
+      requestKey,
+      reportEndDate,
+      reportStartDate,
+    ]
+  );
+
   return {
     advisorBrief,
     advisorBriefUnavailable,
     isLoading,
+    isApplyingReviewAction,
+    reviewActionError,
+    applyReviewAction,
     refresh,
   };
 }

--- a/src/apps/portfolio/api.ts
+++ b/src/apps/portfolio/api.ts
@@ -65,6 +65,8 @@ type PortfolioTransactionLedgerResponse = {
   transactions: PortfolioWorkspace["recent_transactions"];
 };
 
+export type PortfolioLookThroughMode = "direct_only" | "prefer_look_through";
+
 type PortfolioIncomeSummaryResponse = NonNullable<PortfolioWorkspace["income_summary"]>;
 
 type PortfolioActivitySummaryResponse = NonNullable<PortfolioWorkspace["activity_summary"]>;
@@ -427,7 +429,7 @@ export async function getPortfolioAllocationViews(
   params: {
     asOfDate?: string;
     reportingCurrency?: string;
-    lookThroughMode?: "direct_only" | "full";
+    lookThroughMode?: PortfolioLookThroughMode;
   } = {}
 ): Promise<PortfolioAllocationResponse | null> {
   try {

--- a/src/apps/portfolio/components/portfolio-allocation-panel.tsx
+++ b/src/apps/portfolio/components/portfolio-allocation-panel.tsx
@@ -7,7 +7,10 @@ import {
   WorkbenchSummaryToolbar,
 } from "@/design-system";
 
-import { getPortfolioAllocationViews } from "../api";
+import {
+  getPortfolioAllocationViews,
+  type PortfolioLookThroughMode,
+} from "../api";
 import { formatCurrency, formatPct } from "../formatters";
 import type {
   PortfolioAllocationLookThrough,
@@ -39,8 +42,6 @@ const ALLOCATION_COLORS = [
 
 type ChartType = (typeof CHART_TYPES)[number]["key"];
 type AllocationDimension = (typeof DIMENSIONS)[number]["key"];
-type LookThroughMode = "direct_only" | "full";
-
 function handleInteractiveKeyPress(
   event: KeyboardEvent<Element>,
   onActivate: () => void
@@ -73,13 +74,13 @@ export default function PortfolioAllocationPanel({
   const [resolvedAllocationViews, setResolvedAllocationViews] =
     useState<PortfolioAllocationView[]>(allocationViews);
   const [lookThroughRequestedMode, setLookThroughRequestedMode] =
-    useState<LookThroughMode>("direct_only");
+    useState<PortfolioLookThroughMode>("direct_only");
   const [lookThroughEffectiveMode, setLookThroughEffectiveMode] =
-    useState<LookThroughMode>("direct_only");
+    useState<PortfolioLookThroughMode>("direct_only");
   const [lookThroughSupported, setLookThroughSupported] = useState(false);
   const [lookThroughBusy, setLookThroughBusy] = useState(false);
   const [lookThroughProbeComplete, setLookThroughProbeComplete] = useState(false);
-  const [cachedFullResponse, setCachedFullResponse] = useState<{
+  const [cachedLookThroughResponse, setCachedLookThroughResponse] = useState<{
     views: PortfolioAllocationView[];
     lookThrough: PortfolioAllocationLookThrough | null;
   } | null>(null);
@@ -104,7 +105,7 @@ export default function PortfolioAllocationPanel({
     setLookThroughSupported(false);
     setLookThroughBusy(true);
     setLookThroughProbeComplete(false);
-    setCachedFullResponse(null);
+    setCachedLookThroughResponse(null);
 
     void Promise.all([
       getPortfolioAllocationViews(portfolioId, {
@@ -115,9 +116,9 @@ export default function PortfolioAllocationPanel({
       getPortfolioAllocationViews(portfolioId, {
         asOfDate,
         reportingCurrency,
-        lookThroughMode: "full",
+        lookThroughMode: "prefer_look_through",
       }),
-    ]).then(([directResponse, fullResponse]) => {
+    ]).then(([directResponse, lookThroughResponse]) => {
       if (cancelled) {
         return;
       }
@@ -130,13 +131,13 @@ export default function PortfolioAllocationPanel({
       );
 
       const supportsExpandedLookThrough = isExpandedLookThroughSupported(
-        fullResponse?.look_through ?? null
+        lookThroughResponse?.look_through ?? null
       );
       setLookThroughSupported(supportsExpandedLookThrough);
-      if (supportsExpandedLookThrough && fullResponse?.views?.length) {
-        setCachedFullResponse({
-          views: fullResponse.views,
-          lookThrough: fullResponse.look_through ?? null,
+      if (supportsExpandedLookThrough && lookThroughResponse?.views?.length) {
+        setCachedLookThroughResponse({
+          views: lookThroughResponse.views,
+          lookThrough: lookThroughResponse.look_through ?? null,
         });
       }
       setLookThroughProbeComplete(true);
@@ -168,13 +169,14 @@ export default function PortfolioAllocationPanel({
     selectedAllocation?.dimension === activeDimension ? selectedAllocation.bucket : null;
 
   const lookThroughLabel =
-    lookThroughRequestedMode === "full" && lookThroughEffectiveMode === "full"
+    lookThroughRequestedMode === "prefer_look_through" &&
+    lookThroughEffectiveMode === "prefer_look_through"
       ? "Expanded exposure"
       : "Direct holdings";
 
   const syncAllocationViewState = (
     nextViews: PortfolioAllocationView[],
-    nextRequestedMode: LookThroughMode,
+    nextRequestedMode: PortfolioLookThroughMode,
     nextLookThrough: PortfolioAllocationLookThrough | null | undefined
   ) => {
     setResolvedAllocationViews(nextViews);
@@ -198,16 +200,18 @@ export default function PortfolioAllocationPanel({
   };
 
   const toggleLookThrough = async () => {
-    const nextMode: LookThroughMode =
-      lookThroughRequestedMode === "full" ? "direct_only" : "full";
+    const nextMode: PortfolioLookThroughMode =
+      lookThroughRequestedMode === "prefer_look_through"
+        ? "direct_only"
+        : "prefer_look_through";
     setLookThroughBusy(true);
 
     try {
       const response =
-        nextMode === "full" && cachedFullResponse
+        nextMode === "prefer_look_through" && cachedLookThroughResponse
           ? {
-              views: cachedFullResponse.views,
-              look_through: cachedFullResponse.lookThrough,
+              views: cachedLookThroughResponse.views,
+              look_through: cachedLookThroughResponse.lookThrough,
             }
           : await getPortfolioAllocationViews(portfolioId, {
               asOfDate,
@@ -269,10 +273,10 @@ export default function PortfolioAllocationPanel({
             className="portfolio-allocation-toggle"
             disabled={!lookThroughSupported || lookThroughBusy}
             aria-disabled={!lookThroughSupported || lookThroughBusy}
-            aria-pressed={lookThroughRequestedMode === "full"}
+            aria-pressed={lookThroughRequestedMode === "prefer_look_through"}
             aria-label={
               lookThroughSupported
-                ? `Look-through ${lookThroughRequestedMode === "full" ? "on" : "off"}`
+                ? `Look-through ${lookThroughRequestedMode === "prefer_look_through" ? "on" : "off"}`
                 : lookThroughProbeComplete
                   ? "Look-through unavailable for current portfolio snapshot"
                   : "Checking look-through support"
@@ -288,7 +292,9 @@ export default function PortfolioAllocationPanel({
               void toggleLookThrough();
             }}
           >
-            {lookThroughRequestedMode === "full" ? "Look-through on" : "Look-through off"}
+            {lookThroughRequestedMode === "prefer_look_through"
+              ? "Look-through on"
+              : "Look-through off"}
           </button>
         </div>
       </WorkbenchSummaryToolbar>
@@ -620,9 +626,9 @@ function formatDimensionLabel(value: string): string {
 
 function normalizeLookThroughMode(
   value: string | null | undefined,
-  fallback: LookThroughMode = "direct_only"
-): LookThroughMode {
-  return value === "full" ? "full" : fallback;
+  fallback: PortfolioLookThroughMode = "direct_only"
+): PortfolioLookThroughMode {
+  return value === "prefer_look_through" ? "prefer_look_through" : fallback;
 }
 
 function isExpandedLookThroughSupported(
@@ -631,7 +637,9 @@ function isExpandedLookThroughSupported(
   if (!lookThrough) {
     return false;
   }
-  return lookThrough.applied || lookThrough.effective_mode === "full";
+  return (
+    lookThrough.applied || lookThrough.effective_mode === "prefer_look_through"
+  );
 }
 
 function polarToCartesian(centerX: number, centerY: number, radius: number, angleInDegrees: number) {

--- a/src/features/domain-products/api.ts
+++ b/src/features/domain-products/api.ts
@@ -1,0 +1,174 @@
+const BFF_PROXY_BASE = "/api/bff/api/v1";
+
+export type DomainProductRepositorySummary = {
+  repository: string;
+  producedProductCount: number;
+  consumedDependencyCount: number;
+};
+
+export type DomainProduct = {
+  productId: string;
+  productName: string;
+  productVersion: string;
+  producerRepository: string;
+  ownerRepository: string;
+  authoritativeDomain: string;
+  productFamily: string;
+  lifecycleStatus: string;
+  requiredTrustMetadata: string[];
+  approvedConsumers: string[];
+  currentRoutes: string[];
+  sourcePath: string;
+};
+
+export type DomainProductDependency = {
+  dependencyId: string;
+  productName: string;
+  producerRepository: string;
+  requiredProductVersion: string;
+  requiredTrustMetadata: string[];
+  consumptionMode: string;
+  businessPurpose: string;
+  validationLanes: string[];
+  failurePosture: string;
+};
+
+export type DomainProductConsumer = {
+  consumerRepository: string;
+  dependencyCount: number;
+  sourcePath: string;
+  dependencies: DomainProductDependency[];
+};
+
+export type DomainProductCatalogData = {
+  consumerSystem: string;
+  correlationId: string;
+  contractId: string;
+  contractVersion: string;
+  generatedAtUtc: string;
+  productCount: number;
+  dependencyCount: number;
+  repositoryCount: number;
+  repositories: DomainProductRepositorySummary[];
+  products: DomainProduct[];
+  consumers: DomainProductConsumer[];
+};
+
+export type DomainProductGraphNode = {
+  nodeId: string;
+  nodeType: string;
+  productId?: string | null;
+  productName?: string | null;
+  productVersion?: string | null;
+  producerRepository?: string | null;
+  repository?: string | null;
+};
+
+export type DomainProductGraphEdge = {
+  edgeType: string;
+  from: string;
+  to: string;
+  consumptionMode?: string | null;
+  failurePosture?: string | null;
+  validationLanes?: string[];
+};
+
+export type DomainProductGraphData = {
+  consumerSystem: string;
+  correlationId: string;
+  contractId: string;
+  contractVersion: string;
+  generatedAtUtc: string;
+  nodeCount: number;
+  edgeCount: number;
+  nodes: DomainProductGraphNode[];
+  edges: DomainProductGraphEdge[];
+};
+
+export type DomainProductTrustSummary = {
+  certificationState: string;
+  telemetrySnapshotCount: number;
+  certifiedSnapshotCount: number;
+  attentionRequiredCount: number;
+  issueCount: number;
+};
+
+export type DomainProductTrustCertification = {
+  productId: string;
+  producerRepository: string;
+  productName: string;
+  productVersion: string;
+  sourceRepository: string;
+  telemetryPath: string;
+  emittedAtUtc: string;
+  certificationState: string;
+  freshnessState: string | null;
+  completenessStatus: string | null;
+  reconciliationStatus: string | null;
+  dataQualityStatus: string | null;
+  lineageMaterialized: boolean | null;
+  blocked: boolean | null;
+  issueCount: number;
+};
+
+export type DomainProductTrustIssue = {
+  code: string;
+  severity: string;
+  productId: string;
+  detail: string;
+};
+
+export type DomainProductTrustCertificationData = {
+  consumerSystem: string;
+  correlationId: string;
+  trustAvailable: boolean;
+  trustPosture: string;
+  unavailableReason: string | null;
+  contractId: string | null;
+  contractVersion: string | null;
+  governedByRfcs: string[];
+  generatedAtUtc: string | null;
+  sourceTelemetryPath: string | null;
+  summary: DomainProductTrustSummary | null;
+  productCertifications: DomainProductTrustCertification[];
+  issues: DomainProductTrustIssue[];
+};
+
+export type DomainProductDiscoveryData = {
+  catalog: DomainProductCatalogData;
+  dependencyGraph: DomainProductGraphData;
+  trustCertification: DomainProductTrustCertificationData;
+};
+
+type GatewayEnvelope<T> = {
+  data: T;
+};
+
+async function fetchGatewayData<T>(path: string): Promise<T> {
+  const params = new URLSearchParams({ consumerSystem: "lotus-workbench" });
+  const response = await fetch(`${BFF_PROXY_BASE}${path}?${params.toString()}`, {
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`Domain product discovery fetch failed (${response.status}): ${detail}`);
+  }
+  const payload = (await response.json()) as GatewayEnvelope<T>;
+  return payload.data;
+}
+
+export async function getDomainProductDiscovery(): Promise<DomainProductDiscoveryData> {
+  const [catalog, dependencyGraph, trustCertification] = await Promise.all([
+    fetchGatewayData<DomainProductCatalogData>("/domain-products/catalog"),
+    fetchGatewayData<DomainProductGraphData>("/domain-products/dependency-graph"),
+    fetchGatewayData<DomainProductTrustCertificationData>(
+      "/domain-products/trust-certification"
+    ),
+  ]);
+
+  return {
+    catalog,
+    dependencyGraph,
+    trustCertification,
+  };
+}

--- a/src/features/domain-products/domain-product-discovery-client.tsx
+++ b/src/features/domain-products/domain-product-discovery-client.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  SectionBlock,
+  SemanticBadge,
+  Text,
+  WorkbenchPageFrame,
+  WorkbenchSectionStack,
+} from "@/design-system";
+
+import {
+  DomainProduct,
+  DomainProductDiscoveryData,
+  DomainProductTrustCertification,
+  getDomainProductDiscovery,
+} from "./api";
+
+type DiscoveryState =
+  | { kind: "loading" }
+  | { kind: "ready"; data: DomainProductDiscoveryData }
+  | { kind: "error"; message: string };
+
+type TrustTone = "success" | "warn" | "danger" | "default";
+
+export default function DomainProductDiscoveryClient() {
+  const [state, setState] = useState<DiscoveryState>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getDomainProductDiscovery()
+      .then((data) => {
+        if (!cancelled) {
+          setState({ kind: "ready", data });
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setState({
+            kind: "error",
+            message: error instanceof Error ? error.message : "Domain product discovery failed.",
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state.kind === "loading") {
+    return (
+      <DiscoveryFrame trustBadge={<SemanticBadge>Loading</SemanticBadge>}>
+        <SectionBlock title="Loading Domain Products">
+          <div className="domain-products-loading" role="status">
+            Loading governed catalog and trust certification from gateway.
+          </div>
+        </SectionBlock>
+      </DiscoveryFrame>
+    );
+  }
+
+  if (state.kind === "error") {
+    return (
+      <DiscoveryFrame trustBadge={<SemanticBadge tone="danger">Unavailable</SemanticBadge>}>
+        <SectionBlock title="Discovery Unavailable">
+          <div className="domain-products-state domain-products-state-danger" role="alert">
+            {state.message}
+          </div>
+        </SectionBlock>
+      </DiscoveryFrame>
+    );
+  }
+
+  return <ReadyDiscovery data={state.data} />;
+}
+
+function ReadyDiscovery({ data }: { data: DomainProductDiscoveryData }) {
+  const trustByProductId = useMemo(() => {
+    return new Map(
+      data.trustCertification.productCertifications.map((certification) => [
+        certification.productId,
+        certification,
+      ])
+    );
+  }, [data.trustCertification.productCertifications]);
+
+  const trustTone = getTrustTone(data.trustCertification.trustPosture);
+  const products = data.catalog.products;
+  const hasProducts = products.length > 0;
+  const hasPartialTrust =
+    !data.trustCertification.trustAvailable ||
+    data.trustCertification.trustPosture !== "certified" ||
+    data.trustCertification.productCertifications.some(
+      (certification) =>
+        certification.certificationState !== "certified" ||
+        certification.freshnessState === "stale" ||
+        certification.blocked === true
+    );
+
+  return (
+    <DiscoveryFrame
+      trustBadge={
+        <SemanticBadge tone={trustTone} emphasis="strong">
+          {formatStateLabel(data.trustCertification.trustPosture)}
+        </SemanticBadge>
+      }
+    >
+      {!hasProducts ? (
+        <SectionBlock title="No Governed Products">
+          <div className="domain-products-state">
+            Gateway returned an empty domain-product catalog for lotus-workbench.
+          </div>
+        </SectionBlock>
+      ) : null}
+
+      {hasPartialTrust ? (
+        <SectionBlock
+          title="Trust Attention"
+          actions={<SemanticBadge tone={trustTone}>RFC-0087</SemanticBadge>}
+        >
+          <TrustAttention data={data} />
+        </SectionBlock>
+      ) : null}
+
+      <section className="domain-products-overview" aria-label="Domain product summary">
+        <SummaryTile label="Products" value={data.catalog.productCount} />
+        <SummaryTile label="Consumers" value={data.catalog.consumers.length} />
+        <SummaryTile label="Dependencies" value={data.catalog.dependencyCount} />
+        <SummaryTile
+          label="Certified"
+          value={data.trustCertification.summary?.certifiedSnapshotCount ?? 0}
+        />
+      </section>
+
+      <SectionBlock
+        title="Governed Product Catalog"
+        subtitle="Producer-owned contracts surfaced through gateway."
+      >
+        <div className="domain-products-grid">
+          {products.map((product) => (
+            <ProductCard
+              key={product.productId}
+              product={product}
+              trust={trustByProductId.get(product.productId)}
+            />
+          ))}
+        </div>
+      </SectionBlock>
+
+      <SectionBlock
+        title="Consumer Dependency Catalog"
+        subtitle="Approved consumers and declared dependencies."
+      >
+        <div className="domain-products-dependencies">
+          {data.catalog.consumers.map((consumer) => (
+            <div key={consumer.consumerRepository} className="domain-products-row">
+              <div>
+                <Text variant="label">{consumer.consumerRepository}</Text>
+                <Text variant="secondary">{consumer.sourcePath}</Text>
+              </div>
+              <div className="domain-products-chip-row">
+                {consumer.dependencies.map((dependency) => (
+                  <SemanticBadge key={dependency.dependencyId}>
+                    {dependency.productName} {dependency.requiredProductVersion}
+                  </SemanticBadge>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </SectionBlock>
+
+      <SectionBlock title="Dependency Graph" subtitle="Gateway-rendered impact posture.">
+        <div className="domain-products-graph">
+          <SummaryTile label="Graph nodes" value={data.dependencyGraph.nodeCount} />
+          <SummaryTile label="Graph edges" value={data.dependencyGraph.edgeCount} />
+          <SummaryTile
+            label="Fail-closed edges"
+            value={
+              data.dependencyGraph.edges.filter((edge) => edge.failurePosture === "fail_closed")
+                .length
+            }
+          />
+        </div>
+      </SectionBlock>
+    </DiscoveryFrame>
+  );
+}
+
+function DiscoveryFrame({
+  trustBadge,
+  children,
+}: {
+  trustBadge: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="page-container domain-products-page">
+      <WorkbenchPageFrame
+        title="Domain Product Discovery"
+        subtitle="Review governed data products, consumers, dependencies, and live trust posture from gateway."
+        actions={
+          <>
+            {trustBadge}
+            <SemanticBadge>Gateway sourced</SemanticBadge>
+          </>
+        }
+      >
+        <WorkbenchSectionStack>{children}</WorkbenchSectionStack>
+      </WorkbenchPageFrame>
+    </main>
+  );
+}
+
+function TrustAttention({ data }: { data: DomainProductDiscoveryData }) {
+  if (!data.trustCertification.trustAvailable) {
+    return (
+      <div className="domain-products-state domain-products-state-warn">
+        {data.trustCertification.unavailableReason ??
+          "Live trust certification has not been generated."}
+      </div>
+    );
+  }
+
+  const issues = data.trustCertification.issues;
+  if (issues.length === 0) {
+    return (
+      <div className="domain-products-state domain-products-state-warn">
+        Trust posture is {formatStateLabel(data.trustCertification.trustPosture)}.
+      </div>
+    );
+  }
+
+  return (
+    <div className="domain-products-issues">
+      {issues.map((issue) => (
+        <div key={`${issue.productId}:${issue.code}:${issue.detail}`} className="domain-products-row">
+          <div>
+            <Text variant="label">{issue.code}</Text>
+            <Text variant="secondary">{issue.productId}</Text>
+          </div>
+          <Text variant="secondary">{issue.detail}</Text>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ProductCard({
+  product,
+  trust,
+}: {
+  product: DomainProduct;
+  trust: DomainProductTrustCertification | undefined;
+}) {
+  const trustState = trust?.certificationState ?? "unavailable";
+  const trustTone = getTrustTone(trustState);
+
+  return (
+    <article className="domain-products-card">
+      <div className="domain-products-card-header">
+        <div>
+          <Text variant="label">{product.producerRepository}</Text>
+          <h2>{product.productName}</h2>
+          <Text variant="secondary">{product.productVersion}</Text>
+        </div>
+        <SemanticBadge tone={trustTone}>{formatStateLabel(trustState)}</SemanticBadge>
+      </div>
+      <dl className="domain-products-facts">
+        <div>
+          <dt>Lifecycle</dt>
+          <dd>{product.lifecycleStatus}</dd>
+        </div>
+        <div>
+          <dt>Owner</dt>
+          <dd>{product.ownerRepository}</dd>
+        </div>
+        <div>
+          <dt>Approved consumers</dt>
+          <dd>{product.approvedConsumers.join(", ") || "none"}</dd>
+        </div>
+        <div>
+          <dt>Freshness</dt>
+          <dd>{trust?.freshnessState ?? "unavailable"}</dd>
+        </div>
+        <div>
+          <dt>Completeness</dt>
+          <dd>{trust?.completenessStatus ?? "unavailable"}</dd>
+        </div>
+        <div>
+          <dt>Lineage</dt>
+          <dd>{trust?.lineageMaterialized ? "materialized" : "unavailable"}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+function SummaryTile({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="domain-products-summary-tile">
+      <Text variant="label">{label}</Text>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function getTrustTone(state: string): TrustTone {
+  if (state === "certified") return "success";
+  if (state === "attention_required" || state === "unavailable") return "warn";
+  if (state === "blocked") return "danger";
+  return "default";
+}
+
+function formatStateLabel(state: string): string {
+  return state.replaceAll("_", " ");
+}

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -1,5 +1,6 @@
 import {
   WorkbenchAnalytics,
+  WorkbenchAdvisorBriefWorkflowPackRunReviewActionRequest,
   WorkbenchPerformanceAdvisorBrief,
   WorkbenchPerformanceAttributionTrend,
   WorkbenchOverview,
@@ -361,6 +362,41 @@ export async function getWorkbenchPerformanceAdvisorBriefClient(
     "performance advisor brief",
     buildPerformanceWorkspaceQuery(params)
   );
+}
+
+export async function postWorkbenchPerformanceAdvisorBriefReviewActionClient(
+  portfolioId: string,
+  params: {
+    period: string;
+    chartFrequency: string;
+    contributionDimension: string;
+    attributionDimension: string;
+    detailBasis: string;
+    benchmark?: string;
+    reportStartDate?: string;
+    reportEndDate?: string;
+  },
+  payload: WorkbenchAdvisorBriefWorkflowPackRunReviewActionRequest
+): Promise<WorkbenchPerformanceAdvisorBrief> {
+  const response = await fetch(
+    buildWorkbenchUrl(
+      "client",
+      `/workbench/${portfolioId}/performance/advisor-brief/review-actions`,
+      buildPerformanceWorkspaceQuery(params)
+    ),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      cache: "no-store",
+    }
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to record performance advisor brief review action (${response.status})`
+    );
+  }
+  return (await response.json()) as WorkbenchPerformanceAdvisorBrief;
 }
 
 function buildRiskWorkspaceQuery(params: {

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -524,6 +524,20 @@ export type WorkbenchAdvisorBriefWorkflowPackRunFinding = {
   summary: string;
 };
 
+export type WorkbenchAdvisorBriefWorkflowPackRunReviewActionType =
+  | "ACCEPT"
+  | "REJECT"
+  | "REVISE"
+  | "SUPERSEDE"
+  | "ABANDON";
+
+export type WorkbenchAdvisorBriefWorkflowPackRunReviewActionRequest = {
+  action_type: WorkbenchAdvisorBriefWorkflowPackRunReviewActionType;
+  reviewed_by: string;
+  reason: string;
+  replacement_run_id?: string | null;
+};
+
 export type WorkbenchAdvisorBriefWorkflowPackRun = {
   run_id: string;
   runtime_state: string;

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -518,6 +518,26 @@ export type WorkbenchAdvisorBriefSupportabilityItem = {
   reason?: string | null;
 };
 
+export type WorkbenchAdvisorBriefWorkflowPackRunFinding = {
+  finding_id: string;
+  severity: string;
+  summary: string;
+};
+
+export type WorkbenchAdvisorBriefWorkflowPackRun = {
+  run_id: string;
+  runtime_state: string;
+  review_state: string;
+  allowed_review_actions: string[];
+  supportability_status: string;
+  review_pending: boolean;
+  superseded: boolean;
+  workflow_authority_owner: string;
+  current_summary_note: string;
+  replacement_run_id?: string | null;
+  findings: WorkbenchAdvisorBriefWorkflowPackRunFinding[];
+};
+
 export type WorkbenchPerformanceAdvisorBrief = {
   correlation_id: string;
   contract_version: string;
@@ -539,6 +559,7 @@ export type WorkbenchPerformanceAdvisorBrief = {
   risks_and_exceptions: WorkbenchAdvisorBriefNarrativeItem[];
   source_metrics: WorkbenchAdvisorBriefSourceMetric[];
   supportability: WorkbenchAdvisorBriefSupportabilityItem[];
+  workflow_pack_run?: WorkbenchAdvisorBriefWorkflowPackRun | null;
   ai_audit: {
     task_id?: string;
     output_label?: string;

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -542,7 +542,7 @@ export type WorkbenchAdvisorBriefWorkflowPackRun = {
   run_id: string;
   runtime_state: string;
   review_state: string;
-  allowed_review_actions: string[];
+  allowed_review_actions: WorkbenchAdvisorBriefWorkflowPackRunReviewActionType[];
   supportability_status: string;
   review_pending: boolean;
   superseded: boolean;

--- a/tests/unit/domain-product-discovery-client.test.tsx
+++ b/tests/unit/domain-product-discovery-client.test.tsx
@@ -1,0 +1,268 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import DomainProductDiscoveryClient from "../../src/features/domain-products/domain-product-discovery-client";
+import type { DomainProductDiscoveryData } from "../../src/features/domain-products/api";
+
+const getDomainProductDiscoveryMock = vi.fn();
+
+vi.mock("../../src/features/domain-products/api", async () => {
+  const actual = await vi.importActual("../../src/features/domain-products/api");
+  return {
+    ...(actual as object),
+    getDomainProductDiscovery: () => getDomainProductDiscoveryMock(),
+  };
+});
+
+describe("DomainProductDiscoveryClient", () => {
+  beforeEach(() => {
+    getDomainProductDiscoveryMock.mockReset();
+  });
+
+  it("renders real catalog, dependency, and certified trust facts", async () => {
+    getDomainProductDiscoveryMock.mockResolvedValue(buildDiscovery());
+
+    render(<DomainProductDiscoveryClient />);
+
+    expect(
+      screen.getByText("Loading governed catalog and trust certification from gateway.")
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Domain Product Discovery" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("PortfolioStateSnapshot")).toBeInTheDocument();
+    expect(screen.getAllByText("lotus-core").length).toBeGreaterThan(0);
+    expect(screen.getByText("lotus-workbench, lotus-risk")).toBeInTheDocument();
+    expect(screen.getByText("materialized")).toBeInTheDocument();
+    expect(screen.getByText("RiskMetricsReport v1")).toBeInTheDocument();
+    expect(screen.getByText("Fail-closed edges")).toBeInTheDocument();
+  });
+
+  it("renders unavailable trust without inventing certification", async () => {
+    getDomainProductDiscoveryMock.mockResolvedValue(
+      buildDiscovery({
+        trustAvailable: false,
+        trustPosture: "unavailable",
+        unavailableReason: "Platform live trust certification artifact is unavailable.",
+        summary: null,
+        productCertifications: [],
+      })
+    );
+
+    render(<DomainProductDiscoveryClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Trust Attention")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Platform live trust certification artifact is unavailable.")
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("unavailable").length).toBeGreaterThan(0);
+  });
+
+  it("renders stale trust issue details as partial truth", async () => {
+    getDomainProductDiscoveryMock.mockResolvedValue(
+      buildDiscovery({
+        trustPosture: "attention_required",
+        summary: {
+          certificationState: "attention_required",
+          telemetrySnapshotCount: 1,
+          certifiedSnapshotCount: 0,
+          attentionRequiredCount: 1,
+          issueCount: 1,
+        },
+        productCertifications: [
+          {
+            productId: "lotus-core:PortfolioStateSnapshot:v1",
+            producerRepository: "lotus-core",
+            productName: "PortfolioStateSnapshot",
+            productVersion: "v1",
+            sourceRepository: "lotus-core",
+            telemetryPath: "contracts/trust-telemetry/portfolio-state.telemetry.v1.json",
+            emittedAtUtc: "2026-04-19T00:00:00Z",
+            certificationState: "attention_required",
+            freshnessState: "stale",
+            completenessStatus: "complete",
+            reconciliationStatus: "reconciled",
+            dataQualityStatus: "quality_passed",
+            lineageMaterialized: true,
+            blocked: false,
+            issueCount: 1,
+          },
+        ],
+        issues: [
+          {
+            code: "freshness_not_current",
+            severity: "warning",
+            productId: "lotus-core:PortfolioStateSnapshot:v1",
+            detail: "Freshness state is stale.",
+          },
+        ],
+      })
+    );
+
+    render(<DomainProductDiscoveryClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText("freshness_not_current")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Freshness state is stale.")).toBeInTheDocument();
+    expect(screen.getAllByText("attention required").length).toBeGreaterThan(0);
+  });
+
+  it("renders the empty catalog state", async () => {
+    const discovery = buildDiscovery();
+    getDomainProductDiscoveryMock.mockResolvedValue({
+      ...discovery,
+      catalog: {
+        ...discovery.catalog,
+        productCount: 0,
+        products: [],
+      },
+    });
+
+    render(<DomainProductDiscoveryClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No Governed Products")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Gateway returned an empty domain-product catalog for lotus-workbench.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders gateway errors truthfully", async () => {
+    getDomainProductDiscoveryMock.mockRejectedValue(new Error("gateway unavailable"));
+
+    render(<DomainProductDiscoveryClient />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("gateway unavailable");
+    });
+  });
+});
+
+function buildDiscovery(
+  trustOverrides: Partial<DomainProductDiscoveryData["trustCertification"]> = {}
+): DomainProductDiscoveryData {
+  return {
+    catalog: {
+      consumerSystem: "lotus-workbench",
+      correlationId: "corr-catalog",
+      contractId: "lotus-domain-product-catalog",
+      contractVersion: "1.0.0",
+      generatedAtUtc: "2026-04-19T00:00:00Z",
+      productCount: 1,
+      dependencyCount: 1,
+      repositoryCount: 1,
+      repositories: [
+        {
+          repository: "lotus-core",
+          producedProductCount: 1,
+          consumedDependencyCount: 0,
+        },
+      ],
+      products: [
+        {
+          productId: "lotus-core:PortfolioStateSnapshot:v1",
+          productName: "PortfolioStateSnapshot",
+          productVersion: "v1",
+          producerRepository: "lotus-core",
+          ownerRepository: "lotus-core",
+          authoritativeDomain: "portfolio_state",
+          productFamily: "simulation_and_projected_state",
+          lifecycleStatus: "active",
+          requiredTrustMetadata: ["as_of_date", "data_quality_status"],
+          approvedConsumers: ["lotus-workbench", "lotus-risk"],
+          currentRoutes: ["/integration/portfolios/{portfolio_id}/state"],
+          sourcePath: "contracts/domain-data-products/lotus-core-products.v1.json",
+        },
+      ],
+      consumers: [
+        {
+          consumerRepository: "lotus-risk",
+          dependencyCount: 1,
+          sourcePath: "contracts/domain-data-products/lotus-risk-consumers.v1.json",
+          dependencies: [
+            {
+              dependencyId: "lotus-risk:RiskMetricsReport:v1",
+              productName: "RiskMetricsReport",
+              producerRepository: "lotus-risk",
+              requiredProductVersion: "v1",
+              requiredTrustMetadata: ["data_quality_status"],
+              consumptionMode: "api_read",
+              businessPurpose: "Source risk analytics input state.",
+              validationLanes: ["feature", "pr-merge"],
+              failurePosture: "fail_closed",
+            },
+          ],
+        },
+      ],
+    },
+    dependencyGraph: {
+      consumerSystem: "lotus-workbench",
+      correlationId: "corr-graph",
+      contractId: "lotus-domain-product-dependency-graph",
+      contractVersion: "1.0.0",
+      generatedAtUtc: "2026-04-19T00:00:00Z",
+      nodeCount: 2,
+      edgeCount: 1,
+      nodes: [],
+      edges: [
+        {
+          edgeType: "consumes",
+          from: "repo:lotus-risk",
+          to: "product:lotus-core:PortfolioStateSnapshot:v1",
+          consumptionMode: "api_read",
+          failurePosture: "fail_closed",
+          validationLanes: ["feature", "pr-merge"],
+        },
+      ],
+    },
+    trustCertification: {
+      consumerSystem: "lotus-workbench",
+      correlationId: "corr-trust",
+      trustAvailable: true,
+      trustPosture: "certified",
+      unavailableReason: null,
+      contractId: "lotus-domain-product-live-trust-certification",
+      contractVersion: "1.0.0",
+      governedByRfcs: ["RFC-0087"],
+      generatedAtUtc: "2026-04-19T00:00:00Z",
+      sourceTelemetryPath: "contracts/trust-telemetry",
+      summary: {
+        certificationState: "certified",
+        telemetrySnapshotCount: 1,
+        certifiedSnapshotCount: 1,
+        attentionRequiredCount: 0,
+        issueCount: 0,
+      },
+      productCertifications: [
+        {
+          productId: "lotus-core:PortfolioStateSnapshot:v1",
+          producerRepository: "lotus-core",
+          productName: "PortfolioStateSnapshot",
+          productVersion: "v1",
+          sourceRepository: "lotus-core",
+          telemetryPath: "contracts/trust-telemetry/portfolio-state.telemetry.v1.json",
+          emittedAtUtc: "2026-04-19T00:00:00Z",
+          certificationState: "certified",
+          freshnessState: "current",
+          completenessStatus: "complete",
+          reconciliationStatus: "reconciled",
+          dataQualityStatus: "quality_passed",
+          lineageMaterialized: true,
+          blocked: false,
+          issueCount: 0,
+        },
+      ],
+      issues: [],
+      ...trustOverrides,
+    },
+  };
+}

--- a/tests/unit/domain-products-api.test.ts
+++ b/tests/unit/domain-products-api.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getDomainProductDiscovery } from "../../src/features/domain-products/api";
+
+describe("domain product discovery api", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads catalog, dependency graph, and trust certification through the gateway BFF", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/domain-products/catalog?")) {
+        return jsonResponse({
+          data: {
+            consumerSystem: "lotus-workbench",
+            correlationId: "corr-catalog",
+            contractId: "lotus-domain-product-catalog",
+            contractVersion: "1.0.0",
+            generatedAtUtc: "2026-04-19T00:00:00Z",
+            productCount: 1,
+            dependencyCount: 1,
+            repositoryCount: 1,
+            repositories: [],
+            products: [
+              {
+                productId: "lotus-core:PortfolioStateSnapshot:v1",
+                productName: "PortfolioStateSnapshot",
+                productVersion: "v1",
+                producerRepository: "lotus-core",
+                ownerRepository: "lotus-core",
+                authoritativeDomain: "portfolio_state",
+                productFamily: "simulation_and_projected_state",
+                lifecycleStatus: "active",
+                requiredTrustMetadata: ["as_of_date", "data_quality_status"],
+                approvedConsumers: ["lotus-workbench"],
+                currentRoutes: ["/integration/portfolios/{portfolio_id}/state"],
+                sourcePath: "contracts/domain-data-products/lotus-core-products.v1.json",
+              },
+            ],
+            consumers: [],
+          },
+        });
+      }
+      if (url.includes("/domain-products/dependency-graph?")) {
+        return jsonResponse({
+          data: {
+            consumerSystem: "lotus-workbench",
+            correlationId: "corr-graph",
+            contractId: "lotus-domain-product-dependency-graph",
+            contractVersion: "1.0.0",
+            generatedAtUtc: "2026-04-19T00:00:00Z",
+            nodeCount: 1,
+            edgeCount: 0,
+            nodes: [],
+            edges: [],
+          },
+        });
+      }
+      if (url.includes("/domain-products/trust-certification?")) {
+        return jsonResponse({
+          data: {
+            consumerSystem: "lotus-workbench",
+            correlationId: "corr-trust",
+            trustAvailable: true,
+            trustPosture: "certified",
+            unavailableReason: null,
+            contractId: "lotus-domain-product-live-trust-certification",
+            contractVersion: "1.0.0",
+            governedByRfcs: ["RFC-0087"],
+            generatedAtUtc: "2026-04-19T00:00:00Z",
+            sourceTelemetryPath: "contracts/trust-telemetry",
+            summary: {
+              certificationState: "certified",
+              telemetrySnapshotCount: 1,
+              certifiedSnapshotCount: 1,
+              attentionRequiredCount: 0,
+              issueCount: 0,
+            },
+            productCertifications: [],
+            issues: [],
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const discovery = await getDomainProductDiscovery();
+
+    expect(discovery.catalog.products[0].producerRepository).toBe("lotus-core");
+    expect(discovery.dependencyGraph.contractId).toBe("lotus-domain-product-dependency-graph");
+    expect(discovery.trustCertification.trustPosture).toBe("certified");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/bff/api/v1/domain-products/catalog?consumerSystem=lotus-workbench",
+      { cache: "no-store" }
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/bff/api/v1/domain-products/dependency-graph?consumerSystem=lotus-workbench",
+      { cache: "no-store" }
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/bff/api/v1/domain-products/trust-certification?consumerSystem=lotus-workbench",
+      { cache: "no-store" }
+    );
+  });
+
+  it("fails when gateway discovery returns an error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("catalog missing", { status: 503 }))
+    );
+
+    await expect(getDomainProductDiscovery()).rejects.toThrow(
+      "Domain product discovery fetch failed (503): catalog missing"
+    );
+  });
+});
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -36,9 +36,13 @@ describe("canonical live validation script", () => {
       "utf8"
     );
 
+    expect(script).toContain("[int]$SeedWaitSeconds = 900");
+    expect(script).toContain("$global:LASTEXITCODE = 0");
+    expect(script).toContain("Command failed with exit code $LASTEXITCODE");
     expect(script).toContain("--portfolio-id $PortfolioId");
     expect(script).toContain("--end-date 2026-04-10");
     expect(script).toContain("--benchmark-start-date 2025-01-06");
+    expect(script).toContain("--wait-seconds $SeedWaitSeconds");
     expect(script).toContain("[string]$ScreenshotDirectory");
     expect(script).toContain("ScreenshotDirectory = $ScreenshotDirectory");
   });

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -64,6 +64,9 @@ describe("canonical live validation script", () => {
     expect(script).toContain("/risk/drawdown?");
     expect(script).toContain("/risk/rolling?");
     expect(script).toContain("/risk/attribution?");
+    expect(script).toContain('from "./validation/workflow-pack-proof.mjs"');
+    expect(script).toContain("validateAdvisorBriefWorkflowPackReviewChain");
+    expect(script).toContain("workflowPackChecks.push");
     expect(calculationModule).toContain("calculationChecks");
     expect(calculationModule).toContain("Contribution total does not reconcile with net portfolio return");
     expect(calculationModule).toContain("Historical risk attribution residual is too high");
@@ -207,6 +210,9 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain("tableByExactLabel");
     expect(browserWorkflowModule).toContain("requireVisible");
     expect(browserWorkflowModule).toContain("Observation Trail");
+    expect(browserWorkflowModule).toContain("performAcceptReviewActionProof");
+    expect(browserWorkflowModule).toContain("Accept Brief");
+    expect(browserWorkflowModule).toContain("bounded workflow-pack ledger posture");
     expect(browserWorkflowModule).toContain("/^Performance Overview/");
     expect(browserWorkflowModule).toContain("/^Performance Analysis/");
     expect(browserWorkflowModule).toContain('"Asset Class attribution table"');
@@ -221,5 +227,7 @@ describe("canonical live validation script", () => {
     expect(runbook).toContain("ScreenshotDirectory");
     expect(runbook).toContain("structured screenshot evidence");
     expect(runbook).toContain("SHOT-INDEX.md");
+    expect(runbook).toContain("workflowPackChecks");
+    expect(runbook).toContain("ACCEPT`, `REVISE`, and");
   });
 });

--- a/tests/unit/live-validation-calculation-sanity.test.ts
+++ b/tests/unit/live-validation-calculation-sanity.test.ts
@@ -41,8 +41,8 @@ describe("live validation calculation sanity helpers", () => {
         },
         capabilities: {
           evidence: {
-            state: "unavailable",
-            reason: "gateway contract pending",
+            state: "partial",
+            reason: "lineage evidence remains partial",
           },
         },
       },
@@ -80,7 +80,7 @@ describe("live validation calculation sanity helpers", () => {
           panel: "performance.analysis.attribution",
           state: "partial",
         }),
-        expect.objectContaining({ panel: "performance.evidence", state: "unavailable" }),
+        expect.objectContaining({ panel: "performance.evidence", state: "partial" }),
       ])
     );
   });

--- a/tests/unit/live-validation-contract-modules.test.ts
+++ b/tests/unit/live-validation-contract-modules.test.ts
@@ -83,6 +83,7 @@ describe("live validation contract modules", () => {
       expect(shotIndex).toContain("performance.risk.snapshot");
       expect(shotIndex).toContain(summaryPath);
       expect(shotIndex).toContain("2026-04-10");
+      expect(persistedSummary.workflowPackChecks).toEqual([]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/tests/unit/live-validation-panel-governance.test.ts
+++ b/tests/unit/live-validation-panel-governance.test.ts
@@ -35,7 +35,7 @@ const registry: TestRegistry = {
       panelId: "performance.evidence",
       owningService: "lotus-gateway",
       gatewayEndpoint: null,
-      requiredSupportState: "unavailable",
+      requiredSupportState: "partial",
       allowedStates: ["ready", "partial", "unavailable", "supported_blank"],
       knownLimitations: ["deferred to RFC-0079"],
       ownerFollowUpRfc: "RFC-0079",
@@ -51,8 +51,8 @@ describe("live validation panel governance", () => {
     governance.recordPanelClassification("portfolio.summary", "ready", "lotus-gateway", {
       portfolioId: "PB_SG_GLOBAL_BAL_001",
     });
-    governance.recordPanelClassification("performance.evidence", "unavailable", "lotus-gateway", {
-      reason: "gateway contract pending",
+    governance.recordPanelClassification("performance.evidence", "partial", "lotus-gateway", {
+      reason: "lineage evidence remains partial",
     });
 
     governance.assertNoUnsupportedBlankPanels();
@@ -68,7 +68,7 @@ describe("live validation panel governance", () => {
         }),
         expect.objectContaining({
           panel: "performance.evidence",
-          state: "unavailable",
+          state: "partial",
           ownerFollowUpRfc: "RFC-0079",
         }),
       ])
@@ -82,8 +82,8 @@ describe("live validation panel governance", () => {
     governance.recordPanelClassification("portfolio.summary", "supported_blank", "lotus-gateway", {
       reason: "unexpected blank",
     });
-    governance.recordPanelClassification("performance.evidence", "unavailable", "lotus-gateway", {
-      reason: "gateway contract pending",
+    governance.recordPanelClassification("performance.evidence", "partial", "lotus-gateway", {
+      reason: "lineage evidence remains partial",
     });
 
     expect(() => governance.assertNoUnsupportedBlankPanels()).toThrow(
@@ -98,8 +98,8 @@ describe("live validation panel governance", () => {
     governance.recordPanelClassification("portfolio.summary", "ready", "lotus-performance", {
       portfolioId: "PB_SG_GLOBAL_BAL_001",
     });
-    governance.recordPanelClassification("performance.evidence", "unavailable", "lotus-gateway", {
-      reason: "gateway contract pending",
+    governance.recordPanelClassification("performance.evidence", "partial", "lotus-gateway", {
+      reason: "lineage evidence remains partial",
     });
 
     expect(() => governance.assertPanelSupportabilityAlignment()).toThrow("registry owner");

--- a/tests/unit/live-validation-probes.test.ts
+++ b/tests/unit/live-validation-probes.test.ts
@@ -1,4 +1,37 @@
-import { checkDns, fetchJson, fetchText } from "../../scripts/live/validation/probes.mjs";
+import * as probeHelpers from "../../scripts/live/validation/probes.mjs";
+
+const { checkDns, fetchJson, fetchText, postJson } = probeHelpers as {
+  checkDns: (
+    summary: { dns: unknown[]; apiChecks: unknown[] },
+    hostname: string,
+    options?: {
+      required?: boolean;
+      lookup?: (hostname: string) => Promise<{ address: string }>;
+    }
+  ) => Promise<{ ok: boolean; required: boolean; warning?: string }>;
+  fetchJson: <T = unknown>(
+    summary: { dns: unknown[]; apiChecks: unknown[] },
+    url: string,
+    description: string,
+    timeoutMs: number,
+    fetchImpl?: typeof fetch
+  ) => Promise<T>;
+  fetchText: (
+    summary: { dns: unknown[]; apiChecks: unknown[] },
+    url: string,
+    description: string,
+    timeoutMs: number,
+    fetchImpl?: typeof fetch
+  ) => Promise<string>;
+  postJson: <T = unknown>(
+    summary: { dns: unknown[]; apiChecks: unknown[] },
+    url: string,
+    description: string,
+    timeoutMs: number,
+    body: unknown,
+    fetchImpl?: typeof fetch
+  ) => Promise<T>;
+};
 
 function createSummary() {
   return {
@@ -68,12 +101,57 @@ describe("live validation probe helpers", () => {
         url: "http://gateway.dev.lotus/api/v1/example",
         status: 200,
         kind: "json",
+        method: "GET",
       },
       {
         description: "Example text",
         url: "http://workbench.dev.lotus/example",
         status: 200,
         kind: "text",
+        method: "GET",
+      },
+    ]);
+  });
+
+  it("records successful JSON POST probes in the summary", async () => {
+    const summary = createSummary();
+    const calls: Array<{ url: string; method?: string; headers?: HeadersInit; body?: string }> = [];
+
+    const payload = await postJson(
+      summary,
+      "http://gateway.dev.lotus/api/v1/example",
+      "Example POST",
+      1000,
+      { ok: true },
+      async (url: string | URL | Request, init?: RequestInit) => {
+        calls.push({
+          url: String(url),
+          method: init?.method,
+          headers: init?.headers,
+          body: init?.body as string,
+        });
+        return new Response(JSON.stringify({ posted: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+    );
+
+    expect(payload).toEqual({ posted: true });
+    expect(calls).toEqual([
+      expect.objectContaining({
+        url: "http://gateway.dev.lotus/api/v1/example",
+        method: "POST",
+        body: JSON.stringify({ ok: true }),
+      }),
+    ]);
+    expect(summary.apiChecks).toEqual([
+      {
+        description: "Example POST",
+        url: "http://gateway.dev.lotus/api/v1/example",
+        status: 200,
+        kind: "json",
+        method: "POST",
       },
     ]);
   });

--- a/tests/unit/live-validation-workflow-pack-proof.test.ts
+++ b/tests/unit/live-validation-workflow-pack-proof.test.ts
@@ -1,0 +1,153 @@
+// @ts-expect-error The live validator proof helper is authored as .mjs and exercised here at runtime.
+import * as workflowPackProofModule from "../../scripts/live/validation/workflow-pack-proof.mjs";
+
+const {
+  validateAdvisorBriefWorkflowPackReviewChain,
+} = workflowPackProofModule as {
+  validateAdvisorBriefWorkflowPackReviewChain: (options: {
+    summary: { apiChecks: unknown[]; workflowPackChecks: unknown[] };
+    gatewayBaseUrl: string;
+    portfolioId: string;
+    benchmarkCode: string;
+    canonicalAsOfDate: string;
+    timeoutMs: number;
+    fetchJson: (
+      summary: unknown,
+      url: string,
+      description: string,
+      timeoutMs: number,
+    ) => Promise<unknown>;
+    postJson: (
+      summary: unknown,
+      url: string,
+      description: string,
+      timeoutMs: number,
+      body: Record<string, unknown>,
+    ) => Promise<unknown>;
+  }) => Promise<void>;
+};
+
+function createSummary() {
+  return {
+    apiChecks: [],
+    workflowPackChecks: [],
+  };
+}
+
+describe("live validation workflow-pack proof", () => {
+  it("records advisor-brief review-action lineage checks for accept, supersede, and revise", async () => {
+    const summary = createSummary();
+    const getCalls: string[] = [];
+    const postCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+
+    await validateAdvisorBriefWorkflowPackReviewChain({
+      summary,
+      gatewayBaseUrl: "http://gateway.dev.lotus",
+      portfolioId: "PB_SG_GLOBAL_BAL_001",
+      benchmarkCode: "BMK_PB_GLOBAL_BALANCED_60_40",
+      canonicalAsOfDate: "2026-04-10",
+      timeoutMs: 1000,
+      fetchJson: async (_summary: unknown, url: string) => {
+        getCalls.push(url);
+        if (url.includes("report_start_date=2026-02-01")) {
+          return {
+            workflow_pack_run: {
+              run_id: "packrun-revise-replacement",
+              review_state: "AWAITING_REVIEW",
+            },
+          };
+        }
+        if (url.includes("detail_basis=NET") && url.includes("period=EXPLICIT")) {
+          return { workflow_pack_run: { run_id: "packrun-explicit-net", review_state: "AWAITING_REVIEW" } };
+        }
+        if (url.includes("detail_basis=GROSS") && url.includes("period=EXPLICIT")) {
+          return { workflow_pack_run: { run_id: "packrun-explicit-gross", review_state: "AWAITING_REVIEW" } };
+        }
+        if (url.includes("detail_basis=GROSS") && url.includes("period=YTD")) {
+          return { workflow_pack_run: { run_id: "packrun-ytd-gross", review_state: "AWAITING_REVIEW" } };
+        }
+        return { workflow_pack_run: { run_id: "packrun-explicit-net", review_state: "AWAITING_REVIEW" } };
+      },
+      postJson: async (
+        _summary: unknown,
+        url: string,
+        _description: string,
+        _timeoutMs: number,
+        body: Record<string, unknown>
+      ) => {
+        postCalls.push({ url, body });
+        if (body.action_type === "ACCEPT") {
+          return {
+            workflow_pack_run: {
+              run_id: "packrun-ytd-net",
+              review_state: "ACCEPTED",
+              supportability_status: "READY",
+            },
+          };
+        }
+        if (body.action_type === "SUPERSEDE") {
+          return {
+            workflow_pack_run: {
+              run_id: "packrun-explicit-net",
+              review_state: "SUPERSEDED",
+              supportability_status: "HISTORICAL",
+              superseded: true,
+              replacement_run_id: body.replacement_run_id,
+            },
+          };
+        }
+        return {
+          workflow_pack_run: {
+            run_id: "packrun-ytd-gross",
+            review_state: "REVISED",
+            supportability_status: "HISTORICAL",
+            superseded: true,
+            replacement_run_id: body.replacement_run_id,
+          },
+        };
+      },
+    });
+
+    expect(getCalls).toHaveLength(4);
+    expect(postCalls).toEqual([
+      expect.objectContaining({
+        url: expect.stringContaining("/performance/advisor-brief/review-actions?period=YTD"),
+        body: expect.objectContaining({ action_type: "ACCEPT" }),
+      }),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          action_type: "SUPERSEDE",
+          replacement_run_id: "packrun-explicit-gross",
+        }),
+      }),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          action_type: "REVISE",
+          replacement_run_id: "packrun-revise-replacement",
+        }),
+      }),
+    ]);
+    expect(summary.workflowPackChecks).toEqual([
+      expect.objectContaining({
+        actionType: "ACCEPT",
+        sourceRunId: "packrun-ytd-net",
+        resultReviewState: "ACCEPTED",
+        resultSupportabilityStatus: "READY",
+      }),
+      expect.objectContaining({
+        actionType: "SUPERSEDE",
+        sourceRunId: "packrun-explicit-net",
+        replacementRunId: "packrun-explicit-gross",
+        resultReviewState: "SUPERSEDED",
+        resultSupportabilityStatus: "HISTORICAL",
+      }),
+      expect.objectContaining({
+        actionType: "REVISE",
+        sourceRunId: "packrun-ytd-gross",
+        replacementRunId: "packrun-revise-replacement",
+        resultReviewState: "REVISED",
+        resultSupportabilityStatus: "HISTORICAL",
+      }),
+    ]);
+  });
+});

--- a/tests/unit/performance-advisor-brief-mode.test.tsx
+++ b/tests/unit/performance-advisor-brief-mode.test.tsx
@@ -70,6 +70,26 @@ vi.mock("../../src/features/workbench/api", () => ({
       { label: "Advisor Brief", value: "Ready", tone: "success" },
       { label: "Evidence", value: "Partial", tone: "warn" },
     ],
+    workflow_pack_run: {
+      run_id: "packrun_advisor_brief_req-1",
+      runtime_state: "COMPLETED",
+      review_state: "AWAITING_REVIEW",
+      allowed_review_actions: ["ACCEPT", "REJECT", "REVISE"],
+      supportability_status: "ACTION_REQUIRED",
+      review_pending: true,
+      superseded: false,
+      workflow_authority_owner: "lotus-gateway",
+      current_summary_note:
+        "Run completed but still requires bounded human review before downstream use.",
+      replacement_run_id: null,
+      findings: [
+        {
+          finding_id: "review_pending",
+          severity: "ACTION_REQUIRED",
+          summary: "Run is awaiting review.",
+        },
+      ],
+    },
     ai_audit: {
       task_id: "explain.v1",
       output_label: "EXPLANATION_ONLY",
@@ -126,7 +146,15 @@ describe("PerformanceAdvisorBriefMode", () => {
       expect(supportability).toHaveTextContent("Review items");
       expect(supportability).toHaveTextContent("Evidence");
       expect(supportability).toHaveTextContent("Partial");
-      expect(supportability).toHaveTextContent("AI provider unavailable for full narrative generation.");
+      expect(supportability).toHaveTextContent("AI Review");
+      expect(supportability).toHaveTextContent("AWAITING REVIEW");
+      expect(supportability).toHaveTextContent(
+        "Run completed but still requires bounded human review before downstream use."
+      );
+      expect(supportability).toHaveTextContent("ACTION REQUIRED: Run is awaiting review.");
+      expect(supportability).toHaveTextContent(
+        "AI provider unavailable for full narrative generation."
+      );
     });
     expect(screen.getByLabelText("Brief synopsis")).toHaveTextContent(
       "Gateway advisor brief is ready with source-grounded talking points."

--- a/tests/unit/performance-advisor-brief-mode.test.tsx
+++ b/tests/unit/performance-advisor-brief-mode.test.tsx
@@ -496,4 +496,58 @@ describe("PerformanceAdvisorBriefMode", () => {
       expect(screen.queryByLabelText("Advisor brief review actions")).not.toBeInTheDocument();
     });
   });
+
+  it("shows superseded workflow-pack lineage without treating the replaced run as active-ready posture", async () => {
+    vi.mocked(getWorkbenchPerformanceAdvisorBriefClient).mockReset().mockResolvedValue({
+      ...readyAdvisorBriefResponse,
+      correlation_id: "corr-advisor-brief-superseded",
+      summary: "A newer bounded advisor brief has replaced this run.",
+      workflow_pack_run: {
+        ...readyAdvisorBriefResponse.workflow_pack_run!,
+        review_state: "ACCEPTED",
+        allowed_review_actions: [],
+        supportability_status: "READY",
+        review_pending: false,
+        superseded: true,
+        current_summary_note: "Run was superseded by a newer bounded advisor-brief run.",
+        replacement_run_id: "packrun_advisor_brief_req-2",
+        findings: [],
+      },
+    });
+
+    const workspace = buildSupportedPerformanceScenario().workspace;
+
+    render(
+      <PerformanceAdvisorBriefMode
+        workspace={workspace}
+        capabilities={getPerformanceWorkspaceCapabilities(workspace)}
+        period={workspace.period}
+        detailBasis="NET"
+        contributionDimension="asset_class"
+        attributionDimension="asset_class"
+        chartFrequency="monthly"
+        benchmark={workspace.benchmark_code ?? undefined}
+        onRequestChange={vi.fn()}
+        isUpdating={false}
+        isDetailsPending={false}
+        onSelectMode={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      const supportability = screen.getByLabelText("Advisor brief supportability");
+      expect(supportability).toHaveTextContent("AI Review");
+      expect(supportability).toHaveTextContent("ACCEPTED");
+      expect(supportability).toHaveTextContent(
+        "Supportability READY • Superseded by packrun_advisor_brief_req-2"
+      );
+      expect(supportability).toHaveTextContent(
+        "Run was superseded by a newer bounded advisor-brief run."
+      );
+      expect(supportability).toHaveTextContent(
+        "Superseded by workflow-pack run packrun_advisor_brief_req-2."
+      );
+      expect(screen.queryByLabelText("Advisor brief review actions")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/tests/unit/performance-advisor-brief-mode.test.tsx
+++ b/tests/unit/performance-advisor-brief-mode.test.tsx
@@ -190,8 +190,11 @@ describe("PerformanceAdvisorBriefMode", () => {
       expect(supportability).toHaveTextContent("Review items");
       expect(supportability).toHaveTextContent("Evidence");
       expect(supportability).toHaveTextContent("Partial");
+      expect(supportability).toHaveTextContent("packrun_advisor_brief_req-1");
+      expect(supportability).toHaveTextContent("Authority lotus-gateway");
       expect(supportability).toHaveTextContent("AI Review");
       expect(supportability).toHaveTextContent("AWAITING REVIEW");
+      expect(supportability).toHaveTextContent("Supportability ACTION REQUIRED");
       expect(supportability).toHaveTextContent(
         "Run completed but still requires bounded human review before downstream use."
       );
@@ -479,8 +482,11 @@ describe("PerformanceAdvisorBriefMode", () => {
       const supportability = screen.getByLabelText("Advisor brief supportability");
       expect(supportability).toHaveTextContent("AI Run");
       expect(supportability).toHaveTextContent("COMPLETED");
+      expect(supportability).toHaveTextContent("packrun_advisor_brief_req-1");
+      expect(supportability).toHaveTextContent("Authority lotus-gateway");
       expect(supportability).toHaveTextContent("AI Review");
       expect(supportability).toHaveTextContent("ACCEPTED");
+      expect(supportability).toHaveTextContent("Supportability READY");
       expect(supportability).toHaveTextContent(
         "Run accepted for bounded downstream workflow use."
       );

--- a/tests/unit/performance-advisor-brief-mode.test.tsx
+++ b/tests/unit/performance-advisor-brief-mode.test.tsx
@@ -477,6 +477,10 @@ describe("PerformanceAdvisorBriefMode", () => {
         }
       );
       const supportability = screen.getByLabelText("Advisor brief supportability");
+      expect(supportability).toHaveTextContent("AI Run");
+      expect(supportability).toHaveTextContent("COMPLETED");
+      expect(supportability).toHaveTextContent("AI Review");
+      expect(supportability).toHaveTextContent("ACCEPTED");
       expect(supportability).toHaveTextContent(
         "Run accepted for bounded downstream workflow use."
       );

--- a/tests/unit/performance-advisor-brief-mode.test.tsx
+++ b/tests/unit/performance-advisor-brief-mode.test.tsx
@@ -77,7 +77,7 @@ const readyAdvisorBriefResponse: WorkbenchPerformanceAdvisorBrief = {
     run_id: "packrun_advisor_brief_req-1",
     runtime_state: "COMPLETED",
     review_state: "AWAITING_REVIEW",
-    allowed_review_actions: ["ACCEPT", "REJECT", "REVISE"],
+    allowed_review_actions: ["ACCEPT", "REJECT", "REVISE", "SUPERSEDE"],
     supportability_status: "ACTION_REQUIRED",
     review_pending: true,
     superseded: false,
@@ -125,7 +125,6 @@ vi.mock("../../src/features/workbench/api", () => ({
   postWorkbenchPerformanceAdvisorBriefReviewActionClient: vi.fn(async () => ({
     ...readyAdvisorBriefResponse,
     correlation_id: "corr-advisor-brief-review",
-    summary: "Advisor brief accepted for bounded downstream workflow use.",
     workflow_pack_run: {
       ...readyAdvisorBriefResponse.workflow_pack_run,
       review_state: "ACCEPTED",
@@ -144,7 +143,6 @@ describe("PerformanceAdvisorBriefMode", () => {
     vi.mocked(postWorkbenchPerformanceAdvisorBriefReviewActionClient).mockResolvedValue({
       ...readyAdvisorBriefResponse,
       correlation_id: "corr-advisor-brief-review",
-      summary: "Advisor brief accepted for bounded downstream workflow use.",
       workflow_pack_run: {
         ...readyAdvisorBriefResponse.workflow_pack_run!,
         review_state: "ACCEPTED",
@@ -449,6 +447,7 @@ describe("PerformanceAdvisorBriefMode", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Advisor brief review actions")).toBeInTheDocument();
     });
+    expect(screen.getByLabelText("Replacement run id")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Reviewed by"), {
       target: { value: "advisor_1" },
@@ -491,9 +490,105 @@ describe("PerformanceAdvisorBriefMode", () => {
         "Run accepted for bounded downstream workflow use."
       );
       expect(screen.getByLabelText("Brief synopsis")).toHaveTextContent(
-        "Advisor brief accepted for bounded downstream workflow use."
+        "Gateway advisor brief is ready with source-grounded talking points."
       );
       expect(screen.queryByLabelText("Advisor brief review actions")).not.toBeInTheDocument();
+    });
+  });
+
+  it("requires replacement lineage input for revision actions before posting the bounded review action", async () => {
+    vi.mocked(getWorkbenchPerformanceAdvisorBriefClient).mockResolvedValue({
+      ...readyAdvisorBriefResponse,
+      workflow_pack_run: {
+        ...readyAdvisorBriefResponse.workflow_pack_run!,
+        allowed_review_actions: ["REVISE", "SUPERSEDE"],
+      },
+    });
+    vi.mocked(postWorkbenchPerformanceAdvisorBriefReviewActionClient).mockResolvedValue({
+      ...readyAdvisorBriefResponse,
+      correlation_id: "corr-advisor-brief-revise",
+      workflow_pack_run: {
+        ...readyAdvisorBriefResponse.workflow_pack_run!,
+        review_state: "REVISED",
+        allowed_review_actions: [],
+        supportability_status: "HISTORICAL",
+        review_pending: false,
+        superseded: true,
+        current_summary_note: "Run was revised in favor of a replacement advisor-brief run.",
+        replacement_run_id: "packrun_advisor_brief_req-2",
+        findings: [],
+      },
+    });
+
+    const workspace = buildSupportedPerformanceScenario().workspace;
+
+    render(
+      <PerformanceAdvisorBriefMode
+        workspace={workspace}
+        capabilities={getPerformanceWorkspaceCapabilities(workspace)}
+        period={workspace.period}
+        detailBasis="NET"
+        contributionDimension="asset_class"
+        attributionDimension="asset_class"
+        chartFrequency="monthly"
+        benchmark={workspace.benchmark_code ?? undefined}
+        onRequestChange={vi.fn()}
+        isUpdating={false}
+        isDetailsPending={false}
+        onSelectMode={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Advisor brief review actions")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Reviewed by"), {
+      target: { value: "advisor_2" },
+    });
+    fireEvent.change(screen.getByLabelText("Review reason"), {
+      target: {
+        value: "A replacement advisor brief run is available for downstream use.",
+      },
+    });
+
+    const reviseButton = screen.getByRole("button", { name: "Request Revision" });
+    expect(reviseButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Replacement run id"), {
+      target: { value: "packrun_advisor_brief_req-2" },
+    });
+
+    expect(reviseButton).toBeEnabled();
+    fireEvent.click(reviseButton);
+
+    await waitFor(() => {
+      expect(postWorkbenchPerformanceAdvisorBriefReviewActionClient).toHaveBeenCalledWith(
+        "PF_1001",
+        {
+          period: "YTD",
+          chartFrequency: "monthly",
+          contributionDimension: "asset_class",
+          attributionDimension: "asset_class",
+          detailBasis: "NET",
+          benchmark: "BMK_GLOBAL_BALANCED_60_40",
+          reportStartDate: "2026-01-01",
+          reportEndDate: "2026-02-24",
+        },
+        {
+          action_type: "REVISE",
+          reviewed_by: "advisor_2",
+          reason: "A replacement advisor brief run is available for downstream use.",
+          replacement_run_id: "packrun_advisor_brief_req-2",
+        }
+      );
+      const supportability = screen.getByLabelText("Advisor brief supportability");
+      expect(supportability).toHaveTextContent(
+        "Run was revised in favor of a replacement advisor-brief run."
+      );
+      expect(supportability).toHaveTextContent(
+        "Superseded by workflow-pack run packrun_advisor_brief_req-2."
+      );
     });
   });
 

--- a/tests/unit/performance-advisor-brief-mode.test.tsx
+++ b/tests/unit/performance-advisor-brief-mode.test.tsx
@@ -1,118 +1,162 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import PerformanceAdvisorBriefMode from "../../src/apps/performance/components/performance-advisor-brief-mode";
 import { getPerformanceWorkspaceCapabilities } from "../../src/apps/performance/capabilities";
-import { getWorkbenchPerformanceAdvisorBriefClient } from "../../src/features/workbench/api";
+import {
+  getWorkbenchPerformanceAdvisorBriefClient,
+  postWorkbenchPerformanceAdvisorBriefReviewActionClient,
+} from "../../src/features/workbench/api";
+import type { WorkbenchPerformanceAdvisorBrief } from "../../src/features/workbench/types";
 import { buildSupportedPerformanceScenario } from "../fixtures/performance-workspace-fixtures";
 
-vi.mock("../../src/features/workbench/api", () => ({
-  getWorkbenchPerformanceAdvisorBriefClient: vi.fn(async () => ({
-    correlation_id: "corr-advisor-brief",
-    contract_version: "v1",
+const readyAdvisorBriefResponse: WorkbenchPerformanceAdvisorBrief = {
+  correlation_id: "corr-advisor-brief",
+  contract_version: "v1",
+  portfolio_id: "PF_1001",
+  portfolio: {
     portfolio_id: "PF_1001",
-    portfolio: {
-      portfolio_id: "PF_1001",
-      client_id: "CIF_1001",
-      base_currency: "USD",
-      booking_center_code: "SG",
-    },
-    as_of_date: "2026-02-24",
-    period: "YTD",
-    report_start_date: "2026-01-01",
-    report_end_date: "2026-02-24",
-    detail_basis: "NET",
-    chart_frequency: "monthly",
-    contribution_dimension: "asset_class",
-    attribution_dimension: "asset_class",
-    benchmark_code: "BMK_GLOBAL_BALANCED_60_40",
-    status: "ready",
-    summary: "Gateway advisor brief is ready with source-grounded talking points.",
-    talking_points: [
-      {
-        headline: "Portfolio delivered 5.42% versus benchmark 4.91%.",
-        detail: "Active return was 0.51% over the selected period.",
-        tone: "positive",
-        evidence_refs: [
-          {
-            metric_label: "Active Return",
-            metric_value: "0.51%",
-            source_surface: "performance.return_path",
-            target_mode: "summary",
-            route: "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET",
-          },
-        ],
-      },
-    ],
-    recommended_actions: [
-      {
-        label: "Open Return Path",
-        target_mode: "summary",
-        route: "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET",
-      },
-      {
-        label: "Review Contribution",
-        target_mode: "analysis",
-        route: "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET",
-      },
-    ],
-    risks_and_exceptions: [],
-    source_metrics: [
-      {
-        label: "Active Return",
-        value: "0.51%",
-        support_label: "YTD Net",
-        target_mode: "summary",
-        route: "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET",
-      },
-    ],
-    supportability: [
-      { label: "Advisor Brief", value: "Ready", tone: "success" },
-      { label: "Evidence", value: "Partial", tone: "warn" },
-    ],
-    workflow_pack_run: {
-      run_id: "packrun_advisor_brief_req-1",
-      runtime_state: "COMPLETED",
-      review_state: "AWAITING_REVIEW",
-      allowed_review_actions: ["ACCEPT", "REJECT", "REVISE"],
-      supportability_status: "ACTION_REQUIRED",
-      review_pending: true,
-      superseded: false,
-      workflow_authority_owner: "lotus-gateway",
-      current_summary_note:
-        "Run completed but still requires bounded human review before downstream use.",
-      replacement_run_id: null,
-      findings: [
+    client_id: "CIF_1001",
+    base_currency: "USD",
+    booking_center_code: "SG",
+  },
+  as_of_date: "2026-02-24",
+  period: "YTD",
+  report_start_date: "2026-01-01",
+  report_end_date: "2026-02-24",
+  detail_basis: "NET",
+  chart_frequency: "monthly",
+  contribution_dimension: "asset_class",
+  attribution_dimension: "asset_class",
+  benchmark_code: "BMK_GLOBAL_BALANCED_60_40",
+  status: "ready",
+  summary: "Gateway advisor brief is ready with source-grounded talking points.",
+  talking_points: [
+    {
+      headline: "Portfolio delivered 5.42% versus benchmark 4.91%.",
+      detail: "Active return was 0.51% over the selected period.",
+      tone: "positive",
+      evidence_refs: [
         {
-          finding_id: "review_pending",
-          severity: "ACTION_REQUIRED",
-          summary: "Run is awaiting review.",
+          metric_label: "Active Return",
+          metric_value: "0.51%",
+          source_surface: "performance.return_path",
+          target_mode: "summary",
+          route: "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET",
         },
       ],
     },
-    ai_audit: {
-      task_id: "explain.v1",
-      output_label: "EXPLANATION_ONLY",
-      prompt_version: "foundation.explain.v1",
-      provider_mode: "local_openai_compatible",
-      provider_id: "text.local",
-      adapter_kind: "OPENAI_COMPATIBLE_LOCAL",
-      model_id: "qwen3:8b",
-      generated_at: "2026-02-24T00:00:00Z",
-      stubbed: false,
+  ],
+  recommended_actions: [
+    {
+      label: "Open Return Path",
+      target_mode: "summary",
+      route: "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET",
     },
-    ai_evidence: {
-      source_refs: [
-        "lotus-gateway:workbench:PF_1001:performance-summary:YTD",
-        "lotus-ai:task:explain.v1",
-      ],
+    {
+      label: "Review Contribution",
+      target_mode: "analysis",
+      route: "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET",
     },
-    warnings: ["AI provider returned bounded narrative only."],
-    partial_failures: [{ source_service: "lotus-ai", error_code: "PROVIDER_PARTIAL", detail: "AI provider unavailable for full narrative generation." }],
+  ],
+  risks_and_exceptions: [],
+  source_metrics: [
+    {
+      label: "Active Return",
+      value: "0.51%",
+      support_label: "YTD Net",
+      target_mode: "summary",
+      route: "/performance?portfolioId=PF_1001&period=YTD&detailBasis=NET",
+    },
+  ],
+  supportability: [
+    { label: "Advisor Brief", value: "Ready", tone: "success" },
+    { label: "Evidence", value: "Partial", tone: "warn" },
+  ],
+  workflow_pack_run: {
+    run_id: "packrun_advisor_brief_req-1",
+    runtime_state: "COMPLETED",
+    review_state: "AWAITING_REVIEW",
+    allowed_review_actions: ["ACCEPT", "REJECT", "REVISE"],
+    supportability_status: "ACTION_REQUIRED",
+    review_pending: true,
+    superseded: false,
+    workflow_authority_owner: "lotus-gateway",
+    current_summary_note:
+      "Run completed but still requires bounded human review before downstream use.",
+    replacement_run_id: null,
+    findings: [
+      {
+        finding_id: "review_pending",
+        severity: "ACTION_REQUIRED",
+        summary: "Run is awaiting review.",
+      },
+    ],
+  },
+  ai_audit: {
+    task_id: "explain.v1",
+    output_label: "EXPLANATION_ONLY",
+    prompt_version: "foundation.explain.v1",
+    provider_mode: "local_openai_compatible",
+    provider_id: "text.local",
+    adapter_kind: "OPENAI_COMPATIBLE_LOCAL",
+    model_id: "qwen3:8b",
+    generated_at: "2026-02-24T00:00:00Z",
+    stubbed: false,
+  },
+  ai_evidence: {
+    source_refs: [
+      "lotus-gateway:workbench:PF_1001:performance-summary:YTD",
+      "lotus-ai:task:explain.v1",
+    ],
+  },
+  warnings: ["AI provider returned bounded narrative only."],
+  partial_failures: [
+    {
+      source_service: "lotus-ai",
+      error_code: "PROVIDER_PARTIAL",
+      detail: "AI provider unavailable for full narrative generation.",
+    },
+  ],
+};
+
+vi.mock("../../src/features/workbench/api", () => ({
+  getWorkbenchPerformanceAdvisorBriefClient: vi.fn(async () => readyAdvisorBriefResponse),
+  postWorkbenchPerformanceAdvisorBriefReviewActionClient: vi.fn(async () => ({
+    ...readyAdvisorBriefResponse,
+    correlation_id: "corr-advisor-brief-review",
+    summary: "Advisor brief accepted for bounded downstream workflow use.",
+    workflow_pack_run: {
+      ...readyAdvisorBriefResponse.workflow_pack_run,
+      review_state: "ACCEPTED",
+      allowed_review_actions: [],
+      supportability_status: "READY",
+      review_pending: false,
+      current_summary_note: "Run accepted for bounded downstream workflow use.",
+      findings: [],
+    },
   })),
 }));
 
 describe("PerformanceAdvisorBriefMode", () => {
+  beforeEach(() => {
+    vi.mocked(getWorkbenchPerformanceAdvisorBriefClient).mockResolvedValue(readyAdvisorBriefResponse);
+    vi.mocked(postWorkbenchPerformanceAdvisorBriefReviewActionClient).mockResolvedValue({
+      ...readyAdvisorBriefResponse,
+      correlation_id: "corr-advisor-brief-review",
+      summary: "Advisor brief accepted for bounded downstream workflow use.",
+      workflow_pack_run: {
+        ...readyAdvisorBriefResponse.workflow_pack_run!,
+        review_state: "ACCEPTED",
+        allowed_review_actions: [],
+        supportability_status: "READY",
+        review_pending: false,
+        current_summary_note: "Run accepted for bounded downstream workflow use.",
+        findings: [],
+      },
+    });
+  });
+
   it("renders a source-grounded brief with supportability, metrics, and AI contract metadata", async () => {
     const workspace = buildSupportedPerformanceScenario().workspace;
     const onSelectMode = vi.fn();
@@ -375,6 +419,71 @@ describe("PerformanceAdvisorBriefMode", () => {
     expect(supportability).toHaveTextContent("Generating");
     await waitFor(() => {
       expect(getWorkbenchPerformanceAdvisorBriefClient).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("records a bounded review action and refreshes the run posture in place", async () => {
+    vi.mocked(postWorkbenchPerformanceAdvisorBriefReviewActionClient).mockClear();
+    const workspace = buildSupportedPerformanceScenario().workspace;
+
+    render(
+      <PerformanceAdvisorBriefMode
+        workspace={workspace}
+        capabilities={getPerformanceWorkspaceCapabilities(workspace)}
+        period={workspace.period}
+        detailBasis="NET"
+        contributionDimension="asset_class"
+        attributionDimension="asset_class"
+        chartFrequency="monthly"
+        benchmark={workspace.benchmark_code ?? undefined}
+        onRequestChange={vi.fn()}
+        isUpdating={false}
+        isDetailsPending={false}
+        onSelectMode={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Advisor brief review actions")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Reviewed by"), {
+      target: { value: "advisor_1" },
+    });
+    fireEvent.change(screen.getByLabelText("Review reason"), {
+      target: {
+        value: "Advisor brief accepted for bounded downstream workflow use.",
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Accept Brief" }));
+
+    await waitFor(() => {
+      expect(postWorkbenchPerformanceAdvisorBriefReviewActionClient).toHaveBeenCalledWith(
+        "PF_1001",
+        {
+          period: "YTD",
+          chartFrequency: "monthly",
+          contributionDimension: "asset_class",
+          attributionDimension: "asset_class",
+          detailBasis: "NET",
+          benchmark: "BMK_GLOBAL_BALANCED_60_40",
+          reportStartDate: "2026-01-01",
+          reportEndDate: "2026-02-24",
+        },
+        {
+          action_type: "ACCEPT",
+          reviewed_by: "advisor_1",
+          reason: "Advisor brief accepted for bounded downstream workflow use.",
+        }
+      );
+      const supportability = screen.getByLabelText("Advisor brief supportability");
+      expect(supportability).toHaveTextContent(
+        "Run accepted for bounded downstream workflow use."
+      );
+      expect(screen.getByLabelText("Brief synopsis")).toHaveTextContent(
+        "Advisor brief accepted for bounded downstream workflow use."
+      );
+      expect(screen.queryByLabelText("Advisor brief review actions")).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/unit/performance-advisor-brief-view-model.test.ts
+++ b/tests/unit/performance-advisor-brief-view-model.test.ts
@@ -636,4 +636,76 @@ describe("buildPerformanceAdvisorBriefViewModel", () => {
       expect.arrayContaining(["lotus-ai:workflow-pack-run:packrun_advisor_brief_req-1"])
     );
   });
+
+  it("marks superseded workflow-pack runs as non-active posture and preserves replacement lineage", () => {
+    const scenario = buildSupportedPerformanceScenario();
+
+    const brief = buildPerformanceAdvisorBriefViewModel({
+      workspace: scenario.workspace,
+      advisorBrief: {
+        correlation_id: "corr-workflow-pack-superseded",
+        contract_version: "v1",
+        portfolio_id: "PF_1001",
+        portfolio: scenario.workspace.portfolio,
+        as_of_date: scenario.workspace.as_of_date,
+        period: scenario.workspace.period,
+        report_start_date: scenario.workspace.report_start_date,
+        report_end_date: scenario.workspace.report_end_date,
+        detail_basis: "NET",
+        chart_frequency: "monthly",
+        contribution_dimension: "asset_class",
+        attribution_dimension: "asset_class",
+        benchmark_code: scenario.workspace.benchmark_code,
+        status: "ready",
+        summary: "Superseded workflow-pack backed advisor brief.",
+        talking_points: [],
+        recommended_actions: [],
+        risks_and_exceptions: [],
+        source_metrics: [],
+        supportability: [{ label: "Advisor Brief", value: "Ready", tone: "success" }],
+        workflow_pack_run: {
+          run_id: "packrun_advisor_brief_req-1",
+          runtime_state: "COMPLETED",
+          review_state: "ACCEPTED",
+          allowed_review_actions: [],
+          supportability_status: "READY",
+          review_pending: false,
+          superseded: true,
+          workflow_authority_owner: "lotus-gateway",
+          current_summary_note: "Run was superseded by a newer bounded advisor-brief run.",
+          replacement_run_id: "packrun_advisor_brief_req-2",
+          findings: [],
+        },
+        ai_audit: { stubbed: false, source_refs: [] },
+        ai_evidence: { source_refs: [] },
+        warnings: [],
+        partial_failures: [],
+      },
+      capabilities: scenario.capabilities,
+      period: scenario.workspace.period,
+      detailBasis: "NET",
+      contributionDimension: "asset_class",
+      attributionDimension: "asset_class",
+      chartFrequency: "monthly",
+      benchmark: scenario.workspace.benchmark_code ?? undefined,
+      isDetailsPending: false,
+    });
+
+    expect(brief.supportability).toEqual(
+      expect.arrayContaining([
+        {
+          label: "AI Review",
+          value: "ACCEPTED",
+          tone: "warn",
+          detail: "Supportability READY • Superseded by packrun_advisor_brief_req-2",
+        },
+      ])
+    );
+    expect(brief.reviewNotes).toEqual(
+      expect.arrayContaining([
+        "Run was superseded by a newer bounded advisor-brief run.",
+        "Superseded by workflow-pack run packrun_advisor_brief_req-2.",
+      ])
+    );
+  });
 });

--- a/tests/unit/performance-advisor-brief-view-model.test.ts
+++ b/tests/unit/performance-advisor-brief-view-model.test.ts
@@ -612,8 +612,18 @@ describe("buildPerformanceAdvisorBriefViewModel", () => {
 
     expect(brief.supportability).toEqual(
       expect.arrayContaining([
-        { label: "AI Run", value: "COMPLETED", tone: "success" },
-        { label: "AI Review", value: "AWAITING REVIEW", tone: "warn" },
+        {
+          label: "AI Run",
+          value: "COMPLETED",
+          tone: "success",
+          detail: "packrun_advisor_brief_req-1 • Authority lotus-gateway",
+        },
+        {
+          label: "AI Review",
+          value: "AWAITING REVIEW",
+          tone: "warn",
+          detail: "Supportability ACTION REQUIRED",
+        },
       ])
     );
     expect(brief.reviewNotes).toEqual(

--- a/tests/unit/performance-advisor-brief-view-model.test.ts
+++ b/tests/unit/performance-advisor-brief-view-model.test.ts
@@ -548,4 +548,82 @@ describe("buildPerformanceAdvisorBriefViewModel", () => {
       "lotus-gateway:workbench:PF_1001:performance-advisor-brief:YTD",
     ]);
   });
+
+  it("maps workflow-pack posture into supportability, review notes, and audit provenance", () => {
+    const scenario = buildSupportedPerformanceScenario();
+
+    const brief = buildPerformanceAdvisorBriefViewModel({
+      workspace: scenario.workspace,
+      advisorBrief: {
+        correlation_id: "corr-workflow-pack",
+        contract_version: "v1",
+        portfolio_id: "PF_1001",
+        portfolio: scenario.workspace.portfolio,
+        as_of_date: scenario.workspace.as_of_date,
+        period: scenario.workspace.period,
+        report_start_date: scenario.workspace.report_start_date,
+        report_end_date: scenario.workspace.report_end_date,
+        detail_basis: "NET",
+        chart_frequency: "monthly",
+        contribution_dimension: "asset_class",
+        attribution_dimension: "asset_class",
+        benchmark_code: scenario.workspace.benchmark_code,
+        status: "ready",
+        summary: "Workflow-pack backed advisor brief.",
+        talking_points: [],
+        recommended_actions: [],
+        risks_and_exceptions: [],
+        source_metrics: [],
+        supportability: [{ label: "Advisor Brief", value: "Ready", tone: "success" }],
+        workflow_pack_run: {
+          run_id: "packrun_advisor_brief_req-1",
+          runtime_state: "COMPLETED",
+          review_state: "AWAITING_REVIEW",
+          allowed_review_actions: ["ACCEPT", "REJECT", "REVISE"],
+          supportability_status: "ACTION_REQUIRED",
+          review_pending: true,
+          superseded: false,
+          workflow_authority_owner: "lotus-gateway",
+          current_summary_note:
+            "Run completed but still requires bounded human review before downstream use.",
+          replacement_run_id: null,
+          findings: [
+            {
+              finding_id: "review_pending",
+              severity: "ACTION_REQUIRED",
+              summary: "Run is awaiting review.",
+            },
+          ],
+        },
+        ai_audit: { stubbed: false, source_refs: [] },
+        ai_evidence: { source_refs: [] },
+        warnings: [],
+        partial_failures: [],
+      },
+      capabilities: scenario.capabilities,
+      period: scenario.workspace.period,
+      detailBasis: "NET",
+      contributionDimension: "asset_class",
+      attributionDimension: "asset_class",
+      chartFrequency: "monthly",
+      benchmark: scenario.workspace.benchmark_code ?? undefined,
+      isDetailsPending: false,
+    });
+
+    expect(brief.supportability).toEqual(
+      expect.arrayContaining([
+        { label: "AI Run", value: "COMPLETED", tone: "success" },
+        { label: "AI Review", value: "AWAITING REVIEW", tone: "warn" },
+      ])
+    );
+    expect(brief.reviewNotes).toEqual(
+      expect.arrayContaining([
+        "Run completed but still requires bounded human review before downstream use.",
+        "ACTION REQUIRED: Run is awaiting review.",
+      ])
+    );
+    expect(brief.audit.sourceRefs).toEqual(
+      expect.arrayContaining(["lotus-ai:workflow-pack-run:packrun_advisor_brief_req-1"])
+    );
+  });
 });

--- a/tests/unit/portfolio-allocation-panel.test.tsx
+++ b/tests/unit/portfolio-allocation-panel.test.tsx
@@ -39,12 +39,12 @@ describe("PortfolioAllocationPanel", () => {
           throw new Error(`Unexpected fetch: ${url}`);
         }
 
-        if (url.includes("look_through_mode=full")) {
+        if (url.includes("look_through_mode=prefer_look_through")) {
           return jsonResponse({
             reporting_currency: "USD",
             look_through: {
-              requested_mode: "full",
-              effective_mode: "full",
+              requested_mode: "prefer_look_through",
+              effective_mode: "prefer_look_through",
               applied: true,
             },
             views: [
@@ -287,7 +287,9 @@ describe("PortfolioAllocationPanel", () => {
         return jsonResponse({
           reporting_currency: "USD",
           look_through: {
-            requested_mode: url.includes("look_through_mode=full") ? "full" : "direct_only",
+            requested_mode: url.includes("look_through_mode=prefer_look_through")
+              ? "prefer_look_through"
+              : "direct_only",
             effective_mode: "direct_only",
             applied: false,
           },

--- a/tests/unit/portfolio-api.test.ts
+++ b/tests/unit/portfolio-api.test.ts
@@ -747,8 +747,8 @@ describe("portfolio api", () => {
       jsonResponse({
         reporting_currency: "USD",
         look_through: {
-          requested_mode: "full",
-          effective_mode: "full",
+          requested_mode: "prefer_look_through",
+          effective_mode: "prefer_look_through",
           applied: true,
         },
         views: [{ dimension: "region", buckets: [] }],
@@ -759,15 +759,15 @@ describe("portfolio api", () => {
     const payload = await getPortfolioAllocationViews("MANUAL_PB_USD_001", {
       asOfDate: "2026-03-28",
       reportingCurrency: "USD",
-      lookThroughMode: "full",
+      lookThroughMode: "prefer_look_through",
     });
 
-    expect(payload?.look_through?.effective_mode).toBe("full");
+    expect(payload?.look_through?.effective_mode).toBe("prefer_look_through");
     const requestUrl = String((fetchSpy.mock as { lastCall?: unknown[] }).lastCall?.[0] ?? "");
     expect(requestUrl).toContain("/allocations?");
     expect(requestUrl).toContain("as_of_date=2026-03-28");
     expect(requestUrl).toContain("reporting_currency=USD");
-    expect(requestUrl).toContain("look_through_mode=full");
+    expect(requestUrl).toContain("look_through_mode=prefer_look_through");
   });
 
   it("reuses cached BFF responses for identical requests", async () => {

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -17,6 +17,7 @@ import {
   getWorkbenchPerformanceWorkspaceDetails,
   getWorkbenchPerformanceWorkspaceSummaryClient,
   getWorkbenchPerformanceWorkspaceSummary,
+  postWorkbenchPerformanceAdvisorBriefReviewActionClient,
 } from "../../src/features/workbench/api";
 
 const expectedBaseUrl = "/api/bff/api/v1";
@@ -924,6 +925,96 @@ describe("workbench api", () => {
     const requestedUrl = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].toString();
     expect(requestedUrl).toContain(
       "/api/bff/api/v1/workbench/PF_1001/performance/advisor-brief?period=YTD&chart_frequency=monthly&contribution_dimension=asset_class&attribution_dimension=asset_class&detail_basis=NET&benchmark_code=BMK_GLOBAL_BALANCED_60_40&report_start_date=2026-01-01&report_end_date=2026-02-24"
+    );
+  });
+
+  it("posts advisor brief review actions through the client-side gateway seam", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr-advisor-brief-review",
+            contract_version: "v1",
+            portfolio_id: "PF_1001",
+            portfolio: {
+              portfolio_id: "PF_1001",
+              client_id: "CIF_1",
+              base_currency: "USD",
+              booking_center_code: "SG",
+            },
+            as_of_date: "2026-02-24",
+            period: "YTD",
+            report_start_date: "2026-01-01",
+            report_end_date: "2026-02-24",
+            detail_basis: "NET",
+            chart_frequency: "monthly",
+            contribution_dimension: "asset_class",
+            attribution_dimension: "asset_class",
+            benchmark_code: "BMK_GLOBAL_BALANCED_60_40",
+            status: "ready",
+            summary: "Advisor brief accepted.",
+            talking_points: [],
+            recommended_actions: [],
+            risks_and_exceptions: [],
+            source_metrics: [],
+            supportability: [],
+            workflow_pack_run: {
+              run_id: "packrun_advisor_brief_req-1",
+              runtime_state: "COMPLETED",
+              review_state: "ACCEPTED",
+              allowed_review_actions: [],
+              supportability_status: "READY",
+              review_pending: false,
+              superseded: false,
+              workflow_authority_owner: "lotus-gateway",
+              current_summary_note:
+                "Run accepted for bounded downstream workflow use.",
+              replacement_run_id: null,
+              findings: [],
+            },
+            ai_audit: {},
+            ai_evidence: {},
+            warnings: [],
+            partial_failures: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await postWorkbenchPerformanceAdvisorBriefReviewActionClient(
+      "PF_1001",
+      {
+        period: "YTD",
+        chartFrequency: "monthly",
+        contributionDimension: "asset_class",
+        attributionDimension: "asset_class",
+        detailBasis: "NET",
+        benchmark: "BMK_GLOBAL_BALANCED_60_40",
+        reportStartDate: "2026-01-01",
+        reportEndDate: "2026-02-24",
+      },
+      {
+        action_type: "ACCEPT",
+        reviewed_by: "advisor_1",
+        reason: "Advisor brief accepted for bounded downstream workflow use.",
+      }
+    );
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/bff/api/v1/workbench/PF_1001/performance/advisor-brief/review-actions?period=YTD&chart_frequency=monthly&contribution_dimension=asset_class&attribution_dimension=asset_class&detail_basis=NET&benchmark_code=BMK_GLOBAL_BALANCED_60_40&report_start_date=2026-01-01&report_end_date=2026-02-24",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action_type: "ACCEPT",
+          reviewed_by: "advisor_1",
+          reason: "Advisor brief accepted for bounded downstream workflow use.",
+        }),
+        cache: "no-store",
+      }
     );
   });
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -6,6 +6,7 @@
 - `/portfolios`
 - `/intake`
 - `/performance`
+- `/data-products`
 - `/workbench`
 - `/workbench/{portfolioId}`
 - `/api/bff/*`
@@ -32,6 +33,8 @@ promote dormant labels into product ownership just because historical route file
 ## Current contract notes
 
 - risk is currently served through `/performance` route mode selection, not a separate top-level URL
+- data-product discovery is served through `/data-products` and consumes gateway
+  `/api/v1/domain-products/*` APIs through the internal BFF only
 - internal browser-to-gateway traffic can flow through `/api/bff/*`
 - canonical product proof should use `workbench.dev.lotus`, not ad hoc localhost URLs
 - shell navigation support is narrower than the historical route set: `Proposal` and `Advisory`
@@ -57,6 +60,12 @@ Performance risk mode:
 
 ```txt
 http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk
+```
+
+Data products:
+
+```txt
+http://workbench.dev.lotus/data-products
 ```
 
 Capability-gated navigation truth:

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -36,10 +36,15 @@ BFF_BASE_URL=http://gateway.dev.lotus
 http://workbench.dev.lotus/portfolio
 http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001
 http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk
+http://workbench.dev.lotus/data-products
 ```
 
 If the product loads against localhost but not the canonical hostnames, fix the governed hosts and
 runtime flow before debugging UI components.
+
+`/data-products` uses the Workbench BFF to consume gateway domain-product catalog,
+dependency-graph, and live trust certification endpoints. It should show an unavailable trust
+posture until the gateway has access to the platform-generated RFC-0087 certification artifact.
 
 ## First docs to read
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -15,6 +15,7 @@
 
 - primary product client for Lotus
 - Portfolio and Performance are the most mature active front-office surfaces
+- `/data-products` provides gateway-backed domain-product discovery and live trust posture
 - recommendations and proposals remain compatibility routes, not the main supported shell apps
 - shell navigation currently treats `Proposal` and `Advisory` as disabled capability-gated entries
 


### PR DESCRIPTION
## Summary
- add typed workflow_pack_run support to the gateway advisor-brief client contract
- map workflow-pack posture into existing advisor-brief supportability, review notes, and audit provenance
- cover the view-model and rendered mode behavior with targeted tests

## Validation
- make check
