### PR TITLE
docs(mesh): document mesh wiki posture

### DIFF
--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -1,0 +1,19 @@
+# Mesh Data Products
+
+## Mesh role
+
+`lotus-workbench` is the self-serve discovery and operator/customer-facing consumption surface for Lotus mesh products.
+
+## Governed surface
+
+- Route: `/data-products`
+- Integration boundary: Workbench BFF to `lotus-gateway`
+- Displayed facts: product identity, producer repository, lifecycle, approved consumers, dependencies, certification/trust state, and degraded states
+
+## Platform relationship
+
+Workbench consumes gateway APIs only. It must not read `lotus-platform/generated/`, `platform-contracts/`, or `output/trust-certification/` directly.
+
+## Operating rule
+
+Workbench discovery must show truthful loading, empty, partial, stale, blocked, unavailable, and error states. It must not show decorative mesh trust when gateway/platform certification evidence is missing.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -17,3 +17,5 @@
 - [Security and Governance](Security-and-Governance)
 - [RFC Index](RFC-Index)
 - [Roadmap](Roadmap)
+
+- [Mesh Data Products](Mesh-Data-Products)


### PR DESCRIPTION
Updates the authored repo wiki with an explicit Mesh Data Products page and sidebar link so the repo's published wiki can reflect the implemented Lotus mesh RFC posture. This is documentation-only; no runtime or API behavior changes.