### PR TITLE
Polish portfolio workspace summary UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10167,4 +10167,511 @@ a:hover {
   }
 }
 
+/* Portfolio premium banking-grade shell overrides. Keep these page-scoped to avoid drift in other workbench apps. */
+.portfolio-page.app-page-shell {
+  max-width: 1500px;
+  margin-inline: auto;
+  padding: 24px;
+  background:
+    linear-gradient(180deg, rgba(248, 250, 252, 0.96), rgba(248, 250, 252, 0.72)),
+    #f8fafc;
+}
+
+.portfolio-layout {
+  --workstation-rail-width: 224px;
+  --workbench-rail-width: 280px;
+  --workstation-shell-gap: 16px;
+}
+
+.portfolio-page-frame {
+  gap: 16px;
+}
+
+.portfolio-page-frame .workbench-page-header {
+  align-items: flex-start;
+  gap: 24px;
+  padding-block: 0 4px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.portfolio-page-frame .workbench-page-header-copy {
+  gap: 0;
+}
+
+.portfolio-page-frame .workbench-page-header-title {
+  max-width: none;
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+  color: #0f172a;
+}
+
+.portfolio-page-header-status {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-height: 32px;
+}
+
+.portfolio-page-header-status > span {
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.portfolio-page-sections,
+.portfolio-page-frame-body,
+.portfolio-summary-cluster,
+.portfolio-detailed-cluster {
+  gap: 16px;
+}
+
+.portfolio-rail,
+.portfolio-side-card,
+.portfolio-hero,
+.portfolio-summary-band,
+.portfolio-summary-module-card,
+.portfolio-data-grid .ag-root-wrapper,
+.portfolio-allocation-chart-card,
+.portfolio-allocation-ranked,
+.portfolio-insight-card,
+.portfolio-grid-empty-state,
+.portfolio-empty-state,
+.portfolio-readiness-clear-state {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.portfolio-rail {
+  max-width: none;
+  padding: 0;
+}
+
+.portfolio-rail-header {
+  padding: 20px 20px 12px;
+}
+
+.portfolio-rail-kicker {
+  margin-bottom: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.portfolio-rail-header h2 {
+  font-size: 16px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+.portfolio-rail-list {
+  gap: 8px;
+  padding: 0 12px 12px;
+}
+
+.portfolio-rail-item {
+  gap: 4px;
+  padding: 12px;
+  border-radius: 10px;
+  background: transparent;
+}
+
+.portfolio-rail-item-title {
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.portfolio-rail-item span {
+  font-size: 12px;
+}
+
+.portfolio-rail-item:hover {
+  background: #f8fafc;
+}
+
+.portfolio-rail-item-active {
+  background: #f1f5f9;
+  box-shadow: inset 3px 0 0 #334155;
+}
+
+.portfolio-workspace-toolbar.page-toolbar {
+  padding: 16px;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.portfolio-workspace-toolbar-row {
+  gap: 16px;
+}
+
+.portfolio-workspace-toolbar-field label {
+  margin-bottom: 6px;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mode-tabs.lotus-mode-tabs,
+.portfolio-workspace-view-mode-tabs.workbench-segmented-control {
+  gap: 0;
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.mode-tabs-button.lotus-mode-tabs-button,
+.portfolio-workspace-view-mode-tabs .workbench-segmented-control-button {
+  min-height: 36px;
+  padding: 0 16px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: #64748b;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.mode-tabs-button.lotus-mode-tabs-button.workbench-segmented-control-button-active,
+.portfolio-workspace-view-mode-tabs .workbench-segmented-control-button-active {
+  border-bottom-color: #334155;
+  background: transparent;
+  color: #0f172a;
+  box-shadow: none;
+}
+
+.portfolio-workspace-toolbar .workbench-segmented-control:not(.mode-tabs) {
+  padding: 2px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.portfolio-workspace-toolbar-context {
+  margin-top: 12px;
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.portfolio-hero {
+  align-items: flex-start;
+  gap: 24px;
+  padding: 24px;
+}
+
+.portfolio-hero-content {
+  gap: 8px;
+}
+
+.portfolio-hero .section-label,
+.portfolio-hero .ui-text-label,
+.portfolio-hero .ui-text-eyebrow {
+  font-size: 12px;
+}
+
+.portfolio-hero h2 {
+  font-size: clamp(28px, 2.2vw, 36px);
+  font-weight: 700;
+  line-height: 1.02;
+  letter-spacing: -0.045em;
+  color: #0f172a;
+}
+
+.portfolio-hero-meta {
+  gap: 8px;
+}
+
+.portfolio-hero-meta span {
+  font-size: 13px;
+  font-weight: 550;
+}
+
+.portfolio-hero-actions {
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.portfolio-action-link {
+  min-height: 36px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.portfolio-summary-band {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  overflow: hidden;
+}
+
+.portfolio-summary-band-item {
+  padding: 16px;
+  border-left: 1px solid #e2e8f0;
+}
+
+.portfolio-summary-band-item:first-child {
+  border-left: 0;
+}
+
+.kpi-stat-tile {
+  gap: 8px;
+}
+
+.kpi-stat-label {
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+}
+
+.kpi-stat-value {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.035em;
+}
+
+.kpi-stat-support {
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.portfolio-workspace-section .section-header,
+.portfolio-workspace-section .section-block-header {
+  margin-bottom: 8px;
+}
+
+.portfolio-page .ui-text-section-title,
+.portfolio-workspace-section h2 {
+  font-size: 18px;
+  font-weight: 650;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.workbench-summary-card .workbench-summary-card-title,
+.portfolio-side-card-title {
+  font-size: 16px;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.workbench-summary-card .workbench-summary-card-subtitle,
+.portfolio-card-subtitle {
+  background: transparent;
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.portfolio-primary-grid {
+  gap: 16px;
+}
+
+.portfolio-primary-grid > .portfolio-summary-module-card:first-child,
+.portfolio-primary-grid > .portfolio-summary-module-card:nth-child(2) {
+  grid-column: span 6;
+}
+
+.portfolio-allocation-toolbar {
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.portfolio-allocation-body,
+.portfolio-allocation-panel-compact .portfolio-allocation-body {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
+}
+
+.portfolio-allocation-panel-compact .portfolio-allocation-chart-card {
+  min-height: 14rem;
+  padding: 16px;
+}
+
+.portfolio-empty-state,
+.portfolio-grid-empty-state,
+.portfolio-allocation-empty,
+.portfolio-readiness-clear-state {
+  padding: 24px;
+}
+
+.portfolio-empty-state::before,
+.portfolio-grid-empty-state::before,
+.portfolio-readiness-clear-state::before {
+  content: "";
+  width: 32px;
+  height: 32px;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  background:
+    linear-gradient(90deg, transparent 11px, #cbd5e1 12px, transparent 13px),
+    linear-gradient(0deg, transparent 11px, #cbd5e1 12px, transparent 13px),
+    #f8fafc;
+}
+
+.portfolio-context-panel,
+.portfolio-side-groups,
+.portfolio-side-definition-list,
+.portfolio-mandate-grid {
+  gap: 12px;
+}
+
+.portfolio-context-row,
+.portfolio-page .suite-row,
+.portfolio-side-definition-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, auto);
+  align-items: start;
+  gap: 8px 16px;
+  padding: 10px 0;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.portfolio-context-row:first-child,
+.portfolio-side-definition-row:first-child,
+.portfolio-page .suite-row:first-of-type {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.portfolio-context-row dt,
+.portfolio-side-definition-row dt,
+.portfolio-page .suite-row span {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.portfolio-context-row dd,
+.portfolio-side-definition-row dd,
+.portfolio-page .suite-row strong {
+  font-size: 14px;
+  font-weight: 650;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.portfolio-workflow-item {
+  position: relative;
+  padding: 14px 28px 14px 0;
+  transition:
+    background 140ms ease,
+    transform 140ms ease;
+}
+
+.portfolio-workflow-item::after {
+  content: "›";
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #94a3b8;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.portfolio-workflow-item:hover {
+  background: #f8fafc;
+}
+
+.portfolio-actions-card .portfolio-workflow-item {
+  padding-right: 24px;
+}
+
+.portfolio-data-grid {
+  --ag-row-height: 44px;
+  --ag-header-height: 44px;
+  --ag-cell-horizontal-padding: 16px;
+}
+
+.portfolio-data-grid .ag-root-wrapper {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.portfolio-data-grid .ag-header-cell-text {
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.portfolio-data-grid .ag-cell {
+  font-size: 14px;
+}
+
+@media (max-width: 1280px) {
+  .portfolio-page.app-page-shell {
+    max-width: none;
+  }
+
+  .portfolio-layout {
+    --workstation-rail-width: 208px;
+    --workbench-rail-width: 260px;
+  }
+}
+
+@media (max-width: 1200px) {
+  .portfolio-page.app-page-shell {
+    padding: 16px;
+  }
+
+  .portfolio-summary-band {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .portfolio-summary-band-item:nth-child(odd) {
+    border-left: 0;
+  }
+}
+
+@media (max-width: 820px) {
+  .portfolio-page-frame .workbench-page-header,
+  .portfolio-hero {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .portfolio-page-header-status,
+  .portfolio-hero-actions {
+    justify-content: flex-start;
+  }
+
+  .portfolio-primary-grid > .portfolio-summary-module-card:first-child,
+  .portfolio-primary-grid > .portfolio-summary-module-card:nth-child(2) {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .portfolio-page.app-page-shell {
+    padding: 12px;
+  }
+
+  .portfolio-summary-band {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .portfolio-summary-band-item {
+    border-left: 0;
+    border-top: 1px solid #e2e8f0;
+  }
+
+  .portfolio-summary-band-item:first-child {
+    border-top: 0;
+  }
+}
+
 

--- a/src/apps/portfolio/components/portfolio-workspace.tsx
+++ b/src/apps/portfolio/components/portfolio-workspace.tsx
@@ -60,11 +60,8 @@ import {
   getRelatedTransactionsForSecurity,
   getActivityDisplayCurrency,
   getBookReadinessStatus,
-  getBookReadinessSupport,
-  getBookReadinessTone,
   getIncomeDisplayCurrency,
   getInvestedAssetWeight,
-  getNetFlowTone,
   getOrderedWorkflowCues,
   getRequestedWindowActivityAmount,
   getRequestedWindowActivityCount,
@@ -410,14 +407,13 @@ export default function PortfolioWorkspaceView({
               className="portfolio-page-frame"
               bodyClassName="portfolio-page-frame-body"
               title="Portfolio"
-              subtitle="Front-office portfolio context, readiness, and decision support"
               actions={
-                <>
-                  <SemanticBadge>{portfolios.length} portfolios</SemanticBadge>
+                <div className="portfolio-page-header-status">
+                  <span>{formatCount(portfolios.length, "portfolio")}</span>
                   <SemanticBadge tone={portfolios.length ? "success" : "warn"}>
                     {portfolios.length ? "Catalog live" : "Catalog unavailable"}
                   </SemanticBadge>
-                </>
+                </div>
               }
             >
               <WorkbenchSectionStack className="portfolio-page-sections">
@@ -439,7 +435,6 @@ export default function PortfolioWorkspaceView({
                       <PortfolioSummaryHeaderSection
                         workspace={workspace}
                         context={context}
-                        activityDisplayCurrency={activityDisplayCurrency}
                         orderedWorkflowCues={orderedWorkflowCues}
                         primaryWorkflowCueKey={primaryWorkflowCue?.key ?? null}
                         readinessIndicators={priorityReadinessIndicators}
@@ -633,7 +628,6 @@ export default function PortfolioWorkspaceView({
 function PortfolioSummaryHeaderSection({
   workspace,
   context,
-  activityDisplayCurrency,
   orderedWorkflowCues,
   primaryWorkflowCueKey,
   readinessIndicators,
@@ -641,7 +635,6 @@ function PortfolioSummaryHeaderSection({
 }: {
   workspace: PortfolioWorkspace;
   context: PortfolioWorkspaceContext;
-  activityDisplayCurrency: string;
   orderedWorkflowCues: Array<{ key: string; label: string; href: string }>;
   primaryWorkflowCueKey: string | null;
   readinessIndicators: ReturnType<typeof buildPortfolioReadinessIndicators>;
@@ -711,7 +704,7 @@ function PortfolioSummaryHeaderSection({
           },
           {
             key: "available_cash",
-            label: "Available Cash",
+            label: "Cash",
             value: formatCurrency(workspace.summary.total_cash_base, workspace.portfolio.base_currency),
             definition:
               "Available cash inventory in the portfolio base currency across published cash balances.",
@@ -719,32 +712,12 @@ function PortfolioSummaryHeaderSection({
             onClick: () => onOpenMetricDrawer("available_cash"),
           },
           {
-            key: "holdings",
-            label: "Holdings",
-            value: workspace.summary.position_count,
-            definition: "Number of currently valued holdings in the portfolio book.",
-            support: formatCount(workspace.summary.position_count, "holding"),
-            onClick: () => onOpenMetricDrawer("holdings"),
-          },
-          {
-            key: "net_flow_30d",
-            label: "30D Net Flow",
-            value: formatCurrency(getRequestedWindowActivityAmount(workspace), activityDisplayCurrency),
-            definition:
-              "Net booked portfolio activity across the requested 30-day reporting window, including funding, fees, and other ledger movements.",
-            support: `${getRequestedWindowActivityCount(workspace)} booked events`,
-            tone: getNetFlowTone(workspace),
-            onClick: () => onOpenMetricDrawer("net_flow_30d"),
-          },
-          {
-            key: "book_readiness",
-            label: "Book Readiness",
-            value: getBookReadinessStatus(workspace),
-            definition:
-              "Operational readiness based on holdings coverage, reporting status, publish eligibility, and active blocking exceptions.",
-            support: getBookReadinessSupport(workspace),
-            tone: getBookReadinessTone(workspace),
-            onClick: () => onOpenMetricDrawer("book_readiness"),
+            key: "cash_accounts",
+            label: "Cash Accounts",
+            value: workspace.summary.cash_balance_count ?? 0,
+            definition: "Number of published cash balance records supporting the available cash figure.",
+            support: formatCount(workspace.summary.cash_balance_count ?? 0, "account"),
+            onClick: () => onOpenMetricDrawer("cash_accounts"),
           },
         ]}
       />
@@ -1042,7 +1015,7 @@ function PortfolioInsightsSection({
           <PortfolioCollapsibleModule
             className="portfolio-summary-module-card"
             compact={isSummaryView}
-            title="Top Holdings"
+            title="Top Positions"
             subtitle={`Largest holdings by market value or weight as of ${formatDate(context.selectedAsOfDate)}.`}
             expanded={getSectionExpanded("top-holdings")}
             onToggle={() => toggleSection("top-holdings")}
@@ -1421,6 +1394,7 @@ type PortfolioMetricDrawerKey =
   | "aum"
   | "invested_assets"
   | "available_cash"
+  | "cash_accounts"
   | "holdings"
   | "net_flow_30d"
   | "book_readiness";
@@ -1520,6 +1494,41 @@ function buildMetricDrawer(
             content: renderDrawerParagraphs([
               "Available cash aggregates current cash balances across portfolio cash instruments.",
               "Use it with projected cashflow to assess short-horizon funding capacity.",
+            ]),
+          },
+          {
+            key: "detail",
+            label: "Underlying Detail",
+            content: renderDrawerDefinitionList(
+              (workspace.cash_balances ?? []).length
+                ? (workspace.cash_balances ?? []).map((balance) => [
+                    balance.instrument_name,
+                    formatCurrency(balance.market_value_base ?? balance.quantity, workspace.portfolio.base_currency),
+                  ])
+                : [["Cash Accounts", "No published cash balances available"]]
+            ),
+          },
+        ],
+        fullPageHref: "#portfolio-insights",
+        fullPageLabel: "Open liquidity",
+      };
+    case "cash_accounts":
+      return {
+        kicker: "Metric Detail",
+        title: "Cash Accounts",
+        subtitle: "Published cash balance records supporting available cash and liquidity review.",
+        summaryItems: [
+          { label: "Accounts", value: String(workspace.summary.cash_balance_count ?? 0) },
+          { label: "Available Cash", value: formatCurrency(workspace.summary.total_cash_base, workspace.portfolio.base_currency) },
+          ...commonSummary,
+        ],
+        tabs: [
+          {
+            key: "definition",
+            label: "Definition",
+            content: renderDrawerParagraphs([
+              "Cash accounts counts published cash balances in the current portfolio context.",
+              "Use it with available cash and projected cashflow to assess funding coverage and liquidity completeness.",
             ]),
           },
           {
@@ -1855,7 +1864,7 @@ function resolveExceptionEvidence(
     case "holdings":
       return [
         ["Positions", formatCount(workspace.positions.length, "position")],
-        ["Top Holdings", formatCount(workspace.top_positions.length, "holding")],
+        ["Top Positions", formatCount(workspace.top_positions.length, "holding")],
         ["Reported Position Count", formatCount(workspace.summary.position_count, "holding")],
       ];
     case "pricing":

--- a/tests/e2e/portfolio-workbench.smoke.spec.ts
+++ b/tests/e2e/portfolio-workbench.smoke.spec.ts
@@ -108,7 +108,7 @@ test.describe('Portfolio workbench smoke', () => {
     test.skip(!session.available, 'Portfolio foundation upstream unavailable in standalone smoke environment.');
 
     await expect(page.getByRole('heading', { name: /Portfolio Allocation/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /Top Holdings/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Top Positions/i })).toBeVisible();
     await expect(page.getByRole('heading', { name: /Performance Snapshot/i })).toBeVisible();
     await expect(page.getByRole('heading', { name: /^Income$/i })).toBeVisible();
     await expect(page.getByRole('heading', { name: /^Activity$/i })).toBeVisible();

--- a/tests/integration/portfolios-page.test.tsx
+++ b/tests/integration/portfolios-page.test.tsx
@@ -114,14 +114,12 @@ describe("PortfolioFoundationPage", () => {
     expect(screen.getAllByText("1,250,000 USD").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("1,145,000 USD").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("105,000 USD").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("12 holdings")).toBeInTheDocument();
+    expect(screen.getByText("2 accounts")).toBeInTheDocument();
     expect(document.querySelector(".portfolio-summary-band")).toBeTruthy();
-    expect(document.querySelectorAll(".portfolio-summary-band-item")).toHaveLength(6);
-    expect(screen.getByText("Generated 24 Feb 2026 • 14 report rows")).toBeInTheDocument();
+    expect(document.querySelectorAll(".portfolio-summary-band-item")).toHaveLength(4);
     await waitFor(() => {
       expect(screen.getByText("Income Plus")).toBeInTheDocument();
       expect(screen.getAllByText("14,750 USD").length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText("2 booked events")).toBeInTheDocument();
       expect(screen.getByText("Large position dominates portfolio risk")).toBeInTheDocument();
     });
     expect(screen.getByLabelText("As of")).toHaveValue("2026-02-24");
@@ -161,7 +159,7 @@ describe("PortfolioFoundationPage", () => {
     expect(summaryCluster?.querySelector("#portfolio-summary")).toBeTruthy();
     expect(summaryCluster?.querySelector("#portfolio-attention")).toBeTruthy();
     expect(screen.getByRole("heading", { name: /Portfolio Allocation/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Top Holdings/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Top Positions/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Performance Snapshot/i })).toBeInTheDocument();
     expect(screen.getByText("Unavailable")).toBeInTheDocument();
     const performanceSnapshotCard = screen
@@ -232,7 +230,7 @@ describe("PortfolioFoundationPage", () => {
       .getByRole("heading", { name: /Portfolio Allocation/i })
       .closest(".portfolio-summary-module-card");
     const topHoldingsCard = screen
-      .getByRole("heading", { name: /Top Holdings/i })
+      .getByRole("heading", { name: /Top Positions/i })
       .closest(".portfolio-summary-module-card");
     expect(allocationCard).toBeTruthy();
     expect(topHoldingsCard).toBeTruthy();


### PR DESCRIPTION
## Summary
- simplify the portfolio workspace summary header and reduce duplicated readiness/activity metrics in the first-screen band
- rename holdings-facing UI labels to clearer portfolio-position language where the panel is position-backed
- add a cash-account metric drawer backed by existing cash balance data

## Validation
- `npm test -- --run tests/integration/portfolios-page.test.tsx tests/e2e/portfolio-workbench.smoke.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check main...feat/premium-portfolio-ui-polish`