### PR TITLE
Render RFC-0097 advisor-brief task-flow posture

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -42,7 +42,8 @@ Current repository posture:
 3. the `Portfolio` and `Performance` surfaces are the most mature live workflows,
 4. `/data-products` provides self-serve gateway-backed domain-product catalog, dependency, and
    live trust discovery for RFC-0088,
-5. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
+5. the Performance advisor-brief surface consumes gateway-backed workflow-pack run posture and RFC-0097 task-flow posture without synthesizing review state or lineage client-side,
+6. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map
 

--- a/docs/rfcs/RFC-0097-slice-workbench-task-flow-posture-review.md
+++ b/docs/rfcs/RFC-0097-slice-workbench-task-flow-posture-review.md
@@ -13,6 +13,9 @@ task-flow state, review state, or replacement lineage from narrative text or fal
 3. Added task-flow supportability and replacement-lineage notes to the gateway-backed view model.
 4. Kept the existing review-action form governed by `workflow_pack_run.allowed_review_actions`.
 5. Updated repository context and wiki integration notes for the new gateway-backed posture.
+6. Tightened the canonical live workflow-pack proof so advisor-brief validation now fails if
+   gateway responses omit task-flow identity, source-run references, review-state mapping,
+   replacement lineage, or `READY_FOR_HANDOFF` posture.
 
 ## Review Findings
 
@@ -24,6 +27,9 @@ task-flow state, review state, or replacement lineage from narrative text or fal
    posture is read-only.
 4. Unit coverage now proves source-ref preservation, supportability rendering, replacement lineage
    rendering, and API payload preservation.
+5. The live validator now checks initial task-flow posture before review actions and refreshed
+   task-flow posture after `ACCEPT`, `SUPERSEDE`, and `REVISE`; this closes the previous evidence
+   gap where live proof could pass on `workflow_pack_run` alone.
 
 ## Proof
 
@@ -47,12 +53,15 @@ task-flow state, review state, or replacement lineage from narrative text or fal
    - passed.
 9. Handoff-readiness follow-up `npm run lint`
    - passed.
+10. Live proof hardening follow-up `npm test -- --run tests/unit/live-validation-workflow-pack-proof.test.ts`
+    - 2 passed.
+11. Live proof hardening follow-up `git diff --check`
+    - passed with existing CRLF normalization warnings only.
 
 ## Remaining RFC-0097 Gaps
 
-1. Heartbeat attention needs an adapter for stale, blocked, degraded, and review-waiting task flows.
-2. Domain handoff execution remains a future cross-service slice.
-3. A live end-to-end validation pass should prove task-flow posture across `lotus-ai` ->
+1. Domain handoff execution remains a future cross-service slice.
+2. A live end-to-end validation pass should prove task-flow posture across `lotus-ai` ->
    `lotus-gateway` -> `lotus-workbench` before RFC closure.
-4. Final governance review, API certification posture, docs/context/wiki publication, skills
+3. Final governance review, API certification posture, docs/context/wiki publication, skills
    assessment, and branch hygiene remain required.

--- a/docs/rfcs/RFC-0097-slice-workbench-task-flow-posture-review.md
+++ b/docs/rfcs/RFC-0097-slice-workbench-task-flow-posture-review.md
@@ -1,0 +1,50 @@
+# RFC-0097 Workbench Task-Flow Posture Slice Review
+
+## Scope
+
+This slice makes Workbench consume Gateway-published RFC-0097 task-flow posture for the
+Performance advisor-brief surface. Workbench remains a renderer of gateway truth: it does not infer
+task-flow state, review state, or replacement lineage from narrative text or fallback previews.
+
+## Implemented
+
+1. Added typed `workflow_pack_task_flow` support to the Workbench advisor-brief gateway contract.
+2. Added task-flow provenance refs to advisor-brief audit source refs.
+3. Added task-flow supportability and replacement-lineage notes to the gateway-backed view model.
+4. Kept the existing review-action form governed by `workflow_pack_run.allowed_review_actions`.
+5. Updated repository context and wiki integration notes for the new gateway-backed posture.
+
+## Review Findings
+
+1. The implementation avoids a new UI surface because the existing supportability rail already
+   presents bounded run and review posture clearly.
+2. The fallback advisor-brief view model remains untouched so synthetic preview data cannot pretend
+   to prove RFC-0097 posture.
+3. The UI continues to hide review actions when gateway returns no allowed review actions; task-flow
+   posture is read-only.
+4. Unit coverage now proves source-ref preservation, supportability rendering, replacement lineage
+   rendering, and API payload preservation.
+
+## Proof
+
+1. `npm test -- --run tests/unit/performance-advisor-brief-view-model.test.ts tests/unit/performance-advisor-brief-mode.test.tsx tests/unit/workbench-api.test.ts`
+   - 44 passed.
+2. `npm run typecheck`
+   - passed.
+3. `npm run lint`
+   - passed.
+4. `npm run build`
+   - passed with existing autoprefixer mixed-support warnings in `src/app/globals.css`.
+5. `git diff --check`
+   - passed with existing CRLF normalization warnings only.
+6. `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench`
+   - reported expected branch-local drift for `Integrations.md`; publish after merge to `main`.
+
+## Remaining RFC-0097 Gaps
+
+1. Heartbeat attention needs an adapter for stale, blocked, degraded, and review-waiting task flows.
+2. Domain handoff execution remains a future cross-service slice.
+3. A live end-to-end validation pass should prove task-flow posture across `lotus-ai` ->
+   `lotus-gateway` -> `lotus-workbench` before RFC closure.
+4. Final governance review, API certification posture, docs/context/wiki publication, skills
+   assessment, and branch hygiene remain required.

--- a/docs/rfcs/RFC-0097-slice-workbench-task-flow-posture-review.md
+++ b/docs/rfcs/RFC-0097-slice-workbench-task-flow-posture-review.md
@@ -39,6 +39,14 @@ task-flow state, review state, or replacement lineage from narrative text or fal
    - passed with existing CRLF normalization warnings only.
 6. `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench`
    - reported expected branch-local drift for `Integrations.md`; publish after merge to `main`.
+7. Handoff-readiness follow-up: Workbench now preserves and renders gateway task-flow
+   `handoff_refs`.
+   `npm test -- --run tests/unit/performance-advisor-brief-view-model.test.ts tests/unit/performance-advisor-brief-mode.test.tsx tests/unit/workbench-api.test.ts`
+   - 44 passed.
+8. Handoff-readiness follow-up `npm run typecheck`
+   - passed.
+9. Handoff-readiness follow-up `npm run lint`
+   - passed.
 
 ## Remaining RFC-0097 Gaps
 

--- a/scripts/live/validation/workflow-pack-proof.mjs
+++ b/scripts/live/validation/workflow-pack-proof.mjs
@@ -27,6 +27,120 @@ function assertWorkflowPackRunPresence(payload, description) {
   return run;
 }
 
+function assertWorkflowPackTaskFlowPresence(payload, description) {
+  const taskFlow = payload?.workflow_pack_task_flow;
+  if (!taskFlow?.task_flow_id) {
+    throw new Error(`${description} returned no workflow-pack task-flow identity.`);
+  }
+  return taskFlow;
+}
+
+function assertTaskFlowRunRef(taskFlow, runId, description) {
+  const runRefs = Array.isArray(taskFlow.run_refs) ? taskFlow.run_refs : [];
+  if (!runRefs.includes(runId)) {
+    throw new Error(
+      `${description} task-flow run_refs did not include source run '${runId}'.`
+    );
+  }
+}
+
+function assertTaskFlowReviewState(taskFlow, runId, expectedReviewState, description) {
+  const reviewStates =
+    taskFlow.review_states && typeof taskFlow.review_states === "object"
+      ? taskFlow.review_states
+      : {};
+  if (reviewStates[runId] !== expectedReviewState) {
+    throw new Error(
+      `${description} task-flow review state for '${runId}' was '${String(
+        reviewStates[runId]
+      )}' instead of '${expectedReviewState}'.`
+    );
+  }
+}
+
+function assertAcceptedTaskFlowPosture(payload, runId) {
+  const taskFlow = assertWorkflowPackTaskFlowPresence(
+    payload,
+    "Advisor brief ACCEPT review action"
+  );
+  assertTaskFlowRunRef(taskFlow, runId, "Advisor brief ACCEPT review action");
+  assertTaskFlowReviewState(taskFlow, runId, "ACCEPTED", "Advisor brief ACCEPT review action");
+  if (taskFlow.flow_status !== "COMPLETED") {
+    throw new Error(
+      `Advisor brief ACCEPT review action returned task-flow status '${String(
+        taskFlow.flow_status
+      )}' instead of 'COMPLETED'.`
+    );
+  }
+  if (taskFlow.supportability_status !== "READY") {
+    throw new Error(
+      `Advisor brief ACCEPT review action returned task-flow supportability '${String(
+        taskFlow.supportability_status
+      )}' instead of 'READY'.`
+    );
+  }
+  const handoffRefs = Array.isArray(taskFlow.handoff_refs) ? taskFlow.handoff_refs : [];
+  if (!handoffRefs.some((handoff) => handoff?.handoff_type === "READY_FOR_HANDOFF")) {
+    throw new Error(
+      "Advisor brief ACCEPT review action returned no READY_FOR_HANDOFF task-flow handoff."
+    );
+  }
+  return taskFlow;
+}
+
+function assertInitialTaskFlowPosture(payload, runId, description) {
+  const taskFlow = assertWorkflowPackTaskFlowPresence(payload, description);
+  assertTaskFlowRunRef(taskFlow, runId, description);
+  if (!taskFlow.flow_status) {
+    throw new Error(`${description} returned no task-flow status.`);
+  }
+  if (!taskFlow.supportability_status) {
+    throw new Error(`${description} returned no task-flow supportability status.`);
+  }
+  return taskFlow;
+}
+
+function assertReplacementTaskFlowPosture(
+  payload,
+  expectedReviewState,
+  sourceRunId,
+  replacementRunId
+) {
+  const taskFlow = assertWorkflowPackTaskFlowPresence(
+    payload,
+    `Advisor brief ${expectedReviewState} review action`
+  );
+  assertTaskFlowRunRef(taskFlow, sourceRunId, `Advisor brief ${expectedReviewState} review action`);
+  assertTaskFlowReviewState(
+    taskFlow,
+    sourceRunId,
+    expectedReviewState,
+    `Advisor brief ${expectedReviewState} review action`
+  );
+  if (taskFlow.flow_status !== "SUPERSEDED") {
+    throw new Error(
+      `Advisor brief ${expectedReviewState} review action returned task-flow status '${String(
+        taskFlow.flow_status
+      )}' instead of 'SUPERSEDED'.`
+    );
+  }
+  if (taskFlow.supportability_status !== "HISTORICAL") {
+    throw new Error(
+      `Advisor brief ${expectedReviewState} review action returned task-flow supportability '${String(
+        taskFlow.supportability_status
+      )}' instead of 'HISTORICAL'.`
+    );
+  }
+  if (taskFlow.replacement_lineage?.replacement_run_id !== replacementRunId) {
+    throw new Error(
+      `Advisor brief ${expectedReviewState} review action returned task-flow replacement_run_id '${String(
+        taskFlow.replacement_lineage?.replacement_run_id
+      )}' instead of '${replacementRunId}'.`
+    );
+  }
+  return taskFlow;
+}
+
 function assertAcceptedRunPosture(payload) {
   const run = assertWorkflowPackRunPresence(payload, "Advisor brief ACCEPT review action");
   if (run.review_state !== "ACCEPTED") {
@@ -106,10 +220,14 @@ export async function validateAdvisorBriefWorkflowPackReviewChain({
     }
   );
   const acceptedRun = assertAcceptedRunPosture(acceptedBrief);
+  const acceptedTaskFlow = assertAcceptedTaskFlowPosture(acceptedBrief, acceptedRun.run_id);
   recordWorkflowPackCheck(summary, {
     actionType: "ACCEPT",
     route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${acceptQuery}`,
     sourceRunId: acceptedRun.run_id,
+    taskFlowId: acceptedTaskFlow.task_flow_id,
+    taskFlowStatus: acceptedTaskFlow.flow_status,
+    taskFlowSupportabilityStatus: acceptedTaskFlow.supportability_status,
     resultReviewState: acceptedRun.review_state,
     resultSupportabilityStatus: acceptedRun.supportability_status,
   });
@@ -144,8 +262,18 @@ export async function validateAdvisorBriefWorkflowPackReviewChain({
     supersedeOriginal,
     "Advisor brief supersede source run"
   );
+  assertInitialTaskFlowPosture(
+    supersedeOriginal,
+    supersedeSourceRun.run_id,
+    "Advisor brief supersede source run"
+  );
   const supersedeReplacementRun = assertWorkflowPackRunPresence(
     supersedeReplacement,
+    "Advisor brief supersede replacement run"
+  );
+  assertInitialTaskFlowPosture(
+    supersedeReplacement,
+    supersedeReplacementRun.run_id,
     "Advisor brief supersede replacement run"
   );
   const supersededBrief = await postJson(
@@ -165,11 +293,20 @@ export async function validateAdvisorBriefWorkflowPackReviewChain({
     "SUPERSEDED",
     supersedeReplacementRun.run_id
   );
+  const supersededTaskFlow = assertReplacementTaskFlowPosture(
+    supersededBrief,
+    "SUPERSEDED",
+    supersedeSourceRun.run_id,
+    supersedeReplacementRun.run_id
+  );
   recordWorkflowPackCheck(summary, {
     actionType: "SUPERSEDE",
     route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${supersedeOriginalQuery}`,
     sourceRunId: supersedeSourceRun.run_id,
     replacementRunId: supersedeReplacementRun.run_id,
+    taskFlowId: supersededTaskFlow.task_flow_id,
+    taskFlowStatus: supersededTaskFlow.flow_status,
+    taskFlowSupportabilityStatus: supersededTaskFlow.supportability_status,
     resultReviewState: supersededRun.review_state,
     resultSupportabilityStatus: supersededRun.supportability_status,
   });
@@ -202,8 +339,18 @@ export async function validateAdvisorBriefWorkflowPackReviewChain({
     reviseOriginal,
     "Advisor brief revise source run"
   );
+  assertInitialTaskFlowPosture(
+    reviseOriginal,
+    reviseSourceRun.run_id,
+    "Advisor brief revise source run"
+  );
   const reviseReplacementRun = assertWorkflowPackRunPresence(
     reviseReplacement,
+    "Advisor brief revise replacement run"
+  );
+  assertInitialTaskFlowPosture(
+    reviseReplacement,
+    reviseReplacementRun.run_id,
     "Advisor brief revise replacement run"
   );
   const revisedBrief = await postJson(
@@ -223,11 +370,20 @@ export async function validateAdvisorBriefWorkflowPackReviewChain({
     "REVISED",
     reviseReplacementRun.run_id
   );
+  const revisedTaskFlow = assertReplacementTaskFlowPosture(
+    revisedBrief,
+    "REVISED",
+    reviseSourceRun.run_id,
+    reviseReplacementRun.run_id
+  );
   recordWorkflowPackCheck(summary, {
     actionType: "REVISE",
     route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${reviseOriginalQuery}`,
     sourceRunId: reviseSourceRun.run_id,
     replacementRunId: reviseReplacementRun.run_id,
+    taskFlowId: revisedTaskFlow.task_flow_id,
+    taskFlowStatus: revisedTaskFlow.flow_status,
+    taskFlowSupportabilityStatus: revisedTaskFlow.supportability_status,
     resultReviewState: revisedRun.review_state,
     resultSupportabilityStatus: revisedRun.supportability_status,
   });

--- a/src/apps/performance/advisor-brief/build-gateway-advisor-brief-view-model.ts
+++ b/src/apps/performance/advisor-brief/build-gateway-advisor-brief-view-model.ts
@@ -178,6 +178,10 @@ function buildGatewayReviewNotes(advisorBrief: WorkbenchPerformanceAdvisorBrief)
           (lineage) =>
             `${lineage.review_action_ref}: task flow links ${lineage.superseded_run_id} to replacement run ${lineage.replacement_run_id}.`
         ),
+        ...workflowPackTaskFlow.handoff_refs.map(
+          (handoff) =>
+            `Handoff ${handoff.handoff_id} is ${handoff.status.replaceAll("_", " ").toLowerCase()} for ${handoff.owner_service}.`
+        ),
       ]
     : [];
 

--- a/src/apps/performance/advisor-brief/build-gateway-advisor-brief-view-model.ts
+++ b/src/apps/performance/advisor-brief/build-gateway-advisor-brief-view-model.ts
@@ -74,18 +74,22 @@ function resolveAdvisorBriefSourceRefs(advisorBrief: WorkbenchPerformanceAdvisor
   const workflowPackRunRef = advisorBrief.workflow_pack_run
     ? [`lotus-ai:workflow-pack-run:${advisorBrief.workflow_pack_run.run_id}`]
     : [];
+  const workflowPackTaskFlowRef = advisorBrief.workflow_pack_task_flow
+    ? [`lotus-ai:workflow-pack-task-flow:${advisorBrief.workflow_pack_task_flow.task_flow_id}`]
+    : [];
   const aiEvidenceRefs = advisorBrief.ai_evidence.source_refs ?? [];
   if (aiEvidenceRefs.length > 0) {
-    return Array.from(new Set([...aiEvidenceRefs, ...workflowPackRunRef]));
+    return Array.from(new Set([...aiEvidenceRefs, ...workflowPackRunRef, ...workflowPackTaskFlowRef]));
   }
 
   const aiAuditRefs = advisorBrief.ai_audit.source_refs ?? [];
   if (aiAuditRefs.length > 0) {
-    return Array.from(new Set([...aiAuditRefs, ...workflowPackRunRef]));
+    return Array.from(new Set([...aiAuditRefs, ...workflowPackRunRef, ...workflowPackTaskFlowRef]));
   }
 
   return [
     ...workflowPackRunRef,
+    ...workflowPackTaskFlowRef,
     `lotus-gateway:workbench:${advisorBrief.portfolio_id}:performance-advisor-brief:${advisorBrief.period}`,
   ];
 }
@@ -134,11 +138,22 @@ function normalizeGatewaySupportability(
       tone: normalizeWorkflowPackReviewTone(advisorBrief.workflow_pack_run),
       detail: buildWorkflowPackReviewDetail(advisorBrief.workflow_pack_run),
     },
+    ...(advisorBrief.workflow_pack_task_flow
+      ? [
+          {
+            label: "AI Task Flow",
+            value: normalizeTaskFlowStatusValue(advisorBrief.workflow_pack_task_flow.flow_status),
+            tone: normalizeTaskFlowStatusTone(advisorBrief.workflow_pack_task_flow.flow_status),
+            detail: buildTaskFlowDetail(advisorBrief.workflow_pack_task_flow),
+          } satisfies PerformanceAdvisorBriefViewModel["supportability"][number],
+        ]
+      : []),
   ];
 }
 
 function buildGatewayReviewNotes(advisorBrief: WorkbenchPerformanceAdvisorBrief): string[] {
   const workflowPackRun = advisorBrief.workflow_pack_run;
+  const workflowPackTaskFlow = advisorBrief.workflow_pack_task_flow;
   const workflowPackNotes = workflowPackRun
     ? [
         workflowPackRun.current_summary_note,
@@ -151,6 +166,20 @@ function buildGatewayReviewNotes(advisorBrief: WorkbenchPerformanceAdvisorBrief)
           : null,
       ]
     : [];
+  const taskFlowNotes = workflowPackTaskFlow
+    ? [
+        `Task flow ${workflowPackTaskFlow.task_flow_id} is ${normalizeTaskFlowStatusValue(
+          workflowPackTaskFlow.flow_status
+        ).toLowerCase()}.`,
+        workflowPackTaskFlow.current_step_id
+          ? `Current task-flow step: ${workflowPackTaskFlow.current_step_id}.`
+          : null,
+        ...workflowPackTaskFlow.replacement_lineage.map(
+          (lineage) =>
+            `${lineage.review_action_ref}: task flow links ${lineage.superseded_run_id} to replacement run ${lineage.replacement_run_id}.`
+        ),
+      ]
+    : [];
 
   return Array.from(
     new Set(
@@ -158,6 +187,7 @@ function buildGatewayReviewNotes(advisorBrief: WorkbenchPerformanceAdvisorBrief)
         ...advisorBrief.partial_failures.map((failure) => failure.detail),
         ...advisorBrief.warnings,
         ...workflowPackNotes,
+        ...taskFlowNotes,
       ].filter((note): note is string => Boolean(note))
     )
   );
@@ -360,6 +390,37 @@ function normalizeWorkflowPackReviewTone(
     return "success";
   }
   return "warn";
+}
+
+function normalizeTaskFlowStatusValue(flowStatus: string): string {
+  return flowStatus.replaceAll("_", " ");
+}
+
+function normalizeTaskFlowStatusTone(flowStatus: string): "success" | "warn" | "danger" {
+  switch (flowStatus) {
+    case "COMPLETED":
+      return "success";
+    case "FAILED":
+    case "CANCELLED":
+    case "EXPIRED":
+      return "danger";
+    default:
+      return "warn";
+  }
+}
+
+function buildTaskFlowDetail(
+  taskFlow: NonNullable<WorkbenchPerformanceAdvisorBrief["workflow_pack_task_flow"]>
+): string {
+  const detailParts = [
+    taskFlow.task_flow_id,
+    `${taskFlow.workflow_pack_id}@${taskFlow.version}`,
+    `Supportability ${normalizeTaskFlowStatusValue(taskFlow.supportability_status)}`,
+  ];
+  if (taskFlow.replacement_lineage.length > 0) {
+    detailParts.push(`${taskFlow.replacement_lineage.length} lineage edge(s)`);
+  }
+  return detailParts.join(" • ");
 }
 
 function normalizeAdvisorTargetMode(targetMode: string): PerformanceWorkspaceMode {

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -552,6 +552,26 @@ export type WorkbenchAdvisorBriefWorkflowPackRun = {
   findings: WorkbenchAdvisorBriefWorkflowPackRunFinding[];
 };
 
+export type WorkbenchAdvisorBriefWorkflowPackTaskFlowLineage = {
+  superseded_run_id: string;
+  replacement_run_id: string;
+  review_action_ref: string;
+  reason: string;
+};
+
+export type WorkbenchAdvisorBriefWorkflowPackTaskFlow = {
+  task_flow_id: string;
+  workflow_pack_id: string;
+  version: string;
+  flow_status: string;
+  current_step_id?: string | null;
+  run_refs: string[];
+  review_states: Record<string, string>;
+  supportability_status: string;
+  replacement_lineage: WorkbenchAdvisorBriefWorkflowPackTaskFlowLineage[];
+  updated_at: string;
+};
+
 export type WorkbenchPerformanceAdvisorBrief = {
   correlation_id: string;
   contract_version: string;
@@ -574,6 +594,7 @@ export type WorkbenchPerformanceAdvisorBrief = {
   source_metrics: WorkbenchAdvisorBriefSourceMetric[];
   supportability: WorkbenchAdvisorBriefSupportabilityItem[];
   workflow_pack_run?: WorkbenchAdvisorBriefWorkflowPackRun | null;
+  workflow_pack_task_flow?: WorkbenchAdvisorBriefWorkflowPackTaskFlow | null;
   ai_audit: {
     task_id?: string;
     output_label?: string;

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -559,6 +559,13 @@ export type WorkbenchAdvisorBriefWorkflowPackTaskFlowLineage = {
   reason: string;
 };
 
+export type WorkbenchAdvisorBriefWorkflowPackTaskFlowHandoff = {
+  handoff_id: string;
+  owner_service: string;
+  status: string;
+  domain_ref?: string | null;
+};
+
 export type WorkbenchAdvisorBriefWorkflowPackTaskFlow = {
   task_flow_id: string;
   workflow_pack_id: string;
@@ -569,6 +576,7 @@ export type WorkbenchAdvisorBriefWorkflowPackTaskFlow = {
   review_states: Record<string, string>;
   supportability_status: string;
   replacement_lineage: WorkbenchAdvisorBriefWorkflowPackTaskFlowLineage[];
+  handoff_refs: WorkbenchAdvisorBriefWorkflowPackTaskFlowHandoff[];
   updated_at: string;
 };
 

--- a/tests/unit/live-validation-workflow-pack-proof.test.ts
+++ b/tests/unit/live-validation-workflow-pack-proof.test.ts
@@ -34,11 +34,119 @@ function createSummary() {
   };
 }
 
+function createTaskFlow({
+  taskFlowId,
+  runId,
+  reviewState,
+  flowStatus,
+  supportabilityStatus,
+  replacementRunId,
+  handoffType,
+}: {
+  taskFlowId: string;
+  runId: string;
+  reviewState: string;
+  flowStatus: string;
+  supportabilityStatus: string;
+  replacementRunId?: unknown;
+  handoffType?: string;
+}) {
+  return {
+    task_flow_id: taskFlowId,
+    run_refs: [runId],
+    review_states: {
+      [runId]: reviewState,
+    },
+    flow_status: flowStatus,
+    supportability_status: supportabilityStatus,
+    replacement_lineage:
+      replacementRunId === undefined ? null : { replacement_run_id: replacementRunId },
+    handoff_refs: handoffType === undefined ? [] : [{ handoff_type: handoffType }],
+  };
+}
+
+function createAdvisorBriefPayload({
+  runId,
+  reviewState = "AWAITING_REVIEW",
+  supportabilityStatus,
+  superseded,
+  replacementRunId,
+  taskFlowId,
+  taskFlowStatus = "AWAITING_REVIEW",
+  taskFlowSupportabilityStatus = "ACTION_REQUIRED",
+  handoffType,
+}: {
+  runId: string;
+  reviewState?: string;
+  supportabilityStatus?: string;
+  superseded?: boolean;
+  replacementRunId?: unknown;
+  taskFlowId: string;
+  taskFlowStatus?: string;
+  taskFlowSupportabilityStatus?: string;
+  handoffType?: string;
+}) {
+  return {
+    workflow_pack_run: {
+      run_id: runId,
+      review_state: reviewState,
+      ...(supportabilityStatus === undefined
+        ? {}
+        : { supportability_status: supportabilityStatus }),
+      ...(superseded === undefined ? {} : { superseded }),
+      ...(replacementRunId === undefined ? {} : { replacement_run_id: replacementRunId }),
+    },
+    workflow_pack_task_flow: createTaskFlow({
+      taskFlowId,
+      runId,
+      reviewState,
+      flowStatus: taskFlowStatus,
+      supportabilityStatus: taskFlowSupportabilityStatus,
+      replacementRunId,
+      handoffType,
+    }),
+  };
+}
+
+function createFetchAdvisorBriefPayload() {
+  return (url: string) => {
+    if (url.includes("report_start_date=2026-02-01")) {
+      return createAdvisorBriefPayload({
+        runId: "packrun-revise-replacement",
+        taskFlowId: "taskflow-revise-replacement",
+      });
+    }
+    if (url.includes("detail_basis=NET") && url.includes("period=EXPLICIT")) {
+      return createAdvisorBriefPayload({
+        runId: "packrun-explicit-net",
+        taskFlowId: "taskflow-explicit-net",
+      });
+    }
+    if (url.includes("detail_basis=GROSS") && url.includes("period=EXPLICIT")) {
+      return createAdvisorBriefPayload({
+        runId: "packrun-explicit-gross",
+        taskFlowId: "taskflow-explicit-gross",
+      });
+    }
+    if (url.includes("detail_basis=GROSS") && url.includes("period=YTD")) {
+      return createAdvisorBriefPayload({
+        runId: "packrun-ytd-gross",
+        taskFlowId: "taskflow-ytd-gross",
+      });
+    }
+    return createAdvisorBriefPayload({
+      runId: "packrun-ytd-net",
+      taskFlowId: "taskflow-ytd-net",
+    });
+  };
+}
+
 describe("live validation workflow-pack proof", () => {
   it("records advisor-brief review-action lineage checks for accept, supersede, and revise", async () => {
     const summary = createSummary();
     const getCalls: string[] = [];
     const postCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const fetchAdvisorBriefPayload = createFetchAdvisorBriefPayload();
 
     await validateAdvisorBriefWorkflowPackReviewChain({
       summary,
@@ -49,24 +157,7 @@ describe("live validation workflow-pack proof", () => {
       timeoutMs: 1000,
       fetchJson: async (_summary: unknown, url: string) => {
         getCalls.push(url);
-        if (url.includes("report_start_date=2026-02-01")) {
-          return {
-            workflow_pack_run: {
-              run_id: "packrun-revise-replacement",
-              review_state: "AWAITING_REVIEW",
-            },
-          };
-        }
-        if (url.includes("detail_basis=NET") && url.includes("period=EXPLICIT")) {
-          return { workflow_pack_run: { run_id: "packrun-explicit-net", review_state: "AWAITING_REVIEW" } };
-        }
-        if (url.includes("detail_basis=GROSS") && url.includes("period=EXPLICIT")) {
-          return { workflow_pack_run: { run_id: "packrun-explicit-gross", review_state: "AWAITING_REVIEW" } };
-        }
-        if (url.includes("detail_basis=GROSS") && url.includes("period=YTD")) {
-          return { workflow_pack_run: { run_id: "packrun-ytd-gross", review_state: "AWAITING_REVIEW" } };
-        }
-        return { workflow_pack_run: { run_id: "packrun-explicit-net", review_state: "AWAITING_REVIEW" } };
+        return fetchAdvisorBriefPayload(url);
       },
       postJson: async (
         _summary: unknown,
@@ -77,34 +168,38 @@ describe("live validation workflow-pack proof", () => {
       ) => {
         postCalls.push({ url, body });
         if (body.action_type === "ACCEPT") {
-          return {
-            workflow_pack_run: {
-              run_id: "packrun-ytd-net",
-              review_state: "ACCEPTED",
-              supportability_status: "READY",
-            },
-          };
+          return createAdvisorBriefPayload({
+            runId: "packrun-ytd-net",
+            reviewState: "ACCEPTED",
+            supportabilityStatus: "READY",
+            taskFlowId: "taskflow-ytd-net",
+            taskFlowStatus: "COMPLETED",
+            taskFlowSupportabilityStatus: "READY",
+            handoffType: "READY_FOR_HANDOFF",
+          });
         }
         if (body.action_type === "SUPERSEDE") {
-          return {
-            workflow_pack_run: {
-              run_id: "packrun-explicit-net",
-              review_state: "SUPERSEDED",
-              supportability_status: "HISTORICAL",
-              superseded: true,
-              replacement_run_id: body.replacement_run_id,
-            },
-          };
-        }
-        return {
-          workflow_pack_run: {
-            run_id: "packrun-ytd-gross",
-            review_state: "REVISED",
-            supportability_status: "HISTORICAL",
+          return createAdvisorBriefPayload({
+            runId: "packrun-explicit-net",
+            reviewState: "SUPERSEDED",
+            supportabilityStatus: "HISTORICAL",
             superseded: true,
-            replacement_run_id: body.replacement_run_id,
-          },
-        };
+            replacementRunId: body.replacement_run_id,
+            taskFlowId: "taskflow-explicit-net",
+            taskFlowStatus: "SUPERSEDED",
+            taskFlowSupportabilityStatus: "HISTORICAL",
+          });
+        }
+        return createAdvisorBriefPayload({
+          runId: "packrun-ytd-gross",
+          reviewState: "REVISED",
+          supportabilityStatus: "HISTORICAL",
+          superseded: true,
+          replacementRunId: body.replacement_run_id,
+          taskFlowId: "taskflow-ytd-gross",
+          taskFlowStatus: "SUPERSEDED",
+          taskFlowSupportabilityStatus: "HISTORICAL",
+        });
       },
     });
 
@@ -131,6 +226,9 @@ describe("live validation workflow-pack proof", () => {
       expect.objectContaining({
         actionType: "ACCEPT",
         sourceRunId: "packrun-ytd-net",
+        taskFlowId: "taskflow-ytd-net",
+        taskFlowStatus: "COMPLETED",
+        taskFlowSupportabilityStatus: "READY",
         resultReviewState: "ACCEPTED",
         resultSupportabilityStatus: "READY",
       }),
@@ -138,6 +236,9 @@ describe("live validation workflow-pack proof", () => {
         actionType: "SUPERSEDE",
         sourceRunId: "packrun-explicit-net",
         replacementRunId: "packrun-explicit-gross",
+        taskFlowId: "taskflow-explicit-net",
+        taskFlowStatus: "SUPERSEDED",
+        taskFlowSupportabilityStatus: "HISTORICAL",
         resultReviewState: "SUPERSEDED",
         resultSupportabilityStatus: "HISTORICAL",
       }),
@@ -145,6 +246,9 @@ describe("live validation workflow-pack proof", () => {
         actionType: "REVISE",
         sourceRunId: "packrun-ytd-gross",
         replacementRunId: "packrun-revise-replacement",
+        taskFlowId: "taskflow-ytd-gross",
+        taskFlowStatus: "SUPERSEDED",
+        taskFlowSupportabilityStatus: "HISTORICAL",
         resultReviewState: "REVISED",
         resultSupportabilityStatus: "HISTORICAL",
       }),
@@ -153,6 +257,7 @@ describe("live validation workflow-pack proof", () => {
 
   it("accepts truthfully action-required accept posture when the run remains degraded", async () => {
     const summary = createSummary();
+    const fetchAdvisorBriefPayload = createFetchAdvisorBriefPayload();
 
     await validateAdvisorBriefWorkflowPackReviewChain({
       summary,
@@ -162,19 +267,7 @@ describe("live validation workflow-pack proof", () => {
       canonicalAsOfDate: "2026-04-10",
       timeoutMs: 1000,
       fetchJson: async (_summary: unknown, url: string) => {
-        if (url.includes("report_start_date=2026-02-01")) {
-          return { workflow_pack_run: { run_id: "packrun-revise-replacement", review_state: "AWAITING_REVIEW" } };
-        }
-        if (url.includes("detail_basis=NET") && url.includes("period=EXPLICIT")) {
-          return { workflow_pack_run: { run_id: "packrun-explicit-net", review_state: "AWAITING_REVIEW" } };
-        }
-        if (url.includes("detail_basis=GROSS") && url.includes("period=EXPLICIT")) {
-          return { workflow_pack_run: { run_id: "packrun-explicit-gross", review_state: "AWAITING_REVIEW" } };
-        }
-        if (url.includes("detail_basis=GROSS") && url.includes("period=YTD")) {
-          return { workflow_pack_run: { run_id: "packrun-ytd-gross", review_state: "AWAITING_REVIEW" } };
-        }
-        return { workflow_pack_run: { run_id: "packrun-ytd-net", review_state: "AWAITING_REVIEW" } };
+        return fetchAdvisorBriefPayload(url);
       },
       postJson: async (
         _summary: unknown,
@@ -184,35 +277,39 @@ describe("live validation workflow-pack proof", () => {
         body: Record<string, unknown>
       ) => {
         if (body.action_type === "ACCEPT") {
-          return {
-            workflow_pack_run: {
-              run_id: "packrun-ytd-net",
-              review_state: "ACCEPTED",
-              supportability_status: "ACTION_REQUIRED",
-              superseded: false,
-            },
-          };
+          return createAdvisorBriefPayload({
+            runId: "packrun-ytd-net",
+            reviewState: "ACCEPTED",
+            supportabilityStatus: "ACTION_REQUIRED",
+            superseded: false,
+            taskFlowId: "taskflow-ytd-net",
+            taskFlowStatus: "COMPLETED",
+            taskFlowSupportabilityStatus: "READY",
+            handoffType: "READY_FOR_HANDOFF",
+          });
         }
         if (body.action_type === "SUPERSEDE") {
-          return {
-            workflow_pack_run: {
-              run_id: "packrun-explicit-net",
-              review_state: "SUPERSEDED",
-              supportability_status: "HISTORICAL",
-              superseded: true,
-              replacement_run_id: body.replacement_run_id,
-            },
-          };
-        }
-        return {
-          workflow_pack_run: {
-            run_id: "packrun-ytd-gross",
-            review_state: "REVISED",
-            supportability_status: "HISTORICAL",
+          return createAdvisorBriefPayload({
+            runId: "packrun-explicit-net",
+            reviewState: "SUPERSEDED",
+            supportabilityStatus: "HISTORICAL",
             superseded: true,
-            replacement_run_id: body.replacement_run_id,
-          },
-        };
+            replacementRunId: body.replacement_run_id,
+            taskFlowId: "taskflow-explicit-net",
+            taskFlowStatus: "SUPERSEDED",
+            taskFlowSupportabilityStatus: "HISTORICAL",
+          });
+        }
+        return createAdvisorBriefPayload({
+          runId: "packrun-ytd-gross",
+          reviewState: "REVISED",
+          supportabilityStatus: "HISTORICAL",
+          superseded: true,
+          replacementRunId: body.replacement_run_id,
+          taskFlowId: "taskflow-ytd-gross",
+          taskFlowStatus: "SUPERSEDED",
+          taskFlowSupportabilityStatus: "HISTORICAL",
+        });
       },
     });
 
@@ -221,6 +318,9 @@ describe("live validation workflow-pack proof", () => {
         expect.objectContaining({
           actionType: "ACCEPT",
           sourceRunId: "packrun-ytd-net",
+          taskFlowId: "taskflow-ytd-net",
+          taskFlowStatus: "COMPLETED",
+          taskFlowSupportabilityStatus: "READY",
           resultReviewState: "ACCEPTED",
           resultSupportabilityStatus: "ACTION_REQUIRED",
         }),

--- a/tests/unit/performance-advisor-brief-mode.test.tsx
+++ b/tests/unit/performance-advisor-brief-mode.test.tsx
@@ -93,6 +93,20 @@ const readyAdvisorBriefResponse: WorkbenchPerformanceAdvisorBrief = {
       },
     ],
   },
+  workflow_pack_task_flow: {
+    task_flow_id: "taskflow_advisor_brief_req-1",
+    workflow_pack_id: "advisor_brief.pack",
+    version: "v1",
+    flow_status: "WAITING_FOR_REVIEW",
+    current_step_id: "generate_advisor_brief",
+    run_refs: ["packrun_advisor_brief_req-1"],
+    review_states: {
+      "packrun_advisor_brief_req-1": "AWAITING_REVIEW",
+    },
+    supportability_status: "ACTION_REQUIRED",
+    replacement_lineage: [],
+    updated_at: "2026-04-21T03:00:00Z",
+  },
   ai_audit: {
     task_id: "explain.v1",
     output_label: "EXPLANATION_ONLY",
@@ -134,6 +148,14 @@ vi.mock("../../src/features/workbench/api", () => ({
       current_summary_note: "Run accepted for bounded downstream workflow use.",
       findings: [],
     },
+    workflow_pack_task_flow: {
+      ...readyAdvisorBriefResponse.workflow_pack_task_flow!,
+      flow_status: "COMPLETED",
+      review_states: {
+        "packrun_advisor_brief_req-1": "ACCEPTED",
+      },
+      supportability_status: "READY",
+    },
   })),
 }));
 
@@ -151,6 +173,14 @@ describe("PerformanceAdvisorBriefMode", () => {
         review_pending: false,
         current_summary_note: "Run accepted for bounded downstream workflow use.",
         findings: [],
+      },
+      workflow_pack_task_flow: {
+        ...readyAdvisorBriefResponse.workflow_pack_task_flow!,
+        flow_status: "COMPLETED",
+        review_states: {
+          "packrun_advisor_brief_req-1": "ACCEPTED",
+        },
+        supportability_status: "READY",
       },
     });
   });
@@ -193,6 +223,10 @@ describe("PerformanceAdvisorBriefMode", () => {
       expect(supportability).toHaveTextContent("AI Review");
       expect(supportability).toHaveTextContent("AWAITING REVIEW");
       expect(supportability).toHaveTextContent("Supportability ACTION REQUIRED");
+      expect(supportability).toHaveTextContent("AI Task Flow");
+      expect(supportability).toHaveTextContent("WAITING FOR REVIEW");
+      expect(supportability).toHaveTextContent("taskflow_advisor_brief_req-1");
+      expect(supportability).toHaveTextContent("Current task-flow step: generate_advisor_brief.");
       expect(supportability).toHaveTextContent(
         "Run completed but still requires bounded human review before downstream use."
       );

--- a/tests/unit/performance-advisor-brief-mode.test.tsx
+++ b/tests/unit/performance-advisor-brief-mode.test.tsx
@@ -105,6 +105,7 @@ const readyAdvisorBriefResponse: WorkbenchPerformanceAdvisorBrief = {
     },
     supportability_status: "ACTION_REQUIRED",
     replacement_lineage: [],
+    handoff_refs: [],
     updated_at: "2026-04-21T03:00:00Z",
   },
   ai_audit: {
@@ -155,6 +156,14 @@ vi.mock("../../src/features/workbench/api", () => ({
         "packrun_advisor_brief_req-1": "ACCEPTED",
       },
       supportability_status: "READY",
+      handoff_refs: [
+        {
+          handoff_id: "taskflow_advisor_brief_req-1_handoff_packrun_advisor_brief_req-1",
+          owner_service: "lotus-gateway",
+          status: "READY_FOR_HANDOFF",
+          domain_ref: null,
+        },
+      ],
     },
   })),
 }));
@@ -181,6 +190,14 @@ describe("PerformanceAdvisorBriefMode", () => {
           "packrun_advisor_brief_req-1": "ACCEPTED",
         },
         supportability_status: "READY",
+        handoff_refs: [
+          {
+            handoff_id: "taskflow_advisor_brief_req-1_handoff_packrun_advisor_brief_req-1",
+            owner_service: "lotus-gateway",
+            status: "READY_FOR_HANDOFF",
+            domain_ref: null,
+          },
+        ],
       },
     });
   });
@@ -520,6 +537,9 @@ describe("PerformanceAdvisorBriefMode", () => {
       expect(supportability).toHaveTextContent("AI Review");
       expect(supportability).toHaveTextContent("ACCEPTED");
       expect(supportability).toHaveTextContent("Supportability READY");
+      expect(supportability).toHaveTextContent(
+        "Handoff taskflow_advisor_brief_req-1_handoff_packrun_advisor_brief_req-1 is ready for handoff for lotus-gateway."
+      );
       expect(supportability).toHaveTextContent(
         "Run accepted for bounded downstream workflow use."
       );

--- a/tests/unit/performance-advisor-brief-view-model.test.ts
+++ b/tests/unit/performance-advisor-brief-view-model.test.ts
@@ -595,6 +595,18 @@ describe("buildPerformanceAdvisorBriefViewModel", () => {
             },
           ],
         },
+        workflow_pack_task_flow: {
+          task_flow_id: "taskflow_advisor_brief_req-1",
+          workflow_pack_id: "advisor_brief.pack",
+          version: "v1",
+          flow_status: "WAITING_FOR_REVIEW",
+          current_step_id: "generate_advisor_brief",
+          run_refs: ["packrun_advisor_brief_req-1"],
+          review_states: { "packrun_advisor_brief_req-1": "AWAITING_REVIEW" },
+          supportability_status: "ACTION_REQUIRED",
+          replacement_lineage: [],
+          updated_at: "2026-04-21T03:00:00Z",
+        },
         ai_audit: { stubbed: false, source_refs: [] },
         ai_evidence: { source_refs: [] },
         warnings: [],
@@ -624,16 +636,27 @@ describe("buildPerformanceAdvisorBriefViewModel", () => {
           tone: "warn",
           detail: "Supportability ACTION REQUIRED",
         },
+        {
+          label: "AI Task Flow",
+          value: "WAITING FOR REVIEW",
+          tone: "warn",
+          detail: "taskflow_advisor_brief_req-1 • advisor_brief.pack@v1 • Supportability ACTION REQUIRED",
+        },
       ])
     );
     expect(brief.reviewNotes).toEqual(
       expect.arrayContaining([
         "Run completed but still requires bounded human review before downstream use.",
         "ACTION REQUIRED: Run is awaiting review.",
+        "Task flow taskflow_advisor_brief_req-1 is waiting for review.",
+        "Current task-flow step: generate_advisor_brief.",
       ])
     );
     expect(brief.audit.sourceRefs).toEqual(
-      expect.arrayContaining(["lotus-ai:workflow-pack-run:packrun_advisor_brief_req-1"])
+      expect.arrayContaining([
+        "lotus-ai:workflow-pack-run:packrun_advisor_brief_req-1",
+        "lotus-ai:workflow-pack-task-flow:taskflow_advisor_brief_req-1",
+      ])
     );
   });
 
@@ -676,6 +699,25 @@ describe("buildPerformanceAdvisorBriefViewModel", () => {
           replacement_run_id: "packrun_advisor_brief_req-2",
           findings: [],
         },
+        workflow_pack_task_flow: {
+          task_flow_id: "taskflow_advisor_brief_req-1",
+          workflow_pack_id: "advisor_brief.pack",
+          version: "v1",
+          flow_status: "SUPERSEDED",
+          current_step_id: null,
+          run_refs: ["packrun_advisor_brief_req-1"],
+          review_states: { "packrun_advisor_brief_req-1": "SUPERSEDED" },
+          supportability_status: "HISTORICAL",
+          replacement_lineage: [
+            {
+              superseded_run_id: "packrun_advisor_brief_req-1",
+              replacement_run_id: "packrun_advisor_brief_req-2",
+              review_action_ref: "SUPERSEDE",
+              reason: "Advisor brief superseded in favor of the replacement run.",
+            },
+          ],
+          updated_at: "2026-04-21T03:00:00Z",
+        },
         ai_audit: { stubbed: false, source_refs: [] },
         ai_evidence: { source_refs: [] },
         warnings: [],
@@ -699,12 +741,20 @@ describe("buildPerformanceAdvisorBriefViewModel", () => {
           tone: "warn",
           detail: "Supportability READY • Superseded by packrun_advisor_brief_req-2",
         },
+        {
+          label: "AI Task Flow",
+          value: "SUPERSEDED",
+          tone: "warn",
+          detail: "taskflow_advisor_brief_req-1 • advisor_brief.pack@v1 • Supportability HISTORICAL • 1 lineage edge(s)",
+        },
       ])
     );
     expect(brief.reviewNotes).toEqual(
       expect.arrayContaining([
         "Run was superseded by a newer bounded advisor-brief run.",
         "Superseded by workflow-pack run packrun_advisor_brief_req-2.",
+        "Task flow taskflow_advisor_brief_req-1 is superseded.",
+        "SUPERSEDE: task flow links packrun_advisor_brief_req-1 to replacement run packrun_advisor_brief_req-2.",
       ])
     );
   });

--- a/tests/unit/performance-advisor-brief-view-model.test.ts
+++ b/tests/unit/performance-advisor-brief-view-model.test.ts
@@ -605,6 +605,7 @@ describe("buildPerformanceAdvisorBriefViewModel", () => {
           review_states: { "packrun_advisor_brief_req-1": "AWAITING_REVIEW" },
           supportability_status: "ACTION_REQUIRED",
           replacement_lineage: [],
+          handoff_refs: [],
           updated_at: "2026-04-21T03:00:00Z",
         },
         ai_audit: { stubbed: false, source_refs: [] },
@@ -716,6 +717,14 @@ describe("buildPerformanceAdvisorBriefViewModel", () => {
               reason: "Advisor brief superseded in favor of the replacement run.",
             },
           ],
+          handoff_refs: [
+            {
+              handoff_id: "taskflow_advisor_brief_req-1_handoff_packrun_advisor_brief_req-1",
+              owner_service: "lotus-gateway",
+              status: "READY_FOR_HANDOFF",
+              domain_ref: null,
+            },
+          ],
           updated_at: "2026-04-21T03:00:00Z",
         },
         ai_audit: { stubbed: false, source_refs: [] },
@@ -755,6 +764,7 @@ describe("buildPerformanceAdvisorBriefViewModel", () => {
         "Superseded by workflow-pack run packrun_advisor_brief_req-2.",
         "Task flow taskflow_advisor_brief_req-1 is superseded.",
         "SUPERSEDE: task flow links packrun_advisor_brief_req-1 to replacement run packrun_advisor_brief_req-2.",
+        "Handoff taskflow_advisor_brief_req-1_handoff_packrun_advisor_brief_req-1 is ready for handoff for lotus-gateway.",
       ])
     );
   });

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -913,6 +913,7 @@ describe("workbench api", () => {
               },
               supportability_status: "ACTION_REQUIRED",
               replacement_lineage: [],
+              handoff_refs: [],
               updated_at: "2026-04-21T03:00:00Z",
             },
             ai_audit: {},
@@ -1002,6 +1003,14 @@ describe("workbench api", () => {
               },
               supportability_status: "READY",
               replacement_lineage: [],
+              handoff_refs: [
+                {
+                  handoff_id: "taskflow_advisor_brief_req-1_handoff_packrun_advisor_brief_req-1",
+                  owner_service: "lotus-gateway",
+                  status: "READY_FOR_HANDOFF",
+                  domain_ref: null,
+                },
+              ],
               updated_at: "2026-04-21T03:00:00Z",
             },
             ai_audit: {},

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -901,6 +901,20 @@ describe("workbench api", () => {
             risks_and_exceptions: [],
             source_metrics: [],
             supportability: [],
+            workflow_pack_task_flow: {
+              task_flow_id: "taskflow_advisor_brief_req-1",
+              workflow_pack_id: "advisor_brief.pack",
+              version: "v1",
+              flow_status: "WAITING_FOR_REVIEW",
+              current_step_id: "generate_advisor_brief",
+              run_refs: ["packrun_advisor_brief_req-1"],
+              review_states: {
+                "packrun_advisor_brief_req-1": "AWAITING_REVIEW",
+              },
+              supportability_status: "ACTION_REQUIRED",
+              replacement_lineage: [],
+              updated_at: "2026-04-21T03:00:00Z",
+            },
             ai_audit: {},
             ai_evidence: {},
             warnings: [],
@@ -911,7 +925,7 @@ describe("workbench api", () => {
       )
     );
 
-    await getWorkbenchPerformanceAdvisorBriefClient("PF_1001", {
+    const advisorBrief = await getWorkbenchPerformanceAdvisorBriefClient("PF_1001", {
       period: "YTD",
       chartFrequency: "monthly",
       contributionDimension: "asset_class",
@@ -925,6 +939,9 @@ describe("workbench api", () => {
     const requestedUrl = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].toString();
     expect(requestedUrl).toContain(
       "/api/bff/api/v1/workbench/PF_1001/performance/advisor-brief?period=YTD&chart_frequency=monthly&contribution_dimension=asset_class&attribution_dimension=asset_class&detail_basis=NET&benchmark_code=BMK_GLOBAL_BALANCED_60_40&report_start_date=2026-01-01&report_end_date=2026-02-24"
+    );
+    expect(advisorBrief.workflow_pack_task_flow?.task_flow_id).toBe(
+      "taskflow_advisor_brief_req-1"
     );
   });
 
@@ -972,6 +989,20 @@ describe("workbench api", () => {
                 "Run accepted for bounded downstream workflow use.",
               replacement_run_id: null,
               findings: [],
+            },
+            workflow_pack_task_flow: {
+              task_flow_id: "taskflow_advisor_brief_req-1",
+              workflow_pack_id: "advisor_brief.pack",
+              version: "v1",
+              flow_status: "COMPLETED",
+              current_step_id: null,
+              run_refs: ["packrun_advisor_brief_req-1"],
+              review_states: {
+                "packrun_advisor_brief_req-1": "ACCEPTED",
+              },
+              supportability_status: "READY",
+              replacement_lineage: [],
+              updated_at: "2026-04-21T03:00:00Z",
             },
             ai_audit: {},
             ai_evidence: {},

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -31,3 +31,6 @@
 3. canonical front-office validation depends on governed `*.dev.lotus` routing and seeded data
 4. shell navigation supportability is informed by gateway-backed capability posture rather than by
    the mere existence of historical routes
+5. Performance advisor-brief workflow-pack run posture and RFC-0097 task-flow lineage are rendered
+   from gateway payloads; Workbench does not infer replacement lineage from narrative text or local
+   fallback previews


### PR DESCRIPTION
## Summary
- type gateway `workflow_pack_task_flow` payloads in Workbench
- render task-flow supportability, provenance, replacement lineage, and handoff posture in the advisor-brief supportability rail
- keep fallback previews out of RFC-0097 posture proof
- tighten the canonical live advisor-brief workflow-pack validator so live proof fails without task-flow identity, source-run refs, review-state mapping, replacement lineage, and READY_FOR_HANDOFF posture
- update repo context, wiki source, and slice review evidence

## Proof
- `npm test -- --run tests/unit/live-validation-workflow-pack-proof.test.ts tests/unit/performance-advisor-brief-view-model.test.ts tests/unit/performance-advisor-brief-mode.test.tsx tests/unit/workbench-api.test.ts` -> 46 passed
- `npm run typecheck` passed
- `npm run lint` passed
- prior `npm run build` passed with existing autoprefixer mixed-support warnings in `src/app/globals.css`
- `git diff --check` passed with CRLF normalization warnings only

## Wiki
- repo-local `wiki/Integrations.md` changed; publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-workbench`.

## RFC Closure Notes
- This PR closes the Workbench task-flow posture and live-proof hardening slices for RFC-0097.
- RFC-0097 remains `In Implementation` until ai/gateway/workbench/platform PRs merge, live end-to-end advisor-brief proof passes, and repo wikis are published from `main`.