### PR TITLE
chore(live): pin lotus-ai env for canonical proof

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -110,6 +110,11 @@ runtime without waiting for the full validation lane to finish.
 The canonical bring-up script also accepts `-SeedWaitSeconds` when the governed seed needs a longer
 drain window than the default `900` seconds.
 
+The canonical bring-up script accepts `-LotusAiEnvFile` to make the `lotus-ai` provider posture
+explicit for proof runs. Use `.env.example` for deterministic provider-disabled front-office proof.
+Use the repo-local `.env` only when the required live provider dependency, such as the `local-llm`
+Ollama compose profile and model, is intentionally running.
+
 When a prior local RFC-086 load/performance run has left stale `lotus-core` Kafka or Postgres
 state behind, use `-CleanCoreState` on the startup script to run `docker compose down -v
 --remove-orphans` in `lotus-core` before the canonical rebuild and reseed. This reset is explicit

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -3,6 +3,7 @@ param(
   [string]$PortfolioId = "PB_SG_GLOBAL_BAL_001",
   [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40",
   [string]$ScreenshotDirectory = "",
+  [string]$LotusAiEnvFile = "",
   [int]$SeedWaitSeconds = 900,
   [switch]$CleanCoreState,
   [switch]$BuildImages,
@@ -85,6 +86,36 @@ function Stop-HostProcessOnPort {
   Start-Sleep -Seconds 2
 }
 
+function Resolve-LotusAiEnvFile {
+  param([string]$EnvFile)
+
+  if ([string]::IsNullOrWhiteSpace($EnvFile)) {
+    return ""
+  }
+
+  $resolved = if ([System.IO.Path]::IsPathRooted($EnvFile)) {
+    $EnvFile
+  } else {
+    Join-Path $aiRepo $EnvFile
+  }
+  if (-not (Test-Path $resolved)) {
+    throw "Lotus AI env file not found: $resolved"
+  }
+  return $resolved
+}
+
+function Get-EnvScopedComposeCommand {
+  param(
+    [string]$Command,
+    [string]$EnvFile
+  )
+
+  if ([string]::IsNullOrWhiteSpace($EnvFile)) {
+    return $Command
+  }
+  return "`$env:LOTUS_AI_ENV_FILE = '$EnvFile'; $Command"
+}
+
 Write-Host "Previewing managed canonical hosts block from lotus-platform ..."
 Invoke-RepoCommand $platformRepo "powershell -ExecutionPolicy Bypass -File automation\\Sync-Dev-Ingress-Hosts.ps1"
 
@@ -98,10 +129,11 @@ $composeUpCommand = "docker compose up -d"
 if ($BuildImages) {
   $composeUpCommand = "$composeUpCommand --build"
 }
+$resolvedLotusAiEnvFile = Resolve-LotusAiEnvFile -EnvFile $LotusAiEnvFile
 Invoke-RepoCommand $coreRepo $composeUpCommand
 Invoke-RepoCommand $performanceRepo $composeUpCommand
 Invoke-RepoCommand $riskRepo $composeUpCommand
-Invoke-RepoCommand $aiRepo $composeUpCommand
+Invoke-RepoCommand $aiRepo (Get-EnvScopedComposeCommand -Command $composeUpCommand -EnvFile $resolvedLotusAiEnvFile)
 Invoke-RepoCommand $adviseRepo $composeUpCommand
 Invoke-RepoCommand $reportRepo $composeUpCommand
 


### PR DESCRIPTION
## Summary
- add a canonical live-runtime option to pin the lotus-ai Docker Compose env file
- document deterministic provider-disabled Advisor Brief proof using lotus-ai/.env.example
- avoid accidentally depending on a machine-local .env that points at an unstarted local LLM profile

## Proof
- PowerShell AST parse for scripts/live/Start-LotusFrontOfficeCanonical.ps1
- git diff --check