### PR TITLE
fix(live): validate task-flow lineage arrays

### DIFF
--- a/scripts/live/validation/workflow-pack-proof.mjs
+++ b/scripts/live/validation/workflow-pack-proof.mjs
@@ -131,11 +131,12 @@ function assertReplacementTaskFlowPosture(
       )}' instead of 'HISTORICAL'.`
     );
   }
-  if (taskFlow.replacement_lineage?.replacement_run_id !== replacementRunId) {
+  const lineageRefs = Array.isArray(taskFlow.replacement_lineage)
+    ? taskFlow.replacement_lineage
+    : [];
+  if (!lineageRefs.some((lineage) => lineage?.replacement_run_id === replacementRunId)) {
     throw new Error(
-      `Advisor brief ${expectedReviewState} review action returned task-flow replacement_run_id '${String(
-        taskFlow.replacement_lineage?.replacement_run_id
-      )}' instead of '${replacementRunId}'.`
+      `Advisor brief ${expectedReviewState} review action returned no task-flow replacement lineage edge for '${replacementRunId}'.`
     );
   }
   return taskFlow;

--- a/tests/unit/live-validation-workflow-pack-proof.test.ts
+++ b/tests/unit/live-validation-workflow-pack-proof.test.ts
@@ -60,7 +60,7 @@ function createTaskFlow({
     flow_status: flowStatus,
     supportability_status: supportabilityStatus,
     replacement_lineage:
-      replacementRunId === undefined ? null : { replacement_run_id: replacementRunId },
+      replacementRunId === undefined ? [] : [{ replacement_run_id: replacementRunId }],
     handoff_refs: handoffStatus === undefined ? [] : [{ status: handoffStatus }],
   };
 }


### PR DESCRIPTION
## Summary
- align the live advisor-brief workflow-pack validator with the gateway/AI contract shape for task-flow replacement lineage arrays
- tighten the validator unit fixture so it proves the real array contract instead of a singleton object

## Proof
- npm test -- --run tests/unit/live-validation-workflow-pack-proof.test.ts
- npm run typecheck
- git diff --check