### PR TITLE
Protect canonical period requests in Workbench

### DIFF
--- a/tests/unit/performance-periods.test.ts
+++ b/tests/unit/performance-periods.test.ts
@@ -15,6 +15,13 @@ describe("performance period vocabulary", () => {
     ]);
   });
 
+  it("does not expose legacy service aliases in user-facing controls", () => {
+    expect(CANONICAL_PERFORMANCE_PERIOD_OPTIONS).not.toContain("ONE_YEAR");
+    expect(CANONICAL_PERFORMANCE_PERIOD_OPTIONS).not.toContain("THREE_YEAR");
+    expect(CANONICAL_PERFORMANCE_PERIOD_OPTIONS).not.toContain("FIVE_YEAR");
+    expect(CANONICAL_PERFORMANCE_PERIOD_OPTIONS).not.toContain("ITD");
+  });
+
   it("keeps YTD distinct from trailing 1Y semantics", () => {
     expect(getPerformancePeriodDefinition("YTD")).toEqual({
       code: "YTD",

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -574,6 +574,37 @@ describe("workbench api", () => {
     );
   });
 
+  it("keeps canonical trailing periods in client-side risk summary requests", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            state: "ready",
+            payload: { periods: [] },
+            supportability: [],
+            warnings: [],
+            partial_failures: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await getWorkbenchRiskSummaryClient("PF_1001", {
+      period: "3Y",
+      detailBasis: "NET",
+      benchmark: "BMK_GLOBAL_BALANCED_60_40",
+      asOfDate: "2026-02-24",
+      reportingCurrency: "USD",
+    });
+
+    const requestedUrl = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].toString();
+    expect(requestedUrl).toContain("/api/bff/api/v1/workbench/PF_1001/risk/summary?");
+    expect(requestedUrl).toContain("period=3Y");
+    expect(requestedUrl).not.toContain("THREE_YEAR");
+  });
+
   it("omits optional benchmark context from the client-side risk summary request when none is selected", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary
- lock Workbench period controls to platform-governed canonical period labels
- add client-side regression coverage proving risk summary requests send `period=3Y`, not legacy service aliases
- confirm no user-facing legacy period aliases are exposed in canonical controls

## Validation
- `npm test -- --run tests/unit/performance-periods.test.ts tests/unit/workbench-api.test.ts`
- `make lint`
- `make typecheck`

## Docs / Wiki
- No docs or wiki update is needed: production UI behavior was already canonical, and this PR adds regression coverage rather than changing product-facing documentation.