### PR TITLE
Record RFC-0100 Workbench report job posture

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -43,7 +43,10 @@ Current repository posture:
 4. `/data-products` provides self-serve gateway-backed domain-product catalog, dependency, and
    live trust discovery for RFC-0088,
 5. the Performance advisor-brief surface consumes gateway-backed workflow-pack run posture and RFC-0097 task-flow posture without synthesizing review state or lineage client-side,
-6. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
+6. Workbench currently reads reporting snapshot data through gateway but does not initiate
+   portfolio review report-generation jobs; RFC-0100 records this no-change decision in
+   `docs/operations/report-job-invocation-posture.md`,
+7. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map
 

--- a/docs/operations/report-job-invocation-posture.md
+++ b/docs/operations/report-job-invocation-posture.md
@@ -1,0 +1,46 @@
+# Report Job Invocation Posture
+
+This note records the RFC-0100 Workbench adoption decision.
+
+## Current State
+
+`lotus-workbench` does not currently initiate portfolio review report-generation jobs.
+
+Current reporting usage is limited to gateway-owned reporting snapshot reads:
+
+- `src/features/workbench/api.ts`
+  calls `/reports/{portfolioId}/snapshot` through the Workbench BFF/gateway path.
+- `src/app/workbench/[portfolioId]/page.tsx`
+  renders the reporting snapshot panel when the gateway snapshot call succeeds.
+
+Code search on the RFC-0100 branch found no Workbench calls to:
+
+- `report.dev.lotus`
+- `/reports/portfolio-reviews`
+- `/api/v1/report-jobs`
+- `/reports/portfolios/{portfolio_id}/review`
+
+## Decision
+
+No Workbench code change is required for RFC-0100.
+
+When Workbench later adds a user-facing portfolio review generation action, it must call
+`lotus-gateway` only:
+
+- `POST /api/v1/reports/portfolio-reviews`
+- `GET /api/v1/report-jobs/{job_id}`
+- `POST /api/v1/report-jobs/{job_id}/cancel` when cancellation is exposed
+
+Workbench must not call `lotus-report` directly for report job creation, status, cancellation,
+rendering, or archive retrieval.
+
+## Validation Evidence
+
+Validation performed for this decision:
+
+```powershell
+rg -n "portfolio.*review|report job|report_job|reports/portfolio|lotus-report|report\\.dev|/reports|portfolio-reviews|report-jobs" src tests docs README.md REPOSITORY-ENGINEERING-CONTEXT.md
+```
+
+The search showed reporting snapshot consumption through gateway, but no report-generation job
+submission flow to migrate.


### PR DESCRIPTION
## Summary

- Records the RFC-0100 Workbench adoption decision.
- Confirms Workbench has no current portfolio review report-generation submit flow to migrate.
- Documents that future Workbench report job initiation must use lotus-gateway only:
  - POST /api/v1/reports/portfolio-reviews
  - GET /api/v1/report-jobs/{job_id}
  - POST /api/v1/report-jobs/{job_id}/cancel when cancellation is exposed
- Updates repository engineering context with the no-change decision.

## Validation

- Code search evidence recorded in docs/operations/report-job-invocation-posture.md
- git diff --check
- wiki check: Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench reported no repo-authored wiki drift for this PR.

## RFC-0100 posture

No Workbench product UI change is included because there is no existing report-generation flow. Current reporting snapshot reads already go through gateway.