### PR TITLE
Add RFC 0104 Workbench report batch operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test-results/
 playwright-report/
 .playwright-cli/
 output/playwright/
+output/*.pdf
 output/pr-monitor.json
 output/agent-status.md
 output/async-docker-build-*.log

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -43,9 +43,10 @@ Current repository posture:
 4. `/data-products` provides self-serve gateway-backed domain-product catalog, dependency, and
    live trust discovery for RFC-0088,
 5. the Performance advisor-brief surface consumes gateway-backed workflow-pack run posture and RFC-0097 task-flow posture without synthesizing review state or lineage client-side,
-6. Workbench currently reads reporting snapshot data through gateway but does not initiate
-   portfolio review report-generation jobs; RFC-0100 records this no-change decision in
-   `docs/operations/report-job-invocation-posture.md`,
+6. Workbench reads reporting snapshot data through gateway and exposes the RFC-0104 explicit
+   single-portfolio report batch materialization/status/run-once panel through the gateway BFF; it
+   honors route-level report date and backend benchmark controls for proof while still avoiding
+   direct `lotus-report` calls,
 7. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map

--- a/docs/operations/report-job-invocation-posture.md
+++ b/docs/operations/report-job-invocation-posture.md
@@ -1,32 +1,38 @@
 # Report Job Invocation Posture
 
-This note records the RFC-0100 Workbench adoption decision.
+This note records the RFC-0100 and RFC-0104 Workbench adoption decisions.
 
 ## Current State
 
-`lotus-workbench` does not currently initiate portfolio review report-generation jobs.
+`lotus-workbench` does not directly initiate standalone portfolio review report-generation jobs.
+It now exposes a bounded RFC-0104 batch operation for the current portfolio through the governed
+gateway batch API.
 
-Current reporting usage is limited to gateway-owned reporting snapshot reads:
+Current reporting usage is:
 
 - `src/features/workbench/api.ts`
-  calls `/reports/{portfolioId}/snapshot` through the Workbench BFF/gateway path.
+  calls `/reports/{portfolioId}/snapshot` and `/report-batches` through the Workbench BFF/gateway
+  path.
 - `src/app/workbench/[portfolioId]/page.tsx`
-  renders the reporting snapshot panel when the gateway snapshot call succeeds.
+  renders the reporting snapshot panel when the gateway snapshot call succeeds and the report batch
+  operations panel for explicit single-portfolio PDF batch materialization/status/run-once.
+  The optional route query `?asOfDate=YYYY-MM-DD` selects the report date for snapshot and batch
+  operations; `?benchmark=<backend benchmark code>` is passed into the batch request options.
 
-Code search on the RFC-0100 branch found no Workbench calls to:
+Code search on the RFC-0104 Workbench branch found no direct Workbench calls to:
 
 - `report.dev.lotus`
-- `/reports/portfolio-reviews`
-- `/api/v1/report-jobs`
 - `/reports/portfolios/{portfolio_id}/review`
 
 ## Decision
 
-No Workbench code change is required for RFC-0100.
+No direct `lotus-report` Workbench integration is allowed.
 
-When Workbench later adds a user-facing portfolio review generation action, it must call
-`lotus-gateway` only:
+Workbench reporting actions must call `lotus-gateway` only:
 
+- `POST /api/v1/report-batches`
+- `GET /api/v1/report-batches/{batch_id}`
+- `POST /api/v1/report-batches/{batch_id}:run-once`
 - `POST /api/v1/reports/portfolio-reviews`
 - `GET /api/v1/report-jobs/{job_id}`
 - `POST /api/v1/report-jobs/{job_id}/cancel` when cancellation is exposed
@@ -34,13 +40,17 @@ When Workbench later adds a user-facing portfolio review generation action, it m
 Workbench must not call `lotus-report` directly for report job creation, status, cancellation,
 rendering, or archive retrieval.
 
+For canonical RFC-0104 proof, use an implemented report date and backend benchmark identity such as
+`/workbench/PB_SG_GLOBAL_BAL_001?asOfDate=2026-04-22&benchmark=BMK_PB_GLOBAL_BALANCED_60_40`.
+The page distinguishes portfolio data date from report date when they differ.
+
 ## Validation Evidence
 
 Validation performed for this decision:
 
 ```powershell
-rg -n "portfolio.*review|report job|report_job|reports/portfolio|lotus-report|report\\.dev|/reports|portfolio-reviews|report-jobs" src tests docs README.md REPOSITORY-ENGINEERING-CONTEXT.md
+rg -n "portfolio.*review|report batch|report-batches|report job|report_job|reports/portfolio|lotus-report|report\\.dev|/reports|portfolio-reviews|report-jobs" src tests docs README.md REPOSITORY-ENGINEERING-CONTEXT.md
 ```
 
-The search showed reporting snapshot consumption through gateway, but no report-generation job
-submission flow to migrate.
+The search shows reporting snapshot and batch operation consumption through gateway, with no direct
+`lotus-report` service invocation from Workbench.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -163,6 +163,33 @@
   --focus-ring: 0 0 0 2px rgba(54, 95, 139, 0.32);
 }
 
+.report-batch-operations-panel .section-block-body {
+  gap: 0.75rem;
+}
+
+.report-batch-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  justify-content: flex-end;
+}
+
+.report-batch-status-strip,
+.report-batch-run-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+.report-batch-status-strip span,
+.report-batch-run-summary span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -23,6 +23,7 @@ import OverviewCards from "@/features/workbench/components/overview-cards";
 import PartialFailureBanner from "@/features/workbench/components/partial-failure-banner";
 import PerformanceSnapshot from "@/features/workbench/components/performance-snapshot";
 import RebalanceStatus from "@/features/workbench/components/rebalance-status";
+import ReportBatchOperationsPanel from "@/features/workbench/components/report-batch-operations-panel";
 import ReportingSnapshotPanel from "@/features/workbench/components/reporting-snapshot-panel";
 import SandboxControls from "@/features/workbench/components/sandbox-controls";
 
@@ -55,6 +56,7 @@ export default async function WorkbenchPage({
     groupBy?: string;
     benchmark?: string;
     preset?: string;
+    asOfDate?: string;
   }>;
 }) {
   const { portfolioId } = await params;
@@ -63,6 +65,7 @@ export default async function WorkbenchPage({
   const period = resolvedSearch.period?.trim() || "YTD";
   const benchmark = resolvedSearch.benchmark?.trim() || "MODEL_60_40";
   const preset = resolvedSearch.preset?.trim() || "EXEC_SUMMARY";
+  const requestedAsOfDate = resolvedSearch.asOfDate?.trim() || undefined;
   const groupBy =
     resolvedSearch.groupBy?.trim() === "SECURITY" ? "SECURITY" : "ASSET_CLASS";
 
@@ -109,7 +112,10 @@ export default async function WorkbenchPage({
   }
 
   try {
-    reportingSnapshot = await getReportingSnapshot(portfolioId, data.as_of_date);
+    reportingSnapshot = await getReportingSnapshot(
+      portfolioId,
+      requestedAsOfDate ?? data.as_of_date
+    );
   } catch {
     reportingSnapshot = null;
   }
@@ -131,12 +137,17 @@ export default async function WorkbenchPage({
     ...data.partial_failures,
     ...(analytics?.partial_failures ?? []),
   ];
+  const reportingAsOfDate = requestedAsOfDate ?? data.as_of_date;
+  const pageSubtitle =
+    reportingAsOfDate === data.as_of_date
+      ? `As of: ${data.as_of_date}`
+      : `Portfolio data as of: ${data.as_of_date} | Report date: ${reportingAsOfDate}`;
 
   return (
     <main className="page-container">
       <WorkbenchPageFrame
         title={`Advisor Workbench: ${data.portfolio.portfolio_id}`}
-        subtitle={`As of: ${data.as_of_date}`}
+        subtitle={pageSubtitle}
         actions={
           <>
             <SemanticBadge tone={partialFailures.length > 0 ? "warn" : "success"}>
@@ -242,6 +253,14 @@ export default async function WorkbenchPage({
                   body="This panel will populate when reporting aggregation is online."
                 />
               )}
+
+              <ReportBatchOperationsPanel
+                portfolioId={data.portfolio.portfolio_id}
+                asOfDate={reportingAsOfDate}
+                reportingCurrency={data.portfolio.base_currency}
+                bookingCenterCode={data.portfolio.booking_center_code}
+                benchmarkCode={benchmark}
+              />
             </div>
 
             <div className="workbench-col">

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -13,6 +13,9 @@ import {
   WorkbenchPerformanceWorkspaceDetails,
   WorkbenchPerformanceWorkspaceSummary,
   WorkbenchPortfolio360,
+  ReportBatchHandleResponse,
+  ReportBatchStatusResponse,
+  ReportBatchWorkerRunResponse,
   WorkbenchReportingSnapshot,
   WorkbenchSandboxState,
 } from "./types";
@@ -57,6 +60,19 @@ async function fetchWorkbenchJson<T>(url: string, errorLabel: string): Promise<T
   const response = await fetch(url, { cache: "no-store" });
   if (!response.ok) {
     throw new Error(`Failed to fetch ${errorLabel} (${response.status})`);
+  }
+  return (await response.json()) as T;
+}
+
+async function fetchWorkbenchMutation<T>(
+  url: string,
+  errorLabel: string,
+  init: RequestInit
+): Promise<T> {
+  const response = await fetch(url, { cache: "no-store", ...init });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to ${errorLabel} (${response.status}): ${body}`);
   }
   return (await response.json()) as T;
 }
@@ -575,5 +591,166 @@ export async function getReportingSnapshot(
     `/reports/${portfolioId}/snapshot`,
     "reporting snapshot",
     query
+  );
+}
+
+function buildReportBatchCallerHeaders(params: {
+  actorId: string;
+  tenantId: string;
+  region: string;
+  bookingCenterCode?: string | null;
+  role?: string;
+  correlationId: string;
+}): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Actor-Id": params.actorId,
+    "X-Caller-Application": "lotus-workbench",
+    "X-Tenant-Id": params.tenantId,
+    "X-Region": params.region,
+    "X-Role": params.role ?? "front-office-operator",
+    "X-Correlation-Id": params.correlationId,
+  };
+  if (params.bookingCenterCode) {
+    headers["X-Booking-Center-Code"] = params.bookingCenterCode;
+  }
+  return headers;
+}
+
+export async function createPortfolioReportBatch(params: {
+  portfolioId: string;
+  asOfDate: string;
+  reportingCurrency: string;
+  tenantId?: string;
+  region?: string;
+  bookingCenterCode?: string | null;
+  actorId?: string;
+  sections?: string[];
+  benchmarkCode?: string;
+}): Promise<ReportBatchHandleResponse> {
+  const tenantId = params.tenantId ?? "tenant-sg";
+  const region = params.region ?? "APAC";
+  const actorId = params.actorId ?? "workbench-report-operator";
+  const correlationId = `corr-workbench-report-batch-${params.portfolioId}-${params.asOfDate}`;
+  const idempotencyKey = [
+    "workbench-report-batch",
+    params.portfolioId,
+    params.asOfDate,
+    params.reportingCurrency,
+  ].join("-");
+
+  return await fetchWorkbenchMutation<ReportBatchHandleResponse>(
+    buildWorkbenchUrl("client", "/report-batches"),
+    "create report batch",
+    {
+      method: "POST",
+      headers: {
+        ...buildReportBatchCallerHeaders({
+          actorId,
+          tenantId,
+          region,
+          bookingCenterCode: params.bookingCenterCode,
+          correlationId,
+        }),
+        "Idempotency-Key": idempotencyKey,
+      },
+      body: JSON.stringify({
+        selector_mode: "explicit_portfolio_list",
+        portfolio_ids: [params.portfolioId],
+        source_candidates: [
+          {
+            portfolio_id: params.portfolioId,
+            tenant_id: tenantId,
+            region,
+            active: true,
+            selected: true,
+            source_system: "lotus-core",
+            source_object: "PortfolioScope",
+          },
+        ],
+        as_of_date: params.asOfDate,
+        requested_output_formats: ["pdf"],
+        reporting_currency: params.reportingCurrency,
+        options: {
+          sections: params.sections ?? ["OVERVIEW", "PERFORMANCE", "RISK_ANALYTICS"],
+          ...(params.benchmarkCode ? { benchmark_code: params.benchmarkCode } : {}),
+          source_surface: "lotus-workbench",
+        },
+        max_batch_size: 1,
+      }),
+    }
+  );
+}
+
+export async function getReportBatchStatus(
+  batchId: string,
+  params: {
+    tenantId?: string;
+    region?: string;
+    bookingCenterCode?: string | null;
+    actorId?: string;
+  } = {}
+): Promise<ReportBatchStatusResponse> {
+  const tenantId = params.tenantId ?? "tenant-sg";
+  const region = params.region ?? "APAC";
+  const actorId = params.actorId ?? "workbench-report-operator";
+  return await fetchWorkbenchMutation<ReportBatchStatusResponse>(
+    buildWorkbenchUrl("client", `/report-batches/${encodeURIComponent(batchId)}`),
+    "report batch status",
+    {
+      method: "GET",
+      headers: buildReportBatchCallerHeaders({
+        actorId,
+        tenantId,
+        region,
+        bookingCenterCode: params.bookingCenterCode,
+        correlationId: `corr-workbench-report-batch-status-${batchId}`,
+      }),
+    }
+  );
+}
+
+export async function runReportBatchOnce(params: {
+  batchId: string;
+  tenantId?: string;
+  region?: string;
+  bookingCenterCode?: string | null;
+  actorId?: string;
+}): Promise<ReportBatchWorkerRunResponse> {
+  const tenantId = params.tenantId ?? "tenant-sg";
+  const region = params.region ?? "APAC";
+  const actorId = params.actorId ?? "workbench-report-operator";
+  return await fetchWorkbenchMutation<ReportBatchWorkerRunResponse>(
+    buildWorkbenchUrl("client", `/report-batches/${encodeURIComponent(params.batchId)}:run-once`),
+    "run report batch",
+    {
+      method: "POST",
+      headers: buildReportBatchCallerHeaders({
+        actorId,
+        tenantId,
+        region,
+        bookingCenterCode: params.bookingCenterCode,
+        correlationId: `corr-workbench-report-batch-run-${params.batchId}`,
+      }),
+      body: JSON.stringify({
+        worker_id: "lotus-workbench-report-batch-operator",
+        recover_expired_leases: true,
+        dispatch_policy: {
+          max_active_batches: 100,
+          max_active_items: 100,
+          max_active_upstream_jobs: 100,
+          max_active_render_jobs: 100,
+          max_active_archive_jobs: 100,
+          lease_seconds: 300,
+        },
+        runtime_load: {
+          active_batches: 0,
+          active_items: 0,
+          active_upstream_jobs: 0,
+          active_render_jobs: 0,
+          active_archive_jobs: 0,
+        },
+      }),
+    }
   );
 }

--- a/src/features/workbench/components/report-batch-operations-panel.tsx
+++ b/src/features/workbench/components/report-batch-operations-panel.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState } from "react";
+
+import { ActionButton, AnalyticsTable, ScreenStatePanel, SectionBlock, SemanticBadge } from "@/design-system";
+import {
+  createPortfolioReportBatch,
+  getReportBatchStatus,
+  runReportBatchOnce,
+} from "@/features/workbench/api";
+import type {
+  ReportBatchHandleResponse,
+  ReportBatchStatusResponse,
+  ReportBatchWorkerRunResponse,
+} from "@/features/workbench/types";
+
+type Props = {
+  portfolioId: string;
+  asOfDate: string;
+  reportingCurrency: string;
+  bookingCenterCode?: string | null;
+  benchmarkCode?: string;
+};
+
+function statusTone(status: string): "default" | "success" | "warn" | "danger" {
+  const normalized = status.toLowerCase();
+  if (normalized === "completed" || normalized === "succeeded") {
+    return "success";
+  }
+  if (normalized === "failed" || normalized === "cancelled") {
+    return "danger";
+  }
+  if (normalized === "running" || normalized === "materialized" || normalized === "waiting_on_report_job") {
+    return "warn";
+  }
+  return "default";
+}
+
+function summarizeCounts(status: ReportBatchStatusResponse | null): string {
+  if (!status) {
+    return "No batch materialized";
+  }
+  return Object.entries(status.status_counts)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(" | ");
+}
+
+function isTerminalBatchStatus(status: string | undefined): boolean {
+  return status === "completed" || status === "completed_with_failures" || status === "failed" || status === "cancelled";
+}
+
+export default function ReportBatchOperationsPanel({
+  portfolioId,
+  asOfDate,
+  reportingCurrency,
+  bookingCenterCode,
+  benchmarkCode,
+}: Props) {
+  const [handle, setHandle] = useState<ReportBatchHandleResponse | null>(null);
+  const [status, setStatus] = useState<ReportBatchStatusResponse | null>(null);
+  const [runResult, setRunResult] = useState<ReportBatchWorkerRunResponse | null>(null);
+  const [pendingAction, setPendingAction] = useState<"create" | "refresh" | "run" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const batchId = status?.batch_id ?? handle?.batch_id ?? null;
+  const runDisabled = !batchId || pendingAction !== null || isTerminalBatchStatus(status?.status);
+  const reconciledReportJobId =
+    runResult?.report_job_ids[0] ??
+    status?.items.find((item) => item.report_job_id !== null)?.report_job_id ??
+    "No report job";
+
+  async function createBatch() {
+    setPendingAction("create");
+    setError(null);
+    try {
+      const nextHandle = await createPortfolioReportBatch({
+        portfolioId,
+        asOfDate,
+        reportingCurrency,
+        bookingCenterCode,
+        benchmarkCode,
+      });
+      setHandle(nextHandle);
+      setStatus(await getReportBatchStatus(nextHandle.batch_id, { bookingCenterCode }));
+      setRunResult(null);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Report batch materialization failed.");
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function refreshStatus() {
+    if (!batchId) return;
+    setPendingAction("refresh");
+    setError(null);
+    try {
+      setStatus(await getReportBatchStatus(batchId, { bookingCenterCode }));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Report batch status refresh failed.");
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function runOnce() {
+    if (!batchId) return;
+    setPendingAction("run");
+    setError(null);
+    try {
+      const result = await runReportBatchOnce({
+        batchId,
+        bookingCenterCode,
+      });
+      setRunResult(result);
+      setStatus(await getReportBatchStatus(batchId, { bookingCenterCode }));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Report batch run failed.");
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  return (
+    <SectionBlock
+      title="Report Batch Operations"
+      subtitle={`PDF portfolio review batch for ${asOfDate}`}
+      className="report-batch-operations-panel"
+      actions={
+        <div className="report-batch-action-row">
+          <ActionButton priority="primary" onClick={createBatch} disabled={pendingAction !== null}>
+            {handle ? "Reopen Batch" : "Create Batch"}
+          </ActionButton>
+          <ActionButton onClick={refreshStatus} disabled={!batchId || pendingAction !== null}>
+            Refresh Status
+          </ActionButton>
+          <ActionButton onClick={runOnce} disabled={runDisabled}>
+            Run Once
+          </ActionButton>
+        </div>
+      }
+    >
+      {error ? (
+        <ScreenStatePanel
+          kind="error"
+          surface="portfolio"
+          title="Report batch operation failed"
+          body={error}
+        />
+      ) : null}
+
+      <div className="report-batch-status-strip">
+        <SemanticBadge tone={statusTone(status?.status ?? handle?.status ?? "not_created")}>
+          {status?.status ?? handle?.status ?? "Not created"}
+        </SemanticBadge>
+        <span>{batchId ?? "No batch id"}</span>
+        <span>{summarizeCounts(status)}</span>
+      </div>
+
+      {runResult ? (
+        <div className="report-batch-run-summary">
+          <span>Leased {runResult.leased_count}</span>
+          <span>Dispatched {runResult.dispatched_count}</span>
+          <span>Executed {runResult.executed_count}</span>
+          <span>{reconciledReportJobId}</span>
+          {runResult.back_pressure_reasons.length > 0 ? (
+            <span>Back pressure {runResult.back_pressure_reasons.join(", ")}</span>
+          ) : null}
+          {runResult.skipped_reason ? <span>Skipped {runResult.skipped_reason}</span> : null}
+        </div>
+      ) : null}
+
+      <AnalyticsTable
+        ariaLabel="Report batch items"
+        variant="portfolio"
+        density="comfortable"
+        columns={[
+          { key: "portfolio", label: "Portfolio" },
+          { key: "status", label: "Status" },
+          { key: "job", label: "Report Job" },
+          { key: "attempts", label: "Attempts", align: "right" },
+        ]}
+        rows={(status?.items ?? []).map((item) => ({
+          key: item.batch_item_id,
+          cells: [
+            item.portfolio_id,
+            item.status,
+            item.report_job_id ?? "Not linked",
+            item.attempt_count.toString(),
+          ],
+        }))}
+        emptyState={{
+          title: "No batch items yet",
+          body: "Create a report batch to materialize the current portfolio review item.",
+        }}
+      />
+    </SectionBlock>
+  );
+}

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1066,3 +1066,74 @@ export type WorkbenchReportingSnapshot = {
   generatedAt: string;
   rows: Array<Record<string, unknown>>;
 };
+
+export type ReportBatchHandleResponse = {
+  batch_id: string;
+  status: string;
+  status_url: string;
+  idempotency_key: string;
+  item_count: number;
+};
+
+export type ReportBatchItemStatus = {
+  batch_item_id: string;
+  item_position: number;
+  portfolio_id: string;
+  status: string;
+  report_job_id: string | null;
+  attempt_count: number;
+  retry_eligible: boolean;
+  next_retry_at: string | null;
+  last_error_category: string | null;
+  last_error_summary: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  cancelled_at: string | null;
+};
+
+export type ReportBatchStatusResponse = {
+  batch_id: string;
+  selector_mode: string;
+  tenant_id: string;
+  region: string;
+  materialized_portfolio_ids: string[];
+  as_of_date: string;
+  requested_output_formats: string[];
+  reporting_currency: string | null;
+  status: string;
+  item_count: number;
+  status_counts: Record<string, number>;
+  items: ReportBatchItemStatus[];
+  created_at: string;
+  updated_at: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  cancelled_at: string | null;
+  failed_at: string | null;
+  correlation_id: string;
+  trace_id: string;
+};
+
+export type ReportBatchWorkerRunResponse = {
+  batch_id: string;
+  status: string;
+  batch_status_before: string;
+  batch_status_after: string;
+  recovered_count: number;
+  leased_count: number;
+  dispatched_count: number;
+  executed_count: number;
+  report_job_ids: string[];
+  back_pressure_reasons: string[];
+  skipped_reason: string | null;
+  execution_results: Array<{
+    batch_item_id: string;
+    report_job_id: string;
+    item_status: string;
+    report_job_status: string;
+    failure_category: string | null;
+    retry_eligible: boolean;
+  }>;
+  status_url: string;
+};

--- a/tests/integration/workbench-page.test.tsx
+++ b/tests/integration/workbench-page.test.tsx
@@ -248,5 +248,68 @@ describe("WorkbenchPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/Create and update a sandbox session to see projected holdings\./i)).toBeInTheDocument();
   });
+
+  it("uses an explicit route as-of date for reporting batch operations", async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = input.toString();
+      if (url.includes("/api/v1/workbench/PF_3001/portfolio-360")) {
+        return {
+          ok: true,
+          json: async () => ({
+            correlation_id: "corr_1",
+            contract_version: "v1",
+            as_of_date: "2026-04-27",
+            portfolio: {
+              portfolio_id: "PF_3001",
+              client_id: "CL_3001",
+              base_currency: "USD",
+              booking_center_code: "SG",
+            },
+            overview: {
+              market_value_base: 100,
+              cash_weight_pct: 0,
+              position_count: 1,
+            },
+            performance_snapshot: null,
+            rebalance_snapshot: null,
+            current_positions: [],
+            projected_positions: [],
+            projected_summary: null,
+            active_session_id: null,
+            warnings: [],
+            partial_failures: [],
+          }),
+        } as Response;
+      }
+
+      if (url.includes("/api/v1/workbench/PF_3001/analytics?")) {
+        throw new Error("analytics unavailable");
+      }
+
+      if (url.includes("/api/v1/reports/PF_3001/snapshot?asOfDate=2026-04-10")) {
+        throw new Error("reporting unavailable");
+      }
+
+      return { ok: false, json: async () => ({}) } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      await WorkbenchPage({
+        params: Promise.resolve({ portfolioId: "PF_3001" }),
+        searchParams: Promise.resolve({ asOfDate: "2026-04-10" }),
+      })
+    );
+
+    expect(
+      screen.getByText("Portfolio data as of: 2026-04-27 | Report date: 2026-04-10")
+    ).toBeInTheDocument();
+    expect(screen.getByText("PDF portfolio review batch for 2026-04-10")).toBeInTheDocument();
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        input.toString().includes("/api/v1/reports/PF_3001/snapshot?asOfDate=2026-04-10")
+      )
+    ).toBe(true);
+  });
 });
 

--- a/tests/unit/report-batch-operations-panel.test.tsx
+++ b/tests/unit/report-batch-operations-panel.test.tsx
@@ -1,0 +1,228 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const createPortfolioReportBatchMock = vi.fn();
+const getReportBatchStatusMock = vi.fn();
+const runReportBatchOnceMock = vi.fn();
+
+vi.mock("../../src/features/workbench/api", () => ({
+  createPortfolioReportBatch: (...args: unknown[]) => createPortfolioReportBatchMock(...args),
+  getReportBatchStatus: (...args: unknown[]) => getReportBatchStatusMock(...args),
+  runReportBatchOnce: (...args: unknown[]) => runReportBatchOnceMock(...args),
+}));
+
+import ReportBatchOperationsPanel from "../../src/features/workbench/components/report-batch-operations-panel";
+
+const completedStatus = {
+  batch_id: "rbch_1",
+  selector_mode: "explicit_portfolio_list",
+  tenant_id: "tenant-sg",
+  region: "APAC",
+  materialized_portfolio_ids: ["PF_1001"],
+  as_of_date: "2026-02-24",
+  requested_output_formats: ["pdf"],
+  reporting_currency: "USD",
+  status: "completed",
+  item_count: 1,
+  status_counts: { succeeded: 1 },
+  items: [
+    {
+      batch_item_id: "rbit_1",
+      item_position: 1,
+      portfolio_id: "PF_1001",
+      status: "succeeded",
+      report_job_id: "rjob_1",
+      attempt_count: 1,
+      retry_eligible: false,
+      next_retry_at: null,
+      last_error_category: null,
+      last_error_summary: null,
+      created_at: "2026-02-24T00:00:00Z",
+      started_at: "2026-02-24T00:00:01Z",
+      completed_at: "2026-02-24T00:00:02Z",
+      cancelled_at: null,
+    },
+  ],
+  created_at: "2026-02-24T00:00:00Z",
+  updated_at: "2026-02-24T00:00:02Z",
+  started_at: "2026-02-24T00:00:01Z",
+  completed_at: "2026-02-24T00:00:02Z",
+  cancelled_at: null,
+  failed_at: null,
+  correlation_id: "corr",
+  trace_id: "trace",
+};
+
+const materializedStatus = {
+  ...completedStatus,
+  status: "materialized",
+  status_counts: { materialized: 1 },
+  items: [
+    {
+      ...completedStatus.items[0],
+      status: "materialized",
+      report_job_id: null,
+      attempt_count: 0,
+      started_at: null,
+      completed_at: null,
+    },
+  ],
+  completed_at: null,
+};
+
+describe("ReportBatchOperationsPanel", () => {
+  afterEach(() => {
+    createPortfolioReportBatchMock.mockReset();
+    getReportBatchStatusMock.mockReset();
+    runReportBatchOnceMock.mockReset();
+  });
+
+  it("creates a report batch and renders durable item status", async () => {
+    createPortfolioReportBatchMock.mockResolvedValue({
+      batch_id: "rbch_1",
+      status: "materialized",
+      status_url: "/api/v1/report-batches/rbch_1",
+      idempotency_key: "idem",
+      item_count: 1,
+    });
+    getReportBatchStatusMock.mockResolvedValue(completedStatus);
+
+    render(
+      <ReportBatchOperationsPanel
+        portfolioId="PF_1001"
+        asOfDate="2026-02-24"
+        reportingCurrency="USD"
+        bookingCenterCode="SG"
+        benchmarkCode="BMK_GLOBAL_BALANCED_60_40"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Batch" }));
+
+    await waitFor(() => {
+      expect(createPortfolioReportBatchMock).toHaveBeenCalledWith({
+        portfolioId: "PF_1001",
+        asOfDate: "2026-02-24",
+        reportingCurrency: "USD",
+        bookingCenterCode: "SG",
+        benchmarkCode: "BMK_GLOBAL_BALANCED_60_40",
+      });
+    });
+    expect(getReportBatchStatusMock).toHaveBeenCalledWith("rbch_1", { bookingCenterCode: "SG" });
+    expect(await screen.findByText("rbch_1")).toBeInTheDocument();
+    expect(screen.getByText("succeeded: 1")).toBeInTheDocument();
+    expect(screen.getByText("rjob_1")).toBeInTheDocument();
+  });
+
+  it("runs a bounded worker pass for the current batch", async () => {
+    createPortfolioReportBatchMock.mockResolvedValue({
+      batch_id: "rbch_1",
+      status: "materialized",
+      status_url: "/api/v1/report-batches/rbch_1",
+      idempotency_key: "idem",
+      item_count: 1,
+    });
+    getReportBatchStatusMock.mockResolvedValueOnce(materializedStatus).mockResolvedValue(completedStatus);
+    runReportBatchOnceMock.mockResolvedValue({
+      batch_id: "rbch_1",
+      status: "completed",
+      batch_status_before: "materialized",
+      batch_status_after: "completed",
+      recovered_count: 0,
+      leased_count: 1,
+      dispatched_count: 1,
+      executed_count: 1,
+      report_job_ids: ["rjob_1"],
+      back_pressure_reasons: [],
+      skipped_reason: null,
+      execution_results: [],
+      status_url: "/api/v1/report-batches/rbch_1",
+    });
+
+    render(
+      <ReportBatchOperationsPanel
+        portfolioId="PF_1001"
+        asOfDate="2026-02-24"
+        reportingCurrency="USD"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Batch" }));
+    await screen.findByText("rbch_1");
+    fireEvent.click(screen.getByRole("button", { name: "Run Once" }));
+
+    await waitFor(() => {
+      expect(runReportBatchOnceMock).toHaveBeenCalledWith({
+        batchId: "rbch_1",
+        bookingCenterCode: undefined,
+      });
+    });
+    expect(await screen.findByText("Leased 1")).toBeInTheDocument();
+    expect(screen.getByText("Executed 1")).toBeInTheDocument();
+  });
+
+  it("surfaces worker back pressure reasons without hiding batch status", async () => {
+    createPortfolioReportBatchMock.mockResolvedValue({
+      batch_id: "rbch_1",
+      status: "materialized",
+      status_url: "/api/v1/report-batches/rbch_1",
+      idempotency_key: "idem",
+      item_count: 1,
+    });
+    getReportBatchStatusMock.mockResolvedValue(materializedStatus);
+    runReportBatchOnceMock.mockResolvedValue({
+      batch_id: "rbch_1",
+      status: "materialized",
+      batch_status_before: "materialized",
+      batch_status_after: "materialized",
+      recovered_count: 0,
+      leased_count: 0,
+      dispatched_count: 0,
+      executed_count: 0,
+      report_job_ids: [],
+      back_pressure_reasons: ["max_active_items_reached"],
+      skipped_reason: null,
+      execution_results: [],
+      status_url: "/api/v1/report-batches/rbch_1",
+    });
+
+    render(
+      <ReportBatchOperationsPanel
+        portfolioId="PF_1001"
+        asOfDate="2026-02-24"
+        reportingCurrency="USD"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Batch" }));
+    await screen.findByText("rbch_1");
+    fireEvent.click(screen.getByRole("button", { name: "Run Once" }));
+
+    expect(await screen.findByText("Back pressure max_active_items_reached")).toBeInTheDocument();
+  });
+
+  it("does not offer run once after a terminal batch status is loaded", async () => {
+    createPortfolioReportBatchMock.mockResolvedValue({
+      batch_id: "rbch_1",
+      status: "materialized",
+      status_url: "/api/v1/report-batches/rbch_1",
+      idempotency_key: "idem",
+      item_count: 1,
+    });
+    getReportBatchStatusMock.mockResolvedValue(completedStatus);
+
+    render(
+      <ReportBatchOperationsPanel
+        portfolioId="PF_1001"
+        asOfDate="2026-02-24"
+        reportingCurrency="USD"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Batch" }));
+    await screen.findByText("succeeded: 1");
+
+    expect(screen.getByRole("button", { name: "Run Once" })).toBeDisabled();
+  });
+});

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   applySandboxChanges,
+  createPortfolioReportBatch,
   createSandboxSession,
+  getReportBatchStatus,
   getReportingSnapshot,
   getWorkbenchAnalytics,
   getWorkbenchRiskAttributionClient,
@@ -18,6 +20,7 @@ import {
   getWorkbenchPerformanceWorkspaceSummaryClient,
   getWorkbenchPerformanceWorkspaceSummary,
   postWorkbenchPerformanceAdvisorBriefReviewActionClient,
+  runReportBatchOnce,
 } from "../../src/features/workbench/api";
 
 const expectedBaseUrl = "/api/bff/api/v1";
@@ -1115,6 +1118,161 @@ describe("workbench api", () => {
       expect.stringContaining("/api/v1/reports/PF_1001/snapshot?asOfDate=2026-02-24"),
       expect.objectContaining({ cache: "no-store" })
     );
+  });
+
+  it("creates an explicit portfolio report batch through the gateway BFF", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            batch_id: "rbch_1",
+            status: "materialized",
+            status_url: "/api/v1/report-batches/rbch_1",
+            idempotency_key: "workbench-report-batch-PF_1001-2026-02-24-USD",
+            item_count: 1,
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await createPortfolioReportBatch({
+      portfolioId: "PF_1001",
+      asOfDate: "2026-02-24",
+      reportingCurrency: "USD",
+      bookingCenterCode: "SG",
+      benchmarkCode: "BMK_GLOBAL_BALANCED_60_40",
+    });
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const [url, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(String(init?.body));
+    const headers = init?.headers as Record<string, string>;
+
+    expect(url).toBe(`${expectedBaseUrl}/report-batches`);
+    expect(init).toEqual(expect.objectContaining({ method: "POST", cache: "no-store" }));
+    expect(headers["Idempotency-Key"]).toBe("workbench-report-batch-PF_1001-2026-02-24-USD");
+    expect(headers["X-Caller-Application"]).toBe("lotus-workbench");
+    expect(headers["X-Tenant-Id"]).toBe("tenant-sg");
+    expect(headers["X-Region"]).toBe("APAC");
+    expect(body).toEqual(
+      expect.objectContaining({
+        selector_mode: "explicit_portfolio_list",
+        portfolio_ids: ["PF_1001"],
+        as_of_date: "2026-02-24",
+        requested_output_formats: ["pdf"],
+        reporting_currency: "USD",
+        max_batch_size: 1,
+      })
+    );
+    expect(body.source_candidates[0]).toEqual(
+      expect.objectContaining({
+        portfolio_id: "PF_1001",
+        tenant_id: "tenant-sg",
+        region: "APAC",
+        active: true,
+        selected: true,
+        source_system: "lotus-core",
+      })
+    );
+    expect(body.options).toEqual(
+      expect.objectContaining({
+        benchmark_code: "BMK_GLOBAL_BALANCED_60_40",
+        source_surface: "lotus-workbench",
+      })
+    );
+  });
+
+  it("loads report batch status through the gateway BFF", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            batch_id: "rbch_1",
+            selector_mode: "explicit_portfolio_list",
+            tenant_id: "tenant-sg",
+            region: "APAC",
+            materialized_portfolio_ids: ["PF_1001"],
+            as_of_date: "2026-02-24",
+            requested_output_formats: ["pdf"],
+            reporting_currency: "USD",
+            status: "completed",
+            item_count: 1,
+            status_counts: { succeeded: 1 },
+            items: [],
+            created_at: "2026-02-24T00:00:00Z",
+            updated_at: null,
+            started_at: null,
+            completed_at: null,
+            cancelled_at: null,
+            failed_at: null,
+            correlation_id: "corr",
+            trace_id: "trace",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await getReportBatchStatus("rbch_1");
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/report-batches/rbch_1`,
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          "X-Actor-Id": "workbench-report-operator",
+          "X-Caller-Application": "lotus-workbench",
+          "X-Tenant-Id": "tenant-sg",
+          "X-Region": "APAC",
+          "X-Correlation-Id": "corr-workbench-report-batch-status-rbch_1",
+        }),
+      })
+    );
+  });
+
+  it("runs one bounded report batch worker pass through the gateway BFF", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            batch_id: "rbch_1",
+            status: "completed",
+            batch_status_before: "materialized",
+            batch_status_after: "completed",
+            recovered_count: 0,
+            leased_count: 1,
+            dispatched_count: 1,
+            executed_count: 1,
+            report_job_ids: ["rjob_1"],
+            back_pressure_reasons: [],
+            skipped_reason: null,
+            execution_results: [],
+            status_url: "/api/v1/report-batches/rbch_1",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await runReportBatchOnce({ batchId: "rbch_1", bookingCenterCode: "SG" });
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const [url, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(String(init?.body));
+    const headers = init?.headers as Record<string, string>;
+
+    expect(url).toBe(`${expectedBaseUrl}/report-batches/rbch_1:run-once`);
+    expect(init).toEqual(expect.objectContaining({ method: "POST", cache: "no-store" }));
+    expect(headers["X-Caller-Application"]).toBe("lotus-workbench");
+    expect(body.worker_id).toBe("lotus-workbench-report-batch-operator");
+    expect(body.dispatch_policy.max_active_items).toBe(100);
+    expect(body.dispatch_policy.max_active_batches).toBe(100);
+    expect(body.runtime_load.active_batches).toBe(0);
   });
 
   it("raises a labeled error when the split summary endpoint fails", async () => {

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -34,3 +34,7 @@
 5. Performance advisor-brief workflow-pack run posture and RFC-0097 task-flow lineage are rendered
    from gateway payloads; Workbench does not infer replacement lineage from narrative text or local
    fallback previews
+6. RFC-0104 report batch operations use `/api/bff/api/v1/report-batches` only; Workbench does not
+   call `lotus-report` directly for batch materialization, status, or bounded run-once execution
+7. Workbench report batch proof may use `/workbench/<portfolioId>?asOfDate=YYYY-MM-DD&benchmark=<backend benchmark code>`;
+   the route keeps portfolio data date and report batch date visibly distinct when they differ


### PR DESCRIPTION
## Summary
- Add a gateway/BFF-backed RFC-0104 report batch operations panel on `/workbench/[portfolioId]` for explicit single-portfolio PDF batch materialization, status refresh, and bounded run-once execution.
- Add report batch API client/types, route-level `asOfDate` support, and benchmark propagation for canonical proof.
- Update Workbench reporting posture docs, repo context, wiki source, and generated proof artifact ignore rules.

## Validation
- `npm run test -- tests/unit/workbench-api.test.ts tests/unit/report-batch-operations-panel.test.tsx tests/integration/workbench-page.test.tsx --runInBand` -> 36 passed.
- `make check` -> lint, typecheck, 624 coverage-backed tests, and production build passed.
- `npm run live:validate` -> passed for `PB_SG_GLOBAL_BAL_001` after targeted Workbench dev refresh.
- Live RFC-0104 batch proof through Workbench/Gateway/Report/Render/Archive: batch `rbch_1408a522732f42f2b6e41fd229cad106`, item `rbit_3e8b0fcb5e124bd483da514366e95fee`, report job `rjob_bd4af9450b3e4461916adc5b4567137d`, snapshot `rsnap_00e2240552d34db6a8bc7bbf656b8ab6`, archive document `doc_0a75c2af6ef74af5bd29d2867cdb33c8`, PDF SHA256 `F2C4E790CD6706E780EBC402448E60A2193772040388F0FF544E1161229F8636`.

## Notes
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` reports expected drift on `Integrations.md` because this PR intentionally updates repo-authored wiki source. Publish after merge.