### PR TITLE
RFC-0108 Slice 1 Workbench observability vocabulary

### DIFF
--- a/src/features/analytics-observability/contract.ts
+++ b/src/features/analytics-observability/contract.ts
@@ -1,0 +1,97 @@
+export const ANALYTICS_UI_ALLOWED_LABELS = [
+  "route",
+  "panel",
+  "service",
+  "operation",
+  "state",
+  "reason",
+  "freshness_bucket",
+  "supportability_state",
+  "attention_type",
+  "severity",
+  "status_class",
+  "error_category",
+  "region",
+  "environment",
+] as const;
+
+export type AnalyticsUiAllowedLabel = (typeof ANALYTICS_UI_ALLOWED_LABELS)[number];
+
+export const ANALYTICS_UI_FORBIDDEN_FIELDS = [
+  "portfolio_id",
+  "client_id",
+  "client_name",
+  "household_id",
+  "account_id",
+  "instrument_id",
+  "holding_id",
+  "transaction_id",
+  "trace_id",
+  "correlation_id",
+  "document_id",
+  "advisor_id",
+  "advisor_behavior",
+  "screen_content",
+  "request_body",
+  "response_body",
+  "raw_entitlement_failure",
+] as const;
+
+export type AnalyticsUiForbiddenField = (typeof ANALYTICS_UI_FORBIDDEN_FIELDS)[number];
+
+export const ANALYTICS_UI_STATE_VOCABULARY = [
+  "loading",
+  "ready",
+  "empty",
+  "partial",
+  "stale",
+  "degraded",
+  "error",
+  "permission_blocked",
+  "unsupported",
+] as const;
+
+export type AnalyticsUiState = (typeof ANALYTICS_UI_STATE_VOCABULARY)[number];
+
+export const WORKBENCH_ANALYTICS_UI_METRIC_FAMILIES = [
+  "lotus_workbench_panel_hydration_duration_seconds",
+  "lotus_workbench_panel_state_total",
+  "lotus_workbench_api_request_duration_seconds",
+] as const;
+
+export type WorkbenchAnalyticsUiMetricFamily =
+  (typeof WORKBENCH_ANALYTICS_UI_METRIC_FAMILIES)[number];
+
+const ALLOWED_LABEL_SET = new Set<string>(ANALYTICS_UI_ALLOWED_LABELS);
+const FORBIDDEN_FIELD_SET = new Set<string>(ANALYTICS_UI_FORBIDDEN_FIELDS);
+const STATE_SET = new Set<string>(ANALYTICS_UI_STATE_VOCABULARY);
+
+export function isAnalyticsUiState(value: string): value is AnalyticsUiState {
+  return STATE_SET.has(value);
+}
+
+export function assertAnalyticsUiLabels(labels: Record<string, unknown>): void {
+  const labelNames = Object.keys(labels);
+  const forbiddenLabels = labelNames.filter((label) => FORBIDDEN_FIELD_SET.has(label));
+  if (forbiddenLabels.length > 0) {
+    throw new Error(
+      `Analytics UI labels include forbidden field(s): ${forbiddenLabels.join(", ")}`
+    );
+  }
+
+  const unsupportedLabels = labelNames.filter((label) => !ALLOWED_LABEL_SET.has(label));
+  if (unsupportedLabels.length > 0) {
+    throw new Error(
+      `Analytics UI labels include unsupported field(s): ${unsupportedLabels.join(", ")}`
+    );
+  }
+}
+
+export function buildAnalyticsUiLabels(
+  labels: Partial<Record<AnalyticsUiAllowedLabel, string>>
+): Partial<Record<AnalyticsUiAllowedLabel, string>> {
+  assertAnalyticsUiLabels(labels);
+  return Object.fromEntries(
+    Object.entries(labels).filter(([, value]) => value !== undefined && value !== "")
+  ) as Partial<Record<AnalyticsUiAllowedLabel, string>>;
+}

--- a/tests/unit/analytics-observability-contract.test.ts
+++ b/tests/unit/analytics-observability-contract.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ANALYTICS_UI_ALLOWED_LABELS,
+  ANALYTICS_UI_FORBIDDEN_FIELDS,
+  ANALYTICS_UI_STATE_VOCABULARY,
+  WORKBENCH_ANALYTICS_UI_METRIC_FAMILIES,
+  assertAnalyticsUiLabels,
+  buildAnalyticsUiLabels,
+  isAnalyticsUiState,
+} from "../../src/features/analytics-observability/contract";
+
+describe("analytics UI observability contract", () => {
+  it("keeps the Workbench-owned metric families explicit and planned-safe", () => {
+    expect(WORKBENCH_ANALYTICS_UI_METRIC_FAMILIES).toEqual([
+      "lotus_workbench_panel_hydration_duration_seconds",
+      "lotus_workbench_panel_state_total",
+      "lotus_workbench_api_request_duration_seconds",
+    ]);
+  });
+
+  it("recognizes only governed analytics UI states", () => {
+    expect(ANALYTICS_UI_STATE_VOCABULARY).toContain("permission_blocked");
+    expect(isAnalyticsUiState("degraded")).toBe(true);
+    expect(isAnalyticsUiState("blocked")).toBe(false);
+  });
+
+  it("accepts only bounded non-sensitive telemetry labels", () => {
+    expect(() =>
+      assertAnalyticsUiLabels({
+        route: "performance",
+        panel: "risk-summary",
+        state: "ready",
+        freshness_bucket: "fresh",
+        status_class: "2xx",
+      })
+    ).not.toThrow();
+  });
+
+  it("rejects forbidden sensitive field names before telemetry emission", () => {
+    for (const field of ANALYTICS_UI_FORBIDDEN_FIELDS) {
+      expect(() => assertAnalyticsUiLabels({ [field]: "sensitive" })).toThrow(
+        "forbidden field"
+      );
+    }
+  });
+
+  it("rejects unsupported ad hoc labels", () => {
+    expect(ANALYTICS_UI_ALLOWED_LABELS).not.toContain("portfolio_id");
+    expect(() => assertAnalyticsUiLabels({ custom_dimension: "drift" })).toThrow(
+      "unsupported field"
+    );
+  });
+
+  it("drops empty optional values while preserving allowed labels", () => {
+    expect(
+      buildAnalyticsUiLabels({
+        route: "portfolio",
+        panel: "",
+        operation: undefined,
+        state: "empty",
+      })
+    ).toEqual({ route: "portfolio", state: "empty" });
+  });
+});

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -25,6 +25,19 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001
 http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk
 ```
 
+## Analytics UI observability posture
+
+- RFC-0108 analytics UI observability vocabulary is code-owned in
+  `src/features/analytics-observability/contract.ts`.
+- The module defines allowed labels, forbidden fields, state vocabulary, and planned Workbench
+  metric-family names before any product telemetry is emitted.
+- Do not add panel, route, or browser telemetry labels outside that contract.
+- `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `trace_id`,
+  `correlation_id`, request bodies, response bodies, and screen content must not become metric
+  labels or browser event fields.
+- Workbench panel metrics, dashboard claims, attention events, audit events, and canonical browser
+  proof remain planned until later RFC-0108 slices promote them with evidence.
+
 ## Output paths
 
 - screenshots and summary:


### PR DESCRIPTION
## Summary
- add Workbench-owned analytics UI observability contract vocabulary
- validate allowed labels, forbidden sensitive fields, state vocabulary, and planned metric families
- update repo-local Operations Runbook to point operators and future work to the code-owned source of truth
- do not emit product telemetry or promote panel metrics in this slice

## Validation
- npm run test -- tests/unit/analytics-observability-contract.test.ts
- npm run typecheck
- git diff --check