### PR TITLE
Add RFC-0108 Slice 2 Workbench telemetry constants

### DIFF
--- a/src/features/analytics-observability/contract.ts
+++ b/src/features/analytics-observability/contract.ts
@@ -53,6 +53,34 @@ export const ANALYTICS_UI_STATE_VOCABULARY = [
 
 export type AnalyticsUiState = (typeof ANALYTICS_UI_STATE_VOCABULARY)[number];
 
+export const ANALYTICS_UI_SEVERITY_LEVELS = [
+  "info",
+  "warning",
+  "action_required",
+  "critical",
+] as const;
+
+export type AnalyticsUiSeverity = (typeof ANALYTICS_UI_SEVERITY_LEVELS)[number];
+
+export const ANALYTICS_UI_ATTENTION_EVENT_TYPES = [
+  "panel_stale",
+  "panel_degraded",
+  "panel_repeated_failure",
+  "source_partial",
+  "permission_blocked",
+] as const;
+
+export type AnalyticsUiAttentionEventType =
+  (typeof ANALYTICS_UI_ATTENTION_EVENT_TYPES)[number];
+
+export const ANALYTICS_UI_AUDIT_EVENT_TYPES = [
+  "analytics_read_allowed",
+  "analytics_read_denied",
+  "protected_diagnostics_lookup",
+] as const;
+
+export type AnalyticsUiAuditEventType = (typeof ANALYTICS_UI_AUDIT_EVENT_TYPES)[number];
+
 export const WORKBENCH_ANALYTICS_UI_METRIC_FAMILIES = [
   "lotus_workbench_panel_hydration_duration_seconds",
   "lotus_workbench_panel_state_total",
@@ -61,6 +89,49 @@ export const WORKBENCH_ANALYTICS_UI_METRIC_FAMILIES = [
 
 export type WorkbenchAnalyticsUiMetricFamily =
   (typeof WORKBENCH_ANALYTICS_UI_METRIC_FAMILIES)[number];
+
+export const WORKBENCH_ANALYTICS_UI_BROWSER_EVENTS = [
+  "workbench.analytics.panel_hydration",
+  "workbench.analytics.panel_state",
+  "workbench.analytics.api_request",
+] as const;
+
+export type WorkbenchAnalyticsUiBrowserEvent =
+  (typeof WORKBENCH_ANALYTICS_UI_BROWSER_EVENTS)[number];
+
+export const ANALYTICS_UI_TRACE_ATTRIBUTES = [
+  "route",
+  "panel",
+  "service",
+  "operation",
+  "state",
+  "freshness_bucket",
+  "supportability_state",
+  "status_class",
+  "error_category",
+] as const satisfies readonly AnalyticsUiAllowedLabel[];
+
+export const ANALYTICS_UI_ATTENTION_EVENT_ATTRIBUTES = [
+  "route",
+  "panel",
+  "attention_type",
+  "severity",
+  "state",
+  "reason",
+  "freshness_bucket",
+  "supportability_state",
+] as const satisfies readonly AnalyticsUiAllowedLabel[];
+
+export const ANALYTICS_UI_AUDIT_EVENT_ATTRIBUTES = [
+  "route",
+  "panel",
+  "operation",
+  "state",
+  "reason",
+  "status_class",
+  "region",
+  "environment",
+] as const satisfies readonly AnalyticsUiAllowedLabel[];
 
 const ALLOWED_LABEL_SET = new Set<string>(ANALYTICS_UI_ALLOWED_LABELS);
 const FORBIDDEN_FIELD_SET = new Set<string>(ANALYTICS_UI_FORBIDDEN_FIELDS);
@@ -71,18 +142,25 @@ export function isAnalyticsUiState(value: string): value is AnalyticsUiState {
 }
 
 export function assertAnalyticsUiLabels(labels: Record<string, unknown>): void {
-  const labelNames = Object.keys(labels);
-  const forbiddenLabels = labelNames.filter((label) => FORBIDDEN_FIELD_SET.has(label));
-  if (forbiddenLabels.length > 0) {
+  assertAnalyticsUiAttributeNames(Object.keys(labels));
+}
+
+export function assertAnalyticsUiAttributeNames(attributeNames: readonly string[]): void {
+  const forbiddenAttributes = attributeNames.filter((attribute) =>
+    FORBIDDEN_FIELD_SET.has(attribute)
+  );
+  if (forbiddenAttributes.length > 0) {
     throw new Error(
-      `Analytics UI labels include forbidden field(s): ${forbiddenLabels.join(", ")}`
+      `Analytics UI attributes include forbidden field(s): ${forbiddenAttributes.join(", ")}`
     );
   }
 
-  const unsupportedLabels = labelNames.filter((label) => !ALLOWED_LABEL_SET.has(label));
-  if (unsupportedLabels.length > 0) {
+  const unsupportedAttributes = attributeNames.filter(
+    (attribute) => !ALLOWED_LABEL_SET.has(attribute)
+  );
+  if (unsupportedAttributes.length > 0) {
     throw new Error(
-      `Analytics UI labels include unsupported field(s): ${unsupportedLabels.join(", ")}`
+      `Analytics UI attributes include unsupported field(s): ${unsupportedAttributes.join(", ")}`
     );
   }
 }

--- a/tests/unit/analytics-observability-contract.test.ts
+++ b/tests/unit/analytics-observability-contract.test.ts
@@ -2,9 +2,17 @@ import { describe, expect, it } from "vitest";
 
 import {
   ANALYTICS_UI_ALLOWED_LABELS,
+  ANALYTICS_UI_ATTENTION_EVENT_ATTRIBUTES,
+  ANALYTICS_UI_ATTENTION_EVENT_TYPES,
+  ANALYTICS_UI_AUDIT_EVENT_ATTRIBUTES,
+  ANALYTICS_UI_AUDIT_EVENT_TYPES,
   ANALYTICS_UI_FORBIDDEN_FIELDS,
+  ANALYTICS_UI_SEVERITY_LEVELS,
   ANALYTICS_UI_STATE_VOCABULARY,
+  ANALYTICS_UI_TRACE_ATTRIBUTES,
+  WORKBENCH_ANALYTICS_UI_BROWSER_EVENTS,
   WORKBENCH_ANALYTICS_UI_METRIC_FAMILIES,
+  assertAnalyticsUiAttributeNames,
   assertAnalyticsUiLabels,
   buildAnalyticsUiLabels,
   isAnalyticsUiState,
@@ -25,6 +33,35 @@ describe("analytics UI observability contract", () => {
     expect(isAnalyticsUiState("blocked")).toBe(false);
   });
 
+  it("keeps telemetry event names and severity vocabularies explicit", () => {
+    expect(WORKBENCH_ANALYTICS_UI_BROWSER_EVENTS).toEqual([
+      "workbench.analytics.panel_hydration",
+      "workbench.analytics.panel_state",
+      "workbench.analytics.api_request",
+    ]);
+    expect(ANALYTICS_UI_SEVERITY_LEVELS).toEqual([
+      "info",
+      "warning",
+      "action_required",
+      "critical",
+    ]);
+    expect(ANALYTICS_UI_ATTENTION_EVENT_TYPES).toContain("panel_degraded");
+    expect(ANALYTICS_UI_AUDIT_EVENT_TYPES).toContain("analytics_read_denied");
+  });
+
+  it("keeps trace, attention, and audit attributes bounded and product-safe", () => {
+    for (const attributes of [
+      ANALYTICS_UI_TRACE_ATTRIBUTES,
+      ANALYTICS_UI_ATTENTION_EVENT_ATTRIBUTES,
+      ANALYTICS_UI_AUDIT_EVENT_ATTRIBUTES,
+    ]) {
+      expect(() => assertAnalyticsUiAttributeNames(attributes)).not.toThrow();
+      expect(attributes).not.toContain("portfolio_id");
+      expect(attributes).not.toContain("client_name");
+      expect(attributes).not.toContain("screen_content");
+    }
+  });
+
   it("accepts only bounded non-sensitive telemetry labels", () => {
     expect(() =>
       assertAnalyticsUiLabels({
@@ -42,12 +79,16 @@ describe("analytics UI observability contract", () => {
       expect(() => assertAnalyticsUiLabels({ [field]: "sensitive" })).toThrow(
         "forbidden field"
       );
+      expect(() => assertAnalyticsUiAttributeNames([field])).toThrow("forbidden field");
     }
   });
 
   it("rejects unsupported ad hoc labels", () => {
     expect(ANALYTICS_UI_ALLOWED_LABELS).not.toContain("portfolio_id");
     expect(() => assertAnalyticsUiLabels({ custom_dimension: "drift" })).toThrow(
+      "unsupported field"
+    );
+    expect(() => assertAnalyticsUiAttributeNames(["custom_dimension"])).toThrow(
       "unsupported field"
     );
   });


### PR DESCRIPTION
## Summary
- adds Slice 2 code-owned analytics UI telemetry contract constants for Workbench
- defines planned browser event names, severity levels, attention/audit event vocabularies, and trace/attention/audit attributes
- adds attribute-list validation so future telemetry cannot drift into sensitive or ad hoc fields

## Validation
- `npm run test -- tests/unit/analytics-observability-contract.test.ts`
- `npm run typecheck`

## Scope notes
- No runtime product telemetry is emitted in this PR.
- Correlation propagation, metrics, dashboards, attention events, audit events, and browser proof remain later RFC-0108 slices.
- No wiki source changed in this repo for Slice 2.
