### PR TITLE
RFC-0108 Slice 3 Workbench correlation propagation

### DIFF
--- a/src/app/api/bff/[...path]/route.ts
+++ b/src/app/api/bff/[...path]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveGatewayBaseUrl } from "@/features/platform-runtime/service-addressing";
+import { prepareAnalyticsUiProxyHeaders } from "@/features/analytics-observability/correlation";
 
 async function proxy(request: NextRequest, params: { path: string[] }) {
   const upstreamPath = params.path.join("/");
@@ -8,13 +9,13 @@ async function proxy(request: NextRequest, params: { path: string[] }) {
 
   const headers = new Headers();
   request.headers.forEach((value, key) => {
-    if (key.toLowerCase() === "host") return;
     headers.set(key, value);
   });
+  const upstreamHeaders = prepareAnalyticsUiProxyHeaders(headers);
 
   const response = await fetch(url, {
     method: request.method,
-    headers,
+    headers: upstreamHeaders,
     body:
       request.method === "GET" || request.method === "HEAD"
         ? undefined

--- a/src/features/analytics-observability/correlation.ts
+++ b/src/features/analytics-observability/correlation.ts
@@ -1,0 +1,146 @@
+const TRACEPARENT_PATTERN = /^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/;
+const TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
+const CORRELATION_STORAGE_PREFIX = "lotus.analytics-ui.correlation";
+const TRACEPARENT_STORAGE_PREFIX = "lotus.analytics-ui.traceparent";
+
+export type AnalyticsUiCorrelationContext = {
+  correlationId: string;
+  traceparent: string;
+  traceId: string;
+};
+
+export function isValidAnalyticsUiTraceparent(
+  value: string | null | undefined
+): value is string {
+  return typeof value === "string" && TRACEPARENT_PATTERN.test(value);
+}
+
+export function buildAnalyticsUiCorrelationHeaders(
+  initialHeaders?: HeadersInit,
+  routeKey = "workbench-analytics"
+): Headers {
+  const headers = new Headers(initialHeaders);
+  const context = resolveAnalyticsUiCorrelationContext(routeKey, {
+    correlationId: headers.get("X-Correlation-Id"),
+    traceparent: headers.get("traceparent"),
+    traceId: headers.get("X-Trace-Id"),
+  });
+
+  headers.set("X-Correlation-Id", context.correlationId);
+  headers.set("X-Trace-Id", context.traceId);
+  headers.set("traceparent", context.traceparent);
+  return headers;
+}
+
+export function prepareAnalyticsUiProxyHeaders(initialHeaders: Headers): Headers {
+  const headers = new Headers(initialHeaders);
+  headers.delete("host");
+  return buildAnalyticsUiCorrelationHeaders(headers, "workbench-bff-proxy");
+}
+
+function resolveAnalyticsUiCorrelationContext(
+  routeKey: string,
+  incoming: {
+    correlationId?: string | null;
+    traceparent?: string | null;
+    traceId?: string | null;
+  }
+): AnalyticsUiCorrelationContext {
+  const correlationId =
+    nonEmpty(incoming.correlationId) ??
+    readOrCreateSessionValue(
+      `${CORRELATION_STORAGE_PREFIX}.${routeKey}`,
+      createAnalyticsUiCorrelationId
+    );
+
+  const traceparent = resolveTraceparent(routeKey, incoming);
+
+  const traceIdFromTraceparent = traceparent.split("-")[1] ?? createAnalyticsUiTraceId();
+
+  return {
+    correlationId,
+    traceparent,
+    traceId: traceIdFromTraceparent,
+  };
+}
+
+function resolveTraceparent(
+  routeKey: string,
+  incoming: { traceparent?: string | null; traceId?: string | null }
+): string {
+  const incomingTraceparent = nonEmpty(incoming.traceparent);
+  if (incomingTraceparent && isValidAnalyticsUiTraceparent(incomingTraceparent)) {
+    return incomingTraceparent;
+  }
+  if (isValidTraceId(incoming.traceId)) {
+    return createAnalyticsUiTraceparent(incoming.traceId);
+  }
+
+  const storageKey = `${TRACEPARENT_STORAGE_PREFIX}.${routeKey}`;
+  const stored = getSessionStorage()?.getItem(storageKey);
+  if (isValidAnalyticsUiTraceparent(stored)) {
+    return stored;
+  }
+
+  const created = createAnalyticsUiTraceparent();
+  getSessionStorage()?.setItem(storageKey, created);
+  return created;
+}
+
+function readOrCreateSessionValue(key: string, createValue: () => string): string {
+  const storage = getSessionStorage();
+  const existing = storage?.getItem(key);
+  if (existing) {
+    return existing;
+  }
+
+  const created = createValue();
+  storage?.setItem(key, created);
+  return created;
+}
+
+function getSessionStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function nonEmpty(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function isValidTraceId(value: string | null | undefined): value is string {
+  return typeof value === "string" && TRACE_ID_PATTERN.test(value);
+}
+
+function createAnalyticsUiCorrelationId(): string {
+  return `corr-workbench-${randomHex(8)}`;
+}
+
+function createAnalyticsUiTraceparent(traceId = createAnalyticsUiTraceId()): string {
+  return `00-${traceId}-${randomHex(8)}-01`;
+}
+
+function createAnalyticsUiTraceId(): string {
+  return randomHex(16);
+}
+
+function randomHex(byteCount: number): string {
+  const bytes = new Uint8Array(byteCount);
+  globalThis.crypto?.getRandomValues?.(bytes);
+  if (bytes.some((byte) => byte !== 0)) {
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+
+  return Array.from({ length: byteCount }, () =>
+    Math.floor(Math.random() * 256)
+      .toString(16)
+      .padStart(2, "0")
+  ).join("");
+}

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -24,6 +24,7 @@ import {
   resolveWorkbenchApiBase,
   type ServiceRequestTarget,
 } from "@/features/platform-runtime/service-addressing";
+import { buildAnalyticsUiCorrelationHeaders } from "@/features/analytics-observability/correlation";
 
 const BFF_PROXY_BASE = `${resolveBffProxyBaseUrl()}/api/v1`;
 type WorkbenchRequestTarget = ServiceRequestTarget;
@@ -56,8 +57,12 @@ function buildPerformanceWorkspaceQuery(params: {
   return query.toString();
 }
 
-async function fetchWorkbenchJson<T>(url: string, errorLabel: string): Promise<T> {
-  const response = await fetch(url, { cache: "no-store" });
+async function fetchWorkbenchJson<T>(
+  url: string,
+  errorLabel: string,
+  init?: RequestInit
+): Promise<T> {
+  const response = await fetch(url, { cache: "no-store", ...init });
   if (!response.ok) {
     throw new Error(`Failed to fetch ${errorLabel} (${response.status})`);
   }
@@ -94,7 +99,11 @@ async function fetchWorkbenchResource<T>(
   errorLabel: string,
   query?: URLSearchParams | string
 ): Promise<T> {
-  return await fetchWorkbenchJson<T>(buildWorkbenchUrl(target, path, query), errorLabel);
+  return await fetchWorkbenchJson<T>(
+    buildWorkbenchUrl(target, path, query),
+    errorLabel,
+    target === "client" ? { headers: buildAnalyticsUiCorrelationHeaders() } : undefined
+  );
 }
 
 function buildPerformanceWorkspaceUrl(
@@ -268,7 +277,8 @@ export async function getWorkbenchPerformanceWorkspaceSummaryClient(
 ): Promise<WorkbenchPerformanceWorkspaceSummary> {
   return await fetchWorkbenchJson<WorkbenchPerformanceWorkspaceSummary>(
     buildPerformanceWorkspaceUrl(portfolioId, params, "/summary", "client"),
-    "performance workspace summary"
+    "performance workspace summary",
+    { headers: buildAnalyticsUiCorrelationHeaders() }
   );
 }
 
@@ -287,7 +297,8 @@ export async function getWorkbenchPerformanceWorkspaceDetailsClient(
 ): Promise<WorkbenchPerformanceWorkspaceDetails> {
   return await fetchWorkbenchJson<WorkbenchPerformanceWorkspaceDetails>(
     buildPerformanceWorkspaceUrl(portfolioId, params, "/details", "client"),
-    "performance workspace details"
+    "performance workspace details",
+    { headers: buildAnalyticsUiCorrelationHeaders() }
   );
 }
 
@@ -402,7 +413,7 @@ export async function postWorkbenchPerformanceAdvisorBriefReviewActionClient(
     ),
     {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: buildAnalyticsUiCorrelationHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(payload),
       cache: "no-store",
     }
@@ -474,7 +485,8 @@ export async function getWorkbenchRiskSummaryClient(
 ): Promise<WorkbenchRiskSummaryResponse> {
   return await fetchWorkbenchJson<WorkbenchRiskSummaryResponse>(
     buildRiskWorkspaceUrl(portfolioId, "/risk/summary", params, "client"),
-    "workbench risk summary"
+    "workbench risk summary",
+    { headers: buildAnalyticsUiCorrelationHeaders() }
   );
 }
 
@@ -489,7 +501,8 @@ export async function getWorkbenchRiskConcentrationClient(
 ): Promise<WorkbenchRiskConcentrationResponse> {
   return await fetchWorkbenchJson<WorkbenchRiskConcentrationResponse>(
     buildRiskWorkspaceUrl(portfolioId, "/risk/concentration", params, "client"),
-    "workbench risk concentration"
+    "workbench risk concentration",
+    { headers: buildAnalyticsUiCorrelationHeaders() }
   );
 }
 
@@ -518,7 +531,8 @@ export async function getWorkbenchRiskDrawdownClient(
   }
   return await fetchWorkbenchJson<WorkbenchRiskDrawdownResponse>(
     buildWorkbenchUrl("client", `/workbench/${portfolioId}/risk/drawdown`, query),
-    "workbench risk drawdown"
+    "workbench risk drawdown",
+    { headers: buildAnalyticsUiCorrelationHeaders() }
   );
 }
 
@@ -547,7 +561,8 @@ export async function getWorkbenchRiskRollingClient(
   }
   return await fetchWorkbenchJson<WorkbenchRiskRollingResponse>(
     buildWorkbenchUrl("client", `/workbench/${portfolioId}/risk/rolling`, query),
-    "workbench risk rolling"
+    "workbench risk rolling",
+    { headers: buildAnalyticsUiCorrelationHeaders() }
   );
 }
 
@@ -576,7 +591,8 @@ export async function getWorkbenchRiskAttributionClient(
   query.set("grouping_dimension", params.groupingDimension);
   return await fetchWorkbenchJson<WorkbenchRiskAttributionResponse>(
     buildWorkbenchUrl("client", `/workbench/${portfolioId}/risk/attribution`, query),
-    "workbench risk attribution"
+    "workbench risk attribution",
+    { headers: buildAnalyticsUiCorrelationHeaders() }
   );
 }
 

--- a/tests/unit/analytics-observability-correlation.test.ts
+++ b/tests/unit/analytics-observability-correlation.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildAnalyticsUiCorrelationHeaders,
+  isValidAnalyticsUiTraceparent,
+} from "../../src/features/analytics-observability/correlation";
+
+describe("analytics UI correlation headers", () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("creates and preserves route-scoped browser correlation context", () => {
+    const first = buildAnalyticsUiCorrelationHeaders(undefined, "performance-workspace");
+    const second = buildAnalyticsUiCorrelationHeaders(undefined, "performance-workspace");
+
+    expect(first.get("X-Correlation-Id")).toMatch(/^corr-workbench-[0-9a-f]{16}$/);
+    expect(first.get("X-Correlation-Id")).toBe(second.get("X-Correlation-Id"));
+    expect(isValidAnalyticsUiTraceparent(first.get("traceparent"))).toBe(true);
+    expect(first.get("traceparent")).toBe(second.get("traceparent"));
+    expect(first.get("X-Trace-Id")).toBe(first.get("traceparent")?.split("-")[1]);
+  });
+
+  it("preserves valid incoming context for BFF requests", () => {
+    const headers = buildAnalyticsUiCorrelationHeaders(
+      {
+        "X-Correlation-Id": "corr-existing",
+        traceparent: "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+      },
+      "performance-workspace"
+    );
+
+    expect(headers.get("X-Correlation-Id")).toBe("corr-existing");
+    expect(headers.get("traceparent")).toBe(
+      "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+    );
+    expect(headers.get("X-Trace-Id")).toBe("0123456789abcdef0123456789abcdef");
+  });
+
+  it("does not emit malformed traceparent headers", () => {
+    const headers = buildAnalyticsUiCorrelationHeaders(
+      {
+        "X-Correlation-Id": "corr-existing",
+        traceparent: "not-a-valid-traceparent",
+      },
+      "risk-workspace"
+    );
+
+    expect(headers.get("traceparent")).not.toBe("not-a-valid-traceparent");
+    expect(isValidAnalyticsUiTraceparent(headers.get("traceparent"))).toBe(true);
+  });
+
+  it("uses a valid X-Trace-Id when replacing malformed traceparent headers", () => {
+    const headers = buildAnalyticsUiCorrelationHeaders(
+      {
+        "X-Trace-Id": "fedcba9876543210fedcba9876543210",
+        traceparent: "not-a-valid-traceparent",
+      },
+      "risk-workspace"
+    );
+
+    expect(headers.get("X-Trace-Id")).toBe("fedcba9876543210fedcba9876543210");
+    expect(headers.get("traceparent")).toMatch(
+      /^00-fedcba9876543210fedcba9876543210-[0-9a-f]{16}-[0-9a-f]{2}$/
+    );
+  });
+});

--- a/tests/unit/bff-route.test.ts
+++ b/tests/unit/bff-route.test.ts
@@ -53,6 +53,13 @@ describe("BFF proxy route", () => {
         cache: "no-store",
       })
     );
+    const upstreamHeaders = upstreamInit?.headers as Headers;
+    expect(upstreamHeaders.get("host")).toBeNull();
+    expect(upstreamHeaders.get("authorization")).toBe("Bearer token");
+    expect(upstreamHeaders.get("X-Correlation-Id")).toMatch(/^corr-workbench-[0-9a-f]{16}$/);
+    expect(upstreamHeaders.get("traceparent")).toMatch(
+      /^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/
+    );
     expect(response.status).toBe(200);
     expect(response.headers.get("transfer-encoding")).toBeNull();
     expect(await response.text()).toBe('{"ok":true}');
@@ -87,5 +94,30 @@ describe("BFF proxy route", () => {
       })
     );
     expect(response.status).toBe(202);
+  });
+
+  it("preserves valid context and replaces malformed traceparent before proxying", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const request = new NextRequest("http://localhost:3000/api/bff/api/v1/workbench/PF_1001/risk/summary", {
+      method: "GET",
+      headers: {
+        "X-Correlation-Id": "corr-workbench-route-1",
+        traceparent: "malformed",
+      },
+    });
+
+    await GET(request, {
+      params: Promise.resolve({ path: ["api", "v1", "workbench", "PF_1001", "risk", "summary"] }),
+    });
+
+    const upstreamInit = fetchMock.mock.calls[0][1];
+    const upstreamHeaders = upstreamInit?.headers as Headers;
+    expect(upstreamHeaders.get("X-Correlation-Id")).toBe("corr-workbench-route-1");
+    expect(upstreamHeaders.get("traceparent")).not.toBe("malformed");
+    expect(upstreamHeaders.get("traceparent")).toMatch(
+      /^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/
+    );
   });
 });

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -572,8 +572,17 @@ describe("workbench api", () => {
     });
 
     const requestedUrl = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].toString();
+    const requestInit = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    const requestHeaders = requestInit?.headers as Headers;
     expect(requestedUrl).toBe(
       "/api/bff/api/v1/workbench/PF_1001/risk/summary?period=YTD&detail_basis=NET&benchmark_code=BMK_GLOBAL_BALANCED_60_40&as_of_date=2026-02-24&reporting_currency=USD"
+    );
+    expect(requestHeaders.get("X-Correlation-Id")).toMatch(/^corr-workbench-[0-9a-f]{16}$/);
+    expect(requestHeaders.get("traceparent")).toMatch(
+      /^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/
+    );
+    expect(requestHeaders.get("X-Trace-Id")).toBe(
+      requestHeaders.get("traceparent")?.split("-")[1]
     );
   });
 
@@ -1079,17 +1088,19 @@ describe("workbench api", () => {
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/bff/api/v1/workbench/PF_1001/performance/advisor-brief/review-actions?period=YTD&chart_frequency=monthly&contribution_dimension=asset_class&attribution_dimension=asset_class&detail_basis=NET&benchmark_code=BMK_GLOBAL_BALANCED_60_40&report_start_date=2026-01-01&report_end_date=2026-02-24",
-      {
+      expect.objectContaining({
         method: "POST",
-        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           action_type: "ACCEPT",
           reviewed_by: "advisor_1",
           reason: "Advisor brief accepted for bounded downstream workflow use.",
         }),
         cache: "no-store",
-      }
+      })
     );
+    const requestHeaders = fetchMock.mock.calls[0][1]?.headers as Headers;
+    expect(requestHeaders.get("Content-Type")).toBe("application/json");
+    expect(requestHeaders.get("X-Correlation-Id")).toMatch(/^corr-workbench-[0-9a-f]{16}$/);
   });
 
   it("calls backend reporting snapshot endpoint", async () => {


### PR DESCRIPTION
## Summary
- add RFC-0108 Slice 3 analytics UI correlation helpers for browser/client requests
- propagate safe correlation and W3C trace context through the BFF proxy
- replace malformed traceparent headers before forwarding upstream

## Evidence
- npm run test -- tests/unit/analytics-observability-correlation.test.ts tests/unit/bff-route.test.ts tests/unit/workbench-api.test.ts tests/unit/analytics-observability-contract.test.ts
- npm run typecheck

## Tiering
- Feature Lane proof: focused unit coverage and TypeScript typecheck
- PR Merge Gate: GitHub checks
- Heavy canonical browser proof remains planned for later RFC-0108 slices that emit user-visible telemetry/state
