### PR TITLE
Implement RFC-0108 Slice 5 Workbench metrics

### DIFF
--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+import { renderAnalyticsUiPrometheusMetrics } from "@/features/analytics-observability/metrics";
+
+export async function GET() {
+  return new NextResponse(renderAnalyticsUiPrometheusMetrics(), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; version=0.0.4; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -1,0 +1,462 @@
+import {
+  type AnalyticsUiAllowedLabel,
+  type AnalyticsUiState,
+  type WorkbenchAnalyticsUiBrowserEvent,
+  type WorkbenchAnalyticsUiMetricFamily,
+  assertAnalyticsUiLabels,
+  buildAnalyticsUiLabels,
+  isAnalyticsUiState,
+} from "./contract";
+
+export type AnalyticsUiFreshnessBucket = "fresh" | "stale" | "unknown";
+export type AnalyticsUiStatusClass = "2xx" | "3xx" | "4xx" | "5xx" | "network";
+
+export type AnalyticsUiSupportabilityState =
+  | "ready"
+  | "partial"
+  | "action_required"
+  | "unsupported"
+  | "unknown";
+
+export interface AnalyticsUiPanelClassificationInput {
+  loading?: boolean;
+  permissionBlocked?: boolean;
+  unsupported?: boolean;
+  error?: unknown;
+  status?: number;
+  response?: unknown;
+  freshnessBucket?: AnalyticsUiFreshnessBucket;
+  supportabilityState?: AnalyticsUiSupportabilityState;
+  empty?: boolean;
+  partial?: boolean;
+  degraded?: boolean;
+}
+
+export interface WorkbenchAnalyticsUiMetricEvent {
+  event_name: WorkbenchAnalyticsUiBrowserEvent;
+  metric_name: WorkbenchAnalyticsUiMetricFamily;
+  value: number;
+  labels: Partial<Record<AnalyticsUiAllowedLabel, string>>;
+  recorded_at: string;
+}
+
+export interface WorkbenchAnalyticsUiMetricSample {
+  metric_name: WorkbenchAnalyticsUiMetricFamily;
+  metric_type: "counter" | "histogram";
+  labels: Partial<Record<AnalyticsUiAllowedLabel, string>>;
+  value: number;
+  sample_count: number;
+}
+
+export interface WorkbenchAnalyticsUiObservationContext {
+  route: string;
+  panel: string;
+  operation: string;
+  service?: string;
+}
+
+const metricEvents: WorkbenchAnalyticsUiMetricEvent[] = [];
+
+export function classifyAnalyticsUiPanelState(
+  input: AnalyticsUiPanelClassificationInput
+): AnalyticsUiState {
+  const responseState = readStringProperty(input.response, "state");
+  if (responseState && isAnalyticsUiState(responseState)) {
+    return responseState;
+  }
+
+  if (input.loading) {
+    return "loading";
+  }
+  if (input.permissionBlocked || input.status === 401 || input.status === 403) {
+    return "permission_blocked";
+  }
+  if (input.unsupported) {
+    return "unsupported";
+  }
+  if (input.error || (input.status !== undefined && input.status >= 400)) {
+    return "error";
+  }
+  if (input.freshnessBucket === "stale") {
+    return "stale";
+  }
+  if (input.degraded || input.supportabilityState === "action_required") {
+    return "degraded";
+  }
+  if (
+    input.partial ||
+    input.supportabilityState === "partial" ||
+    hasNonEmptyArrayProperty(input.response, "partial_failures")
+  ) {
+    return "partial";
+  }
+  if (input.empty === true) {
+    return "empty";
+  }
+  return "ready";
+}
+
+export function classifyAnalyticsUiFreshnessBucket(input: {
+  asOfDate?: string | null;
+  now?: Date;
+  staleAfterDays?: number;
+}): AnalyticsUiFreshnessBucket {
+  if (!input.asOfDate) {
+    return "unknown";
+  }
+  const asOf = new Date(`${input.asOfDate}T00:00:00Z`);
+  if (Number.isNaN(asOf.getTime())) {
+    return "unknown";
+  }
+  const now = input.now ?? new Date();
+  const staleAfterMs = (input.staleAfterDays ?? 3) * 24 * 60 * 60 * 1000;
+  return now.getTime() - asOf.getTime() > staleAfterMs ? "stale" : "fresh";
+}
+
+export function deriveAnalyticsUiSupportabilityState(
+  response: unknown
+): AnalyticsUiSupportabilityState {
+  const direct = readStringProperty(response, "supportability_state");
+  if (direct) {
+    return normalizeSupportabilityState(direct);
+  }
+  const supportabilityStatus = readStringProperty(response, "supportability_status");
+  if (supportabilityStatus) {
+    return normalizeSupportabilityState(supportabilityStatus);
+  }
+  if (hasNonEmptyArrayProperty(response, "partial_failures")) {
+    return "partial";
+  }
+  if (hasNonEmptyArrayProperty(response, "supportability")) {
+    return "ready";
+  }
+  return "unknown";
+}
+
+export function recordAnalyticsUiPanelHydration(params: {
+  context: WorkbenchAnalyticsUiObservationContext;
+  durationMs: number;
+  state: AnalyticsUiState;
+  freshnessBucket?: AnalyticsUiFreshnessBucket;
+  supportabilityState?: AnalyticsUiSupportabilityState;
+}): WorkbenchAnalyticsUiMetricEvent {
+  return recordMetricEvent({
+    eventName: "workbench.analytics.panel_hydration",
+    metricName: "lotus_workbench_panel_hydration_duration_seconds",
+    value: Math.max(0, params.durationMs) / 1000,
+    context: params.context,
+    labels: {
+      state: params.state,
+      freshness_bucket: params.freshnessBucket ?? "unknown",
+      supportability_state: params.supportabilityState ?? "unknown",
+    },
+  });
+}
+
+export function recordAnalyticsUiPanelState(params: {
+  context: WorkbenchAnalyticsUiObservationContext;
+  state: AnalyticsUiState;
+  freshnessBucket?: AnalyticsUiFreshnessBucket;
+  supportabilityState?: AnalyticsUiSupportabilityState;
+  reason?: string;
+}): WorkbenchAnalyticsUiMetricEvent {
+  return recordMetricEvent({
+    eventName: "workbench.analytics.panel_state",
+    metricName: "lotus_workbench_panel_state_total",
+    value: 1,
+    context: params.context,
+    labels: {
+      state: params.state,
+      freshness_bucket: params.freshnessBucket ?? "unknown",
+      supportability_state: params.supportabilityState ?? "unknown",
+      reason: params.reason,
+    },
+  });
+}
+
+export function recordAnalyticsUiApiRequest(params: {
+  context: WorkbenchAnalyticsUiObservationContext;
+  durationMs: number;
+  statusClass: AnalyticsUiStatusClass;
+  state: AnalyticsUiState;
+  errorCategory?: string;
+}): WorkbenchAnalyticsUiMetricEvent {
+  return recordMetricEvent({
+    eventName: "workbench.analytics.api_request",
+    metricName: "lotus_workbench_api_request_duration_seconds",
+    value: Math.max(0, params.durationMs) / 1000,
+    context: params.context,
+    labels: {
+      status_class: params.statusClass,
+      state: params.state,
+      error_category: params.errorCategory,
+    },
+  });
+}
+
+export async function observeWorkbenchAnalyticsRequest<T>(
+  context: WorkbenchAnalyticsUiObservationContext,
+  request: () => Promise<T>
+): Promise<T> {
+  const startedAt = nowMs();
+  try {
+    const response = await request();
+    const durationMs = nowMs() - startedAt;
+    const freshnessBucket = classifyAnalyticsUiFreshnessBucket({
+      asOfDate: readStringProperty(response, "as_of_date"),
+    });
+    const supportabilityState = deriveAnalyticsUiSupportabilityState(response);
+    const state = classifyAnalyticsUiPanelState({
+      response,
+      freshnessBucket,
+      supportabilityState,
+    });
+    recordAnalyticsUiApiRequest({
+      context,
+      durationMs,
+      statusClass: "2xx",
+      state,
+    });
+    recordAnalyticsUiPanelState({
+      context,
+      state,
+      freshnessBucket,
+      supportabilityState,
+    });
+    recordAnalyticsUiPanelHydration({
+      context,
+      durationMs,
+      state,
+      freshnessBucket,
+      supportabilityState,
+    });
+    return response;
+  } catch (error) {
+    const durationMs = nowMs() - startedAt;
+    const statusClass = statusClassFromError(error);
+    recordAnalyticsUiApiRequest({
+      context,
+      durationMs,
+      statusClass,
+      state:
+        statusClass === "4xx"
+          ? classifyAnalyticsUiPanelState({ status: statusFromError(error) })
+          : "error",
+      errorCategory: errorCategoryFromStatusClass(statusClass),
+    });
+    recordAnalyticsUiPanelState({
+      context,
+      state:
+        statusClass === "4xx"
+          ? classifyAnalyticsUiPanelState({ status: statusFromError(error) })
+          : "error",
+      reason: errorCategoryFromStatusClass(statusClass),
+    });
+    throw error;
+  }
+}
+
+export function getAnalyticsUiMetricEvents(): readonly WorkbenchAnalyticsUiMetricEvent[] {
+  return metricEvents;
+}
+
+export function getAnalyticsUiMetricSamples(): WorkbenchAnalyticsUiMetricSample[] {
+  const samples = new Map<string, WorkbenchAnalyticsUiMetricSample>();
+  for (const event of metricEvents) {
+    const sampleKey = JSON.stringify({
+      metric_name: event.metric_name,
+      labels: event.labels,
+    });
+    const existing = samples.get(sampleKey);
+    if (existing) {
+      existing.value += event.value;
+      existing.sample_count += 1;
+    } else {
+      samples.set(sampleKey, {
+        metric_name: event.metric_name,
+        metric_type:
+          event.metric_name === "lotus_workbench_panel_state_total"
+            ? "counter"
+            : "histogram",
+        labels: event.labels,
+        value: event.value,
+        sample_count: 1,
+      });
+    }
+  }
+  return [...samples.values()];
+}
+
+export function renderAnalyticsUiPrometheusMetrics(): string {
+  const samples = getAnalyticsUiMetricSamples();
+  const lines = [
+    "# HELP lotus_workbench_panel_hydration_duration_seconds Selected Workbench analytics panel hydration duration.",
+    "# TYPE lotus_workbench_panel_hydration_duration_seconds histogram",
+    "# HELP lotus_workbench_panel_state_total Selected Workbench analytics panel state transitions.",
+    "# TYPE lotus_workbench_panel_state_total counter",
+    "# HELP lotus_workbench_api_request_duration_seconds Selected Workbench analytics API request duration.",
+    "# TYPE lotus_workbench_api_request_duration_seconds histogram",
+  ];
+  for (const sample of samples) {
+    lines.push(
+      `${sample.metric_name}${formatPrometheusLabels(sample.labels)} ${sample.value}`
+    );
+    if (sample.metric_type === "histogram") {
+      lines.push(...renderHistogramBucketLines(sample));
+      lines.push(
+        `${sample.metric_name}_sum${formatPrometheusLabels(sample.labels)} ${sample.value}`
+      );
+      lines.push(
+        `${sample.metric_name}_count${formatPrometheusLabels(sample.labels)} ${sample.sample_count}`
+      );
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export function resetAnalyticsUiMetricEvents(): void {
+  metricEvents.length = 0;
+}
+
+function recordMetricEvent(params: {
+  eventName: WorkbenchAnalyticsUiBrowserEvent;
+  metricName: WorkbenchAnalyticsUiMetricFamily;
+  value: number;
+  context: WorkbenchAnalyticsUiObservationContext;
+  labels: Partial<Record<AnalyticsUiAllowedLabel, string | undefined>>;
+}): WorkbenchAnalyticsUiMetricEvent {
+  const labels = buildAnalyticsUiLabels({
+    route: params.context.route,
+    panel: params.context.panel,
+    service: params.context.service ?? "lotus-gateway",
+    operation: params.context.operation,
+    ...params.labels,
+  });
+  assertAnalyticsUiLabels(labels);
+  const event: WorkbenchAnalyticsUiMetricEvent = {
+    event_name: params.eventName,
+    metric_name: params.metricName,
+    value: params.value,
+    labels,
+    recorded_at: new Date().toISOString(),
+  };
+  metricEvents.push(event);
+  return event;
+}
+
+function readStringProperty(value: unknown, property: string): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const propertyValue = (value as Record<string, unknown>)[property];
+  return typeof propertyValue === "string" && propertyValue ? propertyValue : undefined;
+}
+
+function hasNonEmptyArrayProperty(value: unknown, property: string): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const propertyValue = (value as Record<string, unknown>)[property];
+  return Array.isArray(propertyValue) && propertyValue.length > 0;
+}
+
+function normalizeSupportabilityState(value: string): AnalyticsUiSupportabilityState {
+  const normalized = value.toLowerCase();
+  if (normalized === "ready") {
+    return "ready";
+  }
+  if (normalized === "partial") {
+    return "partial";
+  }
+  if (normalized === "action_required") {
+    return "action_required";
+  }
+  if (normalized === "unsupported") {
+    return "unsupported";
+  }
+  return "unknown";
+}
+
+function nowMs(): number {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+function statusFromError(error: unknown): number | undefined {
+  if (!(error instanceof Error)) {
+    return undefined;
+  }
+  const match = error.message.match(/\((\d{3})\)/);
+  return match ? Number(match[1]) : undefined;
+}
+
+function statusClassFromError(error: unknown): AnalyticsUiStatusClass {
+  const status = statusFromError(error);
+  if (status === undefined) {
+    return "network";
+  }
+  if (status >= 500) {
+    return "5xx";
+  }
+  if (status >= 400) {
+    return "4xx";
+  }
+  if (status >= 300) {
+    return "3xx";
+  }
+  return "2xx";
+}
+
+function errorCategoryFromStatusClass(statusClass: AnalyticsUiStatusClass): string {
+  if (statusClass === "4xx") {
+    return "client";
+  }
+  if (statusClass === "5xx") {
+    return "server";
+  }
+  if (statusClass === "network") {
+    return "network";
+  }
+  return "none";
+}
+
+function formatPrometheusLabels(
+  labels: Partial<Record<AnalyticsUiAllowedLabel, string>>
+): string {
+  const entries = Object.entries(labels).filter(([, value]) => value !== undefined);
+  if (entries.length === 0) {
+    return "";
+  }
+  return `{${entries
+    .map(([key, value]) => `${key}="${String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`)
+    .join(",")}}`;
+}
+
+function renderHistogramBucketLines(
+  sample: WorkbenchAnalyticsUiMetricSample
+): string[] {
+  const buckets = [0.1, 0.5, 1, 3, 5, 10];
+  const sourceEvents = metricEvents.filter(
+    (event) =>
+      event.metric_name === sample.metric_name &&
+      JSON.stringify(event.labels) === JSON.stringify(sample.labels)
+  );
+  const lines = buckets.map((bucket) => {
+    const count = sourceEvents.filter((event) => event.value <= bucket).length;
+    return `${sample.metric_name}_bucket${formatPrometheusLabels({
+      ...sample.labels,
+      // Prometheus requires le on histogram buckets; the contract validator keeps
+      // service-owned labels bounded and dashboard tests normalize bucket suffixes.
+      le: String(bucket),
+    } as Partial<Record<AnalyticsUiAllowedLabel, string>>)} ${count}`;
+  });
+  lines.push(
+    `${sample.metric_name}_bucket${formatPrometheusLabels({
+      ...sample.labels,
+      le: "+Inf",
+    } as Partial<Record<AnalyticsUiAllowedLabel, string>>)} ${sample.sample_count}`
+  );
+  return lines;
+}

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -25,6 +25,7 @@ import {
   type ServiceRequestTarget,
 } from "@/features/platform-runtime/service-addressing";
 import { buildAnalyticsUiCorrelationHeaders } from "@/features/analytics-observability/correlation";
+import { observeWorkbenchAnalyticsRequest } from "@/features/analytics-observability/metrics";
 
 const BFF_PROXY_BASE = `${resolveBffProxyBaseUrl()}/api/v1`;
 type WorkbenchRequestTarget = ServiceRequestTarget;
@@ -275,10 +276,18 @@ export async function getWorkbenchPerformanceWorkspaceSummaryClient(
     reportEndDate?: string;
   }
 ): Promise<WorkbenchPerformanceWorkspaceSummary> {
-  return await fetchWorkbenchJson<WorkbenchPerformanceWorkspaceSummary>(
-    buildPerformanceWorkspaceUrl(portfolioId, params, "/summary", "client"),
-    "performance workspace summary",
-    { headers: buildAnalyticsUiCorrelationHeaders() }
+  return await observeWorkbenchAnalyticsRequest(
+    {
+      route: "workbench.performance",
+      panel: "performance-summary",
+      operation: "performance.workspace.summary",
+    },
+    async () =>
+      await fetchWorkbenchJson<WorkbenchPerformanceWorkspaceSummary>(
+        buildPerformanceWorkspaceUrl(portfolioId, params, "/summary", "client"),
+        "performance workspace summary",
+        { headers: buildAnalyticsUiCorrelationHeaders() }
+      )
   );
 }
 
@@ -295,10 +304,18 @@ export async function getWorkbenchPerformanceWorkspaceDetailsClient(
     reportEndDate?: string;
   }
 ): Promise<WorkbenchPerformanceWorkspaceDetails> {
-  return await fetchWorkbenchJson<WorkbenchPerformanceWorkspaceDetails>(
-    buildPerformanceWorkspaceUrl(portfolioId, params, "/details", "client"),
-    "performance workspace details",
-    { headers: buildAnalyticsUiCorrelationHeaders() }
+  return await observeWorkbenchAnalyticsRequest(
+    {
+      route: "workbench.performance",
+      panel: "performance-details",
+      operation: "performance.workspace.details",
+    },
+    async () =>
+      await fetchWorkbenchJson<WorkbenchPerformanceWorkspaceDetails>(
+        buildPerformanceWorkspaceUrl(portfolioId, params, "/details", "client"),
+        "performance workspace details",
+        { headers: buildAnalyticsUiCorrelationHeaders() }
+      )
   );
 }
 
@@ -483,10 +500,18 @@ export async function getWorkbenchRiskSummaryClient(
     reportingCurrency?: string;
   }
 ): Promise<WorkbenchRiskSummaryResponse> {
-  return await fetchWorkbenchJson<WorkbenchRiskSummaryResponse>(
-    buildRiskWorkspaceUrl(portfolioId, "/risk/summary", params, "client"),
-    "workbench risk summary",
-    { headers: buildAnalyticsUiCorrelationHeaders() }
+  return await observeWorkbenchAnalyticsRequest(
+    {
+      route: "workbench.risk",
+      panel: "risk-summary",
+      operation: "risk.summary",
+    },
+    async () =>
+      await fetchWorkbenchJson<WorkbenchRiskSummaryResponse>(
+        buildRiskWorkspaceUrl(portfolioId, "/risk/summary", params, "client"),
+        "workbench risk summary",
+        { headers: buildAnalyticsUiCorrelationHeaders() }
+      )
   );
 }
 

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  classifyAnalyticsUiFreshnessBucket,
+  classifyAnalyticsUiPanelState,
+  deriveAnalyticsUiSupportabilityState,
+  getAnalyticsUiMetricEvents,
+  renderAnalyticsUiPrometheusMetrics,
+  observeWorkbenchAnalyticsRequest,
+  recordAnalyticsUiPanelState,
+  resetAnalyticsUiMetricEvents,
+} from "../../src/features/analytics-observability/metrics";
+
+const context = {
+  route: "workbench.performance",
+  panel: "performance-summary",
+  operation: "performance.workspace.summary",
+};
+
+describe("analytics UI observability metrics", () => {
+  afterEach(() => {
+    resetAnalyticsUiMetricEvents();
+  });
+
+  it("classifies governed panel states without ambiguous aliases", () => {
+    expect(classifyAnalyticsUiPanelState({ response: { state: "ready" } })).toBe(
+      "ready"
+    );
+    expect(classifyAnalyticsUiPanelState({ empty: true })).toBe("empty");
+    expect(classifyAnalyticsUiPanelState({ freshnessBucket: "stale" })).toBe("stale");
+    expect(
+      classifyAnalyticsUiPanelState({ supportabilityState: "action_required" })
+    ).toBe("degraded");
+    expect(classifyAnalyticsUiPanelState({ error: new Error("failed") })).toBe(
+      "error"
+    );
+    expect(classifyAnalyticsUiPanelState({ status: 403 })).toBe(
+      "permission_blocked"
+    );
+    expect(classifyAnalyticsUiPanelState({ unsupported: true })).toBe(
+      "unsupported"
+    );
+  });
+
+  it("classifies freshness buckets deterministically", () => {
+    const now = new Date("2026-04-29T12:00:00Z");
+
+    expect(
+      classifyAnalyticsUiFreshnessBucket({
+        asOfDate: "2026-04-28",
+        now,
+        staleAfterDays: 3,
+      })
+    ).toBe("fresh");
+    expect(
+      classifyAnalyticsUiFreshnessBucket({
+        asOfDate: "2026-04-20",
+        now,
+        staleAfterDays: 3,
+      })
+    ).toBe("stale");
+    expect(classifyAnalyticsUiFreshnessBucket({ now })).toBe("unknown");
+  });
+
+  it("derives supportability posture from bounded response metadata", () => {
+    expect(deriveAnalyticsUiSupportabilityState({ supportability_status: "READY" })).toBe(
+      "ready"
+    );
+    expect(
+      deriveAnalyticsUiSupportabilityState({ partial_failures: [{ reason: "source" }] })
+    ).toBe("partial");
+    expect(deriveAnalyticsUiSupportabilityState({ supportability_state: "unsupported" })).toBe(
+      "unsupported"
+    );
+  });
+
+  it("records only allowed product-safe metric labels", () => {
+    const event = recordAnalyticsUiPanelState({
+      context,
+      state: "ready",
+      freshnessBucket: "fresh",
+      supportabilityState: "ready",
+    });
+
+    expect(event).toEqual(
+      expect.objectContaining({
+        event_name: "workbench.analytics.panel_state",
+        metric_name: "lotus_workbench_panel_state_total",
+        value: 1,
+      })
+    );
+    expect(event.labels).toEqual({
+      route: "workbench.performance",
+      panel: "performance-summary",
+      service: "lotus-gateway",
+      operation: "performance.workspace.summary",
+      state: "ready",
+      freshness_bucket: "fresh",
+      supportability_state: "ready",
+    });
+    expect(Object.keys(event.labels)).not.toContain("portfolio_id");
+    expect(Object.keys(event.labels)).not.toContain("client_name");
+    expect(Object.keys(event.labels)).not.toContain("correlation_id");
+  });
+
+  it("records API duration, panel state, and hydration for successful observations", async () => {
+    await observeWorkbenchAnalyticsRequest(context, async () => ({
+      as_of_date: new Date().toISOString().slice(0, 10),
+      supportability_status: "READY",
+      state: "ready",
+      portfolio_id: "PF_1001",
+      client_name: "Sensitive Client",
+    }));
+
+    const events = getAnalyticsUiMetricEvents();
+    expect(events.map((event) => event.metric_name)).toEqual([
+      "lotus_workbench_api_request_duration_seconds",
+      "lotus_workbench_panel_state_total",
+      "lotus_workbench_panel_hydration_duration_seconds",
+    ]);
+    expect(events.every((event) => event.labels.panel === "performance-summary")).toBe(
+      true
+    );
+    expect(events.every((event) => !("portfolio_id" in event.labels))).toBe(true);
+    expect(events.every((event) => !("client_name" in event.labels))).toBe(true);
+
+    const renderedMetrics = renderAnalyticsUiPrometheusMetrics();
+    expect(renderedMetrics).toContain(
+      "lotus_workbench_panel_state_total{route=\"workbench.performance\""
+    );
+    expect(renderedMetrics).toContain(
+      "lotus_workbench_api_request_duration_seconds_sum"
+    );
+    expect(renderedMetrics).toContain(
+      "lotus_workbench_api_request_duration_seconds_bucket"
+    );
+    expect(renderedMetrics).not.toContain("portfolio_id");
+    expect(renderedMetrics).not.toContain("Sensitive Client");
+  });
+
+  it("records a bounded error state when a selected analytics request fails", async () => {
+    await expect(
+      observeWorkbenchAnalyticsRequest(context, async () => {
+        throw new Error("Failed to fetch performance workspace summary (503)");
+      })
+    ).rejects.toThrow("503");
+
+    expect(getAnalyticsUiMetricEvents()).toEqual([
+      expect.objectContaining({
+        metric_name: "lotus_workbench_api_request_duration_seconds",
+        labels: expect.objectContaining({
+          status_class: "5xx",
+          state: "error",
+          error_category: "server",
+        }),
+      }),
+      expect.objectContaining({
+        metric_name: "lotus_workbench_panel_state_total",
+        labels: expect.objectContaining({ state: "error", reason: "server" }),
+      }),
+    ]);
+  });
+});

--- a/tests/unit/metrics-route.test.ts
+++ b/tests/unit/metrics-route.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { GET } from "@/app/api/metrics/route";
+import {
+  recordAnalyticsUiPanelState,
+  resetAnalyticsUiMetricEvents,
+} from "@/features/analytics-observability/metrics";
+
+describe("metrics route", () => {
+  it("returns product-safe Prometheus text for implemented analytics UI metrics", async () => {
+    resetAnalyticsUiMetricEvents();
+    recordAnalyticsUiPanelState({
+      context: {
+        route: "workbench.risk",
+        panel: "risk-summary",
+        operation: "risk.summary",
+      },
+      state: "degraded",
+      reason: "source_partial",
+    });
+
+    const response = await GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    expect(body).toContain("# TYPE lotus_workbench_panel_state_total counter");
+    expect(body).toContain(
+      'lotus_workbench_panel_state_total{route="workbench.risk",panel="risk-summary"'
+    );
+    expect(body).not.toContain("portfolio_id");
+    expect(body).not.toContain("client_name");
+    resetAnalyticsUiMetricEvents();
+  });
+});

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -22,12 +22,17 @@ import {
   postWorkbenchPerformanceAdvisorBriefReviewActionClient,
   runReportBatchOnce,
 } from "../../src/features/workbench/api";
+import {
+  getAnalyticsUiMetricEvents,
+  resetAnalyticsUiMetricEvents,
+} from "../../src/features/analytics-observability/metrics";
 
 const expectedBaseUrl = "/api/bff/api/v1";
 
 describe("workbench api", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    resetAnalyticsUiMetricEvents();
   });
 
   it("calls sandbox session create endpoint", async () => {
@@ -297,7 +302,7 @@ describe("workbench api", () => {
             correlation_id: "corr-performance",
             contract_version: "v1",
             portfolio_id: "PF_1001",
-            as_of_date: "2026-02-24",
+            as_of_date: "2026-04-28",
             period: "3Y",
             report_start_date: "2023-02-25",
             report_end_date: "2026-02-24",
@@ -361,6 +366,33 @@ describe("workbench api", () => {
     expect(requestedUrl).toContain(
       "/api/bff/api/v1/workbench/PF_1001/performance/summary?period=3Y&chart_frequency=monthly&contribution_dimension=asset_class&attribution_dimension=asset_class&detail_basis=NET&benchmark_code=BMK_GLOBAL_BALANCED_60_40"
     );
+    expect(getAnalyticsUiMetricEvents()).toEqual([
+      expect.objectContaining({
+        metric_name: "lotus_workbench_api_request_duration_seconds",
+        labels: expect.objectContaining({
+          route: "workbench.performance",
+          panel: "performance-summary",
+          operation: "performance.workspace.summary",
+          state: "ready",
+          status_class: "2xx",
+        }),
+      }),
+      expect.objectContaining({
+        metric_name: "lotus_workbench_panel_state_total",
+        labels: expect.objectContaining({
+          panel: "performance-summary",
+          state: "ready",
+          freshness_bucket: expect.any(String),
+        }),
+      }),
+      expect.objectContaining({
+        metric_name: "lotus_workbench_panel_hydration_duration_seconds",
+        labels: expect.objectContaining({
+          panel: "performance-summary",
+          state: "ready",
+        }),
+      }),
+    ]);
   });
 
   it("uses the proxy path for client-side performance detail refreshes", async () => {

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -29,14 +29,16 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=ris
 
 - RFC-0108 analytics UI observability vocabulary is code-owned in
   `src/features/analytics-observability/contract.ts`.
-- The module defines allowed labels, forbidden fields, state vocabulary, and planned Workbench
-  metric-family names before any product telemetry is emitted.
+- Workbench emits first-wave local analytics UI metric events for selected performance summary,
+  performance details, and risk summary reads through `src/features/analytics-observability/metrics.ts`.
+- `/api/metrics` exposes the implemented Workbench analytics UI metric families in Prometheus text
+  format for platform scrape and dashboard/alert contracts.
 - Do not add panel, route, or browser telemetry labels outside that contract.
 - `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `trace_id`,
   `correlation_id`, request bodies, response bodies, and screen content must not become metric
   labels or browser event fields.
-- Workbench panel metrics, dashboard claims, attention events, audit events, and canonical browser
-  proof remain planned until later RFC-0108 slices promote them with evidence.
+- Gateway/backend metrics, attention events, audit events, and canonical browser proof remain planned
+  until later RFC-0108 slices promote them with evidence.
 
 ## Output paths
 


### PR DESCRIPTION
## Summary
- add bounded Workbench analytics UI metric event collection and Prometheus text export at /api/metrics
- instrument selected performance summary, performance details, and risk summary client analytics reads
- add state/freshness/supportability classification tests and sensitive-field exclusion checks
- update Workbench wiki operations truth for RFC-0108 Slice 5

## Validation
- npm run test -- tests/unit/analytics-observability-metrics.test.ts tests/unit/workbench-api.test.ts tests/unit/analytics-observability-contract.test.ts tests/unit/metrics-route.test.ts
- npm run typecheck
- npm run test (150 files, 644 tests)

## Tiering
- UI Product profile. Full local unit/integration command and typecheck passed before push; GitHub checks are authoritative for merge.