### PR TITLE
Implement RFC-0108 Slice 6 Workbench attention events

### DIFF
--- a/src/features/analytics-observability/contract.ts
+++ b/src/features/analytics-observability/contract.ts
@@ -85,6 +85,7 @@ export const WORKBENCH_ANALYTICS_UI_METRIC_FAMILIES = [
   "lotus_workbench_panel_hydration_duration_seconds",
   "lotus_workbench_panel_state_total",
   "lotus_workbench_api_request_duration_seconds",
+  "lotus_analytics_ui_attention_events_total",
 ] as const;
 
 export type WorkbenchAnalyticsUiMetricFamily =
@@ -94,6 +95,7 @@ export const WORKBENCH_ANALYTICS_UI_BROWSER_EVENTS = [
   "workbench.analytics.panel_hydration",
   "workbench.analytics.panel_state",
   "workbench.analytics.api_request",
+  "workbench.analytics.attention",
 ] as const;
 
 export type WorkbenchAnalyticsUiBrowserEvent =

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -1,5 +1,7 @@
 import {
+  type AnalyticsUiAttentionEventType,
   type AnalyticsUiAllowedLabel,
+  type AnalyticsUiSeverity,
   type AnalyticsUiState,
   type WorkbenchAnalyticsUiBrowserEvent,
   type WorkbenchAnalyticsUiMetricFamily,
@@ -56,6 +58,8 @@ export interface WorkbenchAnalyticsUiObservationContext {
 }
 
 const metricEvents: WorkbenchAnalyticsUiMetricEvent[] = [];
+const attentionDedupeKeys = new Set<string>();
+const panelFailureCounts = new Map<string, number>();
 
 export function classifyAnalyticsUiPanelState(
   input: AnalyticsUiPanelClassificationInput
@@ -194,6 +198,30 @@ export function recordAnalyticsUiApiRequest(params: {
   });
 }
 
+export function recordAnalyticsUiAttentionEvent(params: {
+  context: WorkbenchAnalyticsUiObservationContext;
+  attentionType: AnalyticsUiAttentionEventType;
+  severity: AnalyticsUiSeverity;
+  state: AnalyticsUiState;
+  reason: string;
+  freshnessBucket?: AnalyticsUiFreshnessBucket;
+  supportabilityState?: AnalyticsUiSupportabilityState;
+}): WorkbenchAnalyticsUiMetricEvent | undefined {
+  const labels = buildAttentionLabels(params);
+  const dedupeKey = JSON.stringify(labels);
+  if (attentionDedupeKeys.has(dedupeKey)) {
+    return undefined;
+  }
+  attentionDedupeKeys.add(dedupeKey);
+  return recordMetricEvent({
+    eventName: "workbench.analytics.attention",
+    metricName: "lotus_analytics_ui_attention_events_total",
+    value: 1,
+    context: params.context,
+    labels,
+  });
+}
+
 export async function observeWorkbenchAnalyticsRequest<T>(
   context: WorkbenchAnalyticsUiObservationContext,
   request: () => Promise<T>
@@ -230,6 +258,13 @@ export async function observeWorkbenchAnalyticsRequest<T>(
       freshnessBucket,
       supportabilityState,
     });
+    recordAttentionForObservation({
+      context,
+      state,
+      response,
+      freshnessBucket,
+      supportabilityState,
+    });
     return response;
   } catch (error) {
     const durationMs = nowMs() - startedAt;
@@ -251,6 +286,16 @@ export async function observeWorkbenchAnalyticsRequest<T>(
           ? classifyAnalyticsUiPanelState({ status: statusFromError(error) })
           : "error",
       reason: errorCategoryFromStatusClass(statusClass),
+    });
+    recordAttentionForObservation({
+      context,
+      state:
+        statusClass === "4xx"
+          ? classifyAnalyticsUiPanelState({ status: statusFromError(error) })
+          : "error",
+      reason: errorCategoryFromStatusClass(statusClass),
+      supportabilityState: "unknown",
+      freshnessBucket: "unknown",
     });
     throw error;
   }
@@ -275,7 +320,8 @@ export function getAnalyticsUiMetricSamples(): WorkbenchAnalyticsUiMetricSample[
       samples.set(sampleKey, {
         metric_name: event.metric_name,
         metric_type:
-          event.metric_name === "lotus_workbench_panel_state_total"
+          event.metric_name === "lotus_workbench_panel_state_total" ||
+          event.metric_name === "lotus_analytics_ui_attention_events_total"
             ? "counter"
             : "histogram",
         labels: event.labels,
@@ -296,6 +342,8 @@ export function renderAnalyticsUiPrometheusMetrics(): string {
     "# TYPE lotus_workbench_panel_state_total counter",
     "# HELP lotus_workbench_api_request_duration_seconds Selected Workbench analytics API request duration.",
     "# TYPE lotus_workbench_api_request_duration_seconds histogram",
+    "# HELP lotus_analytics_ui_attention_events_total Bounded analytics UI attention events for selected Workbench panels.",
+    "# TYPE lotus_analytics_ui_attention_events_total counter",
   ];
   for (const sample of samples) {
     lines.push(
@@ -316,6 +364,117 @@ export function renderAnalyticsUiPrometheusMetrics(): string {
 
 export function resetAnalyticsUiMetricEvents(): void {
   metricEvents.length = 0;
+  attentionDedupeKeys.clear();
+  panelFailureCounts.clear();
+}
+
+function recordAttentionForObservation(params: {
+  context: WorkbenchAnalyticsUiObservationContext;
+  state: AnalyticsUiState;
+  response?: unknown;
+  reason?: string;
+  freshnessBucket?: AnalyticsUiFreshnessBucket;
+  supportabilityState?: AnalyticsUiSupportabilityState;
+}): void {
+  const panelKey = `${params.context.route}:${params.context.panel}`;
+  if (params.state === "error") {
+    const nextFailureCount = (panelFailureCounts.get(panelKey) ?? 0) + 1;
+    panelFailureCounts.set(panelKey, nextFailureCount);
+    if (nextFailureCount >= 3) {
+      recordAnalyticsUiAttentionEvent({
+        context: params.context,
+        attentionType: "panel_repeated_failure",
+        severity: "action_required",
+        state: params.state,
+        reason: sanitizeAttentionReason(params.reason ?? "repeated_failure"),
+        freshnessBucket: params.freshnessBucket,
+        supportabilityState: params.supportabilityState,
+      });
+    }
+    return;
+  }
+
+  panelFailureCounts.delete(panelKey);
+  const reason = resolveAttentionReason(params.response, params.reason);
+  if (params.state === "stale") {
+    recordAnalyticsUiAttentionEvent({
+      context: params.context,
+      attentionType: "panel_stale",
+      severity: "warning",
+      state: params.state,
+      reason,
+      freshnessBucket: params.freshnessBucket,
+      supportabilityState: params.supportabilityState,
+    });
+    return;
+  }
+  if (params.state === "degraded") {
+    recordAnalyticsUiAttentionEvent({
+      context: params.context,
+      attentionType: "panel_degraded",
+      severity:
+        params.supportabilityState === "action_required" ? "action_required" : "warning",
+      state: params.state,
+      reason,
+      freshnessBucket: params.freshnessBucket,
+      supportabilityState: params.supportabilityState,
+    });
+    return;
+  }
+  if (params.state === "partial") {
+    recordAnalyticsUiAttentionEvent({
+      context: params.context,
+      attentionType: "source_partial",
+      severity: "warning",
+      state: params.state,
+      reason,
+      freshnessBucket: params.freshnessBucket,
+      supportabilityState: params.supportabilityState,
+    });
+  }
+}
+
+function buildAttentionLabels(params: {
+  attentionType: AnalyticsUiAttentionEventType;
+  severity: AnalyticsUiSeverity;
+  state: AnalyticsUiState;
+  reason: string;
+  freshnessBucket?: AnalyticsUiFreshnessBucket;
+  supportabilityState?: AnalyticsUiSupportabilityState;
+}): Partial<Record<AnalyticsUiAllowedLabel, string>> {
+  return buildAnalyticsUiLabels({
+    attention_type: params.attentionType,
+    severity: params.severity,
+    state: params.state,
+    reason: sanitizeAttentionReason(params.reason),
+    freshness_bucket: params.freshnessBucket ?? "unknown",
+    supportability_state: params.supportabilityState ?? "unknown",
+  });
+}
+
+function resolveAttentionReason(response: unknown, fallback?: string): string {
+  const warning = readFirstString(response, "warnings");
+  if (warning) {
+    return sanitizeAttentionReason(warning);
+  }
+  const partialFailureReason = readFirstObjectString(response, "partial_failures", [
+    "error_code",
+    "reason",
+    "source_service",
+  ]);
+  if (partialFailureReason) {
+    return sanitizeAttentionReason(partialFailureReason);
+  }
+  return sanitizeAttentionReason(fallback ?? "source_state");
+}
+
+function sanitizeAttentionReason(reason: string): string {
+  const normalized = reason
+    .trim()
+    .replace(/[^A-Za-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 80);
+  return normalized || "unknown";
 }
 
 function recordMetricEvent(params: {
@@ -350,6 +509,46 @@ function readStringProperty(value: unknown, property: string): string | undefine
   }
   const propertyValue = (value as Record<string, unknown>)[property];
   return typeof propertyValue === "string" && propertyValue ? propertyValue : undefined;
+}
+
+function readFirstString(value: unknown, property: string): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const propertyValue = (value as Record<string, unknown>)[property];
+  if (!Array.isArray(propertyValue)) {
+    return undefined;
+  }
+  const firstString = propertyValue.find(
+    (item): item is string => typeof item === "string" && item.length > 0
+  );
+  return firstString;
+}
+
+function readFirstObjectString(
+  value: unknown,
+  property: string,
+  keys: readonly string[]
+): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const propertyValue = (value as Record<string, unknown>)[property];
+  if (!Array.isArray(propertyValue)) {
+    return undefined;
+  }
+  for (const item of propertyValue) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    for (const key of keys) {
+      const candidate = (item as Record<string, unknown>)[key];
+      if (typeof candidate === "string" && candidate) {
+        return candidate;
+      }
+    }
+  }
+  return undefined;
 }
 
 function hasNonEmptyArrayProperty(value: unknown, property: string): boolean {

--- a/tests/unit/analytics-observability-contract.test.ts
+++ b/tests/unit/analytics-observability-contract.test.ts
@@ -24,6 +24,7 @@ describe("analytics UI observability contract", () => {
       "lotus_workbench_panel_hydration_duration_seconds",
       "lotus_workbench_panel_state_total",
       "lotus_workbench_api_request_duration_seconds",
+      "lotus_analytics_ui_attention_events_total",
     ]);
   });
 
@@ -38,6 +39,7 @@ describe("analytics UI observability contract", () => {
       "workbench.analytics.panel_hydration",
       "workbench.analytics.panel_state",
       "workbench.analytics.api_request",
+      "workbench.analytics.attention",
     ]);
     expect(ANALYTICS_UI_SEVERITY_LEVELS).toEqual([
       "info",

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -7,6 +7,7 @@ import {
   getAnalyticsUiMetricEvents,
   renderAnalyticsUiPrometheusMetrics,
   observeWorkbenchAnalyticsRequest,
+  recordAnalyticsUiAttentionEvent,
   recordAnalyticsUiPanelState,
   resetAnalyticsUiMetricEvents,
 } from "../../src/features/analytics-observability/metrics";
@@ -136,6 +137,88 @@ describe("analytics UI observability metrics", () => {
     );
     expect(renderedMetrics).not.toContain("portfolio_id");
     expect(renderedMetrics).not.toContain("Sensitive Client");
+  });
+
+  it("emits one bounded attention event for stale source-backed panel state", async () => {
+    await observeWorkbenchAnalyticsRequest(context, async () => ({
+      as_of_date: "2026-04-01",
+      state: "stale",
+      warnings: ["PERFORMANCE_STALE_SOURCE"],
+      portfolio_id: "PF_SENSITIVE",
+      client_name: "Sensitive Client",
+    }));
+
+    const attentionEvents = getAnalyticsUiMetricEvents().filter(
+      (event) => event.metric_name === "lotus_analytics_ui_attention_events_total"
+    );
+    expect(attentionEvents).toEqual([
+      expect.objectContaining({
+        event_name: "workbench.analytics.attention",
+        labels: expect.objectContaining({
+          route: "workbench.performance",
+          panel: "performance-summary",
+          attention_type: "panel_stale",
+          severity: "warning",
+          state: "stale",
+          reason: "PERFORMANCE_STALE_SOURCE",
+          freshness_bucket: "stale",
+        }),
+      }),
+    ]);
+    expect(JSON.stringify(attentionEvents)).not.toContain("PF_SENSITIVE");
+    expect(JSON.stringify(attentionEvents)).not.toContain("Sensitive Client");
+  });
+
+  it("deduplicates attention events by bounded label identity", () => {
+    const first = recordAnalyticsUiAttentionEvent({
+      context,
+      attentionType: "panel_degraded",
+      severity: "action_required",
+      state: "degraded",
+      reason: "Performance source unavailable for private client",
+      freshnessBucket: "unknown",
+      supportabilityState: "action_required",
+    });
+    const duplicate = recordAnalyticsUiAttentionEvent({
+      context,
+      attentionType: "panel_degraded",
+      severity: "action_required",
+      state: "degraded",
+      reason: "Performance source unavailable for private client",
+      freshnessBucket: "unknown",
+      supportabilityState: "action_required",
+    });
+
+    expect(first).toBeDefined();
+    expect(duplicate).toBeUndefined();
+    expect(getAnalyticsUiMetricEvents()).toHaveLength(1);
+    expect(getAnalyticsUiMetricEvents()[0].labels.reason).toBe(
+      "Performance_source_unavailable_for_private_client"
+    );
+  });
+
+  it("emits repeated-failure attention only after repeated selected panel failures", async () => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await expect(
+        observeWorkbenchAnalyticsRequest(context, async () => {
+          throw new Error("Failed to fetch performance workspace summary (503)");
+        })
+      ).rejects.toThrow("503");
+    }
+
+    const attentionEvents = getAnalyticsUiMetricEvents().filter(
+      (event) => event.metric_name === "lotus_analytics_ui_attention_events_total"
+    );
+    expect(attentionEvents).toEqual([
+      expect.objectContaining({
+        labels: expect.objectContaining({
+          attention_type: "panel_repeated_failure",
+          severity: "action_required",
+          state: "error",
+          reason: "server",
+        }),
+      }),
+    ]);
   });
 
   it("records a bounded error state when a selected analytics request fails", async () => {

--- a/tests/unit/metrics-route.test.ts
+++ b/tests/unit/metrics-route.test.ts
@@ -25,6 +25,7 @@ describe("metrics route", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/plain");
     expect(body).toContain("# TYPE lotus_workbench_panel_state_total counter");
+    expect(body).toContain("# TYPE lotus_analytics_ui_attention_events_total counter");
     expect(body).toContain(
       'lotus_workbench_panel_state_total{route="workbench.risk",panel="risk-summary"'
     );

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -31,14 +31,19 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=ris
   `src/features/analytics-observability/contract.ts`.
 - Workbench emits first-wave local analytics UI metric events for selected performance summary,
   performance details, and risk summary reads through `src/features/analytics-observability/metrics.ts`.
+- Workbench emits bounded local attention events and the
+  `lotus_analytics_ui_attention_events_total` counter for stale, degraded, partial-source, and
+  repeated-failure states on those selected analytics panels. Attention labels are deduplicated and
+  limited to governed route, panel, service, operation, state, reason, freshness, supportability,
+  attention type, and severity fields.
 - `/api/metrics` exposes the implemented Workbench analytics UI metric families in Prometheus text
   format for platform scrape and dashboard/alert contracts.
 - Do not add panel, route, or browser telemetry labels outside that contract.
 - `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `trace_id`,
   `correlation_id`, request bodies, response bodies, and screen content must not become metric
   labels or browser event fields.
-- Gateway/backend metrics, attention events, audit events, and canonical browser proof remain planned
-  until later RFC-0108 slices promote them with evidence.
+- Gateway/backend metrics, audit events, and canonical browser proof remain planned until later
+  RFC-0108 slices promote them with evidence.
 
 ## Output paths
 


### PR DESCRIPTION
## Summary
- Adds bounded Workbench analytics UI attention events and `lotus_analytics_ui_attention_events_total` for selected performance and risk analytics reads.
- Deduplicates attention events by governed label identity and escalates repeated panel failures only after the threshold is met.
- Updates Workbench wiki source with the implemented attention posture and remaining planned scope.

## Evidence
- `npm run test -- tests/unit/analytics-observability-metrics.test.ts tests/unit/analytics-observability-contract.test.ts tests/unit/metrics-route.test.ts tests/unit/workbench-api.test.ts` passed.
- `npm run test` passed: 150 files, 647 tests.
- `npm run typecheck` passed.
- `npm run lint` passed.

## Scope Boundaries
- Gateway/backend metrics, audit events, and canonical browser proof remain planned later RFC-0108 slices.
- No portfolio, client, trace, correlation, request/response body, or screen-content fields are emitted as attention labels.