### PR TITLE
Implement Workbench supportability reconciliation

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -135,7 +135,9 @@ Important validation expectations:
    `src/features/analytics-observability/metrics.ts`; keep the explicit observed-surface registry
    in sync when adding or retiring portfolio, performance, risk, or reporting operator panels, and
    never emit portfolio, client, session, report batch, trace, request body, response body, or
-   screen-content identifiers as metric labels.
+   screen-content identifiers as metric labels. The metrics helper consumes Gateway
+   `source_supportability` arrays for performance/risk freshness and supportability posture, with
+   stale source freshness taking precedence over ready source items.
 
 ### Visual Review Gate
 

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -241,6 +241,12 @@ assert numeric ranges, contribution reconciliation, governed attribution fallbac
 observation coverage, concentration coverage, rolling-window availability, and historical risk
 attribution residuals before screenshots are accepted as demo evidence.
 
+The summary also includes `supportabilityChecks` for Gateway-backed source supportability evidence.
+For performance and risk payloads, the validator records the bounded source service set, item count,
+stale count, partial count, action-required count, and aggregate supportability state derived from
+Gateway `source_supportability` arrays. Stale source supportability takes precedence over fresh
+source supportability so browser proof cannot mask upstream freshness degradation.
+
 The summary also includes `panelClassifications` for the product surfaces validated during the run.
 Panels must be classified as `ready`, `partial`, `unavailable`, or another explicit governed state.
 The validator fails if a supported panel is recorded as blank without a governed empty, partial, or

--- a/scripts/live/validation/calculation-sanity.mjs
+++ b/scripts/live/validation/calculation-sanity.mjs
@@ -30,6 +30,79 @@ function recordCalculationCheck(summary, description, evidence) {
   summary.calculationChecks.push({ description, ...evidence });
 }
 
+function readSourceSupportabilityItems(...payloads) {
+  return payloads.flatMap((payload) =>
+    Array.isArray(payload?.source_supportability) ? payload.source_supportability : []
+  );
+}
+
+function normalizeSupportabilityState(value) {
+  const normalized = typeof value === "string" ? value.toLowerCase() : "";
+  if (["ready", "supported", "ok", "complete"].includes(normalized)) {
+    return "ready";
+  }
+  if (["partial", "stale"].includes(normalized)) {
+    return "partial";
+  }
+  if (["blocked", "degraded", "unavailable", "unsupported", "action_required"].includes(normalized)) {
+    return "action_required";
+  }
+  return "unknown";
+}
+
+function summarizeSourceSupportability(items) {
+  let staleCount = 0;
+  let partialCount = 0;
+  let actionRequiredCount = 0;
+  const services = new Set();
+
+  for (const item of items) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    if (typeof item.source_service === "string" && item.source_service) {
+      services.add(item.source_service);
+    }
+    if (item.freshness_bucket === "stale") {
+      staleCount += 1;
+    }
+    const normalizedState = normalizeSupportabilityState(item.state ?? item.supportability_state);
+    if (normalizedState === "partial") {
+      partialCount += 1;
+    }
+    if (normalizedState === "action_required") {
+      actionRequiredCount += 1;
+    }
+  }
+
+  return {
+    itemCount: items.length,
+    services: [...services].sort(),
+    staleCount,
+    partialCount,
+    actionRequiredCount,
+    state:
+      actionRequiredCount > 0
+        ? "action_required"
+        : partialCount > 0 || staleCount > 0
+          ? "partial"
+          : items.length > 0
+            ? "ready"
+            : "unknown",
+  };
+}
+
+function recordSourceSupportabilityCheck(summary, panel, owner, items) {
+  const supportability = summarizeSourceSupportability(items);
+  summary.supportabilityChecks.push({
+    panel,
+    owner,
+    source: "gateway.source_supportability",
+    ...supportability,
+  });
+  return supportability;
+}
+
 export function assertPerformanceCalculationSanity({
   summary,
   performanceSummary,
@@ -106,12 +179,21 @@ export function assertPerformanceCalculationSanity({
     attributionState: attributionCapability.state,
     attributionRows,
   });
+  const performanceSupportability = recordSourceSupportabilityCheck(
+    summary,
+    "performance.summary",
+    "lotus-gateway",
+    readSourceSupportabilityItems(performanceSummary, performanceDetails)
+  );
 
   recordPanelClassification("performance.summary", "ready", "lotus-performance", {
     returnPathRows: performanceDetails.net_chart.length,
+    sourceSupportabilityState: performanceSupportability.state,
+    sourceSupportabilityItems: performanceSupportability.itemCount,
   });
   recordPanelClassification("performance.analysis.contribution", "ready", "lotus-performance", {
     contributionRows: contributionRows.length,
+    sourceSupportabilityState: performanceSupportability.state,
   });
   recordPanelClassification(
     "performance.analysis.attribution",
@@ -244,9 +326,17 @@ export function assertRiskCalculationSanity({
     rollingWindowsWithLatestVolatility,
     attributionContributorCount: contributors.length,
   });
+  const riskSupportability = recordSourceSupportabilityCheck(
+    summary,
+    "performance.risk.snapshot",
+    "lotus-gateway",
+    readSourceSupportabilityItems(riskSummary, concentration, drawdown, rolling, attribution)
+  );
 
   recordPanelClassification("performance.risk.snapshot", "ready", "lotus-risk", {
     readyMetricCount: readyMetrics.length,
+    sourceSupportabilityState: riskSupportability.state,
+    sourceSupportabilityItems: riskSupportability.itemCount,
   });
   recordPanelClassification("performance.risk.concentration", "ready", "lotus-risk", {
     issuerCoverageRatio: concentrationPayload.issuer_concentration?.coverage_ratio_current,

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -256,6 +256,11 @@ export function deriveAnalyticsUiFreshnessBucket(response: unknown): AnalyticsUi
     return normalizeFreshnessBucket(direct);
   }
 
+  const sourceSupportabilityFreshness = deriveSourceSupportabilityFreshnessBucket(response);
+  if (sourceSupportabilityFreshness !== "unknown") {
+    return sourceSupportabilityFreshness;
+  }
+
   const supportability = readObjectProperty(response, "supportability");
   const supportabilityFreshness = readStringProperty(supportability, "freshness_bucket");
   if (supportabilityFreshness) {
@@ -278,6 +283,12 @@ export function deriveAnalyticsUiSupportabilityState(
   if (supportabilityStatus) {
     return normalizeSupportabilityState(supportabilityStatus);
   }
+  const sourceSupportabilityState = deriveArraySupportabilityState(
+    readArrayProperty(response, "source_supportability")
+  );
+  if (sourceSupportabilityState !== "unknown") {
+    return sourceSupportabilityState;
+  }
   const supportability = readObjectProperty(response, "supportability");
   const nestedSupportabilityState =
     readStringProperty(supportability, "state") ??
@@ -296,6 +307,27 @@ export function deriveAnalyticsUiSupportabilityState(
     return "partial";
   }
   return "unknown";
+}
+
+function deriveSourceSupportabilityFreshnessBucket(response: unknown): AnalyticsUiFreshnessBucket {
+  let hasFreshSource = false;
+  for (const item of readArrayProperty(response, "source_supportability")) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const freshnessBucket = readStringProperty(item, "freshness_bucket");
+    if (!freshnessBucket) {
+      continue;
+    }
+    const normalized = normalizeFreshnessBucket(freshnessBucket);
+    if (normalized === "stale") {
+      return "stale";
+    }
+    if (normalized === "fresh") {
+      hasFreshSource = true;
+    }
+  }
+  return hasFreshSource ? "fresh" : "unknown";
 }
 
 export function recordAnalyticsUiPanelHydration(params: {

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -315,6 +315,53 @@ describe("analytics UI observability metrics", () => {
     expect(JSON.stringify(events)).not.toContain("CIF_SENSITIVE");
   });
 
+  it("derives stale and partial posture from Gateway source supportability", async () => {
+    await observeWorkbenchAnalyticsRequest(context, async () => ({
+      source_supportability: [
+        {
+          source_service: "lotus-performance",
+          operation: "performance.twr",
+          state: "ready",
+          freshness_bucket: "fresh",
+        },
+        {
+          source_service: "lotus-performance",
+          operation: "performance.attribution",
+          state: "partial",
+          freshness_bucket: "stale",
+          reason: "attribution_fallback_available",
+        },
+      ],
+      portfolio_id: "PF_SENSITIVE",
+      trace_id: "TRACE_SENSITIVE",
+    }));
+
+    const events = getAnalyticsUiMetricEvents();
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          metric_name: "lotus_workbench_panel_state_total",
+          labels: expect.objectContaining({
+            state: "stale",
+            freshness_bucket: "stale",
+            supportability_state: "partial",
+          }),
+        }),
+        expect.objectContaining({
+          metric_name: "lotus_analytics_ui_attention_events_total",
+          labels: expect.objectContaining({
+            attention_type: "panel_stale",
+            severity: "warning",
+            state: "stale",
+            supportability_state: "partial",
+          }),
+        }),
+      ])
+    );
+    expect(JSON.stringify(events)).not.toContain("PF_SENSITIVE");
+    expect(JSON.stringify(events)).not.toContain("TRACE_SENSITIVE");
+  });
+
   it("deduplicates attention events by bounded label identity", () => {
     const first = recordAnalyticsUiAttentionEvent({
       context,

--- a/tests/unit/live-validation-calculation-sanity.test.ts
+++ b/tests/unit/live-validation-calculation-sanity.test.ts
@@ -6,12 +6,14 @@ import {
 type TestValidationSummary = {
   calculationChecks: Array<Record<string, unknown>>;
   panelClassifications: Array<Record<string, unknown>>;
+  supportabilityChecks: Array<Record<string, unknown>>;
 };
 
 function createSummary(): TestValidationSummary {
   return {
     calculationChecks: [],
     panelClassifications: [],
+    supportabilityChecks: [],
   };
 }
 
@@ -45,6 +47,14 @@ describe("live validation calculation sanity helpers", () => {
             reason: "lineage evidence remains partial",
           },
         },
+        source_supportability: [
+          {
+            source_service: "lotus-performance",
+            operation: "performance.twr",
+            state: "ready",
+            freshness_bucket: "fresh",
+          },
+        ],
       },
       performanceDetails: {
         net_chart: [{}, {}, {}, {}],
@@ -69,6 +79,14 @@ describe("live validation calculation sanity helpers", () => {
             },
           ],
         },
+        source_supportability: [
+          {
+            source_service: "lotus-performance",
+            operation: "performance.attribution",
+            state: "partial",
+            freshness_bucket: "stale",
+          },
+        ],
       },
     });
 
@@ -83,6 +101,18 @@ describe("live validation calculation sanity helpers", () => {
         expect.objectContaining({ panel: "performance.evidence", state: "partial" }),
       ])
     );
+    expect(summary.supportabilityChecks).toEqual([
+      expect.objectContaining({
+        panel: "performance.summary",
+        owner: "lotus-gateway",
+        source: "gateway.source_supportability",
+        state: "partial",
+        itemCount: 2,
+        staleCount: 1,
+        partialCount: 1,
+        services: ["lotus-performance"],
+      }),
+    ]);
   });
 
   it("fails performance attribution when governed fallback is missing", () => {
@@ -145,8 +175,24 @@ describe("live validation calculation sanity helpers", () => {
             },
           ],
         },
+        source_supportability: [
+          {
+            source_service: "lotus-risk",
+            operation: "risk.summary",
+            state: "ready",
+            freshness_bucket: "fresh",
+          },
+        ],
       },
       concentration: {
+        source_supportability: [
+          {
+            source_service: "lotus-risk",
+            operation: "risk.concentration",
+            state: "ready",
+            freshness_bucket: "fresh",
+          },
+        ],
         payload: {
           portfolio_concentration: { hhi_current: 1356 },
           issuer_concentration: { coverage_ratio_current: 0.99 },
@@ -154,6 +200,14 @@ describe("live validation calculation sanity helpers", () => {
         },
       },
       drawdown: {
+        source_supportability: [
+          {
+            source_service: "lotus-risk",
+            operation: "risk.drawdown",
+            state: "ready",
+            freshness_bucket: "fresh",
+          },
+        ],
         payload: {
           periods: [
             {
@@ -165,6 +219,14 @@ describe("live validation calculation sanity helpers", () => {
         },
       },
       rolling: {
+        source_supportability: [
+          {
+            source_service: "lotus-risk",
+            operation: "risk.rolling",
+            state: "ready",
+            freshness_bucket: "fresh",
+          },
+        ],
         payload: {
           periods: [
             {
@@ -180,6 +242,14 @@ describe("live validation calculation sanity helpers", () => {
         },
       },
       attribution: {
+        source_supportability: [
+          {
+            source_service: "lotus-risk",
+            operation: "risk.attribution",
+            state: "ready",
+            freshness_bucket: "fresh",
+          },
+        ],
         payload: {
           periods: [
             {
@@ -208,6 +278,16 @@ describe("live validation calculation sanity helpers", () => {
         }),
       ])
     );
+    expect(summary.supportabilityChecks).toEqual([
+      expect.objectContaining({
+        panel: "performance.risk.snapshot",
+        owner: "lotus-gateway",
+        source: "gateway.source_supportability",
+        state: "ready",
+        itemCount: 5,
+        services: ["lotus-risk"],
+      }),
+    ]);
   });
 
   it("fails risk attribution when the residual breaches the governed tolerance", () => {

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -40,8 +40,10 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=ris
   limited to governed route, panel, service, operation, state, reason, freshness, supportability,
   attention type, and severity fields.
 - Workbench derives supported-read support state from source-shaped metadata such as
-  `supportability.state`, `supportability.freshness_bucket`, and supportability item arrays before
-  recording panel state, hydration, and attention metrics.
+  `supportability.state`, `supportability.freshness_bucket`, supportability item arrays, and
+  Gateway `source_supportability` arrays before recording panel state, hydration, and attention
+  metrics. Any stale source supportability item takes precedence over fresh source items so stale
+  upstream posture cannot be hidden by another ready source.
 - `/api/metrics` exposes the implemented Workbench analytics UI metric families in Prometheus text
   format for platform scrape and dashboard/alert contracts.
 - Do not add panel, route, or browser telemetry labels outside that contract.
@@ -49,12 +51,12 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=ris
   `report_job_id`, `session_id`, `trace_id`, `correlation_id`, request bodies, response bodies,
   and screen content must not become metric labels or browser event fields.
 - Canonical browser proof for the supported Slice 14 Portfolio, Performance, Risk, and
-  report-batch reads has passed for `PB_SG_GLOBAL_BAL_001`; Gateway/backend metrics, audit
-  completion, full RFC-0079 risk/evidence scope, and residual freshness reconciliation remain
-  governed by later RFC-0108 evidence. The performance evidence surface now renders Gateway-backed
-  RFC-0079 product context for as-of date, period, basis, benchmark, source services, freshness,
-  methodology, calculation versions, coverage, fallbacks, and limitations where the Gateway
-  evidence contract provides it.
+  report-batch reads has passed for `PB_SG_GLOBAL_BAL_001`; full RFC-0079 risk/evidence scope
+  remains governed by later RFC-0108 evidence. The performance evidence surface now renders
+  Gateway-backed RFC-0079 product context for as-of date, period, basis, benchmark, source services,
+  freshness, methodology, calculation versions, coverage, fallbacks, and limitations where the
+  Gateway evidence contract provides it. Canonical validation records `supportabilityChecks` for
+  Gateway `source_supportability` evidence on performance and risk payloads.
 
 ## Output paths
 


### PR DESCRIPTION
## Summary

Implements the Workbench side of RFC-0108 source supportability reconciliation for Gateway-backed performance and risk payloads.

- derives analytics UI freshness and supportability from Gateway `source_supportability` arrays, with stale source evidence taking precedence over fresh evidence
- records canonical validation `supportabilityChecks` for performance and risk payload source services, item counts, stale/partial/action-required counts, and aggregate state
- updates the operator runbook, canonical runtime guide, and repository context so the new evidence path is explicit

## Validation

- `npm test -- --run tests/unit/analytics-observability-metrics.test.ts tests/unit/live-validation-calculation-sanity.test.ts` passed: 17 tests
- `npm run typecheck` passed
- `npm run lint` passed
- `git diff --check` passed, with only existing LF-to-CRLF working-copy warnings
- `make check` passed: lint, typecheck, coverage, and Next build. Coverage run reported 150 test files and 652 tests passed.
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` reported expected pre-merge wiki drift for `Operations-Runbook.md` because this PR updates repo-authored wiki source.

## Canonical Runtime Evidence

Ran `npm run live:stack:up:validate`.

The governed runtime reached the live validation stage and passed canonical host, Gateway readiness, Workbench portfolio/performance route, manage/report readiness, manage/report capability, Gateway foundation workspace, platform capabilities, workbench overview, Gateway performance summary, Gateway risk summary, and Gateway advisor-brief route probes.

The run then failed on the existing advisor-brief workflow-pack review-action proof. Gateway returned HTTP 409 for `ACCEPT` because the live workflow-pack payload was not reviewable:

- `workflow_pack_run.runtime_state`: `FAILED`
- `workflow_pack_run.review_state`: `AWAITING_REVIEW`
- `workflow_pack_run.allowed_review_actions`: `[]`
- `workflow_pack_run.supportability_status`: `ACTION_REQUIRED`
- `workflow_pack_task_flow.flow_status`: `FAILED`

I did not weaken the validator or hide this. The stack was stopped cleanly with `npm run live:stack:down`.

## Wiki

Repo-local wiki source changed. After merge to `main`, publish with:

`powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -Publish -Repository lotus-workbench`
