### PR TITLE
Default canonical AI proof to deterministic env

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -111,9 +111,10 @@ The canonical bring-up script also accepts `-SeedWaitSeconds` when the governed 
 drain window than the default `900` seconds.
 
 The canonical bring-up script accepts `-LotusAiEnvFile` to make the `lotus-ai` provider posture
-explicit for proof runs. Use `.env.example` for deterministic provider-disabled front-office proof.
-Use the repo-local `.env` only when the required live provider dependency, such as the `local-llm`
-Ollama compose profile and model, is intentionally running.
+explicit for proof runs. It defaults to `.env.example` for deterministic provider-disabled
+front-office proof, even when the local `lotus-ai/.env` requests a live or local provider. Use the
+repo-local `.env` only when the required live provider dependency, such as the `local-llm` Ollama
+compose profile and model, is intentionally running.
 
 When a prior local RFC-086 load/performance run has left stale `lotus-core` Kafka or Postgres
 state behind, use `-CleanCoreState` on the startup script to run `docker compose down -v

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -3,7 +3,7 @@ param(
   [string]$PortfolioId = "PB_SG_GLOBAL_BAL_001",
   [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40",
   [string]$ScreenshotDirectory = "",
-  [string]$LotusAiEnvFile = "",
+  [string]$LotusAiEnvFile = ".env.example",
   [int]$SeedWaitSeconds = 900,
   [switch]$CleanCoreState,
   [switch]$BuildImages,
@@ -130,6 +130,7 @@ if ($BuildImages) {
   $composeUpCommand = "$composeUpCommand --build"
 }
 $resolvedLotusAiEnvFile = Resolve-LotusAiEnvFile -EnvFile $LotusAiEnvFile
+Write-Host "Using lotus-ai env file for canonical proof: $resolvedLotusAiEnvFile"
 Invoke-RepoCommand $coreRepo $composeUpCommand
 Invoke-RepoCommand $performanceRepo $composeUpCommand
 Invoke-RepoCommand $riskRepo $composeUpCommand

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -40,6 +40,8 @@ describe("canonical live validation script", () => {
     );
 
     expect(script).toContain("[int]$SeedWaitSeconds = 900");
+    expect(script).toContain('[string]$LotusAiEnvFile = ".env.example"');
+    expect(script).toContain("Using lotus-ai env file for canonical proof");
     expect(script).toContain("[switch]$CleanCoreState");
     expect(script).toContain("$global:LASTEXITCODE = 0");
     expect(script).toContain("Command failed with exit code $LASTEXITCODE");

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -17,6 +17,10 @@ npm run live:validate
 npm run live:stack:down
 ```
 
+The canonical startup script defaults `lotus-ai` to `.env.example` for deterministic
+provider-disabled proof, even if a local `lotus-ai/.env` asks for a live or local provider. Pass
+`-LotusAiEnvFile .env` only when the required provider dependency is intentionally running.
+
 ## Browser-facing probes
 
 ```txt


### PR DESCRIPTION
## Summary
- default canonical front-office startup to \lotus-ai/.env.example\ so local live-provider \.env\ state cannot break deterministic proof runs
- print the resolved AI env file in startup output for auditability
- update runtime docs and repo-authored wiki source with the deterministic provider-disabled posture

## Evidence
- \
pm test -- --run tests/unit/live-canonical-validation-script.test.ts tests/unit/live-validation-workflow-pack-proof.test.ts\
- \git diff --check\
- \
pm run typecheck\
- \
pm run lint\
- \
pm run live:validate\ passed for \PB_SG_GLOBAL_BAL_001\; screenshots written to \output/playwright/live-canonical\

## Wiki
- Repo-authored wiki source updated: \wiki/Operations-Runbook.md\
- \Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench\ reports expected publication drift for \Operations-Runbook.md\ until this PR is merged and wiki publication runs.