### PR TITLE
Consume portfolio supportability posture

### DIFF
--- a/src/apps/portfolio/api.ts
+++ b/src/apps/portfolio/api.ts
@@ -130,6 +130,7 @@ type PortfolioActivitySummaryResponse = NonNullable<PortfolioWorkspace["activity
 
 type PortfolioReadinessResponse = {
   indicators: NonNullable<PortfolioWorkspace["readiness_indicators"]>;
+  supportability?: PortfolioWorkspace["supportability"];
 };
 
 type PortfolioWorkflowResponse = {
@@ -190,6 +191,7 @@ type PortfolioWorkspaceDetailedDetails = Pick<
   | "recent_transactions"
   | "cashflow_outlook"
   | "readiness_indicators"
+  | "supportability"
   | "exception_summaries"
   | "insights"
   | "workflow_actions"
@@ -252,6 +254,7 @@ export async function getPortfolioWorkspaceShell(
         reporting: summaryPayload.reporting,
       },
       readiness_indicators: undefined,
+      supportability: undefined,
       workflow_cues: summaryPayload.workflow_cues,
       workflow_actions: undefined,
       warnings: summaryPayload.warnings,
@@ -405,6 +408,7 @@ export async function getPortfolioWorkspaceDetailedDetails(
       recent_transactions: transactionsPayload.transactions,
       cashflow_outlook: liquidityPayload.cashflow_outlook,
       readiness_indicators: readinessPayload?.indicators ?? undefined,
+      supportability: readinessPayload?.supportability ?? undefined,
       exception_summaries: insightsPayload?.exception_summaries ?? undefined,
       insights: insightsPayload?.insights ?? undefined,
       workflow_actions: workflowPayload?.actions ?? undefined,

--- a/src/apps/portfolio/types.ts
+++ b/src/apps/portfolio/types.ts
@@ -118,6 +118,17 @@ export type PortfolioReadinessIndicator = {
   href: string;
 };
 
+export type PortfolioSupportabilitySummary = {
+  feature_key: "core.observability.portfolio_supportability" | string;
+  state: string;
+  reason: string;
+  freshness_bucket: "fresh" | "stale" | "unknown" | string;
+  ready_domains: number;
+  pending_domains: number;
+  blocked_domains: number;
+  no_activity_domains: number;
+};
+
 export type PortfolioExceptionSummary = {
   key: string;
   title: string;
@@ -375,6 +386,7 @@ export type PortfolioWorkspace = {
     };
   };
   readiness_indicators?: PortfolioReadinessIndicator[];
+  supportability?: PortfolioSupportabilitySummary | null;
   exception_summaries?: PortfolioExceptionSummary[];
   insights?: PortfolioInsight[];
   operations?: {

--- a/tests/unit/portfolio-api.test.ts
+++ b/tests/unit/portfolio-api.test.ts
@@ -601,6 +601,16 @@ describe("portfolio api", () => {
             indicators: [
               { key: "holdings", label: "Holdings", status: "Ready", href: "#portfolio-insights" },
             ],
+            supportability: {
+              feature_key: "core.observability.portfolio_supportability",
+              state: "degraded",
+              reason: "portfolio_supportability_pending",
+              freshness_bucket: "fresh",
+              ready_domains: 3,
+              pending_domains: 1,
+              blocked_domains: 0,
+              no_activity_domains: 0,
+            },
           });
         }
 
@@ -702,6 +712,16 @@ describe("portfolio api", () => {
     expect(merged.cash_balances?.[0].market_value_base).toBe(66122);
     expect(merged.recent_transactions[0].transaction_id).toBe("TX_1");
     expect(merged.readiness_indicators?.[0].status).toBe("Ready");
+    expect(merged.supportability).toEqual({
+      feature_key: "core.observability.portfolio_supportability",
+      state: "degraded",
+      reason: "portfolio_supportability_pending",
+      freshness_bucket: "fresh",
+      ready_domains: 3,
+      pending_domains: 1,
+      blocked_domains: 0,
+      no_activity_domains: 0,
+    });
     expect(merged.insights?.[0].key).toBe("cash-above-target");
     expect(merged.exception_summaries?.[0].key).toBe("pricing");
     expect(merged.workflow_actions?.[0].title).toBe("Review performance");
@@ -721,6 +741,24 @@ describe("portfolio api", () => {
     expect(readinessRequestUrl).toContain("as_of_date=2026-03-28");
     expect(insightsRequestUrl).toContain("as_of_date=2026-03-28");
     expect(workflowRequestUrl).toContain("as_of_date=2026-03-28");
+    expect(getAnalyticsUiMetricEvents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          metric_name: "lotus_workbench_panel_state_total",
+          labels: expect.objectContaining({
+            route: "workbench.portfolio",
+            panel: "portfolio-readiness",
+            operation: "portfolio.readiness",
+            state: "degraded",
+            freshness_bucket: "fresh",
+            supportability_state: "action_required",
+          }),
+        }),
+      ])
+    );
+    const metricsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricsJson).not.toContain("MANUAL_PB_USD_001");
+    expect(metricsJson).not.toContain("MANUAL_CIF_001");
   });
 
   it("requests the transaction ledger with scoped filter parameters", async () => {


### PR DESCRIPTION
## Summary
- type the Gateway portfolio readiness supportability payload in Workbench portfolio models
- preserve readiness supportability through detailed portfolio workspace merging
- add metric proof that `portfolio.readiness` records source-backed degraded/fresh posture without sensitive labels

## Validation
- `npm test -- --run tests/unit/portfolio-api.test.ts tests/unit/analytics-observability-metrics.test.ts` (28 passed)
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

## RFC-0108
This consumes the Gateway source-owned portfolio supportability posture for Workbench analytics UI observability and keeps full all-surface promotion planned until the remaining surfaces are separately certified.