### PR TITLE
feat: surface manage supportability in portfolio UI

### DIFF
--- a/src/apps/portfolio/components/portfolio-performance-snapshot-module.tsx
+++ b/src/apps/portfolio/components/portfolio-performance-snapshot-module.tsx
@@ -51,7 +51,7 @@ export default function PortfolioPerformanceSnapshotModule({
     performance?.sparkline_points?.length
       ? `${performance.sparkline_points.length} source-backed observations`
       : "Open Performance workspace for source-backed return path detail.";
-  const operationalSupport = getOperationalSupportLine(reportingRowCount, rebalance?.status ?? null);
+  const operationalSupport = getOperationalSupportLine(reportingRowCount, rebalance);
   const compactContextLine = buildCompactContextLine({
     benchmarkLabel,
     moneyWeightedMethod: performance?.money_weighted_method ?? null,
@@ -274,12 +274,23 @@ function buildPerformanceWorkspaceHref({
 
 function getOperationalSupportLine(
   reportingRowCount: number,
-  rebalanceStatus: string | null
+  rebalance: PortfolioWorkspace["rebalance"]
 ) {
   const parts = [`${reportingRowCount} report row${reportingRowCount === 1 ? "" : "s"}`];
 
-  if (rebalanceStatus) {
-    parts.push(`Rebalance ${formatPortfolioToken(rebalanceStatus)}`);
+  if (rebalance?.status) {
+    parts.push(`Rebalance ${formatPortfolioToken(rebalance.status)}`);
+  }
+
+  const supportability = rebalance?.supportability;
+  if (supportability?.state) {
+    const supportabilityParts = [
+      formatPortfolioToken(supportability.state),
+      supportability.freshness_bucket ? formatPortfolioToken(supportability.freshness_bucket) : null,
+    ].filter(Boolean);
+    if (supportabilityParts.length > 0) {
+      parts.push(`Action Register ${supportabilityParts.join(", ")}`);
+    }
   }
 
   return parts.join(" • ");

--- a/src/apps/portfolio/types.ts
+++ b/src/apps/portfolio/types.ts
@@ -129,6 +129,16 @@ export type PortfolioSupportabilitySummary = {
   no_activity_domains: number;
 };
 
+export type PortfolioRebalanceSupportabilitySummary = {
+  feature_key: "manage.observability.action_register_supportability" | string;
+  state: string;
+  reason: string | null;
+  freshness_bucket: "fresh" | "stale" | "unknown" | string | null;
+  run_count: number | null;
+  operation_count: number | null;
+  workflow_decision_count: number | null;
+};
+
 export type PortfolioExceptionSummary = {
   key: string;
   title: string;
@@ -349,6 +359,7 @@ export type PortfolioWorkspace = {
     status: string;
     last_run_at_utc: string | null;
     last_rebalance_run_id: string | null;
+    supportability?: PortfolioRebalanceSupportabilitySummary | null;
   } | null;
   control_capabilities?: {
     historical_snapshots: {

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -261,6 +261,12 @@ export function deriveAnalyticsUiFreshnessBucket(response: unknown): AnalyticsUi
     return sourceSupportabilityFreshness;
   }
 
+  const nestedSourceSupportabilityFreshness =
+    deriveNestedSourceSupportabilityFreshnessBucket(response);
+  if (nestedSourceSupportabilityFreshness !== "unknown") {
+    return nestedSourceSupportabilityFreshness;
+  }
+
   const supportability = readObjectProperty(response, "supportability");
   const supportabilityFreshness = readStringProperty(supportability, "freshness_bucket");
   if (supportabilityFreshness) {
@@ -289,6 +295,10 @@ export function deriveAnalyticsUiSupportabilityState(
   if (sourceSupportabilityState !== "unknown") {
     return sourceSupportabilityState;
   }
+  const nestedSourceSupportabilityState = deriveNestedSourceSupportabilityState(response);
+  if (nestedSourceSupportabilityState !== "unknown") {
+    return nestedSourceSupportabilityState;
+  }
   const supportability = readObjectProperty(response, "supportability");
   const nestedSupportabilityState =
     readStringProperty(supportability, "state") ??
@@ -310,11 +320,18 @@ export function deriveAnalyticsUiSupportabilityState(
 }
 
 function deriveSourceSupportabilityFreshnessBucket(response: unknown): AnalyticsUiFreshnessBucket {
+  return deriveSupportabilityFreshnessBucket(readArrayProperty(response, "source_supportability"));
+}
+
+function deriveNestedSourceSupportabilityFreshnessBucket(
+  response: unknown
+): AnalyticsUiFreshnessBucket {
+  return deriveSupportabilityFreshnessBucket(readNestedSupportabilityObjects(response));
+}
+
+function deriveSupportabilityFreshnessBucket(items: unknown[]): AnalyticsUiFreshnessBucket {
   let hasFreshSource = false;
-  for (const item of readArrayProperty(response, "source_supportability")) {
-    if (!item || typeof item !== "object") {
-      continue;
-    }
+  for (const item of items) {
     const freshnessBucket = readStringProperty(item, "freshness_bucket");
     if (!freshnessBucket) {
       continue;
@@ -328,6 +345,20 @@ function deriveSourceSupportabilityFreshnessBucket(response: unknown): Analytics
     }
   }
   return hasFreshSource ? "fresh" : "unknown";
+}
+
+function deriveNestedSourceSupportabilityState(response: unknown): AnalyticsUiSupportabilityState {
+  return deriveArraySupportabilityState(readNestedSupportabilityObjects(response));
+}
+
+function readNestedSupportabilityObjects(response: unknown): Array<Record<string, unknown>> {
+  const items: Array<Record<string, unknown>> = [];
+  const rebalance = readObjectProperty(response, "rebalance");
+  const rebalanceSupportability = readObjectProperty(rebalance, "supportability");
+  if (rebalanceSupportability) {
+    items.push(rebalanceSupportability);
+  }
+  return items;
 }
 
 export function recordAnalyticsUiPanelHydration(params: {

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -315,6 +315,51 @@ describe("analytics UI observability metrics", () => {
     expect(JSON.stringify(events)).not.toContain("CIF_SENSITIVE");
   });
 
+  it("records rebalance source supportability state without sensitive labels", async () => {
+    await observeWorkbenchAnalyticsRequest(context, async () => ({
+      as_of_date: new Date().toISOString().slice(0, 10),
+      rebalance: {
+        status: "PENDING_REVIEW",
+        supportability: {
+          feature_key: "manage.observability.action_register_supportability",
+          state: "degraded",
+          reason: "action_register_stale",
+          freshness_bucket: "stale",
+          run_count: 4,
+          operation_count: 12,
+          workflow_decision_count: 3,
+        },
+      },
+      portfolio_id: "PF_SENSITIVE",
+      client_id: "CIF_SENSITIVE",
+    }));
+
+    const events = getAnalyticsUiMetricEvents();
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          metric_name: "lotus_workbench_panel_state_total",
+          labels: expect.objectContaining({
+            state: "stale",
+            freshness_bucket: "stale",
+            supportability_state: "action_required",
+          }),
+        }),
+        expect.objectContaining({
+          metric_name: "lotus_analytics_ui_attention_events_total",
+          labels: expect.objectContaining({
+            attention_type: "panel_stale",
+            severity: "warning",
+            state: "stale",
+            supportability_state: "action_required",
+          }),
+        }),
+      ])
+    );
+    expect(JSON.stringify(events)).not.toContain("PF_SENSITIVE");
+    expect(JSON.stringify(events)).not.toContain("CIF_SENSITIVE");
+  });
+
   it("derives stale and partial posture from Gateway source supportability", async () => {
     await observeWorkbenchAnalyticsRequest(context, async () => ({
       source_supportability: [

--- a/tests/unit/portfolio-api.test.ts
+++ b/tests/unit/portfolio-api.test.ts
@@ -67,6 +67,15 @@ describe("portfolio api", () => {
               status: "PENDING_REVIEW",
               last_run_at_utc: "2026-03-27T12:00:00Z",
               last_rebalance_run_id: "rr_100",
+              supportability: {
+                feature_key: "manage.observability.action_register_supportability",
+                state: "healthy",
+                reason: "action_register_current",
+                freshness_bucket: "fresh",
+                run_count: 4,
+                operation_count: 12,
+                workflow_decision_count: 3,
+              },
             },
             control_capabilities: {
               historical_snapshots: {
@@ -150,6 +159,15 @@ describe("portfolio api", () => {
       status: "PENDING_REVIEW",
       last_run_at_utc: "2026-03-27T12:00:00Z",
       last_rebalance_run_id: "rr_100",
+      supportability: {
+        feature_key: "manage.observability.action_register_supportability",
+        state: "healthy",
+        reason: "action_register_current",
+        freshness_bucket: "fresh",
+        run_count: 4,
+        operation_count: 12,
+        workflow_decision_count: 3,
+      },
     });
     expect(shell?.control_capabilities?.historical_snapshots.state).toBe("partial");
     expect(shell?.control_capabilities?.reporting_currency_restatement.supported_currencies).toEqual([
@@ -182,8 +200,9 @@ describe("portfolio api", () => {
             route: "workbench.portfolio",
             panel: "portfolio-workspace-shell",
             operation: "portfolio.workspace.shell",
-            state: "stale",
-            freshness_bucket: "stale",
+            state: "ready",
+            freshness_bucket: "fresh",
+            supportability_state: "ready",
           }),
         }),
       ])

--- a/tests/unit/portfolio-performance-snapshot-module.test.tsx
+++ b/tests/unit/portfolio-performance-snapshot-module.test.tsx
@@ -150,7 +150,20 @@ describe("portfolio performance snapshot module", () => {
             },
           ],
         }}
-        rebalance={{ status: "READY", last_run_at_utc: null, last_rebalance_run_id: null }}
+        rebalance={{
+          status: "READY",
+          last_run_at_utc: null,
+          last_rebalance_run_id: null,
+          supportability: {
+            feature_key: "manage.observability.action_register_supportability",
+            state: "healthy",
+            reason: "action_register_current",
+            freshness_bucket: "fresh",
+            run_count: 4,
+            operation_count: 12,
+            workflow_decision_count: 3,
+          },
+        }}
         reportingRowCount={14}
         context={{
           selectedAsOfDate: "2026-03-28",
@@ -251,7 +264,20 @@ describe("portfolio performance snapshot module", () => {
             },
           ],
         }}
-        rebalance={{ status: "READY", last_run_at_utc: null, last_rebalance_run_id: null }}
+        rebalance={{
+          status: "READY",
+          last_run_at_utc: null,
+          last_rebalance_run_id: null,
+          supportability: {
+            feature_key: "manage.observability.action_register_supportability",
+            state: "healthy",
+            reason: "action_register_current",
+            freshness_bucket: "fresh",
+            run_count: 4,
+            operation_count: 12,
+            workflow_decision_count: 3,
+          },
+        }}
         reportingRowCount={14}
         context={{
           selectedAsOfDate: "2026-03-28",
@@ -288,7 +314,9 @@ describe("portfolio performance snapshot module", () => {
     expect(screen.getByText("3 source-backed observations")).toBeInTheDocument();
     expect(screen.getByText("Calculated • Stateful benchmark")).toBeInTheDocument();
     expect(screen.getAllByText("MWR XIRR").length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText("14 report rows • Rebalance Ready")).toBeInTheDocument();
+    expect(
+      screen.getByText("14 report rows • Rebalance Ready • Action Register Healthy, Fresh")
+    ).toBeInTheDocument();
     expect(screen.getByText("Comparison Context")).toBeInTheDocument();
     expect(
       screen.getByRole("img", { name: "Performance snapshot comparison sparkline" })


### PR DESCRIPTION
## Summary
- type and preserve Gateway rebalance action-register supportability in portfolio workspace responses
- show manage action-register posture in the performance snapshot operational support line
- derive bounded analytics UI freshness/supportability from nested rebalance supportability without emitting sensitive labels

## Validation
- npm test -- --run tests/unit/portfolio-api.test.ts tests/unit/portfolio-performance-snapshot-module.test.tsx tests/unit/analytics-observability-metrics.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## RFC-0108
Completes the Workbench consumer half of manage.observability.action_register_supportability reconciliation after Gateway PR #168 exposed the source-backed posture.