### PR TITLE
Observe report evidence supportability in Workbench

### DIFF
--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -824,6 +824,9 @@ function normalizeSupportabilityState(value: string): AnalyticsUiSupportabilityS
 
 function normalizeFreshnessBucket(value: string): AnalyticsUiFreshnessBucket {
   const normalized = value.toLowerCase();
+  if (normalized === "current" || normalized === "ready") {
+    return "fresh";
+  }
   if (normalized === "fresh" || normalized === "stale" || normalized === "unknown") {
     return normalized;
   }

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1086,6 +1086,19 @@ export type ReportBatchHandleResponse = {
   status_url: string;
   idempotency_key: string;
   item_count: number;
+  supportability?: ReportEvidenceSurfaceSupportability | null;
+};
+
+export type ReportEvidenceSurfaceSupportability = {
+  feature_key: "report.observability.evidence_surface_supportability";
+  state: string;
+  reason: string;
+  freshness_bucket: string;
+  evidence_feature_count: number;
+  ready_evidence_feature_count: number;
+  degraded_evidence_feature_count: number;
+  workflow_count: number;
+  ready_workflow_count: number;
 };
 
 export type ReportBatchItemStatus = {
@@ -1126,6 +1139,7 @@ export type ReportBatchStatusResponse = {
   failed_at: string | null;
   correlation_id: string;
   trace_id: string;
+  supportability?: ReportEvidenceSurfaceSupportability | null;
 };
 
 export type ReportBatchWorkerRunResponse = {
@@ -1149,4 +1163,5 @@ export type ReportBatchWorkerRunResponse = {
     retry_eligible: boolean;
   }>;
   status_url: string;
+  supportability?: ReportEvidenceSurfaceSupportability | null;
 };

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -109,6 +109,11 @@ describe("analytics UI observability metrics", () => {
       })
     ).toBe("stale");
     expect(deriveAnalyticsUiFreshnessBucket({ freshness_bucket: "fresh" })).toBe("fresh");
+    expect(
+      deriveAnalyticsUiFreshnessBucket({
+        supportability: { state: "ready", freshness_bucket: "current" },
+      })
+    ).toBe("fresh");
     expect(deriveAnalyticsUiFreshnessBucket({ freshness_bucket: "unexpected" })).toBe(
       "unknown"
     );

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -1201,13 +1201,24 @@ describe("workbench api", () => {
             status_url: "/api/v1/report-batches/rbch_1",
             idempotency_key: "workbench-report-batch-PF_1001-2026-02-24-USD",
             item_count: 1,
+            supportability: {
+              feature_key: "report.observability.evidence_surface_supportability",
+              state: "ready",
+              reason: "evidence_surface_ready",
+              freshness_bucket: "current",
+              evidence_feature_count: 14,
+              ready_evidence_feature_count: 14,
+              degraded_evidence_feature_count: 0,
+              workflow_count: 4,
+              ready_workflow_count: 4,
+            },
           }),
           { status: 201, headers: { "Content-Type": "application/json" } }
         )
       )
     );
 
-    await createPortfolioReportBatch({
+    const response = await createPortfolioReportBatch({
       portfolioId: "PF_1001",
       asOfDate: "2026-02-24",
       reportingCurrency: "USD",
@@ -1252,8 +1263,14 @@ describe("workbench api", () => {
         source_surface: "lotus-workbench",
       })
     );
+    expect(response.supportability?.feature_key).toBe(
+      "report.observability.evidence_surface_supportability"
+    );
+    expect(response.supportability?.state).toBe("ready");
     const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
     expect(metricEventsJson).toContain("report-batch-create");
+    expect(metricEventsJson).toContain('"supportability_state":"ready"');
+    expect(metricEventsJson).toContain('"freshness_bucket":"fresh"');
     expect(metricEventsJson).not.toContain("rbch_1");
     expect(metricEventsJson).not.toContain("PF_1001");
   });

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -36,5 +36,8 @@
    fallback previews
 6. RFC-0104 report batch operations use `/api/bff/api/v1/report-batches` only; Workbench does not
    call `lotus-report` directly for batch materialization, status, or bounded run-once execution
-7. Workbench report batch proof may use `/workbench/<portfolioId>?asOfDate=YYYY-MM-DD&benchmark=<backend benchmark code>`;
+7. report batch materialization, status, and bounded run-once responses consume Gateway-preserved
+   `report.observability.evidence_surface_supportability` metadata and emit only bounded
+   freshness/supportability observability labels
+8. Workbench report batch proof may use `/workbench/<portfolioId>?asOfDate=YYYY-MM-DD&benchmark=<backend benchmark code>`;
    the route keeps portfolio data date and report batch date visibly distinct when they differ


### PR DESCRIPTION
## Summary
- Adds Workbench report-batch supportability types for report.observability.evidence_surface_supportability.
- Normalizes lotus-report current freshness into Workbench fresh observability labels.
- Proves report-batch create metrics carry bounded supportability and freshness without identifiers.
- Updates Workbench integration wiki source for the report-batch observability contract.

## Evidence
- npm test -- --run tests/unit/workbench-api.test.ts tests/unit/analytics-observability-metrics.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Wiki
- Updated repo-local wiki/Integrations.md.
- Pre-merge wiki check expected to report repo-authored source ahead of published wiki until after merge.