### PR TITLE
feat: observe AI surface supportability in advisor brief

### DIFF
--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -358,6 +358,10 @@ function readNestedSupportabilityObjects(response: unknown): Array<Record<string
   if (rebalanceSupportability) {
     items.push(rebalanceSupportability);
   }
+  const aiSurfaceSupportability = readObjectProperty(response, "ai_surface_supportability");
+  if (aiSurfaceSupportability) {
+    items.push(aiSurfaceSupportability);
+  }
   return items;
 }
 

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -531,6 +531,35 @@ export type WorkbenchAdvisorBriefSupportabilityItem = {
   reason?: string | null;
 };
 
+export type WorkbenchAdvisorBriefAiSurfaceSupportabilityItem = {
+  surface_id: string;
+  owning_service: string;
+  workflow_authority_owner: string;
+  workflow_pack_ref: string;
+  supportability_status: string;
+  model_posture: string;
+  latest_ready_run_id?: string | null;
+  latest_action_required_run_id?: string | null;
+  no_sensitive_content_telemetry: boolean;
+  status_summary: string[];
+};
+
+export type WorkbenchAdvisorBriefAiSurfaceSupportability = {
+  feature_key: "ai.observability.ai_surface_supportability" | string;
+  state: string;
+  freshness_bucket: string;
+  posture: string;
+  freshness: string;
+  metric_name: string;
+  supported_surface_count: number;
+  executable_workflow_pack_count: number;
+  action_required_surface_count: number;
+  unavailable_surface_count: number;
+  no_sensitive_content_telemetry: boolean;
+  surfaces: WorkbenchAdvisorBriefAiSurfaceSupportabilityItem[];
+  status_summary: string[];
+};
+
 export type WorkbenchAdvisorBriefWorkflowPackRunFinding = {
   finding_id: string;
   severity: string;
@@ -614,6 +643,7 @@ export type WorkbenchPerformanceAdvisorBrief = {
   risks_and_exceptions: WorkbenchAdvisorBriefNarrativeItem[];
   source_metrics: WorkbenchAdvisorBriefSourceMetric[];
   supportability: WorkbenchAdvisorBriefSupportabilityItem[];
+  ai_surface_supportability?: WorkbenchAdvisorBriefAiSurfaceSupportability | null;
   workflow_pack_run?: WorkbenchAdvisorBriefWorkflowPackRun | null;
   workflow_pack_task_flow?: WorkbenchAdvisorBriefWorkflowPackTaskFlow | null;
   ai_audit: {

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -114,6 +114,14 @@ describe("analytics UI observability metrics", () => {
         supportability: { state: "ready", freshness_bucket: "current" },
       })
     ).toBe("fresh");
+    expect(
+      deriveAnalyticsUiFreshnessBucket({
+        ai_surface_supportability: {
+          state: "action_required",
+          freshness_bucket: "current",
+        },
+      })
+    ).toBe("fresh");
     expect(deriveAnalyticsUiFreshnessBucket({ freshness_bucket: "unexpected" })).toBe(
       "unknown"
     );

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -1003,6 +1003,34 @@ describe("workbench api", () => {
             risks_and_exceptions: [],
             source_metrics: [],
             supportability: [],
+            ai_surface_supportability: {
+              feature_key: "ai.observability.ai_surface_supportability",
+              state: "action_required",
+              freshness_bucket: "fresh",
+              posture: "degraded",
+              freshness: "current",
+              metric_name: "lotus_ai_surface_supportability_state",
+              supported_surface_count: 3,
+              executable_workflow_pack_count: 3,
+              action_required_surface_count: 3,
+              unavailable_surface_count: 0,
+              no_sensitive_content_telemetry: false,
+              surfaces: [
+                {
+                  surface_id: "advisor_brief",
+                  owning_service: "lotus-advise",
+                  workflow_authority_owner: "lotus-advise",
+                  workflow_pack_ref: "advisor_brief.pack@v1",
+                  supportability_status: "ACTION_REQUIRED",
+                  model_posture: "degraded",
+                  latest_ready_run_id: null,
+                  latest_action_required_run_id: "packrun_advisor_brief_req-1",
+                  no_sensitive_content_telemetry: false,
+                  status_summary: ["advisor_brief is grounded in workflow-pack runtime source."],
+                },
+              ],
+              status_summary: ["AI surface supportability is source-backed."],
+            },
             workflow_pack_task_flow: {
               task_flow_id: "taskflow_advisor_brief_req-1",
               workflow_pack_id: "advisor_brief.pack",
@@ -1046,6 +1074,15 @@ describe("workbench api", () => {
     expect(advisorBrief.workflow_pack_task_flow?.task_flow_id).toBe(
       "taskflow_advisor_brief_req-1"
     );
+    expect(advisorBrief.ai_surface_supportability?.feature_key).toBe(
+      "ai.observability.ai_surface_supportability"
+    );
+    expect(advisorBrief.ai_surface_supportability?.state).toBe("action_required");
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain('"supportability_state":"action_required"');
+    expect(metricEventsJson).toContain('"freshness_bucket":"fresh"');
+    expect(metricEventsJson).not.toContain("packrun_advisor_brief_req-1");
+    expect(metricEventsJson).not.toContain("PF_1001");
   });
 
   it("posts advisor brief review actions through the client-side gateway seam", async () => {


### PR DESCRIPTION
## Summary
- type Gateway-preserved ai_surface_supportability on advisor-brief responses
- derive Workbench freshness/supportability metrics from that source-owned block
- prove metric labels remain bounded and do not emit portfolio or run identifiers

## Validation
- npm test -- --run tests/unit/workbench-api.test.ts tests/unit/analytics-observability-metrics.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Wiki
- no wiki source change; existing integration docs already describe advisor-brief workflow-pack supportability posture