### PR TITLE
RFC-0108: Observe render supportability in report batch metrics

### DIFF
--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -362,6 +362,10 @@ function readNestedSupportabilityObjects(response: unknown): Array<Record<string
   if (aiSurfaceSupportability) {
     items.push(aiSurfaceSupportability);
   }
+  const renderSupportability = readObjectProperty(response, "render_supportability");
+  if (renderSupportability) {
+    items.push(renderSupportability);
+  }
   return items;
 }
 

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1117,6 +1117,7 @@ export type ReportBatchHandleResponse = {
   idempotency_key: string;
   item_count: number;
   supportability?: ReportEvidenceSurfaceSupportability | null;
+  render_supportability?: ReportRenderSupportability | null;
 };
 
 export type ReportEvidenceSurfaceSupportability = {
@@ -1129,6 +1130,18 @@ export type ReportEvidenceSurfaceSupportability = {
   degraded_evidence_feature_count: number;
   workflow_count: number;
   ready_workflow_count: number;
+};
+
+export type ReportRenderSupportability = {
+  feature_key: "render.observability.render_supportability";
+  state: string;
+  reason: string;
+  freshness_bucket: string;
+  deterministic_output_supported: boolean;
+  render_store_ready: boolean;
+  template_registry_ready: boolean;
+  default_output_format: string | null;
+  supported_output_formats: string[];
 };
 
 export type ReportBatchItemStatus = {
@@ -1170,6 +1183,7 @@ export type ReportBatchStatusResponse = {
   correlation_id: string;
   trace_id: string;
   supportability?: ReportEvidenceSurfaceSupportability | null;
+  render_supportability?: ReportRenderSupportability | null;
 };
 
 export type ReportBatchWorkerRunResponse = {
@@ -1194,4 +1208,5 @@ export type ReportBatchWorkerRunResponse = {
   }>;
   status_url: string;
   supportability?: ReportEvidenceSurfaceSupportability | null;
+  render_supportability?: ReportRenderSupportability | null;
 };

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -122,6 +122,14 @@ describe("analytics UI observability metrics", () => {
         },
       })
     ).toBe("fresh");
+    expect(
+      deriveAnalyticsUiFreshnessBucket({
+        render_supportability: {
+          state: "ready",
+          freshness_bucket: "current",
+        },
+      })
+    ).toBe("fresh");
     expect(deriveAnalyticsUiFreshnessBucket({ freshness_bucket: "unexpected" })).toBe(
       "unknown"
     );

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -1249,6 +1249,17 @@ describe("workbench api", () => {
               workflow_count: 4,
               ready_workflow_count: 4,
             },
+            render_supportability: {
+              feature_key: "render.observability.render_supportability",
+              state: "ready",
+              reason: "render_supportability_ready",
+              freshness_bucket: "current",
+              deterministic_output_supported: true,
+              render_store_ready: true,
+              template_registry_ready: true,
+              default_output_format: "pdf",
+              supported_output_formats: ["pdf"],
+            },
           }),
           { status: 201, headers: { "Content-Type": "application/json" } }
         )
@@ -1304,6 +1315,9 @@ describe("workbench api", () => {
       "report.observability.evidence_surface_supportability"
     );
     expect(response.supportability?.state).toBe("ready");
+    expect(response.render_supportability?.feature_key).toBe(
+      "render.observability.render_supportability"
+    );
     const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
     expect(metricEventsJson).toContain("report-batch-create");
     expect(metricEventsJson).toContain('"supportability_state":"ready"');


### PR DESCRIPTION
## Summary
- Add typed \ender_supportability\ to Gateway-backed report-batch responses.
- Include nested render supportability in Workbench analytics UI freshness/supportability derivation.
- Cover report-batch API and analytics observability metric behavior.

## Evidence
- \
pm test -- --run tests/unit/analytics-observability-metrics.test.ts tests/unit/workbench-api.test.ts\ -> 42 passed
- \
pm run lint\ -> passed
- \
pm run typecheck\ -> passed
- \git diff --check\ -> passed

## Tiering
- Feature Lane covered locally with lint, typecheck, and focused unit tests.
- PR Merge Gate remains GitHub-owned for full CI.