### PR TITLE
Observe advisory supportability in advisor brief metrics

### DIFF
--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -362,6 +362,10 @@ function readNestedSupportabilityObjects(response: unknown): Array<Record<string
   if (aiSurfaceSupportability) {
     items.push(aiSurfaceSupportability);
   }
+  const advisorySupportability = readObjectProperty(response, "advisory_supportability");
+  if (advisorySupportability) {
+    items.push(advisorySupportability);
+  }
   const renderSupportability = readObjectProperty(response, "render_supportability");
   if (renderSupportability) {
     items.push(renderSupportability);

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -560,6 +560,19 @@ export type WorkbenchAdvisorBriefAiSurfaceSupportability = {
   status_summary: string[];
 };
 
+export type WorkbenchAdvisorBriefAdvisorySupportability = {
+  feature_key: "advise.observability.advisory_supportability" | string;
+  state: string;
+  reason?: string | null;
+  freshness_bucket: string;
+  dependency_count: number;
+  ready_dependency_count: number;
+  degraded_dependency_count: number;
+  enabled_feature_count: number;
+  ready_feature_count: number;
+  metric_name: "lotus_advise_advisory_supportability_total" | string;
+};
+
 export type WorkbenchAdvisorBriefWorkflowPackRunFinding = {
   finding_id: string;
   severity: string;
@@ -644,6 +657,7 @@ export type WorkbenchPerformanceAdvisorBrief = {
   source_metrics: WorkbenchAdvisorBriefSourceMetric[];
   supportability: WorkbenchAdvisorBriefSupportabilityItem[];
   ai_surface_supportability?: WorkbenchAdvisorBriefAiSurfaceSupportability | null;
+  advisory_supportability?: WorkbenchAdvisorBriefAdvisorySupportability | null;
   workflow_pack_run?: WorkbenchAdvisorBriefWorkflowPackRun | null;
   workflow_pack_task_flow?: WorkbenchAdvisorBriefWorkflowPackTaskFlow | null;
   ai_audit: {

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -124,6 +124,15 @@ describe("analytics UI observability metrics", () => {
     ).toBe("fresh");
     expect(
       deriveAnalyticsUiFreshnessBucket({
+        advisory_supportability: {
+          feature_key: "advise.observability.advisory_supportability",
+          state: "ready",
+          freshness_bucket: "current",
+        },
+      })
+    ).toBe("fresh");
+    expect(
+      deriveAnalyticsUiFreshnessBucket({
         render_supportability: {
           state: "ready",
           freshness_bucket: "current",
@@ -372,6 +381,58 @@ describe("analytics UI observability metrics", () => {
             attention_type: "panel_stale",
             severity: "warning",
             state: "stale",
+            supportability_state: "action_required",
+          }),
+        }),
+      ])
+    );
+    expect(JSON.stringify(events)).not.toContain("PF_SENSITIVE");
+    expect(JSON.stringify(events)).not.toContain("CIF_SENSITIVE");
+  });
+
+  it("records advisory source supportability state without sensitive labels", async () => {
+    await observeWorkbenchAnalyticsRequest(
+      {
+        route: "workbench.performance",
+        panel: "performance-advisor-brief",
+        operation: "performance.workspace.advisor-brief",
+      },
+      async () => ({
+        advisory_supportability: {
+          feature_key: "advise.observability.advisory_supportability",
+          state: "degraded",
+          reason: "dependency_degraded",
+          freshness_bucket: "unknown",
+          dependency_count: 5,
+          ready_dependency_count: 2,
+          degraded_dependency_count: 3,
+          enabled_feature_count: 9,
+          ready_feature_count: 7,
+          metric_name: "lotus_advise_advisory_supportability_total",
+        },
+        portfolio_id: "PF_SENSITIVE",
+        client_id: "CIF_SENSITIVE",
+      })
+    );
+
+    const events = getAnalyticsUiMetricEvents();
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          metric_name: "lotus_workbench_panel_state_total",
+          labels: expect.objectContaining({
+            panel: "performance-advisor-brief",
+            state: "degraded",
+            freshness_bucket: "unknown",
+            supportability_state: "action_required",
+          }),
+        }),
+        expect.objectContaining({
+          metric_name: "lotus_analytics_ui_attention_events_total",
+          labels: expect.objectContaining({
+            panel: "performance-advisor-brief",
+            attention_type: "panel_degraded",
+            severity: "action_required",
             supportability_state: "action_required",
           }),
         }),

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -1031,6 +1031,18 @@ describe("workbench api", () => {
               ],
               status_summary: ["AI surface supportability is source-backed."],
             },
+            advisory_supportability: {
+              feature_key: "advise.observability.advisory_supportability",
+              state: "ready",
+              reason: "advisory_ready",
+              freshness_bucket: "current",
+              dependency_count: 5,
+              ready_dependency_count: 5,
+              degraded_dependency_count: 0,
+              enabled_feature_count: 9,
+              ready_feature_count: 9,
+              metric_name: "lotus_advise_advisory_supportability_total",
+            },
             workflow_pack_task_flow: {
               task_flow_id: "taskflow_advisor_brief_req-1",
               workflow_pack_id: "advisor_brief.pack",
@@ -1078,6 +1090,10 @@ describe("workbench api", () => {
       "ai.observability.ai_surface_supportability"
     );
     expect(advisorBrief.ai_surface_supportability?.state).toBe("action_required");
+    expect(advisorBrief.advisory_supportability?.feature_key).toBe(
+      "advise.observability.advisory_supportability"
+    );
+    expect(advisorBrief.advisory_supportability?.ready_feature_count).toBe(9);
     const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
     expect(metricEventsJson).toContain('"supportability_state":"action_required"');
     expect(metricEventsJson).toContain('"freshness_bucket":"fresh"');


### PR DESCRIPTION
## Summary
- add the advisor brief `advisory_supportability` contract type
- include nested advisory supportability in Workbench observability freshness and support-state derivation
- assert degraded advisory supportability emits bounded no-sensitive panel/attention metrics

## Local proof
- `npm test -- --run tests/unit/analytics-observability-metrics.test.ts tests/unit/workbench-api.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npx tsc --noEmit --pretty false`
- `git diff --check`