### PR TITLE
Implement Workbench archive document retrieval

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -46,7 +46,8 @@ Current repository posture:
 6. Workbench reads reporting snapshot data through gateway and exposes the RFC-0104 explicit
    single-portfolio report batch materialization/status/run-once panel through the gateway BFF; it
    honors route-level report date and backend benchmark controls for proof while still avoiding
-   direct `lotus-report` calls,
+   direct `lotus-report` calls, and it now retrieves archived report metadata/downloads through
+   Gateway `/api/v1/documents` via the Workbench BFF rather than calling `lotus-archive` directly,
 7. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map
@@ -134,8 +135,8 @@ Important validation expectations:
    Reporting operator reads is centralized in
    `src/features/analytics-observability/metrics.ts`; keep the explicit observed-surface registry
    in sync when adding or retiring portfolio, performance, risk, or reporting operator panels, and
-   never emit portfolio, client, session, report batch, trace, request body, response body, or
-   screen-content identifiers as metric labels. The metrics helper consumes Gateway
+   never emit portfolio, client, document, session, report batch, trace, request body, response
+   body, or screen-content identifiers as metric labels. The metrics helper consumes Gateway
    `source_supportability` arrays for performance/risk freshness and supportability posture, with
    stale source freshness taking precedence over ready source items.
 

--- a/docs/operations/report-job-invocation-posture.md
+++ b/docs/operations/report-job-invocation-posture.md
@@ -12,10 +12,12 @@ Current reporting usage is:
 
 - `src/features/workbench/api.ts`
   calls `/reports/{portfolioId}/snapshot` and `/report-batches` through the Workbench BFF/gateway
-  path.
+  path, and calls `/documents/{documentId}` plus `/documents/{documentId}/download` through the
+  same BFF/gateway boundary for archived report retrieval.
 - `src/app/workbench/[portfolioId]/page.tsx`
   renders the reporting snapshot panel when the gateway snapshot call succeeds and the report batch
-  operations panel for explicit single-portfolio PDF batch materialization/status/run-once.
+  operations panel for explicit single-portfolio PDF batch materialization/status/run-once plus
+  archived document metadata/download lookup.
   The optional route query `?asOfDate=YYYY-MM-DD` selects the report date for snapshot and batch
   operations; `?benchmark=<backend benchmark code>` is passed into the batch request options.
 
@@ -33,12 +35,15 @@ Workbench reporting actions must call `lotus-gateway` only:
 - `POST /api/v1/report-batches`
 - `GET /api/v1/report-batches/{batch_id}`
 - `POST /api/v1/report-batches/{batch_id}:run-once`
+- `GET /api/v1/documents/{document_id}`
+- `GET /api/v1/documents/{document_id}/download`
 - `POST /api/v1/reports/portfolio-reviews`
 - `GET /api/v1/report-jobs/{job_id}`
 - `POST /api/v1/report-jobs/{job_id}/cancel` when cancellation is exposed
 
 Workbench must not call `lotus-report` directly for report job creation, status, cancellation,
-rendering, or archive retrieval.
+rendering, or archive retrieval. Workbench must also not call `lotus-archive` directly; archived
+document metadata and binary downloads remain Gateway-owned product routes.
 
 For canonical RFC-0104 proof, use an implemented report date and backend benchmark identity such as
 `/workbench/PB_SG_GLOBAL_BAL_001?asOfDate=2026-04-22&benchmark=BMK_PB_GLOBAL_BALANCED_60_40`.

--- a/src/app/api/bff/[...path]/route.ts
+++ b/src/app/api/bff/[...path]/route.ts
@@ -26,7 +26,7 @@ async function proxy(request: NextRequest, params: { path: string[] }) {
   const responseHeaders = new Headers(response.headers);
   responseHeaders.delete("transfer-encoding");
 
-  return new NextResponse(await response.text(), {
+  return new NextResponse(await response.arrayBuffer(), {
     status: response.status,
     headers: responseHeaders,
   });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10538,6 +10538,55 @@ a:hover {
   max-width: 72ch;
 }
 
+.performance-evidence-archive-artifact {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.performance-evidence-archive-support {
+  color: var(--text-muted);
+  font-size: var(--workbench-analytic-fallback-size);
+  line-height: 1.35;
+}
+
+.report-batch-archive-retrieval {
+  display: grid;
+  gap: 0.65rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid rgba(23, 32, 43, 0.08);
+}
+
+.report-batch-archive-controls,
+.report-batch-archive-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: end;
+}
+
+.report-batch-archive-controls .workbench-input {
+  min-width: 220px;
+  max-width: 320px;
+  min-height: 2.25rem;
+  padding: 0 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #ffffff;
+  color: var(--text);
+  font: inherit;
+}
+
+.report-batch-archive-summary {
+  align-items: center;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.report-batch-archive-empty {
+  margin: 0;
+  font-size: var(--text-sm);
+}
+
 @media (max-width: 1200px) {
   .performance-analysis-context-row.workbench-chart-context-row {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/apps/performance/components/performance-evidence-mode.tsx
+++ b/src/apps/performance/components/performance-evidence-mode.tsx
@@ -211,9 +211,20 @@ export default function PerformanceEvidenceMode({
               {calculation.artifacts.length > 0 ? (
                 <ul className="performance-evidence-detail-list" aria-label="Evidence artifacts">
                   {calculation.artifacts.map((artifact) => (
-                    <li key={`${calculation.calculation_id}-${artifact.artifact_name}`}>
-                      <a href={artifact.url}>{artifact.artifact_name}</a>
+                    <li
+                      key={`${calculation.calculation_id}-${artifact.artifact_name}`}
+                      className={artifact.archive_document_id ? "performance-evidence-archive-artifact" : undefined}
+                    >
+                      <a href={artifact.archive_document_download_url ?? artifact.url}>
+                        {artifact.artifact_name}
+                      </a>
                       {artifact.content_type ? ` (${artifact.content_type})` : ""}
+                      {artifact.archive_document_id ? (
+                        <span className="performance-evidence-archive-support">
+                          Archived document metadata and binary download are routed through the
+                          Workbench BFF and Gateway document boundary.
+                        </span>
+                      ) : null}
                     </li>
                   ))}
                 </ul>

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -124,6 +124,11 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     operation: "reporting.report-batch.run-once",
   },
   {
+    route: "workbench.reporting",
+    panel: "archive-document-metadata",
+    operation: "reporting.archive-document.metadata",
+  },
+  {
     route: "workbench.portfolio",
     panel: "portfolio-catalog",
     operation: "portfolio.catalog",

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -16,6 +16,7 @@ import {
   ReportBatchHandleResponse,
   ReportBatchStatusResponse,
   ReportBatchWorkerRunResponse,
+  ArchivedDocumentMetadataResponse,
   WorkbenchReportingSnapshot,
   WorkbenchSandboxState,
 } from "./types";
@@ -844,4 +845,46 @@ export async function runReportBatchOnce(params: {
         }
       )
   );
+}
+
+export async function getArchivedDocumentMetadata(
+  documentId: string,
+  params: {
+    current?: boolean;
+    tenantId?: string;
+    region?: string;
+    bookingCenterCode?: string | null;
+    actorId?: string;
+  } = {}
+): Promise<ArchivedDocumentMetadataResponse> {
+  const tenantId = params.tenantId ?? "tenant-sg";
+  const region = params.region ?? "APAC";
+  const actorId = params.actorId ?? "workbench-report-operator";
+  const query = new URLSearchParams();
+  if (params.current) {
+    query.set("current", "true");
+  }
+
+  return await observeWorkbenchClientResource(
+    "reporting.archive-document.metadata",
+    async () =>
+      await fetchWorkbenchMutation<ArchivedDocumentMetadataResponse>(
+        buildWorkbenchUrl("client", `/documents/${encodeURIComponent(documentId)}`, query),
+        "load archived document metadata",
+        {
+          method: "GET",
+          headers: buildReportBatchCallerHeaders({
+            actorId,
+            tenantId,
+            region,
+            bookingCenterCode: params.bookingCenterCode,
+            correlationId: "corr-workbench-archive-document-metadata",
+          }),
+        }
+      )
+  );
+}
+
+export function buildArchivedDocumentDownloadUrl(documentId: string): string {
+  return buildWorkbenchUrl("client", `/documents/${encodeURIComponent(documentId)}/download`);
 }

--- a/src/features/workbench/components/report-batch-operations-panel.tsx
+++ b/src/features/workbench/components/report-batch-operations-panel.tsx
@@ -4,11 +4,14 @@ import { useState } from "react";
 
 import { ActionButton, AnalyticsTable, ScreenStatePanel, SectionBlock, SemanticBadge } from "@/design-system";
 import {
+  buildArchivedDocumentDownloadUrl,
   createPortfolioReportBatch,
+  getArchivedDocumentMetadata,
   getReportBatchStatus,
   runReportBatchOnce,
 } from "@/features/workbench/api";
 import type {
+  ArchivedDocumentMetadataResponse,
   ReportBatchHandleResponse,
   ReportBatchStatusResponse,
   ReportBatchWorkerRunResponse,
@@ -59,7 +62,9 @@ export default function ReportBatchOperationsPanel({
   const [handle, setHandle] = useState<ReportBatchHandleResponse | null>(null);
   const [status, setStatus] = useState<ReportBatchStatusResponse | null>(null);
   const [runResult, setRunResult] = useState<ReportBatchWorkerRunResponse | null>(null);
-  const [pendingAction, setPendingAction] = useState<"create" | "refresh" | "run" | null>(null);
+  const [archiveDocumentId, setArchiveDocumentId] = useState("");
+  const [archiveMetadata, setArchiveMetadata] = useState<ArchivedDocumentMetadataResponse | null>(null);
+  const [pendingAction, setPendingAction] = useState<"create" | "refresh" | "run" | "archive" | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const batchId = status?.batch_id ?? handle?.batch_id ?? null;
@@ -116,6 +121,26 @@ export default function ReportBatchOperationsPanel({
       setStatus(await getReportBatchStatus(batchId, { bookingCenterCode }));
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Report batch run failed.");
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function loadArchiveDocument() {
+    const documentId = archiveDocumentId.trim();
+    if (!documentId) return;
+    setPendingAction("archive");
+    setError(null);
+    try {
+      setArchiveMetadata(
+        await getArchivedDocumentMetadata(documentId, {
+          current: true,
+          bookingCenterCode,
+        })
+      );
+    } catch (caught) {
+      setArchiveMetadata(null);
+      setError(caught instanceof Error ? caught.message : "Archived document retrieval failed.");
     } finally {
       setPendingAction(null);
     }
@@ -194,6 +219,44 @@ export default function ReportBatchOperationsPanel({
           body: "Create a report batch to materialize the current portfolio review item.",
         }}
       />
+
+      <div className="report-batch-archive-retrieval" aria-label="Archived document retrieval">
+        <div className="report-batch-archive-controls">
+          <label className="workbench-field-label" htmlFor="report-batch-archive-document-id">
+            Archived document ID
+          </label>
+          <input
+            id="report-batch-archive-document-id"
+            className="workbench-input"
+            value={archiveDocumentId}
+            onChange={(event) => setArchiveDocumentId(event.target.value)}
+            placeholder="doc_..."
+          />
+          <ActionButton
+            onClick={loadArchiveDocument}
+            disabled={!archiveDocumentId.trim() || pendingAction !== null}
+          >
+            Load Document
+          </ActionButton>
+        </div>
+        {archiveMetadata ? (
+          <div className="report-batch-archive-summary">
+            <SemanticBadge tone={statusTone(archiveMetadata.purgeStatus)}>
+              {archiveMetadata.outputFormat.toUpperCase()}
+            </SemanticBadge>
+            <span>{archiveMetadata.reportType}</span>
+            <span>{archiveMetadata.asOfDate}</span>
+            <span>{archiveMetadata.retentionPolicyId ?? "No retention policy"}</span>
+            <span>{archiveMetadata.legalHoldStatus}</span>
+            <a href={buildArchivedDocumentDownloadUrl(archiveMetadata.documentId)}>Download</a>
+          </div>
+        ) : (
+          <p className="muted report-batch-archive-empty">
+            Retrieve archived report metadata and downloads through the Workbench BFF and Gateway
+            document boundary.
+          </p>
+        )}
+      </div>
     </SectionBlock>
   );
 }

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -269,6 +269,9 @@ export type PerformanceEvidenceArtifactView = {
   artifact_name: string;
   url: string;
   content_type?: string | null;
+  archive_document_id?: string | null;
+  archive_document_metadata_url?: string | null;
+  archive_document_download_url?: string | null;
 };
 
 export type PerformanceEvidenceStageView = {
@@ -1156,6 +1159,50 @@ export type ReportRenderSupportability = {
   template_registry_ready: boolean;
   default_output_format: string | null;
   supported_output_formats: string[];
+};
+
+export type ArchivedDocumentMetadataResponse = {
+  correlationId: string;
+  contractVersion: string;
+  sourceService: "lotus-archive" | string;
+  documentId: string;
+  reportJobId: string;
+  reportRequestId: string;
+  reportType: string;
+  portfolioScope: string;
+  portfolioId: string;
+  clientReference?: string | null;
+  asOfDate: string;
+  reportingPeriodStart: string;
+  reportingPeriodEnd: string;
+  frequency: string;
+  templateId: string;
+  templateVersion: string;
+  renderServiceVersion: string;
+  reportDataContractVersion: string;
+  checksumAlgorithm: string;
+  checksum: string;
+  sizeBytes: number;
+  mimeType: string;
+  outputFormat: string;
+  classification: string;
+  region: string;
+  tenantId?: string | null;
+  retentionPolicyId?: string | null;
+  retentionStartDate?: string | null;
+  retainUntilDate?: string | null;
+  purgeStatus: string;
+  legalHoldStatus: string;
+  legalHoldCount: number;
+  supersedesDocumentId?: string | null;
+  supersededByDocumentId?: string | null;
+  correctionOfDocumentId?: string | null;
+  reissueOfDocumentId?: string | null;
+  createdByService: string;
+  createdByActor: string;
+  createdAt: string;
+  updatedAt: string;
+  downloadUrl: string;
 };
 
 export type ReportBatchItemStatus = {

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -253,6 +253,11 @@ describe("analytics UI observability metrics", () => {
         "report-batch-run-once",
         "reporting.report-batch.run-once",
       ],
+      [
+        "workbench.reporting",
+        "archive-document-metadata",
+        "reporting.archive-document.metadata",
+      ],
       ["workbench.portfolio", "portfolio-catalog", "portfolio.catalog"],
       ["workbench.portfolio", "portfolio-workspace-shell", "portfolio.workspace.shell"],
       ["workbench.portfolio", "portfolio-book", "portfolio.book"],

--- a/tests/unit/bff-route.test.ts
+++ b/tests/unit/bff-route.test.ts
@@ -96,6 +96,47 @@ describe("BFF proxy route", () => {
     expect(response.status).toBe(202);
   });
 
+  it("preserves binary upstream responses for archived document downloads", async () => {
+    const fetchMock = vi.mocked(fetch);
+    const pdfBytes = new Uint8Array([37, 80, 68, 70, 45, 49, 46, 55]);
+    fetchMock.mockResolvedValue(
+      new Response(pdfBytes, {
+        status: 200,
+        headers: {
+          "content-type": "application/pdf",
+          "content-disposition": "attachment; filename=portfolio-review.pdf",
+          "x-document-checksum-algorithm": "sha256",
+          "x-document-checksum": "abc123",
+        },
+      })
+    );
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/bff/api/v1/documents/doc_1/download",
+      {
+        method: "GET",
+        headers: {
+          "X-Actor-Id": "advisor_1",
+          "X-Tenant-Id": "tenant-sg",
+          "X-Region": "APAC",
+        },
+      }
+    );
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ["api", "v1", "documents", "doc_1", "download"] }),
+    });
+
+    const [upstreamUrl] = fetchMock.mock.calls[0];
+    const body = new Uint8Array(await response.arrayBuffer());
+
+    expect(String(upstreamUrl)).toBe("http://gateway.dev.lotus/api/v1/documents/doc_1/download");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/pdf");
+    expect(response.headers.get("x-document-checksum")).toBe("abc123");
+    expect(Array.from(body)).toEqual(Array.from(pdfBytes));
+  });
+
   it("preserves valid context and replaces malformed traceparent before proxying", async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));

--- a/tests/unit/performance-evidence-mode.test.tsx
+++ b/tests/unit/performance-evidence-mode.test.tsx
@@ -115,6 +115,40 @@ describe("PerformanceEvidenceMode", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders archived artifacts with a gateway-backed download route", () => {
+    const scenario = buildSupportedEvidencePerformanceScenario();
+    if (scenario.workspace.evidence_view) {
+      scenario.workspace.evidence_view.calculations[0].artifacts = [
+        {
+          artifact_name: "portfolio-review.pdf",
+          url: "/api/v1/documents/doc_1/download",
+          content_type: "application/pdf",
+          archive_document_id: "doc_1",
+          archive_document_metadata_url: "/api/bff/api/v1/documents/doc_1?current=true",
+          archive_document_download_url: "/api/bff/api/v1/documents/doc_1/download",
+        },
+      ];
+    }
+
+    render(
+      <PerformanceEvidenceMode
+        capability={scenario.capabilities.evidence}
+        evidenceView={scenario.workspace.evidence_view}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "portfolio-review.pdf" })).toHaveAttribute(
+      "href",
+      "/api/bff/api/v1/documents/doc_1/download"
+    );
+    expect(document.querySelector(".performance-evidence-archive-artifact")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Archived document metadata and binary download are routed through the Workbench BFF and Gateway document boundary."
+      )
+    ).toBeInTheDocument();
+  });
+
   it("renders RFC-0079 limitations when evidence is partially backed", () => {
     const scenario = buildPartialEvidencePerformanceScenario();
 

--- a/tests/unit/report-batch-operations-panel.test.tsx
+++ b/tests/unit/report-batch-operations-panel.test.tsx
@@ -5,9 +5,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const createPortfolioReportBatchMock = vi.fn();
 const getReportBatchStatusMock = vi.fn();
 const runReportBatchOnceMock = vi.fn();
+const getArchivedDocumentMetadataMock = vi.fn();
 
 vi.mock("../../src/features/workbench/api", () => ({
+  buildArchivedDocumentDownloadUrl: (documentId: string) =>
+    `/api/bff/api/v1/documents/${encodeURIComponent(documentId)}/download`,
   createPortfolioReportBatch: (...args: unknown[]) => createPortfolioReportBatchMock(...args),
+  getArchivedDocumentMetadata: (...args: unknown[]) => getArchivedDocumentMetadataMock(...args),
   getReportBatchStatus: (...args: unknown[]) => getReportBatchStatusMock(...args),
   runReportBatchOnce: (...args: unknown[]) => runReportBatchOnceMock(...args),
 }));
@@ -74,6 +78,7 @@ const materializedStatus = {
 describe("ReportBatchOperationsPanel", () => {
   afterEach(() => {
     createPortfolioReportBatchMock.mockReset();
+    getArchivedDocumentMetadataMock.mockReset();
     getReportBatchStatusMock.mockReset();
     runReportBatchOnceMock.mockReset();
   });
@@ -200,6 +205,79 @@ describe("ReportBatchOperationsPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Run Once" }));
 
     expect(await screen.findByText("Back pressure max_active_items_reached")).toBeInTheDocument();
+  });
+
+  it("retrieves archived document metadata through the gateway-backed archive surface", async () => {
+    getArchivedDocumentMetadataMock.mockResolvedValue({
+      correlationId: "corr-archive-document-1",
+      contractVersion: "v1",
+      sourceService: "lotus-archive",
+      documentId: "doc_1",
+      reportJobId: "rjob_1",
+      reportRequestId: "rrq_1",
+      reportType: "PORTFOLIO_REVIEW",
+      portfolioScope: "single_portfolio",
+      portfolioId: "PF_1001",
+      clientReference: "relationship-1",
+      asOfDate: "2026-02-24",
+      reportingPeriodStart: "2026-01-01",
+      reportingPeriodEnd: "2026-02-24",
+      frequency: "ad_hoc",
+      templateId: "portfolio-review",
+      templateVersion: "v1",
+      renderServiceVersion: "render.1",
+      reportDataContractVersion: "v1",
+      checksumAlgorithm: "sha256",
+      checksum: "abc123",
+      sizeBytes: 2048,
+      mimeType: "application/pdf",
+      outputFormat: "pdf",
+      classification: "confidential",
+      region: "APAC",
+      tenantId: "tenant-sg",
+      retentionPolicyId: "retention-7y",
+      retentionStartDate: "2026-02-24",
+      retainUntilDate: "2033-02-24",
+      purgeStatus: "not_due",
+      legalHoldStatus: "none",
+      legalHoldCount: 0,
+      supersedesDocumentId: null,
+      supersededByDocumentId: null,
+      correctionOfDocumentId: null,
+      reissueOfDocumentId: null,
+      createdByService: "lotus-report",
+      createdByActor: "report-worker",
+      createdAt: "2026-02-24T00:00:00Z",
+      updatedAt: "2026-02-24T00:00:00Z",
+      downloadUrl: "/api/v1/documents/doc_1/download",
+    });
+
+    render(
+      <ReportBatchOperationsPanel
+        portfolioId="PF_1001"
+        asOfDate="2026-02-24"
+        reportingCurrency="USD"
+        bookingCenterCode="SG"
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Archived document ID"), {
+      target: { value: "doc_1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Load Document" }));
+
+    await waitFor(() => {
+      expect(getArchivedDocumentMetadataMock).toHaveBeenCalledWith("doc_1", {
+        current: true,
+        bookingCenterCode: "SG",
+      });
+    });
+    expect(await screen.findByText("PORTFOLIO_REVIEW")).toBeInTheDocument();
+    expect(screen.getByText("retention-7y")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Download" })).toHaveAttribute(
+      "href",
+      "/api/bff/api/v1/documents/doc_1/download"
+    );
   });
 
   it("does not offer run once after a terminal batch status is loaded", async () => {

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   applySandboxChanges,
+  buildArchivedDocumentDownloadUrl,
   createPortfolioReportBatch,
   createSandboxSession,
+  getArchivedDocumentMetadata,
   getReportBatchStatus,
   getReportingSnapshot,
   getWorkbenchAnalytics,
@@ -1431,6 +1433,82 @@ describe("workbench api", () => {
     expect(body.dispatch_policy.max_active_items).toBe(100);
     expect(body.dispatch_policy.max_active_batches).toBe(100);
     expect(body.runtime_load.active_batches).toBe(0);
+  });
+
+  it("loads archived document metadata through the gateway BFF without leaking document ids into metrics", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlationId: "corr-archive-document-1",
+            contractVersion: "v1",
+            sourceService: "lotus-archive",
+            documentId: "doc_1",
+            reportJobId: "rjob_1",
+            reportRequestId: "rrq_1",
+            reportType: "PORTFOLIO_REVIEW",
+            portfolioScope: "single_portfolio",
+            portfolioId: "PF_1001",
+            clientReference: "relationship-1",
+            asOfDate: "2026-02-24",
+            reportingPeriodStart: "2026-01-01",
+            reportingPeriodEnd: "2026-02-24",
+            frequency: "ad_hoc",
+            templateId: "portfolio-review",
+            templateVersion: "v1",
+            renderServiceVersion: "render.1",
+            reportDataContractVersion: "v1",
+            checksumAlgorithm: "sha256",
+            checksum: "abc123",
+            sizeBytes: 2048,
+            mimeType: "application/pdf",
+            outputFormat: "pdf",
+            classification: "confidential",
+            region: "APAC",
+            tenantId: "tenant-sg",
+            retentionPolicyId: "retention-7y",
+            retentionStartDate: "2026-02-24",
+            retainUntilDate: "2033-02-24",
+            purgeStatus: "not_due",
+            legalHoldStatus: "none",
+            legalHoldCount: 0,
+            supersedesDocumentId: null,
+            supersededByDocumentId: null,
+            correctionOfDocumentId: null,
+            reissueOfDocumentId: null,
+            createdByService: "lotus-report",
+            createdByActor: "report-worker",
+            createdAt: "2026-02-24T00:00:00Z",
+            updatedAt: "2026-02-24T00:00:00Z",
+            downloadUrl: "/api/v1/documents/doc_1/download",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    const metadata = await getArchivedDocumentMetadata("doc_1", {
+      current: true,
+      bookingCenterCode: "SG",
+    });
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const [url, init] = fetchMock.mock.calls[0];
+    const headers = init?.headers as Record<string, string>;
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+
+    expect(url).toBe(`${expectedBaseUrl}/documents/doc_1?current=true`);
+    expect(init).toEqual(expect.objectContaining({ method: "GET", cache: "no-store" }));
+    expect(headers["X-Caller-Application"]).toBe("lotus-workbench");
+    expect(headers["X-Booking-Center-Code"]).toBe("SG");
+    expect(metadata.downloadUrl).toBe("/api/v1/documents/doc_1/download");
+    expect(metricEventsJson).toContain("archive-document-metadata");
+    expect(metricEventsJson).not.toContain("doc_1");
+    expect(metricEventsJson).not.toContain("PF_1001");
+    expect(buildArchivedDocumentDownloadUrl("doc_1")).toBe(
+      `${expectedBaseUrl}/documents/doc_1/download`
+    );
   });
 
   it("raises a labeled error when the split summary endpoint fails", async () => {

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -41,3 +41,7 @@
    freshness/supportability observability labels
 8. Workbench report batch proof may use `/workbench/<portfolioId>?asOfDate=YYYY-MM-DD&benchmark=<backend benchmark code>`;
    the route keeps portfolio data date and report batch date visibly distinct when they differ
+9. Archived report metadata and binary downloads use Gateway `/api/v1/documents/{document_id}` and
+   `/api/v1/documents/{document_id}/download` through `/api/bff/api/v1/documents/*`; Workbench
+   does not call `lotus-archive` directly, and the BFF preserves binary responses and integrity
+   headers for PDF downloads

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -51,9 +51,9 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=ris
 - `/api/metrics` exposes the implemented Workbench analytics UI metric families in Prometheus text
   format for platform scrape and dashboard/alert contracts.
 - Do not add panel, route, or browser telemetry labels outside that contract.
-- `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `batch_id`,
-  `report_job_id`, `session_id`, `trace_id`, `correlation_id`, request bodies, response bodies,
-  and screen content must not become metric labels or browser event fields.
+- `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `document_id`,
+  `batch_id`, `report_job_id`, `session_id`, `trace_id`, `correlation_id`, request bodies,
+  response bodies, and screen content must not become metric labels or browser event fields.
 - Canonical browser proof for the supported Slice 14 Portfolio, Performance, Risk, and
   report-batch reads has passed for `PB_SG_GLOBAL_BAL_001`; full RFC-0079 risk/evidence scope
   remains governed by later RFC-0108 evidence. The performance evidence surface now renders
@@ -61,6 +61,10 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=ris
   freshness, methodology, calculation versions, coverage, fallbacks, and limitations where the
   Gateway evidence contract provides it. Canonical validation records `supportabilityChecks` for
   Gateway `source_supportability` evidence on performance and risk payloads.
+- The report-batch operations panel includes a Gateway-backed archived document lookup for
+  operator retrieval. Metadata reads use `/api/bff/api/v1/documents/{document_id}?current=true`,
+  downloads use `/api/bff/api/v1/documents/{document_id}/download`, and the shared BFF proxy
+  preserves binary PDF payloads plus checksum/content-disposition headers.
 
 ## Output paths
 


### PR DESCRIPTION
## Summary
- adds Gateway/BFF-backed archived document metadata and download retrieval to the report batch operations panel
- hardens the shared Workbench BFF proxy to preserve binary upstream payloads and archive integrity headers
- extends RFC-0108 analytics UI observed-surface coverage for archive metadata without exposing document/portfolio identifiers in metric labels
- documents the Workbench archive retrieval boundary in repo context, operations docs, and wiki source

## Proof
- npm test -- --run tests/unit/bff-route.test.ts tests/unit/workbench-api.test.ts tests/unit/performance-evidence-mode.test.tsx tests/unit/report-batch-operations-panel.test.tsx
- npm test -- --run tests/unit/analytics-observability-metrics.test.ts
- npm test -- --run
- npm run typecheck
- npm run lint
- npm run build
- git diff --check
- powershell -NoProfile -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench (expected pre-publication drift: Integrations.md, Operations-Runbook.md)

## Notes
- canonical dev hosts were not already running locally, so live browser validation is deferred to CI/canonical runtime follow-up rather than claiming demo-ready screenshot proof
