### PR TITLE
Add RFC-0108 Data Products observability

### DIFF
--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -159,6 +159,21 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     operation: "workbench.sandbox-session.apply",
   },
   {
+    route: "workbench.data-products",
+    panel: "domain-product-catalog",
+    operation: "domain-products.catalog",
+  },
+  {
+    route: "workbench.data-products",
+    panel: "domain-product-dependency-graph",
+    operation: "domain-products.dependency-graph",
+  },
+  {
+    route: "workbench.data-products",
+    panel: "domain-product-trust-certification",
+    operation: "domain-products.trust-certification",
+  },
+  {
     route: "workbench.portfolio",
     panel: "portfolio-catalog",
     operation: "portfolio.catalog",

--- a/src/features/domain-products/api.ts
+++ b/src/features/domain-products/api.ts
@@ -1,3 +1,9 @@
+import {
+  WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES,
+  observeWorkbenchAnalyticsRequest,
+  type WorkbenchAnalyticsUiObservationContext,
+} from "@/features/analytics-observability/metrics";
+
 const BFF_PROXY_BASE = "/api/bff/api/v1";
 
 export type DomainProductRepositorySummary = {
@@ -144,17 +150,44 @@ type GatewayEnvelope<T> = {
   data: T;
 };
 
-async function fetchGatewayData<T>(path: string): Promise<T> {
+type DomainProductObservedOperation = Extract<
+  (typeof WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES)[number]["operation"],
+  `domain-products.${string}`
+>;
+
+const DOMAIN_PRODUCT_OPERATION_BY_PATH = {
+  "/domain-products/catalog": "domain-products.catalog",
+  "/domain-products/dependency-graph": "domain-products.dependency-graph",
+  "/domain-products/trust-certification": "domain-products.trust-certification",
+} as const satisfies Record<string, DomainProductObservedOperation>;
+
+function observedDomainProductSurface(
+  path: keyof typeof DOMAIN_PRODUCT_OPERATION_BY_PATH
+): WorkbenchAnalyticsUiObservationContext {
+  const operation = DOMAIN_PRODUCT_OPERATION_BY_PATH[path];
+  return WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES.find(
+    (surface) => surface.operation === operation
+  )!;
+}
+
+async function fetchGatewayData<T>(
+  path: keyof typeof DOMAIN_PRODUCT_OPERATION_BY_PATH
+): Promise<T> {
   const params = new URLSearchParams({ consumerSystem: "lotus-workbench" });
-  const response = await fetch(`${BFF_PROXY_BASE}${path}?${params.toString()}`, {
-    cache: "no-store",
-  });
-  if (!response.ok) {
-    const detail = await response.text();
-    throw new Error(`Domain product discovery fetch failed (${response.status}): ${detail}`);
-  }
-  const payload = (await response.json()) as GatewayEnvelope<T>;
-  return payload.data;
+  return await observeWorkbenchAnalyticsRequest(
+    observedDomainProductSurface(path),
+    async () => {
+      const response = await fetch(`${BFF_PROXY_BASE}${path}?${params.toString()}`, {
+        cache: "no-store",
+      });
+      if (!response.ok) {
+        const detail = await response.text();
+        throw new Error(`Domain product discovery fetch failed (${response.status}): ${detail}`);
+      }
+      const payload = (await response.json()) as GatewayEnvelope<T>;
+      return payload.data;
+    }
+  );
 }
 
 export async function getDomainProductDiscovery(): Promise<DomainProductDiscoveryData> {

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -276,6 +276,21 @@ describe("analytics UI observability metrics", () => {
         "sandbox-session-apply",
         "workbench.sandbox-session.apply",
       ],
+      [
+        "workbench.data-products",
+        "domain-product-catalog",
+        "domain-products.catalog",
+      ],
+      [
+        "workbench.data-products",
+        "domain-product-dependency-graph",
+        "domain-products.dependency-graph",
+      ],
+      [
+        "workbench.data-products",
+        "domain-product-trust-certification",
+        "domain-products.trust-certification",
+      ],
       ["workbench.portfolio", "portfolio-catalog", "portfolio.catalog"],
       ["workbench.portfolio", "portfolio-workspace-shell", "portfolio.workspace.shell"],
       ["workbench.portfolio", "portfolio-book", "portfolio.book"],

--- a/tests/unit/domain-products-api.test.ts
+++ b/tests/unit/domain-products-api.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getDomainProductDiscovery } from "../../src/features/domain-products/api";
+import {
+  getAnalyticsUiMetricEvents,
+  resetAnalyticsUiMetricEvents,
+} from "../../src/features/analytics-observability/metrics";
 
 describe("domain product discovery api", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    resetAnalyticsUiMetricEvents();
   });
 
   it("loads catalog, dependency graph, and trust certification through the gateway BFF", async () => {
@@ -103,6 +108,18 @@ describe("domain product discovery api", () => {
       "/api/bff/api/v1/domain-products/trust-certification?consumerSystem=lotus-workbench",
       { cache: "no-store" }
     );
+
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("domain-product-catalog");
+    expect(metricEventsJson).toContain("domain-product-dependency-graph");
+    expect(metricEventsJson).toContain("domain-product-trust-certification");
+    expect(metricEventsJson).toContain('"supportability_state":"unknown"');
+    expect(metricEventsJson).not.toContain("lotus-core:PortfolioStateSnapshot:v1");
+    expect(metricEventsJson).not.toContain("corr-catalog");
+    expect(metricEventsJson).not.toContain("corr-graph");
+    expect(metricEventsJson).not.toContain("corr-trust");
+    expect(metricEventsJson).not.toContain("contracts/domain-data-products");
+    expect(metricEventsJson).not.toContain("/integration/portfolios");
   });
 
   it("fails when gateway discovery returns an error", async () => {
@@ -114,6 +131,11 @@ describe("domain product discovery api", () => {
     await expect(getDomainProductDiscovery()).rejects.toThrow(
       "Domain product discovery fetch failed (503): catalog missing"
     );
+
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("domain-product-catalog");
+    expect(metricEventsJson).toContain('"status_class":"5xx"');
+    expect(metricEventsJson).not.toContain("catalog missing");
   });
 });
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -42,9 +42,9 @@ promote dormant labels into product ownership just because historical route file
 - canonical evidence should be taken from `output/playwright/live-canonical/` after
   `npm run live:validate`
 - RFC-0108 observability coverage is implemented for supported Portfolio, Performance, Risk,
-  Reporting, and legacy advisor Workbench gateway-backed reads/mutations. The coverage registry is
-  code-backed and tested so active product surfaces cannot silently drift outside bounded
-  route/panel/operation metrics.
+  Reporting, Data Products, and legacy advisor Workbench gateway-backed reads/mutations. The
+  coverage registry is code-backed and tested so active product surfaces cannot silently drift
+  outside bounded route/panel/operation metrics.
 
 ## Route examples
 

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -17,3 +17,10 @@ Workbench consumes gateway APIs only. It must not read `lotus-platform/generated
 ## Operating rule
 
 Workbench discovery must show truthful loading, empty, partial, stale, blocked, unavailable, and error states. It must not show decorative mesh trust when gateway/platform certification evidence is missing.
+
+## Observability posture
+
+RFC-0108 coverage records bounded route, panel, operation, state, freshness, and supportability
+labels for catalog, dependency graph, and trust-certification reads. Metric labels must not include
+product identifiers, source paths, dependency routes, correlation identifiers, request bodies, or
+response bodies.


### PR DESCRIPTION
## Summary
- add RFC-0108 observed-surface coverage for the active /data-products route
- route catalog, dependency graph, and trust-certification Gateway BFF reads through the central analytics UI observability wrapper
- assert metrics do not leak product IDs, source paths, route details, correlation IDs, request bodies, or response bodies
- update repo-authored wiki source for the Data Products observability posture

## Proof
- npm test -- --run tests/unit/domain-products-api.test.ts tests/unit/analytics-observability-metrics.test.ts
- npm run typecheck
- npm run lint
- npm run build
- git diff --check
- powershell -NoProfile -ExecutionPolicy Bypass -File C:\\Users\\Sandeep\\projects\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench (expected pre-merge drift: API-Surface.md, Mesh-Data-Products.md changed in this branch)