### PR TITLE
feat: add RFC-0108 intake observability

### DIFF
--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -174,6 +174,26 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     operation: "domain-products.trust-certification",
   },
   {
+    route: "workbench.intake",
+    panel: "portfolio-intake-bundle",
+    operation: "intake.portfolio-bundle.ingest",
+  },
+  {
+    route: "workbench.intake",
+    panel: "portfolio-intake-portfolio-lookups",
+    operation: "intake.lookups.portfolios",
+  },
+  {
+    route: "workbench.intake",
+    panel: "portfolio-intake-instrument-lookups",
+    operation: "intake.lookups.instruments",
+  },
+  {
+    route: "workbench.intake",
+    panel: "portfolio-intake-currency-lookups",
+    operation: "intake.lookups.currencies",
+  },
+  {
     route: "workbench.portfolio",
     panel: "portfolio-catalog",
     operation: "portfolio.catalog",

--- a/src/features/intake/api.ts
+++ b/src/features/intake/api.ts
@@ -1,28 +1,37 @@
 import { IntakeEnvelopeResponse, PortfolioBundlePayload } from "./types";
+import {
+  WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES,
+  observeWorkbenchAnalyticsRequest,
+} from "@/features/analytics-observability/metrics";
 
 const BFF_PROXY_BASE = "/api/bff/api/v1";
+const INTAKE_BUNDLE_SURFACE = WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES.find(
+  (surface) => surface.operation === "intake.portfolio-bundle.ingest"
+)!;
 
 export async function ingestPortfolioBundle(
   payload: PortfolioBundlePayload
 ): Promise<IntakeEnvelopeResponse> {
-  const response = await fetch(`${BFF_PROXY_BASE}/intake/portfolio-bundle`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ body: payload }),
+  return await observeWorkbenchAnalyticsRequest(INTAKE_BUNDLE_SURFACE, async () => {
+    const response = await fetch(`${BFF_PROXY_BASE}/intake/portfolio-bundle`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ body: payload }),
+    });
+
+    const body = await response.text();
+    let parsed: IntakeEnvelopeResponse;
+    try {
+      parsed = JSON.parse(body) as IntakeEnvelopeResponse;
+    } catch {
+      throw new Error(`Intake ingestion failed (${response.status}): ${body}`);
+    }
+
+    if (!response.ok) {
+      throw new Error(`Intake ingestion failed (${response.status}): ${body}`);
+    }
+    return parsed;
   });
-
-  const body = await response.text();
-  let parsed: IntakeEnvelopeResponse;
-  try {
-    parsed = JSON.parse(body) as IntakeEnvelopeResponse;
-  } catch {
-    throw new Error(`Intake ingestion failed (${response.status}): ${body}`);
-  }
-
-  if (!response.ok) {
-    throw new Error(`Intake ingestion failed (${response.status}): ${body}`);
-  }
-  return parsed;
 }

--- a/src/features/intake/lookups-api.ts
+++ b/src/features/intake/lookups-api.ts
@@ -1,3 +1,9 @@
+import {
+  WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES,
+  observeWorkbenchAnalyticsRequest,
+  type WorkbenchAnalyticsUiObservationContext,
+} from "@/features/analytics-observability/metrics";
+
 type LookupItem = {
   id: string;
   label: string;
@@ -10,6 +16,20 @@ type LookupEnvelope = {
 };
 
 const BFF_PROXY_BASE = "/api/bff/api/v1";
+const LOOKUP_OPERATION_BY_PATH = {
+  "/lookups/portfolios": "intake.lookups.portfolios",
+  "/lookups/instruments": "intake.lookups.instruments",
+  "/lookups/currencies": "intake.lookups.currencies",
+} as const;
+
+function observedLookupSurface(
+  path: keyof typeof LOOKUP_OPERATION_BY_PATH
+): WorkbenchAnalyticsUiObservationContext {
+  const operation = LOOKUP_OPERATION_BY_PATH[path];
+  return WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES.find(
+    (surface) => surface.operation === operation
+  )!;
+}
 
 type PortfolioLookupFilters = {
   cifId?: string;
@@ -43,24 +63,28 @@ function withQuery(path: string, params: Record<string, string | number | undefi
   return queryString ? `${path}?${queryString}` : path;
 }
 
-async function getLookup(path: string): Promise<LookupItem[]> {
-  const response = await fetch(`${BFF_PROXY_BASE}${path}`, { cache: "no-store" });
-  const body = await response.text();
-  let parsed: LookupEnvelope;
-  try {
-    parsed = JSON.parse(body) as LookupEnvelope;
-  } catch {
-    throw new Error(`Lookup fetch failed (${response.status}): ${body}`);
-  }
-  if (!response.ok) {
-    throw new Error(`Lookup fetch failed (${response.status}): ${body}`);
-  }
-  return parsed.items;
+async function getLookup(path: keyof typeof LOOKUP_OPERATION_BY_PATH, queryPath: string): Promise<LookupItem[]> {
+  return await observeWorkbenchAnalyticsRequest(observedLookupSurface(path), async () => {
+    const response = await fetch(`${BFF_PROXY_BASE}${queryPath}`, { cache: "no-store" });
+    const body = await response.text();
+    let parsed: LookupEnvelope;
+    try {
+      parsed = JSON.parse(body) as LookupEnvelope;
+    } catch {
+      throw new Error(`Lookup fetch failed (${response.status}): ${body}`);
+    }
+    if (!response.ok) {
+      throw new Error(`Lookup fetch failed (${response.status}): ${body}`);
+    }
+    return parsed.items;
+  });
 }
 
 export async function getPortfolioLookups(filters?: PortfolioLookupFilters): Promise<LookupItem[]> {
+  const path = "/lookups/portfolios";
   return await getLookup(
-    withQuery("/lookups/portfolios", {
+    path,
+    withQuery(path, {
       cif_id: filters?.cifId,
       booking_center: filters?.bookingCenter,
       q: filters?.q,
@@ -70,8 +94,10 @@ export async function getPortfolioLookups(filters?: PortfolioLookupFilters): Pro
 }
 
 export async function getInstrumentLookups(filters?: InstrumentLookupFilters): Promise<LookupItem[]> {
+  const path = "/lookups/instruments";
   return await getLookup(
-    withQuery("/lookups/instruments", {
+    path,
+    withQuery(path, {
       limit: filters?.limit ?? 200,
       product_type: filters?.productType,
       q: filters?.q,
@@ -80,8 +106,10 @@ export async function getInstrumentLookups(filters?: InstrumentLookupFilters): P
 }
 
 export async function getCurrencyLookups(filters?: CurrencyLookupFilters): Promise<LookupItem[]> {
+  const path = "/lookups/currencies";
   return await getLookup(
-    withQuery("/lookups/currencies", {
+    path,
+    withQuery(path, {
       instrument_page_limit: filters?.instrumentPageLimit,
       source: filters?.source,
       q: filters?.q,

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -291,6 +291,26 @@ describe("analytics UI observability metrics", () => {
         "domain-product-trust-certification",
         "domain-products.trust-certification",
       ],
+      [
+        "workbench.intake",
+        "portfolio-intake-bundle",
+        "intake.portfolio-bundle.ingest",
+      ],
+      [
+        "workbench.intake",
+        "portfolio-intake-portfolio-lookups",
+        "intake.lookups.portfolios",
+      ],
+      [
+        "workbench.intake",
+        "portfolio-intake-instrument-lookups",
+        "intake.lookups.instruments",
+      ],
+      [
+        "workbench.intake",
+        "portfolio-intake-currency-lookups",
+        "intake.lookups.currencies",
+      ],
       ["workbench.portfolio", "portfolio-catalog", "portfolio.catalog"],
       ["workbench.portfolio", "portfolio-workspace-shell", "portfolio.workspace.shell"],
       ["workbench.portfolio", "portfolio-book", "portfolio.book"],

--- a/tests/unit/intake-api.test.ts
+++ b/tests/unit/intake-api.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ingestPortfolioBundle } from "../../src/features/intake/api";
+import {
+  getAnalyticsUiMetricEvents,
+  resetAnalyticsUiMetricEvents,
+} from "../../src/features/analytics-observability/metrics";
 
 describe("intake api", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    resetAnalyticsUiMetricEvents();
   });
 
   it("calls intake portfolio-bundle endpoint", async () => {
@@ -35,5 +40,39 @@ describe("intake api", () => {
 
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
     expect(fetchMock).toHaveBeenCalledWith("/api/bff/api/v1/intake/portfolio-bundle", expect.any(Object));
+
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("portfolio-intake-bundle");
+    expect(metricEventsJson).toContain("intake.portfolio-bundle.ingest");
+    expect(metricEventsJson).toContain('"supportability_state":"unknown"');
+    expect(metricEventsJson).not.toContain("corr_1");
+    expect(metricEventsJson).not.toContain("ADVISOR_WORKBENCH_UI");
+    expect(metricEventsJson).not.toContain("2026-01-02");
+  });
+
+  it("records bounded failure posture without leaking intake response bodies", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("portfolio PF_PRIVATE failed", { status: 422 }))
+    );
+
+    await expect(
+      ingestPortfolioBundle({
+        sourceSystem: "ADVISOR_WORKBENCH_UI",
+        mode: "UPSERT",
+        businessDates: [{ businessDate: "2026-01-02" }],
+        portfolios: [],
+        instruments: [],
+        transactions: [],
+        marketPrices: [],
+        fxRates: [],
+      })
+    ).rejects.toThrow("Intake ingestion failed (422)");
+
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("portfolio-intake-bundle");
+    expect(metricEventsJson).toContain('"status_class":"4xx"');
+    expect(metricEventsJson).not.toContain("PF_PRIVATE");
+    expect(metricEventsJson).not.toContain("portfolio PF_PRIVATE failed");
   });
 });

--- a/tests/unit/intake-lookups-api.test.ts
+++ b/tests/unit/intake-lookups-api.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getCurrencyLookups, getInstrumentLookups, getPortfolioLookups } from "../../src/features/intake/lookups-api";
+import {
+  getAnalyticsUiMetricEvents,
+  resetAnalyticsUiMetricEvents,
+} from "../../src/features/analytics-observability/metrics";
 
 describe("intake lookups api", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    resetAnalyticsUiMetricEvents();
   });
 
   it("calls lookup endpoints", async () => {
@@ -31,6 +36,14 @@ describe("intake lookups api", () => {
     expect(urls).toContain("/api/bff/api/v1/lookups/portfolios");
     expect(urls).toContain("/api/bff/api/v1/lookups/instruments?limit=200");
     expect(urls).toContain("/api/bff/api/v1/lookups/currencies");
+
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("portfolio-intake-portfolio-lookups");
+    expect(metricEventsJson).toContain("portfolio-intake-instrument-lookups");
+    expect(metricEventsJson).toContain("portfolio-intake-currency-lookups");
+    expect(metricEventsJson).toContain('"supportability_state":"unknown"');
+    expect(metricEventsJson).not.toContain("corr_1");
+    expect(metricEventsJson).not.toContain("USD");
   });
 
   it("preserves instrument and currency lookup filters", async () => {
@@ -64,5 +77,29 @@ describe("intake lookups api", () => {
     expect(urls).toContain(
       "/api/bff/api/v1/lookups/currencies?instrument_page_limit=500&source=INSTRUMENTS&q=USD&limit=10"
     );
+
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("portfolio-intake-instrument-lookups");
+    expect(metricEventsJson).toContain("portfolio-intake-currency-lookups");
+    expect(metricEventsJson).not.toContain("Apple");
+    expect(metricEventsJson).not.toContain("EQUITY");
+    expect(metricEventsJson).not.toContain("INSTRUMENTS");
+  });
+
+  it("records bounded lookup failure posture without leaking lookup response bodies", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("lookup CIF_PRIVATE failed", { status: 503 }))
+    );
+
+    await expect(getPortfolioLookups({ cifId: "CIF_PRIVATE" })).rejects.toThrow(
+      "Lookup fetch failed (503)"
+    );
+
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("portfolio-intake-portfolio-lookups");
+    expect(metricEventsJson).toContain('"status_class":"5xx"');
+    expect(metricEventsJson).not.toContain("CIF_PRIVATE");
+    expect(metricEventsJson).not.toContain("lookup CIF_PRIVATE failed");
   });
 });

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -41,7 +41,7 @@ promote dormant labels into product ownership just because historical route file
   are currently disabled even though compatibility routes still exist
 - canonical evidence should be taken from `output/playwright/live-canonical/` after
   `npm run live:validate`
-- RFC-0108 observability coverage is implemented for supported Portfolio, Performance, Risk,
+- RFC-0108 observability coverage is implemented for supported Portfolio, Intake, Performance, Risk,
   Reporting, Data Products, and legacy advisor Workbench gateway-backed reads/mutations. The
   coverage registry is code-backed and tested so active product surfaces cannot silently drift
   outside bounded route/panel/operation metrics.

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -46,7 +46,8 @@
    does not call `lotus-archive` directly, and the BFF preserves binary responses and integrity
    headers for PDF downloads
 10. RFC-0108 analytics UI observability is centralized in
-    `src/features/analytics-observability/metrics.ts`. Supported Portfolio, Performance, Risk,
-    Reporting, and legacy advisor Workbench gateway-backed reads/mutations emit bounded route,
-    panel, operation, freshness, and supportability labels only; portfolio, document, session,
-    trace, request, response, and screen-content identifiers must not appear in metric labels.
+    `src/features/analytics-observability/metrics.ts`. Supported Portfolio, Intake, Performance,
+    Risk, Reporting, Data Products, and legacy advisor Workbench gateway-backed reads/mutations
+    emit bounded route, panel, operation, freshness, and supportability labels only; portfolio,
+    intake payload, document, session, trace, request, response, and screen-content identifiers
+    must not appear in metric labels.


### PR DESCRIPTION
## Summary
- add RFC-0108 observed-surface registry entries for active /intake bundle ingestion and lookup reads
- wrap intake BFF calls with bounded analytics UI observability without payload, CIF, query, correlation, or response-body labels
- update Workbench wiki source to include Intake in implementation-backed observability coverage

## Local validation
- npm test -- --run tests/unit/intake-api.test.ts tests/unit/intake-lookups-api.test.ts tests/unit/analytics-observability-metrics.test.ts
- npm run typecheck
- npm run lint
- npm run build
- git diff --check
- powershell -NoProfile -ExecutionPolicy Bypass -File C:\\Users\\Sandeep\\projects\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench (expected drift: API-Surface.md, Integrations.md, to publish after merge)