### PR TITLE
Add Workbench BFF caller context defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ Set:
 BFF_BASE_URL=http://gateway.dev.lotus
 ```
 
+The Workbench BFF adds governed caller-context headers before proxying to Gateway when an
+interactive request does not already provide them. Defaults are suitable for the canonical local
+front-office runtime and can be overridden for targeted validation:
+
+```txt
+WORKBENCH_BFF_ACTOR_ID=workbench-system
+WORKBENCH_BFF_CALLER_APPLICATION=lotus-workbench
+WORKBENCH_BFF_TENANT_ID=tenant-sg
+WORKBENCH_BFF_REGION=APAC
+WORKBENCH_BFF_BOOKING_CENTER_CODE=SG
+WORKBENCH_BFF_ROLE=advisor
+```
+
 Canonical front-office runtime:
 
 ```bash

--- a/src/app/api/bff/[...path]/route.ts
+++ b/src/app/api/bff/[...path]/route.ts
@@ -2,6 +2,44 @@ import { NextRequest, NextResponse } from "next/server";
 import { resolveGatewayBaseUrl } from "@/features/platform-runtime/service-addressing";
 import { prepareAnalyticsUiProxyHeaders } from "@/features/analytics-observability/correlation";
 
+const DEFAULT_CALLER_CONTEXT_HEADERS = {
+  "X-Actor-Id": "workbench-system",
+  "X-Caller-Application": "lotus-workbench",
+  "X-Tenant-Id": "tenant-sg",
+  "X-Region": "APAC",
+  "X-Booking-Center-Code": "SG",
+  "X-Role": "advisor",
+} as const;
+
+const CALLER_CONTEXT_ENV_OVERRIDES: Record<
+  keyof typeof DEFAULT_CALLER_CONTEXT_HEADERS,
+  string
+> = {
+  "X-Actor-Id": "WORKBENCH_BFF_ACTOR_ID",
+  "X-Caller-Application": "WORKBENCH_BFF_CALLER_APPLICATION",
+  "X-Tenant-Id": "WORKBENCH_BFF_TENANT_ID",
+  "X-Region": "WORKBENCH_BFF_REGION",
+  "X-Booking-Center-Code": "WORKBENCH_BFF_BOOKING_CENTER_CODE",
+  "X-Role": "WORKBENCH_BFF_ROLE",
+};
+
+function defaultCallerContextValue(
+  headerName: keyof typeof DEFAULT_CALLER_CONTEXT_HEADERS
+) {
+  const configured = process.env[CALLER_CONTEXT_ENV_OVERRIDES[headerName]]?.trim();
+  return configured || DEFAULT_CALLER_CONTEXT_HEADERS[headerName];
+}
+
+function applyDefaultCallerContextHeaders(headers: Headers) {
+  for (const headerName of Object.keys(DEFAULT_CALLER_CONTEXT_HEADERS) as Array<
+    keyof typeof DEFAULT_CALLER_CONTEXT_HEADERS
+  >) {
+    if (!headers.get(headerName)?.trim()) {
+      headers.set(headerName, defaultCallerContextValue(headerName));
+    }
+  }
+}
+
 async function proxy(request: NextRequest, params: { path: string[] }) {
   const upstreamPath = params.path.join("/");
   const search = request.nextUrl.search;
@@ -11,6 +49,7 @@ async function proxy(request: NextRequest, params: { path: string[] }) {
   request.headers.forEach((value, key) => {
     headers.set(key, value);
   });
+  applyDefaultCallerContextHeaders(headers);
   const upstreamHeaders = prepareAnalyticsUiProxyHeaders(headers);
 
   const response = await fetch(url, {

--- a/tests/unit/bff-route.test.ts
+++ b/tests/unit/bff-route.test.ts
@@ -5,14 +5,36 @@ import { GET, POST } from "@/app/api/bff/[...path]/route";
 
 describe("BFF proxy route", () => {
   const originalBffBaseUrl = process.env.BFF_BASE_URL;
+  const callerContextEnvKeys = [
+    "WORKBENCH_BFF_ACTOR_ID",
+    "WORKBENCH_BFF_CALLER_APPLICATION",
+    "WORKBENCH_BFF_TENANT_ID",
+    "WORKBENCH_BFF_REGION",
+    "WORKBENCH_BFF_BOOKING_CENTER_CODE",
+    "WORKBENCH_BFF_ROLE",
+  ] as const;
+  const originalCallerContextEnv = Object.fromEntries(
+    callerContextEnvKeys.map((key) => [key, process.env[key]])
+  );
 
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
     delete process.env.BFF_BASE_URL;
+    for (const key of callerContextEnvKeys) {
+      delete process.env[key];
+    }
   });
 
   afterEach(() => {
     process.env.BFF_BASE_URL = originalBffBaseUrl;
+    for (const key of callerContextEnvKeys) {
+      const original = originalCallerContextEnv[key];
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
   });
 
   it("forwards GET requests to the configured upstream without the host header", async () => {
@@ -56,6 +78,12 @@ describe("BFF proxy route", () => {
     const upstreamHeaders = upstreamInit?.headers as Headers;
     expect(upstreamHeaders.get("host")).toBeNull();
     expect(upstreamHeaders.get("authorization")).toBe("Bearer token");
+    expect(upstreamHeaders.get("X-Actor-Id")).toBe("workbench-system");
+    expect(upstreamHeaders.get("X-Caller-Application")).toBe("lotus-workbench");
+    expect(upstreamHeaders.get("X-Tenant-Id")).toBe("tenant-sg");
+    expect(upstreamHeaders.get("X-Region")).toBe("APAC");
+    expect(upstreamHeaders.get("X-Booking-Center-Code")).toBe("SG");
+    expect(upstreamHeaders.get("X-Role")).toBe("advisor");
     expect(upstreamHeaders.get("X-Correlation-Id")).toMatch(/^corr-workbench-[0-9a-f]{16}$/);
     expect(upstreamHeaders.get("traceparent")).toMatch(
       /^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/
@@ -128,13 +156,50 @@ describe("BFF proxy route", () => {
     });
 
     const [upstreamUrl] = fetchMock.mock.calls[0];
+    const upstreamHeaders = fetchMock.mock.calls[0][1]?.headers as Headers;
     const body = new Uint8Array(await response.arrayBuffer());
 
     expect(String(upstreamUrl)).toBe("http://gateway.dev.lotus/api/v1/documents/doc_1/download");
+    expect(upstreamHeaders.get("X-Actor-Id")).toBe("advisor_1");
+    expect(upstreamHeaders.get("X-Tenant-Id")).toBe("tenant-sg");
+    expect(upstreamHeaders.get("X-Region")).toBe("APAC");
+    expect(upstreamHeaders.get("X-Caller-Application")).toBe("lotus-workbench");
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("application/pdf");
     expect(response.headers.get("x-document-checksum")).toBe("abc123");
     expect(Array.from(body)).toEqual(Array.from(pdfBytes));
+  });
+
+  it("uses configured caller context defaults for upstream analytics reads", async () => {
+    process.env.WORKBENCH_BFF_ACTOR_ID = "automation-advisor";
+    process.env.WORKBENCH_BFF_CALLER_APPLICATION = "lotus-demo-workbench";
+    process.env.WORKBENCH_BFF_TENANT_ID = "tenant-demo";
+    process.env.WORKBENCH_BFF_REGION = "EMEA";
+    process.env.WORKBENCH_BFF_BOOKING_CENTER_CODE = "CH";
+    process.env.WORKBENCH_BFF_ROLE = "relationship-manager";
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/bff/api/v1/workbench/PF_1001/performance/summary",
+      {
+        method: "GET",
+      }
+    );
+
+    await GET(request, {
+      params: Promise.resolve({
+        path: ["api", "v1", "workbench", "PF_1001", "performance", "summary"],
+      }),
+    });
+
+    const upstreamHeaders = fetchMock.mock.calls[0][1]?.headers as Headers;
+    expect(upstreamHeaders.get("X-Actor-Id")).toBe("automation-advisor");
+    expect(upstreamHeaders.get("X-Caller-Application")).toBe("lotus-demo-workbench");
+    expect(upstreamHeaders.get("X-Tenant-Id")).toBe("tenant-demo");
+    expect(upstreamHeaders.get("X-Region")).toBe("EMEA");
+    expect(upstreamHeaders.get("X-Booking-Center-Code")).toBe("CH");
+    expect(upstreamHeaders.get("X-Role")).toBe("relationship-manager");
   });
 
   it("preserves valid context and replaces malformed traceparent before proxying", async () => {

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -36,6 +36,21 @@ Required environment posture:
 BFF_BASE_URL=http://gateway.dev.lotus
 ```
 
+Workbench BFF caller-context defaults:
+
+```txt
+WORKBENCH_BFF_ACTOR_ID=workbench-system
+WORKBENCH_BFF_CALLER_APPLICATION=lotus-workbench
+WORKBENCH_BFF_TENANT_ID=tenant-sg
+WORKBENCH_BFF_REGION=APAC
+WORKBENCH_BFF_BOOKING_CENTER_CODE=SG
+WORKBENCH_BFF_ROLE=advisor
+```
+
+These values are injected only when a browser request does not provide explicit caller context.
+Use the overrides for scenario-specific validation, entitlement testing, or client-demo evidence
+capture that needs a named actor, tenant, region, booking center, or role.
+
 ## First checks
 
 ```txt


### PR DESCRIPTION
## Summary
- Add governed caller-context defaults to the Workbench BFF proxy when browser requests do not provide explicit caller context.
- Preserve explicit caller context from callers and keep correlation/trace propagation behavior unchanged.
- Document the BFF caller-context override variables in README and repo-authored wiki source.

## Local validation
- `npm test -- --runTestsByPath tests/unit/bff-route.test.ts` passed: 5 tests.
- `npm run typecheck` passed.
- `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` ran and reported expected publication drift because the GitHub wiki is behind repo-authored source: `_Sidebar.md`, `Getting-Started.md`, `Observability-Evidence.md`, `Operations-Runbook.md`, `Validation-and-CI.md`. Publish after merge with the governed wiki sync flow.

## RFC-0108 posture
This is the Workbench enabling slice for caller-context entitlement certification. It lets the browser-facing BFF consistently send actor, application, tenant, region, booking center, and role context to Gateway-backed analytics reads while keeping scenario-specific overrides available for demo and entitlement validation.