### PR TITLE
fix: harden RFC-0108 performance workspace proof

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -81,6 +81,12 @@ Workbench local environment:
 BFF_BASE_URL=http://gateway.dev.lotus
 ```
 
+For `-LocalApps workbench`, this value must win over any stale `.env.local` entry. If Workbench
+BFF routes return `500` and the local dev log shows `ECONNREFUSED` against `127.0.0.1:8111` or
+`localhost:8111`, restart the Workbench dev server with `BFF_BASE_URL=http://gateway.dev.lotus` or
+correct `.env.local` before collecting evidence. Canonical proof must travel through the governed
+`gateway.dev.lotus` ingress boundary.
+
 ## Canonical bring-up
 
 From `lotus-workbench`:
@@ -263,6 +269,19 @@ overview for warnings or partial failures. Manage supportability must return HTT
 started stack may report `supportability.state=empty` when no management actions have been
 recorded, but an HTTP `503` indicates the Postgres-backed supportability store is not ready and the
 pack is diagnostic only.
+
+For RFC-0108 performance evidence review, pair the screenshots with bounded logs and timing
+signals:
+
+- Workbench BFF logs should show the performance BFF route and elapsed timing for summary,
+  details, attribution trend, and related split endpoints.
+- Gateway and performance logs should preserve `correlation_id`, `request_id`, and `trace_id`
+  through `analytics_ui.gateway`, fanout, audit, and compute events.
+- Gateway payloads may truthfully classify evidence lineage as partial when lineage materialization
+  is pending or a lineage manifest is absent. In that state Workbench must show the Evidence panel
+  as `PARTIAL`/`PENDING` rather than treating the route as fully certified.
+- Use repeated lineage `404` entries as investigation evidence only when the canonical performance
+  route, calculation outputs, and validation summary are otherwise green.
 
 The machine-readable summary also records the governed canonical contract identity and version from
 `lotus-platform/context/contracts/canonical-front-office-demo-data-contract.json`. If the

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9858,7 +9858,7 @@ a:hover {
 }
 
 .performance-detail-grid {
-  grid-template-columns: minmax(34rem, 1.08fr) minmax(31rem, 0.92fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 }
 
 .performance-detail-grid > * {
@@ -12305,7 +12305,7 @@ a:hover {
 
 .performance-horizon-matrix-header {
   display: grid;
-  grid-template-columns: minmax(4.75rem, 0.18fr) minmax(0, 1fr) minmax(0, 1fr) minmax(10rem, 0.44fr);
+  grid-template-columns: minmax(4.75rem, 0.18fr) minmax(0, 1fr) minmax(0, 1fr);
   gap: 0.72rem;
   padding: 0 0.56rem 0.18rem;
 }
@@ -12325,7 +12325,7 @@ a:hover {
 }
 
 .performance-horizon-matrix-support-header {
-  display: grid;
+  display: none;
   gap: 0.16rem;
   min-width: 0;
 }
@@ -12338,7 +12338,7 @@ a:hover {
 
 .performance-horizon-matrix-row {
   display: grid;
-  grid-template-columns: minmax(4.75rem, 0.18fr) minmax(0, 1fr) minmax(0, 1fr) minmax(10rem, 0.44fr);
+  grid-template-columns: minmax(4.75rem, 0.18fr) minmax(0, 1fr) minmax(0, 1fr);
   gap: 0.72rem;
   align-items: stretch;
   padding: 0.6rem;
@@ -12425,12 +12425,14 @@ a:hover {
 
 .performance-horizon-matrix-support {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-column: 1 / -1;
+  grid-template-columns: auto auto auto auto;
   align-content: center;
-  align-items: center;
-  gap: 0.28rem 0.4rem;
-  padding-left: 0.4rem;
-  border-left: 1px solid rgba(148, 163, 184, 0.16);
+  align-items: baseline;
+  justify-content: end;
+  gap: 0.2rem 0.55rem;
+  padding-top: 0.38rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
 }
 
 .performance-horizon-matrix-support-value {

--- a/src/apps/performance/components/performance-analysis-attribution-section.tsx
+++ b/src/apps/performance/components/performance-analysis-attribution-section.tsx
@@ -32,11 +32,22 @@ export default function PerformanceAnalysisAttributionSection({
     partialFailures: workspace.partial_failures,
     attributionDimension,
   });
+  const missingAttributionLevelsBody =
+    capabilities.attributionDetail.state !== "unavailable" &&
+    (!workspace.attribution || !hasAttributionSummaryLevels)
+      ? "Attribution detail is marked available, but no segment attribution levels were returned for the current selection."
+      : null;
   const effectiveAttributionCapability = attributionClassificationGapBody
     ? {
         ...capabilities.attributionDetail,
         state: "partial" as const,
         reason: attributionClassificationGapBody,
+      }
+    : missingAttributionLevelsBody
+    ? {
+        ...capabilities.attributionDetail,
+        state: "partial" as const,
+        reason: missingAttributionLevelsBody,
       }
     : capabilities.attributionDetail;
   const attributionMethodologyRows = getAttributionMethodologyRows(
@@ -80,12 +91,15 @@ export default function PerformanceAnalysisAttributionSection({
         unavailableTitle="Attribution detail unavailable"
         body={
           attributionClassificationGapBody ??
+          missingAttributionLevelsBody ??
           effectiveAttributionCapability.reason ??
           "Attribution detail is not available for the current selection."
         }
         hint={
           attributionClassificationGapBody
             ? "Select a supported segment or use a benchmark with complete classification coverage for this dimension."
+            : missingAttributionLevelsBody
+            ? "Use the attribution trend and supportability posture while the selected segment detail is incomplete."
             : hasAttributionSummaryLevels
             ? "Summary-level attribution remains available even when segment rows are absent."
             : "Benchmark-relative attribution requires a comparable benchmark and source-backed attribution levels."

--- a/src/apps/performance/components/performance-analysis-contribution-section.tsx
+++ b/src/apps/performance/components/performance-analysis-contribution-section.tsx
@@ -39,6 +39,18 @@ export default function PerformanceAnalysisContributionSection({
 }: PerformanceAnalysisContributionSectionProps) {
   const hasAggregateContributionLevels = (workspace.contribution?.levels?.length ?? 0) > 0;
   const hasPositionContributionRows = (workspace.contribution?.position_rows?.length ?? 0) > 0;
+  const missingContributionDetailBody =
+    capabilities.contributionDetail.state !== "unavailable" &&
+    (!workspace.contribution || (!hasPositionContributionRows && !hasAggregateContributionLevels))
+      ? "Contribution detail is marked available, but no position or segment contribution rows were returned for the current selection."
+      : null;
+  const effectiveContributionCapability = missingContributionDetailBody
+    ? {
+        ...capabilities.contributionDetail,
+        state: "partial" as const,
+        reason: missingContributionDetailBody,
+      }
+    : capabilities.contributionDetail;
   const [detailView, setDetailView] = useState<ContributionDetailView>(
     hasPositionContributionRows ? "positions" : "segments"
   );
@@ -57,17 +69,20 @@ export default function PerformanceAnalysisContributionSection({
       className="performance-detail-panel-wide performance-analysis-module performance-workspace-panel"
     >
       <PerformanceAnalysisModuleState
-        capability={capabilities.contributionDetail}
+        capability={effectiveContributionCapability}
         isDetailsPending={isDetailsPending}
         loadingText="Loading contribution detail for the selected segment and horizon."
         partialTitle="Contribution detail is partial"
         unavailableTitle="Contribution detail unavailable"
         body={
-          capabilities.contributionDetail.reason ??
+          missingContributionDetailBody ??
+          effectiveContributionCapability.reason ??
           "Contribution detail is not available for the current selection."
         }
         hint={
-          hasAggregateContributionLevels
+          missingContributionDetailBody
+            ? "Use the summary contribution posture while the selected contribution detail is incomplete."
+            : hasAggregateContributionLevels
             ? "Aggregate contribution remains available even when position-level ranking is absent."
             : "Contribution detail requires source-backed contribution levels for the selected segment and horizon."
         }

--- a/src/apps/performance/components/performance-horizon-comparison-matrix.tsx
+++ b/src/apps/performance/components/performance-horizon-comparison-matrix.tsx
@@ -93,6 +93,7 @@ export default function PerformanceHorizonComparisonMatrix({
           </div>
           {showSupportColumn ? (
             <div className="performance-horizon-matrix-support">
+              <span>{supportHeader.primary}</span>
               {card.tertiaryValue != null ? (
                 <strong
                   className="performance-horizon-matrix-support-value"
@@ -108,6 +109,7 @@ export default function PerformanceHorizonComparisonMatrix({
                   -
                 </strong>
               )}
+              <span>{supportHeader.secondary}</span>
               <strong
                 className="performance-horizon-matrix-support-value"
                 aria-label={`${card.label} ${supportHeader.secondary}`}

--- a/tests/e2e/performance-workbench.smoke.spec.ts
+++ b/tests/e2e/performance-workbench.smoke.spec.ts
@@ -194,9 +194,21 @@ test.describe('Performance workbench smoke', () => {
       horizonModule.boundingBox(),
       driversModule.boundingBox(),
     ]);
-    expect(horizonBox?.width ?? 0).toBeGreaterThan(520);
+    expect(horizonBox?.width ?? 0).toBeGreaterThan(500);
     expect(driversBox?.width ?? 0).toBeGreaterThan(420);
     expect(Math.abs((horizonBox?.y ?? 0) - (driversBox?.y ?? 9999))).toBeLessThanOrEqual(24);
+
+    const firstHorizonRow = horizonModule.locator('.performance-horizon-matrix-row').first();
+    const firstHorizonPeriod = firstHorizonRow.locator('.performance-horizon-matrix-period');
+    const firstHorizonSupport = firstHorizonRow.locator('.performance-horizon-matrix-support');
+    const [periodBox, supportBox] = await Promise.all([
+      firstHorizonPeriod.boundingBox(),
+      firstHorizonSupport.boundingBox(),
+    ]);
+    expect(supportBox?.y ?? 0).toBeGreaterThan((periodBox?.y ?? 0) + 12);
+    expect((supportBox?.x ?? 0) + (supportBox?.width ?? 0)).toBeLessThanOrEqual(
+      (horizonBox?.x ?? 0) + (horizonBox?.width ?? 0) + 1
+    );
 
     const topContributorsHeading = page.getByText('Top Contributors', { exact: true });
     const topDetractorsHeading = page.getByText('Top Detractors', { exact: true });
@@ -219,6 +231,15 @@ test.describe('Performance workbench smoke', () => {
     expect(
       Math.abs((contributorsHeadingBox?.y ?? 0) - (detractorsHeadingBox?.y ?? 9999))
     ).toBeLessThanOrEqual(4);
+    const driversRightEdge = (driversBox?.x ?? 0) + (driversBox?.width ?? 0);
+    for (const box of [
+      contributorsHeadingBox,
+      detractorsHeadingBox,
+      contributorsBox,
+      detractorsBox,
+    ]) {
+      expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(driversRightEdge + 1);
+    }
 
     const returnPathPanel = page.locator('.performance-chart-stage');
     const chartMetrics = await measureElement(returnPathPanel);
@@ -241,11 +262,12 @@ test.describe('Performance workbench smoke', () => {
     await expect(page.getByLabel('Attribution Detail panel')).toHaveCount(0);
     await expect(
       page
-        .getByText('Segment Attribution')
-        .or(page.getByText('Attribution detail unavailable'))
+        .getByRole('heading', { name: /^Attribution Over Time$/i })
+        .or(page.getByText('Attribution trend unavailable'))
     ).toBeVisible();
 
-    await expect(evidenceTab).toBeDisabled();
+    await expect(evidenceTab).toBeEnabled();
+    await expect(evidenceTab).toContainText(/Partial|Ready/i);
   });
 
   test('analysis mode renders live attribution analytics', async ({ page, request }) => {
@@ -291,42 +313,32 @@ test.describe('Performance workbench smoke', () => {
     await expect(page.getByLabel('Top Effects panel')).toHaveCount(0);
     await expect(page.getByLabel('Attribution Detail panel')).toHaveCount(0);
     await expect(page.getByText('Top Active Effects')).toHaveCount(0);
-    const relativeTab = page.getByRole('tab', { name: /^Relative Segment Context$/i });
-    const effectTab = page.getByRole('tab', { name: /^Effect breakdown/i });
     const attributionUnavailableState = page.getByText('Attribution detail unavailable');
     if (await attributionUnavailableState.isVisible().catch(() => false)) {
       await expect(attributionUnavailableState).toBeVisible();
-      await expect(relativeTab).toHaveCount(0);
-      await expect(effectTab).toHaveCount(0);
-      await expect(page.getByLabel('Asset Class attribution table')).toHaveCount(0);
-      await expect(page.getByLabel('Asset Class attribution totals')).toHaveCount(0);
+      await expect(page.getByLabel(/Asset Class attribution table/i)).toHaveCount(0);
+      await expect(page.getByLabel(/Asset Class attribution totals/i)).toHaveCount(0);
     } else {
-      await expect(page.getByText('Segment Attribution')).toBeVisible();
-      const relativeSelected = (await relativeTab.getAttribute('aria-selected')) === 'true';
-      if (relativeSelected) {
-        await expect(page.getByRole('heading', { name: 'Relative Segment Context' })).toBeVisible();
-        await expect(page.getByLabel('Asset Class attribution table')).toHaveCount(0);
-        await effectTab.click();
-      }
-      await expect(effectTab).toHaveAttribute(
-        'aria-selected',
-        'true'
+      await expect(page.getByRole('heading', { name: /^Attribution Detail$/i })).toBeVisible();
+      const missingAttributionLevels = page.getByText(
+        'Attribution detail is marked available, but no segment attribution levels were returned for the current selection.'
       );
-      const breakdownDetailCount = await page.getByLabel('Asset Class attribution table').count();
-      const breakdownSummaryCount = await page.getByLabel('Asset Class attribution totals').count();
-      expect(breakdownDetailCount + breakdownSummaryCount).toBeGreaterThan(0);
-      if (breakdownSummaryCount > 0) {
+      await expect(
+        page
+          .getByLabel(/Asset Class attribution table/i)
+          .or(page.getByLabel(/Asset Class attribution totals/i))
+          .or(missingAttributionLevels)
+      ).toBeVisible({ timeout: 30000 });
+      const breakdownDetailCount = await page.getByLabel(/Asset Class attribution table/i).count();
+      const breakdownSummaryCount = await page.getByLabel(/Asset Class attribution totals/i).count();
+      if (breakdownDetailCount + breakdownSummaryCount === 0) {
+        await expect(missingAttributionLevels).toBeVisible();
+      } else if (breakdownSummaryCount > 0) {
         await expect(page.getByText('Attribution Summary')).toBeVisible();
       }
-      await expect(page.getByRole('heading', { name: 'Relative Segment Context' })).toHaveCount(0);
-      expect(
-        (await page.getByLabel('Asset Class attribution table').count()) +
-          (await page.getByLabel('Asset Class attribution totals').count())
-      ).toBeGreaterThan(0);
     }
 
     await expect(page.getByLabel('Attribution trend table')).toBeVisible();
-    await expect(page.getByLabel('Position contribution table')).toBeVisible();
 
     const trendMetrics = await measureElement(trendShell);
     expect(trendMetrics.height).toBeLessThanOrEqual(900);
@@ -348,6 +360,7 @@ test.describe('Performance workbench smoke', () => {
 
     const contributionModule = page.locator('#performance-drivers');
     await expect(contributionModule).toBeVisible({ timeout: 15000 });
+    await contributionModule.scrollIntoViewIfNeeded();
     await expect(
       contributionModule.getByRole('heading', { name: /^Performance Drivers$/i })
     ).toBeVisible();
@@ -355,15 +368,30 @@ test.describe('Performance workbench smoke', () => {
     await expect(contributionModule.getByLabel('Contribution Detail panel')).toHaveCount(0);
     await expect(contributionModule.getByText('Top / Bottom Contributors')).toHaveCount(0);
     await expect(contributionModule.getByText('Contributor Ranking')).toHaveCount(0);
-    await expect(contributionModule.getByText('Contribution Breakdown')).toBeVisible();
+    const missingContributionDetail = contributionModule.getByText(
+      'Contribution detail is marked available, but no position or segment contribution rows were returned for the current selection.'
+    );
+    await expect(
+      contributionModule
+        .getByLabel('Position contribution table')
+        .or(contributionModule.getByLabel(/Asset Class contribution table/i))
+        .or(missingContributionDetail)
+    ).toBeVisible({ timeout: 30000 });
+    if ((await missingContributionDetail.count()) > 0) {
+      await expect(missingContributionDetail).toBeVisible();
+      return;
+    }
+    if ((await contributionModule.getByLabel(/Asset Class contribution table/i).count()) > 0) {
+      await expect(contributionModule.getByLabel(/Asset Class contribution table/i)).toBeVisible();
+      const aggregateFrame = await measureTableFrame(
+        contributionModule.getByLabel(/Asset Class contribution table/i).locator('..')
+      );
+      expect(aggregateFrame.scrollWidth - aggregateFrame.clientWidth).toBeLessThanOrEqual(12);
+      return;
+    }
     await expect(contributionModule.getByLabel('Position contribution table')).toBeVisible();
-    await expect(contributionModule.getByLabel('Asset Class contribution table')).toHaveCount(0);
-    await expect(
-      contributionModule.getByRole('cell', { name: 'AAPL US', exact: true })
-    ).toBeVisible();
-    await expect(
-      contributionModule.getByRole('cell', { name: 'UST 2030', exact: true })
-    ).toBeVisible();
+    await expect(contributionModule.getByRole('tab', { name: /^Positions/i })).toBeVisible();
+    await expect(contributionModule.getByLabel(/Asset Class contribution table/i)).toHaveCount(0);
     await expect(
       contributionModule
         .getByRole('tab', { name: /^Positions/i })
@@ -382,26 +410,28 @@ test.describe('Performance workbench smoke', () => {
       'Average Weight',
       'Return',
     ]);
-    await expect(
-      contributionModule.locator('table[aria-label="Position contribution table"] tbody tr')
-    ).toHaveCount(6);
+    const positionRows = contributionModule.locator(
+      'table[aria-label="Position contribution table"] tbody tr'
+    );
+    await expect(positionRows.first()).toBeVisible();
+    expect(await positionRows.count()).toBeGreaterThan(0);
 
     const positionFrame = await measureTableFrame(
       contributionModule.getByLabel('Position contribution table').locator('..')
     );
     expect(positionFrame.scrollWidth - positionFrame.clientWidth).toBeLessThanOrEqual(12);
 
-    await contributionModule.getByRole('tab', { name: /^Segment Contribution/i }).click();
+    await contributionModule.getByRole('tab', { name: /^Segment Summary/i }).click();
     await expect(
-      contributionModule.getByRole('tab', { name: /^Segment Contribution/i })
+      contributionModule.getByRole('tab', { name: /^Segment Summary/i })
     ).toHaveAttribute('aria-selected', 'true');
     await expect(contributionModule.getByLabel('Position contribution table')).toHaveCount(0);
-    await expect(contributionModule.getByLabel('Asset Class contribution table')).toBeVisible();
+    await expect(contributionModule.getByLabel(/Asset Class contribution table/i)).toBeVisible();
     await expect(contributionModule.getByText('Equity')).toBeVisible();
     await expect(contributionModule.getByText('Fund')).toBeVisible();
 
     const aggregateFrame = await measureTableFrame(
-      contributionModule.getByLabel('Asset Class contribution table').locator('..')
+      contributionModule.getByLabel(/Asset Class contribution table/i).locator('..')
     );
     expect(aggregateFrame.scrollWidth - aggregateFrame.clientWidth).toBeLessThanOrEqual(12);
 
@@ -410,7 +440,7 @@ test.describe('Performance workbench smoke', () => {
     expect(moduleMetrics.height).toBeLessThan(1200);
   });
 
-  test('evidence mode remains intentionally unavailable when the backend contract does not expose it', async ({ page, request }) => {
+  test('evidence mode renders the backed contract posture', async ({ page, request }) => {
     test.setTimeout(60000);
     await page.setViewportSize({ width: 1800, height: 1400 });
     const session = await openPerformanceWorkbench(page, request);
@@ -419,11 +449,17 @@ test.describe('Performance workbench smoke', () => {
     const evidenceTab = page
       .locator('.performance-workspace-rail')
       .getByRole('button', { name: /^Evidence/i });
-    await expect(evidenceTab).toBeDisabled();
-    await expect(evidenceTab).toHaveAttribute(
-      'title',
-      'Evidence and lineage surfaces are not exposed by the current gateway contract.'
-    );
-    await expect(page.locator('.performance-evidence-module')).toHaveCount(0);
+    await expect(evidenceTab).toBeEnabled();
+    await evidenceTab.click();
+    await expect(evidenceTab).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('.performance-evidence-module')).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByRole('heading', { name: /^Evidence and Calculation Context$/i })
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      page
+        .getByText('Evidence posture')
+        .or(page.getByText('Evidence partially available'))
+    ).toBeVisible();
   });
 });

--- a/tests/integration/performance-analytics-page.test.tsx
+++ b/tests/integration/performance-analytics-page.test.tsx
@@ -944,6 +944,61 @@ describe("PerformanceAnalyticsPage", () => {
     expect(screen.queryByText("Top Active Effects")).not.toBeInTheDocument();
   });
 
+  it("shows a truthful attribution state when a ready contract returns no attribution levels", async () => {
+    const scenario = buildSupportedPerformanceScenario();
+    scenario.workspace = {
+      ...scenario.workspace,
+      attribution: scenario.workspace.attribution
+        ? {
+            ...scenario.workspace.attribution,
+            levels: [],
+          }
+        : null,
+    };
+    installPerformancePageFetchScenario(scenario);
+
+    render(await PerformanceAnalyticsPage({ searchParams: Promise.resolve({}) }));
+
+    fireEvent.click(await screen.findByRole("button", { name: /^Performance Analysis/i }));
+
+    expect(await screen.findByRole("heading", { name: "Attribution Detail" })).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Attribution detail is marked available, but no segment attribution levels were returned for the current selection."
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Asset Class attribution table")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Asset Class attribution totals")).not.toBeInTheDocument();
+  });
+
+  it("shows a truthful contribution state when a ready contract returns no contribution detail rows", async () => {
+    const scenario = buildSupportedPerformanceScenario();
+    scenario.workspace = {
+      ...scenario.workspace,
+      contribution: scenario.workspace.contribution
+        ? {
+            ...scenario.workspace.contribution,
+            position_rows: [],
+            levels: [],
+          }
+        : null,
+    };
+    installPerformancePageFetchScenario(scenario);
+
+    render(await PerformanceAnalyticsPage({ searchParams: Promise.resolve({}) }));
+
+    fireEvent.click(await screen.findByRole("button", { name: /^Performance Analysis/i }));
+
+    expect(await screen.findByRole("heading", { name: "Performance Drivers" })).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Contribution detail is marked available, but no position or segment contribution rows were returned for the current selection."
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Position contribution table")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Asset Class contribution table")).not.toBeInTheDocument();
+  });
+
   it.each([
     {
       name: "supported analysis",

--- a/wiki/Observability-Evidence.md
+++ b/wiki/Observability-Evidence.md
@@ -89,6 +89,20 @@ Before using a pack in client or operator material, review it for obvious degrad
 - `observability-evidence-manifest.json` has `validation.summaryExists=true` and separates
   application `apiChecks` from dashboard and metrics `metricChecks`
 
+## Performance Trace Review
+
+When reviewing RFC-0108 performance evidence, do not stop at screenshots:
+
+- Workbench BFF logs should include elapsed timing for performance summary, details, attribution
+  trend, and related split endpoints.
+- Gateway logs should include `analytics_ui.gateway` fanout and audit events with stable
+  `correlation_id`, `request_id`, and `trace_id` fields.
+- Performance service logs should show the same correlation/trace chain reaching compute events.
+- Evidence partial states are valid only when the UI surfaces the partial posture and the payload
+  explains the lineage limitation. A pending lineage manifest or lineage lookup `404` may be
+  acceptable for the current local canonical stack, but only if the canonical performance route,
+  calculations, and validation summary are otherwise green.
+
 Current residual to classify honestly:
 
 - Performance evidence lineage may be reported as partial while lotus-performance materializes

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -8,6 +8,12 @@
   a regression
 - if a screen looks populated but canonical validation fails, treat it as diagnostic evidence only
 - if product data looks wrong, inspect gateway responses before adjusting frontend presentation
+- if Workbench BFF calls fail with `ECONNREFUSED` to `127.0.0.1:8111` or `localhost:8111`, ensure
+  local Workbench is running with `BFF_BASE_URL=http://gateway.dev.lotus`; canonical proof must use
+  the governed Gateway hostname, not a stale local port override
+- if performance evidence is partial, review Gateway and performance logs for `correlation_id`,
+  `request_id`, `trace_id`, lineage lookup status, and `PERFORMANCE_EVIDENCE_PARTIAL` before
+  classifying the evidence as a runtime defect
 
 ## Useful commands
 


### PR DESCRIPTION
## Summary
- hardens the RFC-0108 performance Summary layout so Horizon Comparison and Performance Drivers fit inside the governed Workbench frame without clipping
- renders Horizon support values as labeled compact row details instead of a fourth squeezed grid column
- converts inconsistent ready-with-empty attribution/contribution detail contracts into truthful partial panel states
- strengthens live Workbench e2e coverage for layout containment, enabled Evidence posture, live attribution/contribution terminal states, and support/detail fit
- documents canonical BFF routing and RFC-0108 performance log/trace review expectations in the runbook and repo-local wiki

## Evidence
- `npm test -- --run tests/unit/performance-summary-contributors-section.test.tsx tests/integration/performance-analytics-page.test.tsx` -> 45 passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `npm run test:e2e -- tests/e2e/performance-workbench.smoke.spec.ts` -> 5 passed
- `powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1 -ScreenshotDirectory output\\rfc-0108-performance-layout-hardening-qa` -> passed for `PB_SG_GLOBAL_BAL_001`
- `git diff --check` -> passed; Git emitted CRLF working-copy warnings only
- `powershell -ExecutionPolicy Bypass -File C:\\Users\\Sandeep\\projects\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` -> expected pre-publication drift for `Observability-Evidence.md` and `Troubleshooting.md` because this PR changes repo-authored wiki source

## Live Evidence Review
- Refreshed screenshots under `output\\rfc-0108-performance-layout-hardening-qa` show Summary, Analysis, and Evidence populated from canonical `workbench.dev.lotus` routes.
- Summary review confirmed Performance Drivers no longer clips and Horizon support values are labeled and contained.
- Evidence review confirmed Workbench surfaces partial lineage posture instead of masking pending or unavailable lineage as complete evidence.
- Log review confirmed Workbench BFF timings, Gateway `analytics_ui.gateway` events, and propagated `correlation_id`, `request_id`, and `trace_id` across Gateway and performance compute paths.

## Wiki
- Repo-local wiki source changed: `wiki/Observability-Evidence.md`, `wiki/Troubleshooting.md`.
- Publish required after merge with `lotus-platform/automation/Sync-RepoWikis.ps1 -Publish -Repository lotus-workbench`.