### PR TITLE
RFC-0108 observe advisor brief review actions

### DIFF
--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -181,12 +181,21 @@ function Start-WorkbenchDevServer {
   $err = Join-Path $workbenchRepo "workbench-3000.dev.err.log"
   if (Test-Path $out) { Remove-Item $out -Force }
   if (Test-Path $err) { Remove-Item $err -Force }
-  Start-Process -FilePath "npm.cmd" `
-    -ArgumentList "run","dev","--","--hostname","0.0.0.0","--port","3000" `
-    -WorkingDirectory $workbenchRepo `
-    -RedirectStandardOutput $out `
-    -RedirectStandardError $err `
-    -WindowStyle Hidden | Out-Null
+  $previousBffBaseUrl = $env:BFF_BASE_URL
+  $previousNextTelemetryDisabled = $env:NEXT_TELEMETRY_DISABLED
+  $env:BFF_BASE_URL = "http://gateway.dev.lotus"
+  $env:NEXT_TELEMETRY_DISABLED = "1"
+  try {
+    Start-Process -FilePath "npm.cmd" `
+      -ArgumentList "run","dev","--","--hostname","0.0.0.0","--port","3000" `
+      -WorkingDirectory $workbenchRepo `
+      -RedirectStandardOutput $out `
+      -RedirectStandardError $err `
+      -WindowStyle Hidden | Out-Null
+  } finally {
+    $env:BFF_BASE_URL = $previousBffBaseUrl
+    $env:NEXT_TELEMETRY_DISABLED = $previousNextTelemetryDisabled
+  }
   Start-Sleep -Seconds 10
 }
 

--- a/src/app/api/metrics/events/route.ts
+++ b/src/app/api/metrics/events/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+import { recordAnalyticsUiExternalMetricEvent } from "@/features/analytics-observability/metrics";
+
+export async function POST(request: Request) {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ status: "rejected" }, { status: 400 });
+  }
+
+  try {
+    recordAnalyticsUiExternalMetricEvent(payload);
+  } catch {
+    return NextResponse.json({ status: "rejected" }, { status: 400 });
+  }
+
+  return NextResponse.json({ status: "accepted" }, { status: 202 });
+}

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -5,6 +5,8 @@ import {
   type AnalyticsUiState,
   type WorkbenchAnalyticsUiBrowserEvent,
   type WorkbenchAnalyticsUiMetricFamily,
+  WORKBENCH_ANALYTICS_UI_BROWSER_EVENTS,
+  WORKBENCH_ANALYTICS_UI_METRIC_FAMILIES,
   assertAnalyticsUiLabels,
   buildAnalyticsUiLabels,
   isAnalyticsUiState,
@@ -82,6 +84,11 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     route: "workbench.performance",
     panel: "performance-advisor-brief",
     operation: "performance.workspace.advisor-brief",
+  },
+  {
+    route: "workbench.performance",
+    panel: "performance-advisor-brief-review-action",
+    operation: "performance.workspace.advisor-brief.review-action",
   },
   {
     route: "workbench.risk",
@@ -260,9 +267,21 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
   },
 ] as const satisfies readonly WorkbenchAnalyticsUiObservationContext[];
 
-const metricEvents: WorkbenchAnalyticsUiMetricEvent[] = [];
-const attentionDedupeKeys = new Set<string>();
-const panelFailureCounts = new Map<string, number>();
+const analyticsUiMetricStore = globalThis as typeof globalThis & {
+  __lotusAnalyticsUiMetricEvents?: WorkbenchAnalyticsUiMetricEvent[];
+  __lotusAnalyticsUiAttentionDedupeKeys?: Set<string>;
+  __lotusAnalyticsUiPanelFailureCounts?: Map<string, number>;
+};
+
+const metricEvents =
+  analyticsUiMetricStore.__lotusAnalyticsUiMetricEvents ??= [];
+const attentionDedupeKeys =
+  analyticsUiMetricStore.__lotusAnalyticsUiAttentionDedupeKeys ??= new Set<string>();
+const panelFailureCounts =
+  analyticsUiMetricStore.__lotusAnalyticsUiPanelFailureCounts ??= new Map<
+    string,
+    number
+  >();
 
 export function classifyAnalyticsUiPanelState(
   input: AnalyticsUiPanelClassificationInput
@@ -609,6 +628,14 @@ export function getAnalyticsUiMetricEvents(): readonly WorkbenchAnalyticsUiMetri
   return metricEvents;
 }
 
+export function recordAnalyticsUiExternalMetricEvent(
+  input: unknown
+): WorkbenchAnalyticsUiMetricEvent {
+  const event = parseExternalMetricEvent(input);
+  metricEvents.push(event);
+  return event;
+}
+
 export function getAnalyticsUiMetricSamples(): WorkbenchAnalyticsUiMetricSample[] {
   const samples = new Map<string, WorkbenchAnalyticsUiMetricSample>();
   for (const event of metricEvents) {
@@ -804,7 +831,78 @@ function recordMetricEvent(params: {
     recorded_at: new Date().toISOString(),
   };
   metricEvents.push(event);
+  publishBrowserMetricEvent(event);
   return event;
+}
+
+function publishBrowserMetricEvent(event: WorkbenchAnalyticsUiMetricEvent): void {
+  if (typeof window === "undefined" || process.env.NODE_ENV === "test") {
+    return;
+  }
+  void fetch("/api/metrics/events", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(event),
+    cache: "no-store",
+    keepalive: true,
+  }).catch(() => undefined);
+}
+
+function parseExternalMetricEvent(input: unknown): WorkbenchAnalyticsUiMetricEvent {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("Analytics UI metric event must be an object.");
+  }
+  const event = input as Record<string, unknown>;
+  const eventName = event.event_name;
+  const metricName = event.metric_name;
+  const value = event.value;
+  const labels = event.labels;
+  const recordedAt = event.recorded_at;
+  if (
+    typeof eventName !== "string" ||
+    !WORKBENCH_ANALYTICS_UI_BROWSER_EVENTS.includes(
+      eventName as WorkbenchAnalyticsUiBrowserEvent
+    )
+  ) {
+    throw new Error("Analytics UI metric event has unsupported event_name.");
+  }
+  if (
+    typeof metricName !== "string" ||
+    !WORKBENCH_ANALYTICS_UI_METRIC_FAMILIES.includes(
+      metricName as WorkbenchAnalyticsUiMetricFamily
+    )
+  ) {
+    throw new Error("Analytics UI metric event has unsupported metric_name.");
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error("Analytics UI metric event has invalid value.");
+  }
+  if (!labels || typeof labels !== "object" || Array.isArray(labels)) {
+    throw new Error("Analytics UI metric event must include labels.");
+  }
+  const normalizedLabels = buildAnalyticsUiLabels(
+    Object.fromEntries(
+      Object.entries(labels as Record<string, unknown>).filter(
+        (entry): entry is [AnalyticsUiAllowedLabel, string] =>
+          typeof entry[1] === "string"
+      )
+    ) as Partial<Record<AnalyticsUiAllowedLabel, string>>
+  );
+  assertAnalyticsUiLabels(normalizedLabels);
+  if (
+    typeof normalizedLabels.route !== "string" ||
+    typeof normalizedLabels.panel !== "string" ||
+    typeof normalizedLabels.operation !== "string"
+  ) {
+    throw new Error("Analytics UI metric event must include route, panel, and operation labels.");
+  }
+  return {
+    event_name: eventName as WorkbenchAnalyticsUiBrowserEvent,
+    metric_name: metricName as WorkbenchAnalyticsUiMetricFamily,
+    value,
+    labels: normalizedLabels,
+    recorded_at: typeof recordedAt === "string" ? recordedAt : new Date().toISOString(),
+  };
 }
 
 function readStringProperty(value: unknown, property: string): string | undefined {

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -108,8 +108,7 @@ async function fetchWorkbenchMutation<T>(
 ): Promise<T> {
   const response = await fetch(url, { cache: "no-store", ...init });
   if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Failed to ${errorLabel} (${response.status}): ${body}`);
+    throw new WorkbenchApiError(errorLabel, response.status);
   }
   return (await response.json()) as T;
 }
@@ -486,25 +485,23 @@ export async function postWorkbenchPerformanceAdvisorBriefReviewActionClient(
   },
   payload: WorkbenchAdvisorBriefWorkflowPackRunReviewActionRequest
 ): Promise<WorkbenchPerformanceAdvisorBrief> {
-  const response = await fetch(
-    buildWorkbenchUrl(
-      "client",
-      `/workbench/${portfolioId}/performance/advisor-brief/review-actions`,
-      buildPerformanceWorkspaceQuery(params)
-    ),
-    {
-      method: "POST",
-      headers: buildAnalyticsUiCorrelationHeaders({ "Content-Type": "application/json" }),
-      body: JSON.stringify(payload),
-      cache: "no-store",
-    }
+  return await observeWorkbenchResource(
+    "performance.workspace.advisor-brief.review-action",
+    async () =>
+      await fetchWorkbenchMutation<WorkbenchPerformanceAdvisorBrief>(
+        buildWorkbenchUrl(
+          "client",
+          `/workbench/${portfolioId}/performance/advisor-brief/review-actions`,
+          buildPerformanceWorkspaceQuery(params)
+        ),
+        "performance advisor brief review action",
+        {
+          method: "POST",
+          headers: buildAnalyticsUiCorrelationHeaders({ "Content-Type": "application/json" }),
+          body: JSON.stringify(payload),
+        }
+      )
   );
-  if (!response.ok) {
-    throw new Error(
-      `Failed to record performance advisor brief review action (${response.status})`
-    );
-  }
-  return (await response.json()) as WorkbenchPerformanceAdvisorBrief;
 }
 
 function buildRiskWorkspaceQuery(params: {

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -241,6 +241,11 @@ describe("analytics UI observability metrics", () => {
         "performance-advisor-brief",
         "performance.workspace.advisor-brief",
       ],
+      [
+        "workbench.performance",
+        "performance-advisor-brief-review-action",
+        "performance.workspace.advisor-brief.review-action",
+      ],
       ["workbench.risk", "risk-summary", "risk.summary"],
       ["workbench.risk", "risk-concentration", "risk.concentration"],
       ["workbench.risk", "risk-drawdown", "risk.drawdown"],

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -59,6 +59,9 @@ describe("canonical live validation script", () => {
     expect(script).toContain("function Stop-HostProcessOnPort");
     expect(script).toContain("Stopping stale $Description process on :$Port");
     expect(script).toContain("Leaving Docker-owned $Description listener on :$Port");
+    expect(script).toContain("$previousBffBaseUrl = $env:BFF_BASE_URL");
+    expect(script).toContain('$env:BFF_BASE_URL = "http://gateway.dev.lotus"');
+    expect(script).toContain("$previousNextTelemetryDisabled = $env:NEXT_TELEMETRY_DISABLED");
     expect(script).toContain('Test-LocalApp "workbench"');
     expect(script).toContain('Invoke-ComposeUp $manageRepo @{ LOTUS_MANAGE_HOST_PORT = "8001" }');
     expect(script).toContain('Invoke-ComposeUp $workbenchRepo @{ BFF_BASE_URL = "http://host.docker.internal:8100" }');

--- a/tests/unit/metrics-route.test.ts
+++ b/tests/unit/metrics-route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { POST as POST_METRIC_EVENT } from "@/app/api/metrics/events/route";
 import { GET } from "@/app/api/metrics/route";
 import {
   recordAnalyticsUiPanelState,
@@ -32,5 +33,66 @@ describe("metrics route", () => {
     expect(body).not.toContain("portfolio_id");
     expect(body).not.toContain("client_name");
     resetAnalyticsUiMetricEvents();
+  });
+
+  it("accepts bounded client-side metric events for Prometheus export", async () => {
+    resetAnalyticsUiMetricEvents();
+    const response = await POST_METRIC_EVENT(
+      new Request("http://workbench.dev.lotus/api/metrics/events", {
+        method: "POST",
+        body: JSON.stringify({
+          event_name: "workbench.analytics.panel_state",
+          metric_name: "lotus_workbench_panel_state_total",
+          value: 1,
+          labels: {
+            route: "workbench.performance",
+            panel: "performance-advisor-brief-review-action",
+            operation: "performance.workspace.advisor-brief.review-action",
+            service: "lotus-gateway",
+            state: "ready",
+            freshness_bucket: "unknown",
+            supportability_state: "unknown",
+          },
+          recorded_at: "2026-05-01T00:00:00.000Z",
+        }),
+      })
+    );
+
+    const metricsResponse = await GET();
+    const body = await metricsResponse.text();
+
+    expect(response.status).toBe(202);
+    expect(body).toContain("performance-advisor-brief-review-action");
+    expect(body).toContain("performance.workspace.advisor-brief.review-action");
+    expect(body).not.toContain("PB_SG_GLOBAL_BAL_001");
+    expect(body).not.toContain("advisor_1");
+    resetAnalyticsUiMetricEvents();
+  });
+
+  it("rejects client-side metric events with forbidden labels", async () => {
+    resetAnalyticsUiMetricEvents();
+    const response = await POST_METRIC_EVENT(
+      new Request("http://workbench.dev.lotus/api/metrics/events", {
+        method: "POST",
+        body: JSON.stringify({
+          event_name: "workbench.analytics.panel_state",
+          metric_name: "lotus_workbench_panel_state_total",
+          value: 1,
+          labels: {
+            route: "workbench.performance",
+            panel: "performance-advisor-brief-review-action",
+            operation: "performance.workspace.advisor-brief.review-action",
+            portfolio_id: "PB_SG_GLOBAL_BAL_001",
+          },
+        }),
+      })
+    );
+
+    const metricsResponse = await GET();
+    const body = await metricsResponse.text();
+
+    expect(response.status).toBe(400);
+    expect(body).not.toContain("performance-advisor-brief-review-action");
+    expect(body).not.toContain("PB_SG_GLOBAL_BAL_001");
   });
 });

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -1287,6 +1287,59 @@ describe("workbench api", () => {
     const requestHeaders = fetchMock.mock.calls[0][1]?.headers as Headers;
     expect(requestHeaders.get("Content-Type")).toBe("application/json");
     expect(requestHeaders.get("X-Correlation-Id")).toMatch(/^corr-workbench-[0-9a-f]{16}$/);
+
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("performance-advisor-brief-review-action");
+    expect(metricEventsJson).toContain(
+      "performance.workspace.advisor-brief.review-action"
+    );
+    expect(metricEventsJson).not.toContain("PF_1001");
+    expect(metricEventsJson).not.toContain("packrun_advisor_brief_req-1");
+    expect(metricEventsJson).not.toContain("advisor_1");
+    expect(metricEventsJson).not.toContain("Advisor brief accepted");
+  });
+
+  it("keeps advisor brief review action denial errors bounded", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            detail: "raw_entitlement_denied for portfolio PF_1001 and client CIF_1",
+          }),
+          { status: 403, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await expect(
+      postWorkbenchPerformanceAdvisorBriefReviewActionClient(
+        "PF_1001",
+        {
+          period: "YTD",
+          chartFrequency: "monthly",
+          contributionDimension: "asset_class",
+          attributionDimension: "asset_class",
+          detailBasis: "NET",
+          benchmark: "BMK_GLOBAL_BALANCED_60_40",
+          reportStartDate: "2026-01-01",
+          reportEndDate: "2026-02-24",
+        },
+        {
+          action_type: "ACCEPT",
+          reviewed_by: "advisor_1",
+          reason: "Advisor brief accepted for bounded downstream workflow use.",
+        }
+      )
+    ).rejects.toThrow("Failed to fetch performance advisor brief review action (403)");
+
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("performance-advisor-brief-review-action");
+    expect(metricEventsJson).toContain('"state":"permission_blocked"');
+    expect(metricEventsJson).not.toContain("raw_entitlement_denied");
+    expect(metricEventsJson).not.toContain("PF_1001");
+    expect(metricEventsJson).not.toContain("CIF_1");
+    expect(metricEventsJson).not.toContain("advisor_1");
   });
 
   it("calls backend reporting snapshot endpoint", async () => {

--- a/wiki/Observability-Evidence.md
+++ b/wiki/Observability-Evidence.md
@@ -114,6 +114,15 @@ caller-context posture:
   `Access Restricted`
 - Advisor Brief denials should classify the advisor brief view model as `permission_blocked` and
   surface `Advisor brief access is restricted` in supportability and exception copy
+- Advisor Brief review-action denials should emit bounded Workbench metrics for
+  `performance-advisor-brief-review-action` and must not expose the raw Gateway entitlement
+  response body, reviewed-by identity, request body, portfolio id, or client id in UI errors or
+  metric labels
+- Browser-originated review-action metrics should be visible in `/api/metrics` after the
+  same-origin `/api/metrics/events` ingest accepts the bounded event. A successful proof should
+  show `performance-advisor-brief-review-action` and
+  `performance.workspace.advisor-brief.review-action` in Prometheus text while excluding reviewer
+  identity, portfolio id, client id, correlation id, and free-form review reason.
 - Workbench analytics metrics should classify denied `401` or `403` reads as
   `permission_blocked`, while still excluding portfolio id, client id, trace id, request body,
   response body, and entitlement-failure text from labels

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -44,8 +44,8 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=ris
   `src/features/analytics-observability/contract.ts`.
 - Workbench emits local analytics UI metric events for the supported Portfolio workspace,
   client-side Performance summary, Performance details, horizon comparison, attribution trend,
-  advisor brief, Risk summary, Risk concentration, Risk drawdown, Risk rolling, Risk attribution,
-  and explicit report-batch operator reads through
+  advisor brief, advisor brief review actions, Risk summary, Risk concentration, Risk drawdown,
+  Risk rolling, Risk attribution, and explicit report-batch operator reads through
   `src/features/analytics-observability/metrics.ts`.
 - Workbench emits bounded local attention events and the
   `lotus_analytics_ui_attention_events_total` counter for stale, degraded, partial-source, and
@@ -59,10 +59,18 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=ris
   upstream posture cannot be hidden by another ready source.
 - `/api/metrics` exposes the implemented Workbench analytics UI metric families in Prometheus text
   format for platform scrape and dashboard/alert contracts.
+- Client-side Workbench actions, including Advisor Brief review transitions, publish only bounded
+  analytics metric events back to `/api/metrics/events`; the server-side metrics registry then
+  exposes them through `/api/metrics`. This keeps mutation observability visible to Prometheus
+  without accepting raw request bodies, response bodies, portfolio ids, client ids, correlation ids,
+  or reviewer identity as labels.
 - Do not add panel, route, or browser telemetry labels outside that contract.
 - `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `document_id`,
   `batch_id`, `report_job_id`, `session_id`, `trace_id`, `correlation_id`, request bodies,
   response bodies, and screen content must not become metric labels or browser event fields.
+- Gateway or BFF mutation failures should surface bounded status-class posture only. Review-action
+  and report-batch failures must not copy raw upstream problem details or entitlement text into UI
+  error messages or metric labels.
 - Canonical browser proof for the supported Slice 14 Portfolio, Performance, Risk, and
   report-batch reads has passed for `PB_SG_GLOBAL_BAL_001`; full RFC-0079 risk/evidence scope
   remains governed by later RFC-0108 evidence. The performance evidence surface now renders
@@ -74,6 +82,23 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=ris
   operator retrieval. Metadata reads use `/api/bff/api/v1/documents/{document_id}?current=true`,
   downloads use `/api/bff/api/v1/documents/{document_id}/download`, and the shared BFF proxy
   preserves binary PDF payloads plus checksum/content-disposition headers.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Advisor as Advisor browser
+  participant Workbench as Workbench UI
+  participant MetricsEvents as /api/metrics/events
+  participant Metrics as /api/metrics
+  participant Gateway as Gateway BFF target
+
+  Advisor->>Workbench: Submit Advisor Brief review action
+  Workbench->>Gateway: POST review action with caller context
+  Gateway-->>Workbench: Bounded workflow-pack response or status
+  Workbench->>MetricsEvents: POST bounded metric event
+  MetricsEvents-->>Workbench: 202 accepted
+  Metrics->>Metrics: Export Prometheus text from server registry
+```
 
 ## Output paths
 


### PR DESCRIPTION
## Summary
- add RFC-0108 Workbench analytics UI observability for Advisor Brief review-action mutations
- add bounded `/api/metrics/events` ingest so browser-originated Workbench metric events become visible in `/api/metrics`
- bound mutation failure errors through `WorkbenchApiError` instead of copying upstream response bodies into UI errors
- harden `live:stack:up:workbench-local` startup so local Workbench uses `BFF_BASE_URL=http://gateway.dev.lotus`
- update repo-local wiki with the implementation-backed review-action observability path and evidence expectations

## Evidence
- `npm test -- --run tests/unit/metrics-route.test.ts tests/unit/analytics-observability-metrics.test.ts tests/unit/workbench-api.test.ts tests/unit/performance-advisor-brief-mode.test.tsx tests/unit/performance-advisor-brief-view-model.test.ts` -> 5 files, 70 tests passed
- `npm test -- --run tests/unit/live-canonical-validation-script.test.ts tests/unit/metrics-route.test.ts tests/unit/analytics-observability-metrics.test.ts tests/unit/workbench-api.test.ts` -> 4 files, 59 tests passed
- `npm test -- --run tests/unit/portfolio-api.test.ts tests/unit/metrics-route.test.ts tests/unit/workbench-api.test.ts` -> 3 files, 49 tests passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `npm test` -> 151 files, 678 tests passed
- `git diff --check` -> passed
- `npm run live:validate` -> passed for `PB_SG_GLOBAL_BAL_001`; screenshots under `output/playwright/live-canonical`
- live browser proof against `http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=advisor-brief`:
  - Advisor Brief rendered canonical portfolio context for `PB_SG_GLOBAL_BAL_001`
  - review-action POST returned 200 through `/api/bff/api/v1/workbench/.../performance/advisor-brief/review-actions`
  - `/api/metrics/events` accepted bounded browser metrics with 202
  - `/api/metrics` contained `performance-advisor-brief-review-action` and `performance.workspace.advisor-brief.review-action`
  - exported metrics did not contain `advisor_1`, `PB_SG_GLOBAL_BAL_001`, `CIF_SG_000184`, `corr-workbench`, or the free-form review reason
- Gateway log/tracing review:
  - review action carried `correlation_id=corr-workbench-af4a9a1dc4156f14`, `request_id=req_c172e00ddf35`, `trace_id=8490b59eeab23fd9f54b7f8d2ddb42ee`
  - `analytics_ui.gateway` logged `ai.workflow-packs.runs.review-actions` with `state=ready`, `status_class=2xx`

## Wiki
- Updated repo-local `wiki/Observability-Evidence.md` and `wiki/Operations-Runbook.md`.
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` reports expected drift for those two files until this PR is merged and the wiki is published.

## Runtime cleanup
- `npm run live:stack:down` completed after live proof.