### PR TITLE
Harden mutation observability hydration boundary

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -139,7 +139,9 @@ Important validation expectations:
    never emit portfolio, client, document, session, report batch, trace, request body, response
    body, or screen-content identifiers as metric labels. The metrics helper consumes Gateway
    `source_supportability` arrays for performance/risk freshness and supportability posture, with
-   stale source freshness taking precedence over ready source items.
+   stale source freshness taking precedence over ready source items. State-changing Workbench
+   actions should use the mutation observation helper so they emit bounded request, state, and
+   applicable attention metrics without incrementing panel hydration counters.
 
 ### Visual Review Gate
 

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -59,6 +59,10 @@ export interface WorkbenchAnalyticsUiObservationContext {
   service?: string;
 }
 
+export interface WorkbenchAnalyticsUiObservationOptions {
+  recordPanelHydration?: boolean;
+}
+
 export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
   {
     route: "workbench.performance",
@@ -549,9 +553,11 @@ export function recordAnalyticsUiAttentionEvent(params: {
 
 export async function observeWorkbenchAnalyticsRequest<T>(
   context: WorkbenchAnalyticsUiObservationContext,
-  request: () => Promise<T>
+  request: () => Promise<T>,
+  options: WorkbenchAnalyticsUiObservationOptions = {}
 ): Promise<T> {
   const startedAt = nowMs();
+  const recordPanelHydration = options.recordPanelHydration ?? true;
   try {
     const response = await request();
     const durationMs = nowMs() - startedAt;
@@ -574,13 +580,15 @@ export async function observeWorkbenchAnalyticsRequest<T>(
       freshnessBucket,
       supportabilityState,
     });
-    recordAnalyticsUiPanelHydration({
-      context,
-      durationMs,
-      state,
-      freshnessBucket,
-      supportabilityState,
-    });
+    if (recordPanelHydration) {
+      recordAnalyticsUiPanelHydration({
+        context,
+        durationMs,
+        state,
+        freshnessBucket,
+        supportabilityState,
+      });
+    }
     recordAttentionForObservation({
       context,
       state,

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -30,6 +30,7 @@ import {
   WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES,
   observeWorkbenchAnalyticsRequest,
   type WorkbenchAnalyticsUiObservationContext,
+  type WorkbenchAnalyticsUiObservationOptions,
 } from "@/features/analytics-observability/metrics";
 
 const BFF_PROXY_BASE = `${resolveBffProxyBaseUrl()}/api/v1`;
@@ -123,9 +124,23 @@ function observedSurface(
 
 async function observeWorkbenchResource<T>(
   operation: (typeof WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES)[number]["operation"],
+  request: () => Promise<T>,
+  options?: WorkbenchAnalyticsUiObservationOptions
+): Promise<T> {
+  return await observeWorkbenchAnalyticsRequest(
+    observedSurface(operation),
+    request,
+    options
+  );
+}
+
+async function observeWorkbenchMutation<T>(
+  operation: (typeof WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES)[number]["operation"],
   request: () => Promise<T>
 ): Promise<T> {
-  return await observeWorkbenchAnalyticsRequest(observedSurface(operation), request);
+  return await observeWorkbenchResource(operation, request, {
+    recordPanelHydration: false,
+  });
 }
 
 function buildWorkbenchUrl(
@@ -210,7 +225,7 @@ export async function createSandboxSession(
   portfolioId: string,
   payload: { created_by?: string; ttl_hours?: number }
 ): Promise<WorkbenchSandboxState> {
-  return await observeWorkbenchResource(
+  return await observeWorkbenchMutation(
     "workbench.sandbox-session.create",
     async () =>
       await fetchWorkbenchMutation<WorkbenchSandboxState>(
@@ -239,7 +254,7 @@ export async function applySandboxChanges(
     evaluate_policy?: boolean;
   }
 ): Promise<WorkbenchSandboxState> {
-  return await observeWorkbenchResource(
+  return await observeWorkbenchMutation(
     "workbench.sandbox-session.apply",
     async () =>
       await fetchWorkbenchMutation<WorkbenchSandboxState>(
@@ -485,7 +500,7 @@ export async function postWorkbenchPerformanceAdvisorBriefReviewActionClient(
   },
   payload: WorkbenchAdvisorBriefWorkflowPackRunReviewActionRequest
 ): Promise<WorkbenchPerformanceAdvisorBrief> {
-  return await observeWorkbenchResource(
+  return await observeWorkbenchMutation(
     "performance.workspace.advisor-brief.review-action",
     async () =>
       await fetchWorkbenchMutation<WorkbenchPerformanceAdvisorBrief>(
@@ -757,7 +772,7 @@ export async function createPortfolioReportBatch(params: {
     params.reportingCurrency,
   ].join("-");
 
-  return await observeWorkbenchResource(
+  return await observeWorkbenchMutation(
     "reporting.report-batch.create",
     async () =>
       await fetchWorkbenchMutation<ReportBatchHandleResponse>(
@@ -846,7 +861,7 @@ export async function runReportBatchOnce(params: {
   const tenantId = params.tenantId ?? "tenant-sg";
   const region = params.region ?? "APAC";
   const actorId = params.actorId ?? "workbench-report-operator";
-  return await observeWorkbenchResource(
+  return await observeWorkbenchMutation(
     "reporting.report-batch.run-once",
     async () =>
       await fetchWorkbenchMutation<ReportBatchWorkerRunResponse>(

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -208,6 +208,32 @@ describe("analytics UI observability metrics", () => {
     expect(renderedMetrics).not.toContain("Sensitive Client");
   });
 
+  it("can record mutation observations without panel hydration metrics", async () => {
+    await observeWorkbenchAnalyticsRequest(
+      {
+        route: "workbench.performance",
+        panel: "performance-advisor-brief-review-action",
+        operation: "performance.workspace.advisor-brief.review-action",
+      },
+      async () => ({
+        state: "ready",
+        supportability_status: "READY",
+        reviewed_by: "advisor_1",
+        reason: "Free-form review reason must not become metric content.",
+      }),
+      { recordPanelHydration: false }
+    );
+
+    const events = getAnalyticsUiMetricEvents();
+    expect(events.map((event) => event.metric_name)).toEqual([
+      "lotus_workbench_api_request_duration_seconds",
+      "lotus_workbench_panel_state_total",
+    ]);
+    expect(JSON.stringify(events)).toContain("performance-advisor-brief-review-action");
+    expect(JSON.stringify(events)).not.toContain("advisor_1");
+    expect(JSON.stringify(events)).not.toContain("Free-form review reason");
+  });
+
   it("keeps the supported Workbench observed-surface registry explicit", () => {
     expect(
       WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES.map((surface) => [

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -1288,7 +1288,17 @@ describe("workbench api", () => {
     expect(requestHeaders.get("Content-Type")).toBe("application/json");
     expect(requestHeaders.get("X-Correlation-Id")).toMatch(/^corr-workbench-[0-9a-f]{16}$/);
 
-    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    const metricEvents = getAnalyticsUiMetricEvents();
+    const metricEventsJson = JSON.stringify(metricEvents);
+    expect(metricEvents.map((event) => event.metric_name)).toContain(
+      "lotus_workbench_api_request_duration_seconds"
+    );
+    expect(metricEvents.map((event) => event.metric_name)).toContain(
+      "lotus_workbench_panel_state_total"
+    );
+    expect(metricEvents.map((event) => event.metric_name)).not.toContain(
+      "lotus_workbench_panel_hydration_duration_seconds"
+    );
     expect(metricEventsJson).toContain("performance-advisor-brief-review-action");
     expect(metricEventsJson).toContain(
       "performance.workspace.advisor-brief.review-action"

--- a/wiki/Observability-Evidence.md
+++ b/wiki/Observability-Evidence.md
@@ -122,7 +122,10 @@ caller-context posture:
   same-origin `/api/metrics/events` ingest accepts the bounded event. A successful proof should
   show `performance-advisor-brief-review-action` and
   `performance.workspace.advisor-brief.review-action` in Prometheus text while excluding reviewer
-  identity, portfolio id, client id, correlation id, and free-form review reason.
+  identity, portfolio id, client id, correlation id, and free-form review reason. Review actions
+  should emit API request and panel-state metrics, and may emit bounded attention metrics when the
+  returned advisor brief is not fully supportable; they must not increment panel hydration metrics
+  because no panel hydration occurs during the mutation.
 - Workbench analytics metrics should classify denied `401` or `403` reads as
   `permission_blocked`, while still excluding portfolio id, client id, trace id, request body,
   response body, and entitlement-failure text from labels

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -63,7 +63,8 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=ris
   analytics metric events back to `/api/metrics/events`; the server-side metrics registry then
   exposes them through `/api/metrics`. This keeps mutation observability visible to Prometheus
   without accepting raw request bodies, response bodies, portfolio ids, client ids, correlation ids,
-  or reviewer identity as labels.
+  or reviewer identity as labels. State-changing actions are intentionally excluded from panel
+  hydration histograms because the action observes a mutation result rather than a panel load.
 - Do not add panel, route, or browser telemetry labels outside that contract.
 - `portfolio_id`, `client_id`, `client_name`, `holding_id`, `transaction_id`, `document_id`,
   `batch_id`, `report_job_id`, `session_id`, `trace_id`, `correlation_id`, request bodies,


### PR DESCRIPTION
## Summary
- Adds an explicit Workbench mutation observation helper so state-changing operations emit bounded API request and panel-state metrics without incrementing panel hydration histograms.
- Applies the mutation boundary to sandbox session mutations, Advisor Brief review actions, and report-batch create/run operations while leaving read/status surfaces on normal hydration semantics.
- Updates Workbench observability wiki and repository context so operators know mutation metrics are not panel-load hydration evidence.

## Validation
- `npm test -- --run tests/unit/analytics-observability-metrics.test.ts tests/unit/workbench-api.test.ts tests/unit/metrics-route.test.ts` -> 50 passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `git diff --check` -> passed
- `npm test` -> 151 files, 679 tests passed
- `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` -> expected pre-publish drift only in `Observability-Evidence.md`, `Operations-Runbook.md`
- `docker compose up -d --build lotus-workbench` -> image built and container started; existing CSS autoprefixer warnings only
- `npm run live:stack:up` -> canonical stack up, `PB_SG_GLOBAL_BAL_001` seeded complete
- `npm run live:validate` -> passed for `PB_SG_GLOBAL_BAL_001` after restoring Docker-backed `lotus-manage`
- Browser proof against rebuilt Workbench: Advisor Brief review action POST returned 200; `/api/metrics` had 11 review-action lines, API request metric present, panel-state metric present, review-action hydration line count 0, forbidden reviewer/reason/portfolio/correlation leakage `[]`
- Gateway log proof: `ai.workflow-packs.runs.review-actions` completed with correlation/request/trace ids; `manage.rebalance.*` fanout recovered to ready after Docker-backed manage restore
- `npm run live:stack:down` -> canonical runtime stopped

## Notes
- `lotus-manage` is being handled by another agent. This PR does not change that repository. During live proof, local manage was restarted only to restore the governed Docker-backed runtime for validation.