### PR TITLE
Observe performance summary route load

### DIFF
--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -312,9 +312,13 @@ export async function getWorkbenchPerformanceWorkspaceSummary(
     reportEndDate?: string;
   }
 ): Promise<WorkbenchPerformanceWorkspaceSummary> {
-  return await fetchWorkbenchJson<WorkbenchPerformanceWorkspaceSummary>(
-    buildPerformanceWorkspaceUrl(portfolioId, params, "/summary", "server"),
-    "performance workspace summary"
+  return await observeWorkbenchResource(
+    "performance.workspace.summary",
+    async () =>
+      await fetchWorkbenchJson<WorkbenchPerformanceWorkspaceSummary>(
+        buildPerformanceWorkspaceUrl(portfolioId, params, "/summary", "server"),
+        "performance workspace summary"
+      )
   );
 }
 

--- a/tests/integration/performance-analytics-page.test.tsx
+++ b/tests/integration/performance-analytics-page.test.tsx
@@ -4,6 +4,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import PerformanceAnalyticsPage from "../../src/apps/performance/performance-analytics-page";
 import {
+  getAnalyticsUiMetricEvents,
+  resetAnalyticsUiMetricEvents,
+} from "../../src/features/analytics-observability/metrics";
+import {
   buildPerformanceAttributionTrend,
   buildAggregateContributionPerformanceScenario,
   buildBenchmarkUnassignedPerformanceScenario,
@@ -104,6 +108,7 @@ async function expectTextPresent(text: string) {
 describe("PerformanceAnalyticsPage", () => {
   afterEach(() => {
     replaceMock.mockReset();
+    resetAnalyticsUiMetricEvents();
     vi.unstubAllGlobals();
   });
 
@@ -151,6 +156,41 @@ describe("PerformanceAnalyticsPage", () => {
     expect(screen.getByText("Review Context")).toBeInTheDocument();
     expect(screen.getByLabelText("Executive return strip")).toBeInTheDocument();
     expect(screen.queryByLabelText("Trust and completeness strip")).not.toBeInTheDocument();
+  });
+
+  it("records bounded route-load observability for the initial performance summary", async () => {
+    installPerformancePageFetchMock();
+
+    render(await PerformanceAnalyticsPage({ searchParams: Promise.resolve({}) }));
+
+    expect(await screen.findByRole("button", { name: "Performance Overview" })).toBeInTheDocument();
+
+    const summaryEvents = getAnalyticsUiMetricEvents().filter(
+      (event) => event.labels.operation === "performance.workspace.summary"
+    );
+    const summaryMetricNames = new Set(summaryEvents.map((event) => event.metric_name));
+
+    expect(summaryMetricNames.has("lotus_workbench_api_request_duration_seconds")).toBe(true);
+    expect(summaryMetricNames.has("lotus_workbench_panel_state_total")).toBe(true);
+    expect(summaryMetricNames.has("lotus_workbench_panel_hydration_duration_seconds")).toBe(true);
+    expect(summaryEvents.length).toBeGreaterThanOrEqual(3);
+
+    for (const event of summaryEvents) {
+      expect(event.labels).toEqual(
+        expect.objectContaining({
+          route: "workbench.performance",
+          panel: "performance-summary",
+          operation: "performance.workspace.summary",
+          service: "lotus-gateway",
+        })
+      );
+    }
+
+    const renderedMetrics = JSON.stringify(summaryEvents);
+    expect(renderedMetrics).not.toContain("portfolio_id");
+    expect(renderedMetrics).not.toContain("client_id");
+    expect(renderedMetrics).not.toContain("PB_SG_GLOBAL_BAL_001");
+    expect(renderedMetrics).not.toContain("CIF_");
   });
 
   it("prefers the front-office seeded performance portfolio when it is available", async () => {

--- a/wiki/Observability-Evidence.md
+++ b/wiki/Observability-Evidence.md
@@ -92,6 +92,9 @@ Use the non-functional artifacts to explain how teams operate the stack:
 - container inventory proves which apps and support services were live
 - readiness samples show health/readiness posture by app
 - Workbench `/api/metrics` shows Prometheus-formatted UI observability metrics
+- the initial Performance Summary route load emits the same bounded
+  `performance.workspace.summary` API, panel-state, and hydration metrics as supported client-side
+  refreshes
 - Prometheus target and `up` query samples show scrape posture
 - Grafana health and screenshots show dashboard entrypoint posture
 - bounded log tails show where operators start when investigating Gateway, Workbench, Core,


### PR DESCRIPTION
## Summary
- route-load Performance Summary fetch now uses the governed Workbench analytics observation wrapper
- adds integration proof that initial Summary render emits API, panel-state, and hydration metrics without portfolio/client identifiers
- updates the Workbench observability evidence wiki source to document the route-load metric behavior

## Evidence
- `npm test -- --run tests/integration/performance-analytics-page.test.tsx` -> 43 passed
- `npm test -- --run tests/unit/analytics-observability-metrics.test.ts` -> 16 passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `npm test` -> 151 files / 681 tests passed
- `git diff --check` -> passed
- `npm run live:stack:up:validate` -> passed for `PB_SG_GLOBAL_BAL_001`; summary `output/playwright/live-canonical/live-validation-summary.json`
- branch-code live metrics proof after switching Workbench to local Next server: `/api/metrics` reported 22 `performance.workspace.summary` lines and `sensitive_hits=0` for `PB_SG_GLOBAL_BAL_001|portfolio_id|client_id|CIF_`
- wiki check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` reported expected drift for `Observability-Evidence.md` pending post-merge publication

## Notes
- No product data shortcut was added. Workbench still uses Gateway-shaped contracts.
- RFC-0079 evidence lineage remains explicitly partial where the live canonical stack reports pending lineage materialization.