### PR TITLE
Add core/manage canonical runtime proof mode

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -124,6 +124,20 @@ Workbench-focused development can also use:
 npm run live:stack:up:workbench-local
 ```
 
+Core/manage RFC proof can use a narrower governed bring-up path:
+
+```powershell
+npm run live:stack:up:core-manage
+```
+
+This mode still uses the canonical hosts block, starts Docker-backed `lotus-core`, starts
+`lotus-manage` on the canonical coexistence port `8001`, restarts direct ingress, and runs the
+governed `PB_SG_GLOBAL_BAL_001` core seed. It intentionally skips `lotus-performance`,
+`lotus-risk`, `lotus-ai`, `lotus-advise`, `lotus-report`, `lotus-archive`, `lotus-render`,
+`lotus-gateway`, and `lotus-workbench`. Use it only for API-level RFC proof where the evidence
+target is core source-data products plus manage APIs, not populated Workbench screenshots or
+gateway-mediated product flows.
+
 The command exits after the stack is usable. It does not block on browser validation.
 Non-zero seed or upstream startup failures must fail the PowerShell command; a partial bring-up is
 not considered success.

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -132,7 +132,7 @@ npm run live:stack:up:core-manage
 
 This mode still uses the canonical hosts block, starts Docker-backed `lotus-core`, starts
 `lotus-manage` on the canonical coexistence port `8001`, restarts direct ingress, and runs the
-governed `PB_SG_GLOBAL_BAL_001` core seed. It intentionally skips `lotus-performance`,
+governed `PB_SG_GLOBAL_BAL_001` core seed in ingest-only mode. It intentionally skips `lotus-performance`,
 `lotus-risk`, `lotus-ai`, `lotus-advise`, `lotus-report`, `lotus-archive`, `lotus-render`,
 `lotus-gateway`, and `lotus-workbench`. Use it only for API-level RFC proof where the evidence
 target is core source-data products plus manage APIs, not populated Workbench screenshots or

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "playwright test",
     "live:stack:down": "powershell -ExecutionPolicy Bypass -File scripts/live/Stop-LotusFrontOfficeCanonical.ps1",
     "live:stack:up": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1",
+    "live:stack:up:core-manage": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -CoreManageOnly",
     "live:stack:up:workbench-local": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -LocalApps workbench",
     "live:stack:up:validate": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -RunValidation",
     "live:validate": "powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1",

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -8,6 +8,7 @@ param(
   [string[]]$LocalApps = @(),
   [switch]$CleanCoreState,
   [switch]$BuildImages,
+  [switch]$CoreManageOnly,
   [switch]$RunValidation
 )
 
@@ -229,6 +230,32 @@ function Get-EnvScopedComposeCommand {
   return "`$env:LOTUS_AI_ENV_FILE = '$EnvFile'; $Command"
 }
 
+function Start-CanonicalManage {
+  if (Test-LocalApp "manage") {
+    Invoke-RepoCommand $manageRepo "docker compose down --remove-orphans"
+    Write-Host "Starting canonical lotus-manage locally on :8001 ..."
+    & (Join-Path $manageRepo "scripts\\Start-CanonicalManage.ps1") -Port 8001
+    if ($LASTEXITCODE -ne 0) {
+      throw "Canonical lotus-manage local startup failed with exit code $LASTEXITCODE."
+    }
+    return
+  }
+
+  Stop-HostProcessOnPort -Port 8001 -Description "lotus-manage"
+  Invoke-ComposeUp $manageRepo @{ LOTUS_MANAGE_HOST_PORT = "8001" }
+}
+
+function Start-DirectIngress {
+  Write-Host "Ensuring direct ingress container is running..."
+  Remove-ContainerIfPresent "lotus-direct-dev-ingress"
+  docker run -d --name lotus-direct-dev-ingress -p 80:80 -v "${ingressCaddyfile}:/etc/caddy/Caddyfile" caddy:2.8.4 | Out-Null
+}
+
+function Invoke-CanonicalCoreSeed {
+  Write-Host "Seeding governed front-office portfolio data for $PortfolioId ..."
+  Invoke-RepoCommand $coreRepo "python tools/front_office_portfolio_seed.py --portfolio-id $PortfolioId --start-date 2025-03-31 --end-date 2026-04-10 --benchmark-start-date 2025-01-06 --wait-seconds $SeedWaitSeconds"
+}
+
 Write-Host "Previewing managed canonical hosts block from lotus-platform ..."
 Invoke-RepoCommand $platformRepo "powershell -ExecutionPolicy Bypass -File automation\\Sync-Dev-Ingress-Hosts.ps1"
 
@@ -245,22 +272,28 @@ Write-Host "Starting Docker-backed canonical services..."
 $resolvedLotusAiEnvFile = Resolve-LotusAiEnvFile -EnvFile $LotusAiEnvFile
 Write-Host "Using lotus-ai env file for canonical proof: $resolvedLotusAiEnvFile"
 Invoke-ComposeUp $coreRepo
+
+if ($CoreManageOnly) {
+  Write-Host "Core/manage proof mode enabled; skipping non-essential front-office services."
+  Start-CanonicalManage
+  Start-DirectIngress
+  Invoke-CanonicalCoreSeed
+  Write-Host ""
+  Write-Host "Canonical core/manage proof stack is up."
+  Write-Host "  Core query:   http://core-query.dev.lotus"
+  Write-Host "  Core control: http://core-control.dev.lotus"
+  Write-Host "  Manage:       http://manage.dev.lotus"
+  Write-Host ""
+  Write-Host "Run the core and manage API validators for RFC-087/RFC-0036 proof."
+  return
+}
+
 Invoke-ComposeUp $performanceRepo
 Invoke-ComposeUp $riskRepo
 Invoke-RepoCommand $aiRepo (Get-EnvScopedComposeCommand -Command $composeUpCommand -EnvFile $resolvedLotusAiEnvFile)
 Invoke-ComposeUp $adviseRepo
 
-if (Test-LocalApp "manage") {
-  Invoke-RepoCommand $manageRepo "docker compose down --remove-orphans"
-  Write-Host "Starting canonical lotus-manage locally on :8001 ..."
-  & (Join-Path $manageRepo "scripts\\Start-CanonicalManage.ps1") -Port 8001
-  if ($LASTEXITCODE -ne 0) {
-    throw "Canonical lotus-manage local startup failed with exit code $LASTEXITCODE."
-  }
-} else {
-  Stop-HostProcessOnPort -Port 8001 -Description "lotus-manage"
-  Invoke-ComposeUp $manageRepo @{ LOTUS_MANAGE_HOST_PORT = "8001" }
-}
+Start-CanonicalManage
 
 Invoke-ComposeUp $reportRepo
 
@@ -282,9 +315,7 @@ if (Test-LocalApp "render") {
   Invoke-ComposeUp $renderRepo
 }
 
-Write-Host "Ensuring direct ingress container is running..."
-Remove-ContainerIfPresent "lotus-direct-dev-ingress"
-docker run -d --name lotus-direct-dev-ingress -p 80:80 -v "${ingressCaddyfile}:/etc/caddy/Caddyfile" caddy:2.8.4 | Out-Null
+Start-DirectIngress
 
 if (Test-LocalApp "gateway") {
   Invoke-RepoCommand $gatewayRepo "docker compose down --remove-orphans"
@@ -298,8 +329,7 @@ if (Test-LocalApp "gateway") {
   Invoke-ComposeUp $gatewayRepo
 }
 
-Write-Host "Seeding governed front-office portfolio data for $PortfolioId ..."
-Invoke-RepoCommand $coreRepo "python tools/front_office_portfolio_seed.py --portfolio-id $PortfolioId --start-date 2025-03-31 --end-date 2026-04-10 --benchmark-start-date 2025-01-06 --wait-seconds $SeedWaitSeconds"
+Invoke-CanonicalCoreSeed
 
 if (Test-LocalApp "workbench") {
   Invoke-RepoCommand $workbenchRepo "docker compose down --remove-orphans"

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -252,8 +252,15 @@ function Start-DirectIngress {
 }
 
 function Invoke-CanonicalCoreSeed {
+  param([switch]$IngestOnly)
+
+  $seedCommand = "python tools/front_office_portfolio_seed.py --portfolio-id $PortfolioId --start-date 2025-03-31 --end-date 2026-04-10 --benchmark-start-date 2025-01-06 --wait-seconds $SeedWaitSeconds"
+  if ($IngestOnly) {
+    $seedCommand = "$seedCommand --ingest-only"
+  }
+
   Write-Host "Seeding governed front-office portfolio data for $PortfolioId ..."
-  Invoke-RepoCommand $coreRepo "python tools/front_office_portfolio_seed.py --portfolio-id $PortfolioId --start-date 2025-03-31 --end-date 2026-04-10 --benchmark-start-date 2025-01-06 --wait-seconds $SeedWaitSeconds"
+  Invoke-RepoCommand $coreRepo $seedCommand
 }
 
 Write-Host "Previewing managed canonical hosts block from lotus-platform ..."
@@ -277,7 +284,7 @@ if ($CoreManageOnly) {
   Write-Host "Core/manage proof mode enabled; skipping non-essential front-office services."
   Start-CanonicalManage
   Start-DirectIngress
-  Invoke-CanonicalCoreSeed
+  Invoke-CanonicalCoreSeed -IngestOnly
   Write-Host ""
   Write-Host "Canonical core/manage proof stack is up."
   Write-Host "  Core query:   http://core-query.dev.lotus"

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -39,6 +39,8 @@ describe("canonical live validation script", () => {
     expect(runbook).toContain("Docker is the default for every canonical front-office app");
     expect(runbook).toContain("-LocalApps workbench,gateway,manage");
     expect(runbook).toContain("live:stack:up:workbench-local");
+    expect(runbook).toContain("live:stack:up:core-manage");
+    expect(runbook).toContain("Use it only for API-level RFC proof");
     expect(runbook).toContain("GET /api/v1/rebalance/supportability/summary");
   });
 
@@ -76,8 +78,13 @@ describe("canonical live validation script", () => {
     expect(script).toContain("function Test-LocalApp");
     expect(script).toContain("function Invoke-ComposeUp");
     expect(script).toContain("function Start-LocalUvicornService");
+    expect(script).toContain("function Start-CanonicalManage");
+    expect(script).toContain("function Start-DirectIngress");
+    expect(script).toContain("function Invoke-CanonicalCoreSeed");
     expect(script).toContain("Using lotus-ai env file for canonical proof");
     expect(script).toContain("[switch]$CleanCoreState");
+    expect(script).toContain("[switch]$CoreManageOnly");
+    expect(script).toContain("Core/manage proof mode enabled");
     expect(script).toContain("$global:LASTEXITCODE = 0");
     expect(script).toContain("Command failed with exit code $LASTEXITCODE");
     expect(script).toContain("Resetting lotus-core Docker state before canonical reseed");
@@ -132,6 +139,7 @@ describe("canonical live validation script", () => {
     expect(browserValidator).toContain('checkDns(summary, "archive.dev.lotus")');
     expect(browserValidator).toContain('checkDns(summary, "render.dev.lotus")');
     expect(packageJson).toContain('"live:stack:up:workbench-local"');
+    expect(packageJson).toContain('"live:stack:up:core-manage"');
   });
 
   it("asserts canonical performance and risk calculation sanity", () => {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -40,6 +40,7 @@ describe("canonical live validation script", () => {
     expect(runbook).toContain("-LocalApps workbench,gateway,manage");
     expect(runbook).toContain("live:stack:up:workbench-local");
     expect(runbook).toContain("live:stack:up:core-manage");
+    expect(runbook).toContain("core seed in ingest-only mode");
     expect(runbook).toContain("Use it only for API-level RFC proof");
     expect(runbook).toContain("GET /api/v1/rebalance/supportability/summary");
   });
@@ -85,6 +86,8 @@ describe("canonical live validation script", () => {
     expect(script).toContain("[switch]$CleanCoreState");
     expect(script).toContain("[switch]$CoreManageOnly");
     expect(script).toContain("Core/manage proof mode enabled");
+    expect(script).toContain("param([switch]$IngestOnly)");
+    expect(script).toContain("--ingest-only");
     expect(script).toContain("$global:LASTEXITCODE = 0");
     expect(script).toContain("Command failed with exit code $LASTEXITCODE");
     expect(script).toContain("Resetting lotus-core Docker state before canonical reseed");


### PR DESCRIPTION
## Summary
- Adds a core/manage-only canonical runtime mode for RFC-087/RFC-0036 live proof.
- Scopes manage proof seeding to core so the front-office canonical automation can bring up only the required services for manage API validation.
- Documents the core/manage validation path for future DPM proof runs.

## Evidence
- `npm run typecheck` -> passed.
- `npm test -- tests/unit/live-canonical-validation-script.test.ts` -> 11 passed.
- `npm run lint` -> passed.
- The live proof path was used by lotus-core and lotus-manage closure validation: core DPM source products passed 7/7 probes and manage core-sourcing validation passed 11/11 probes.

## Notes
- This PR does not integrate manage into Workbench UI or gateway. It upgrades the canonical automation needed to test core/manage before gateway integration.