### PR TITLE
Enable canonical core-manage stateful proof posture

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -138,6 +138,25 @@ governed `PB_SG_GLOBAL_BAL_001` core seed in ingest-only mode. It intentionally 
 target is core source-data products plus manage APIs, not populated Workbench screenshots or
 gateway-mediated product flows.
 
+When the proof depends on local `lotus-manage` or `lotus-core` code that has changed since the
+last Docker image build, use the build variant so the evidence cannot accidentally validate a stale
+container image:
+
+```powershell
+npm run live:stack:up:core-manage:build
+```
+
+The core/manage proof mode starts Docker-backed `lotus-manage` with the explicit stateful sourcing
+posture required by the validator:
+
+- `DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED=true`
+- `DPM_STATEFUL_CORE_SOURCING_ENABLED=true`
+- `DPM_CORE_BASE_URL=http://host.docker.internal:8202` for Docker-backed manage
+
+Local manage overrides use the canonical host URL `http://core-control.dev.lotus` for the same
+source-data authority. This keeps capability truth aligned with the proof target: stateful mode
+should be advertised only when the managed core source path is actually configured.
+
 The command exits after the stack is usable. It does not block on browser validation.
 Non-zero seed or upstream startup failures must fail the PowerShell command; a partial bring-up is
 not considered success.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "live:stack:down": "powershell -ExecutionPolicy Bypass -File scripts/live/Stop-LotusFrontOfficeCanonical.ps1",
     "live:stack:up": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1",
     "live:stack:up:core-manage": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -CoreManageOnly",
+    "live:stack:up:core-manage:build": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -CoreManageOnly -BuildImages",
     "live:stack:up:workbench-local": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -LocalApps workbench",
     "live:stack:up:validate": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -RunValidation",
     "live:validate": "powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1",

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -121,6 +121,17 @@ function Invoke-ComposeUp {
     [hashtable]$Environment = @{}
   )
 
+  Invoke-WithProcessEnvironment -Environment $Environment -ScriptBlock {
+    Invoke-RepoCommand $RepoPath $composeUpCommand
+  }
+}
+
+function Invoke-WithProcessEnvironment {
+  param(
+    [hashtable]$Environment,
+    [scriptblock]$ScriptBlock
+  )
+
   $previousValues = @{}
   foreach ($key in $Environment.Keys) {
     $previousValues[$key] = [Environment]::GetEnvironmentVariable($key, "Process")
@@ -128,7 +139,7 @@ function Invoke-ComposeUp {
   }
 
   try {
-    Invoke-RepoCommand $RepoPath $composeUpCommand
+    & $ScriptBlock
   } finally {
     foreach ($key in $Environment.Keys) {
       [Environment]::SetEnvironmentVariable($key, $previousValues[$key], "Process")
@@ -231,10 +242,21 @@ function Get-EnvScopedComposeCommand {
 }
 
 function Start-CanonicalManage {
+  $localManageEnvironment = @{
+    LOTUS_MANAGE_HOST_PORT = "8001"
+    DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED = "true"
+    DPM_STATEFUL_CORE_SOURCING_ENABLED = "true"
+    DPM_CORE_BASE_URL = "http://core-control.dev.lotus"
+  }
+  $dockerManageEnvironment = $localManageEnvironment.Clone()
+  $dockerManageEnvironment["DPM_CORE_BASE_URL"] = "http://host.docker.internal:8202"
+
   if (Test-LocalApp "manage") {
     Invoke-RepoCommand $manageRepo "docker compose down --remove-orphans"
     Write-Host "Starting canonical lotus-manage locally on :8001 ..."
-    & (Join-Path $manageRepo "scripts\\Start-CanonicalManage.ps1") -Port 8001
+    Invoke-WithProcessEnvironment -Environment $localManageEnvironment -ScriptBlock {
+      & (Join-Path $manageRepo "scripts\\Start-CanonicalManage.ps1") -Port 8001
+    }
     if ($LASTEXITCODE -ne 0) {
       throw "Canonical lotus-manage local startup failed with exit code $LASTEXITCODE."
     }
@@ -242,7 +264,7 @@ function Start-CanonicalManage {
   }
 
   Stop-HostProcessOnPort -Port 8001 -Description "lotus-manage"
-  Invoke-ComposeUp $manageRepo @{ LOTUS_MANAGE_HOST_PORT = "8001" }
+  Invoke-ComposeUp $manageRepo $dockerManageEnvironment
 }
 
 function Start-DirectIngress {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -99,7 +99,15 @@ describe("canonical live validation script", () => {
     expect(script).toContain('$env:BFF_BASE_URL = "http://gateway.dev.lotus"');
     expect(script).toContain("$previousNextTelemetryDisabled = $env:NEXT_TELEMETRY_DISABLED");
     expect(script).toContain('Test-LocalApp "workbench"');
-    expect(script).toContain('Invoke-ComposeUp $manageRepo @{ LOTUS_MANAGE_HOST_PORT = "8001" }');
+    expect(script).toContain("function Invoke-WithProcessEnvironment");
+    expect(script).toContain("$localManageEnvironment = @{");
+    expect(script).toContain('LOTUS_MANAGE_HOST_PORT = "8001"');
+    expect(script).toContain('DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED = "true"');
+    expect(script).toContain('DPM_STATEFUL_CORE_SOURCING_ENABLED = "true"');
+    expect(script).toContain('DPM_CORE_BASE_URL = "http://core-control.dev.lotus"');
+    expect(script).toContain('$dockerManageEnvironment["DPM_CORE_BASE_URL"] = "http://host.docker.internal:8202"');
+    expect(script).toContain("Invoke-WithProcessEnvironment -Environment $localManageEnvironment");
+    expect(script).toContain("Invoke-ComposeUp $manageRepo $dockerManageEnvironment");
     expect(script).toContain('Invoke-ComposeUp $workbenchRepo @{ BFF_BASE_URL = "http://host.docker.internal:8100" }');
     expect(script).not.toContain("Workbench already responding on :3000");
     expect(script).toContain("--portfolio-id $PortfolioId");


### PR DESCRIPTION
## Summary
- start canonical core/manage proof mode with explicit lotus-manage stateful core-sourcing gates
- use the Docker-reachable core control-plane URL for Docker-backed manage and the canonical host URL for local manage overrides
- add `live:stack:up:core-manage:build` plus runbook guidance to prevent stale-image proof

## Evidence
- `powershell -NoProfile -Command '$script = Get-Content -Raw scripts/live/Start-LotusFrontOfficeCanonical.ps1; [void][scriptblock]::Create($script); Write-Output "Start-LotusFrontOfficeCanonical syntax ok"'` -> syntax ok
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"` -> package.json ok
- `powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -CoreManageOnly -BuildImages` -> canonical core/manage stack up and seeded `PB_SG_GLOBAL_BAL_001`
- paired lotus-manage validator: `LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING=available make live-api-validate-core` -> 11/11 passed

## Notes
This PR supports lotus-manage RFC-0038/RFC-0036 proof only. It does not claim Gateway or Workbench command-center product-surface integration; those remain tracked downstream.