### PR TITLE
RFC-0041 wave addendum for DPM command center

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -29,5 +29,5 @@ Governance boundary:
 | RFC-0021 | UI Architecture Hardening and Design-System Governance | IMPLEMENTED | `docs/rfcs/RFC-0021-ui-architecture-hardening-and-design-system-governance.md` |
 | RFC-0022 | Stateful Risk Workspace and lotus-risk UI Integration | IMPLEMENTED | `docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md` |
 | RFC-0023 | Risk Workspace UX Hardening and Production Readiness | IMPLEMENTED | `docs/rfcs/RFC-0023-risk-workspace-ux-hardening-and-production-readiness.md` |
-| RFC-0098 | DPM Mandate Command Center Experience | PROPOSED - RFC-0040 PROOF-PACK EXPERIENCE ALIGNED | `docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md` |
+| RFC-0098 | DPM Mandate Command Center Experience | PROPOSED - RFC-0041 WAVE ORCHESTRATION EXPERIENCE ALIGNED | `docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md` |
 

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -2,13 +2,13 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | PROPOSED - RFC-0040 PROOF-PACK EXPERIENCE ALIGNED |
+| **Status** | PROPOSED - RFC-0041 WAVE ORCHESTRATION EXPERIENCE ALIGNED |
 | **Created** | 2026-05-03 |
-| **Last Tightened** | 2026-05-03 |
+| **Last Tightened** | 2026-05-04 |
 | **Owner** | `lotus-workbench` |
 | **Primary Upstream Contract** | `lotus-gateway` RFC-0098 `DPM Command Center` |
 | **Business Sponsor Persona** | DPM head, portfolio manager, CIO desk, investment control, operations, sales/pre-sales |
-| **Depends On** | `lotus-gateway` RFC-0098, `lotus-manage` RFC-0037, `lotus-manage` RFC-0038, `lotus-manage` RFC-0040, `lotus-core` RFC-0087, Workbench RFC-0076/RFC-0077 canonical proof contracts |
+| **Depends On** | `lotus-gateway` RFC-0098, `lotus-manage` RFC-0037, `lotus-manage` RFC-0038, `lotus-manage` RFC-0040, `lotus-manage` RFC-0041, `lotus-core` RFC-0087, Workbench RFC-0076/RFC-0077 canonical proof contracts |
 | **Doc Location** | `docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md` |
 | **Implementation Branch** | TBD when implementation begins |
 
@@ -283,6 +283,96 @@ Required UI states:
 
 Supported-feature promotion is forbidden until Gateway implementation, Workbench browser proof,
 canonical screenshots, accessibility checks, and live validation pass.
+
+### 7.0B Rebalance Wave Command Center Addendum
+
+Workbench RFC-0098 must include a rebalance-wave command-center workspace once Gateway exposes the
+RFC-0041 wave composition family backed by `lotus-manage`. This workspace belongs inside the DPM
+command center because waves are the operating container for affected portfolios, source checks,
+construction alternatives, proof-pack linkage, approval, staging, and internal operations handoff.
+
+Workbench must consume Gateway only. It must not call `lotus-manage` directly, must not calculate
+source readiness, aggregate metrics, construction alternatives, proof-pack state, action
+eligibility, supportability, or handoff posture, and must not imply external execution from manage
+handoff refs.
+
+Target user journey:
+
+1. PM or CIO opens the DPM wave command-center view from `/dpm`.
+2. The user previews or opens a wave backed by a Gateway route under
+   `/api/v1/dpm/command-center/waves`.
+3. Workbench renders mixed readiness across ready, degraded, blocked, simulated, selected,
+   proof-pack-ready, approved, staged, and handoff-ready items.
+4. Workbench enables only Gateway-returned actions and shows disabled reasons for every blocked
+   source-check, simulate, select, approve, stage, or handoff action.
+5. Operations opens the supportability drawer and sees support refs, source owner, reason codes,
+   and remediation route without portfolio/client identifiers or raw payloads.
+6. Sales/pre-sales can demonstrate candidate selection through internal handoff, while clearly
+   stating that external execution is not claimed by manage or Workbench.
+
+Required wave panels:
+
+| Panel | Purpose | Required behavior |
+| --- | --- | --- |
+| Wave Header | Show wave identity, trigger, as-of date, state, version, item counts, and supportability. | Preserve Gateway/manage state names and display `external_execution_claimed=false` when handoff refs are shown. |
+| Item Matrix | Let PM, CIO, and operations scan mixed item readiness. | Render item state, reason codes, selected alternative refs, proof-pack refs, and product-safe diagnostics from Gateway only. |
+| Action Rail | Guide source-check, simulate, select, approve, stage, and handoff progression. | Buttons are enabled only from Gateway `action_eligibility`; disabled reasons remain visible and auditable. |
+| Construction Drawer | Compare generated alternatives for eligible items. | Render Gateway construction module data; never run optimization or infer selection locally. |
+| Proof-Pack Evidence Drawer | Explain selected item evidence. | Link proof-pack id, section posture, content hash, Markdown/report/AI input posture, and degraded reasons when Gateway provides them. |
+| Supportability Drawer | Support operator triage. | Show support refs, source owners, remediation routes, and safe diagnostics; hide portfolio/client/raw request/trace details. |
+| Operations Handoff Rail | Show internal staging and handoff posture. | Render staged and handoff-ready refs as internal evidence only; do not expose unsupported execution controls. |
+
+Required UI states:
+
+1. no wave selected,
+2. preview available but not durable,
+3. created wave awaiting source check,
+4. source-checked wave with mixed ready/degraded/blocked items,
+5. simulation in progress,
+6. simulated or partially simulated wave,
+7. alternative selection required,
+8. proof-pack pending or degraded,
+9. approval available or approval blocked,
+10. approved with exceptions,
+11. staged,
+12. handoff-ready with internal handoff evidence,
+13. Gateway unavailable,
+14. manage wave authority unavailable,
+15. supportability blocked/degraded/not found.
+
+```mermaid
+flowchart LR
+  User[PM / CIO / Operations] --> UI[Workbench DPM Wave Workspace]
+  UI --> BFF[Workbench BFF wrapper]
+  BFF --> Gateway[Gateway RFC-0098 wave composition]
+  Gateway --> Manage[lotus-manage RFC-0041 wave authority]
+  Gateway --> Risk[lotus-risk]
+  Gateway --> Perf[lotus-performance]
+  Gateway --> Report[lotus-report]
+  Gateway --> Archive[lotus-archive]
+  Gateway --> AI[lotus-ai]
+```
+
+Workbench must consume these Gateway wave routes when implemented:
+
+| Gateway endpoint | Workbench route/use |
+| --- | --- |
+| `GET /api/v1/dpm/command-center/waves` | `/dpm/waves` list or embedded wave rail |
+| `GET /api/v1/dpm/command-center/waves/{wave_id}` | `/dpm/waves/[waveId]` detail workspace |
+| `GET /api/v1/dpm/command-center/waves/{wave_id}/supportability` | supportability drawer |
+| `POST /api/v1/dpm/command-center/waves/preview` | non-durable preview workflow |
+| `POST /api/v1/dpm/command-center/waves` | durable wave creation |
+| `POST /api/v1/dpm/command-center/waves/{wave_id}/source-check` | source-check action |
+| `POST /api/v1/dpm/command-center/waves/{wave_id}/simulate` | construction simulation action |
+| `POST /api/v1/dpm/command-center/waves/{wave_id}/items/{wave_item_id}/select` | alternative selection drawer |
+| `POST /api/v1/dpm/command-center/waves/{wave_id}/approve` | approval action |
+| `POST /api/v1/dpm/command-center/waves/{wave_id}/stage` | staging action |
+| `POST /api/v1/dpm/command-center/waves/{wave_id}/handoff` | internal operations handoff action |
+
+Supported-feature promotion is forbidden until Gateway implementation is merged, Workbench BFF and
+browser implementation is complete, canonical `PB_SG_GLOBAL_BAL_001` live validation passes, visual
+and accessibility evidence is captured, screenshots are reviewed for layout/state correctness, and
+the wiki/supported-feature material is updated with implementation-backed wording.
 
 Workbench must consume these Gateway routes:
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -45,6 +45,10 @@ promote dormant labels into product ownership just because historical route file
   Reporting, Data Products, and legacy advisor Workbench gateway-backed reads/mutations. The
   coverage registry is code-backed and tested so active product surfaces cannot silently drift
   outside bounded route/panel/operation metrics.
+- RFC-0098 now defines the future DPM rebalance-wave workspace. It is not an active supported
+  route yet; promotion requires Gateway `/api/v1/dpm/command-center/waves*` implementation,
+  Workbench BFF/browser implementation, canonical `PB_SG_GLOBAL_BAL_001` live validation, visual
+  and accessibility evidence, and implementation-backed wiki/support wording.
 
 ## Route examples
 

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -64,7 +64,9 @@ must travel through Gateway-shaped contracts.
     Gateway-composed mandate and proof-pack truth, not a direct caller of manage, risk,
     performance, core, report, archive, or AI. RFC-0040 proof-pack JSON, hashes, Markdown,
     report-input payloads, and AI-evidence payloads remain manage-owned and must reach Workbench
-    through Gateway composition.
+    through Gateway composition. RFC-0041 rebalance-wave preview, create, source-check,
+    simulation, selection, approval, staging, handoff, and supportability also remain
+    manage-owned and must reach Workbench through Gateway wave composition only.
 12. `lotus-advise` owns advisor-led proposal workflows. Workbench proposal compatibility routes are
     not the active RFC-0108 product surface and should not be used as current client-demo evidence.
 
@@ -82,11 +84,13 @@ flowchart TB
   Archive[Document metadata and downloads]
   Render[PDF render readiness]
   Manage[Strategic DPM run lookup, supportability, and proof packs]
+  Waves[Future rebalance-wave workspace]
   Advise[Advisor-led proposal workflows]
   DpmCenter[Future DPM command center UI]
 
   Workbench -->|/api/bff/api/v1/workbench/*| Gateway
   Workbench --> DpmCenter
+  DpmCenter --> Waves
   DpmCenter -->|Gateway RFC-0098 contract| Gateway
   Gateway --> Core
   Gateway --> Performance

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -12,7 +12,8 @@
   context and agent guidance system
 - RFC-0098
   proposed DPM mandate command-center product experience backed by Gateway RFC-0098, including
-  manage-owned RFC-0040 proof-pack evidence rendered through Gateway
+  manage-owned RFC-0040 proof-pack evidence and RFC-0041 rebalance-wave orchestration rendered
+  through Gateway without direct Workbench service calls or client-side readiness calculation
 
 ## Local references
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -15,6 +15,6 @@
 1. keep strengthening Portfolio and Performance truth and density
 2. implement RFC-0098 as the Gateway-backed DPM mandate command-center experience once Gateway
    RFC-0098 provides the certified composition contract, including manage-owned RFC-0040
-   proof-pack evidence rendered through Gateway
+   proof-pack evidence and RFC-0041 rebalance-wave orchestration rendered through Gateway
 3. preserve gateway-first integration discipline
 4. continue aligning route ownership to the product architecture blueprint


### PR DESCRIPTION
## Summary
- aligns Workbench RFC-0098 with Gateway-managed RFC-0041 rebalance-wave realization
- defines target wave workspace panels, states, Gateway routes, supportability drawer, action gating, and canonical proof requirements
- updates RFC index and wiki API/integration/roadmap truth without promoting unsupported UI support

## Validation
- make lint