### PR TITLE
feat: add RFC42 outcome review Workbench panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,16 @@ Boundary rules that matter:
    `PB_SG_GLOBAL_BAL_001`.
 4. `Data Products` is available at `/data-products` for gateway-backed catalog, dependency, and
    live trust discovery.
-5. Recommendations and proposals routes still exist as compatibility paths, but they are no longer
+5. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0042 post-trade outcome-review
+   panel for manage-owned expected-versus-realized dimensions, source lineage, supportability,
+   and report/AI handoff posture. Workbench renders the Gateway contract and does not calculate
+   outcome variance, freshness, supportability, or handoff eligibility locally.
+6. Recommendations and proposals routes still exist as compatibility paths, but they are no longer
    the primary supported front-office app surfaces.
-6. Top-level shell navigation is capability-gated: `Portfolio`, `Performance`, and `Risk` are
+7. Top-level shell navigation is capability-gated: `Portfolio`, `Performance`, and `Risk` are
    active, while `Proposal` and `Advisory` remain disabled in the current normalized shell
    bootstrap contract.
-7. Canonical review-ready browser evidence comes from `npm run live:validate` artifacts under
+8. Canonical review-ready browser evidence comes from `npm run live:validate` artifacts under
    `output/playwright/live-canonical/`, not from ad hoc localhost screenshots.
 
 ## Architecture At A Glance
@@ -73,7 +77,8 @@ Current main surfaces:
 - `performance`
   `/performance` with performance, risk, advisor-brief, and evidence modes
 - `workbench`
-  `/workbench/*` compatibility and portfolio-linked workspace entry
+  `/workbench/*` compatibility and portfolio-linked workspace entry, including the Gateway-backed
+  DPM outcome-review panel when manage has materialized RFC-0042 outcome evidence
 - `data-products`
   `/data-products` self-serve catalog, dependency, and live trust discovery through gateway
 - `api/bff`
@@ -178,6 +183,7 @@ Quick local browser-facing path:
 http://workbench.dev.lotus/portfolio
 http://workbench.dev.lotus/performance
 http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=risk
+http://workbench.dev.lotus/workbench/PB_SG_GLOBAL_BAL_001
 http://workbench.dev.lotus/data-products
 ```
 
@@ -238,6 +244,10 @@ Important current product and route truths:
    `Advisory` items rather than live product routes
 7. evidence-oriented performance views must be documented truthfully as runtime-governed product
    behavior, not as a promise of separate unsupported backend ownership inside Workbench
+8. RFC-0042 outcome-review rendering on `/workbench/{portfolioId}` is backed by Gateway
+   `/api/v1/dpm/command-center/outcome-reviews*`; Workbench may normalize presentation shape but
+   must not derive expected, realized, variance, lineage, source freshness, supportability, report
+   input, or AI evidence eligibility outside the Gateway/manage contract.
 
 Copy-paste route and runtime examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -48,7 +48,11 @@ Current repository posture:
    honors route-level report date and backend benchmark controls for proof while still avoiding
    direct `lotus-report` calls, and it now retrieves archived report metadata/downloads through
    Gateway `/api/v1/documents` via the Workbench BFF rather than calling `lotus-archive` directly,
-7. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
+7. `/workbench/{portfolioId}` renders the RFC-0042 DPM outcome-review panel from Gateway
+   `/api/v1/dpm/command-center/outcome-reviews*`, preserving manage-owned expected-versus-realized
+   dimensions, source lineage, supportability, report-input posture, and AI-evidence posture
+   without client-side outcome calculation,
+8. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map
 
@@ -142,6 +146,10 @@ Important validation expectations:
    stale source freshness taking precedence over ready source items. State-changing Workbench
    actions should use the mutation observation helper so they emit bounded request, state, and
    applicable attention metrics without incrementing panel hydration counters.
+9. DPM outcome-review Workbench reads use the same bounded observability registry. Metric labels
+   must identify only governed route, panel, operation, freshness, supportability, and status
+   classes; outcome review ids, portfolio ids, proof-pack ids, rebalance run ids, request payloads,
+   response payloads, hashes, and lineage references must stay out of metric labels.
 
 ### Visual Review Gate
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -29,5 +29,5 @@ Governance boundary:
 | RFC-0021 | UI Architecture Hardening and Design-System Governance | IMPLEMENTED | `docs/rfcs/RFC-0021-ui-architecture-hardening-and-design-system-governance.md` |
 | RFC-0022 | Stateful Risk Workspace and lotus-risk UI Integration | IMPLEMENTED | `docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md` |
 | RFC-0023 | Risk Workspace UX Hardening and Production Readiness | IMPLEMENTED | `docs/rfcs/RFC-0023-risk-workspace-ux-hardening-and-production-readiness.md` |
-| RFC-0098 | DPM Mandate Command Center Experience | PROPOSED - RFC-0041/0042 WAVE AND OUTCOME EXPERIENCE ALIGNED | `docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md` |
+| RFC-0098 | DPM Mandate Command Center Experience | IN PROGRESS - RFC-0042 OUTCOME PANEL IMPLEMENTED, LIVE PROOF PENDING | `docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md` |
 

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -2,7 +2,7 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | PROPOSED - RFC-0041/0042 WAVE AND OUTCOME EXPERIENCE ALIGNED |
+| **Status** | IN PROGRESS - RFC-0042 OUTCOME PANEL IMPLEMENTED, LIVE PROOF PENDING |
 | **Created** | 2026-05-03 |
 | **Last Tightened** | 2026-05-05 |
 | **Owner** | `lotus-workbench` |
@@ -10,7 +10,7 @@
 | **Business Sponsor Persona** | DPM head, portfolio manager, CIO desk, investment control, operations, sales/pre-sales |
 | **Depends On** | `lotus-gateway` RFC-0098, `lotus-manage` RFC-0037, `lotus-manage` RFC-0038, `lotus-manage` RFC-0040, `lotus-manage` RFC-0041, `lotus-manage` RFC-0042, `lotus-core` RFC-0087, Workbench RFC-0076/RFC-0077 canonical proof contracts |
 | **Doc Location** | `docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md` |
-| **Implementation Branch** | `feat/rfc0042-outcome-realization` for RFC-0042 realization alignment |
+| **Implementation Branch** | `feat/rfc42-outcome-review-workbench` for RFC-0042 outcome-review realization |
 
 ---
 
@@ -386,6 +386,15 @@ Workbench must consume Gateway only. It must not call `lotus-manage`, `lotus-cor
 must not recompute expected values, realized values, variance, tolerance, dimension state, source
 freshness, supportability, report-input posture, or AI-evidence posture.
 
+Implementation note as of 2026-05-05: the first RFC-0042 outcome-review realization is embedded in
+`/workbench/{portfolioId}` using Gateway
+`GET /api/v1/dpm/command-center/outcome-reviews`. It includes typed Workbench API wrappers,
+bounded analytics UI observability surfaces, deterministic view-model normalization, and a
+portfolio-linked panel that renders manage-owned review state, dimension rows, lineage rows,
+snapshot hashes, supportability reasons, blocked actions, and report/AI handoff posture. Dedicated
+`/dpm/outcomes` routing, mutation actions, drawers, and canonical live screenshot proof remain
+future RFC-0098 command-center work unless separately promoted by implementation evidence.
+
 Target user journey:
 
 1. PM opens the DPM outcome workspace from `/dpm` or a wave/proof-pack link.
@@ -455,10 +464,11 @@ Workbench must consume these Gateway outcome routes when implemented:
 | `POST /api/v1/dpm/command-center/outcome-reviews` | durable outcome-review creation |
 | `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/refresh-sources` | source refresh action |
 
-Supported-feature promotion is forbidden until Gateway implementation is merged, Workbench BFF and
-browser implementation is complete, canonical `PB_SG_GLOBAL_BAL_001` live validation passes, visual
-and accessibility evidence is captured, screenshots are reviewed for outcome-state correctness,
-and the wiki/supported-feature material is updated with implementation-backed wording.
+Supported-feature promotion for the embedded `/workbench/{portfolioId}` outcome-review panel now
+requires canonical `PB_SG_GLOBAL_BAL_001` live validation, visual and accessibility evidence,
+screenshots reviewed for outcome-state correctness, and implementation-backed wiki/support wording.
+Promotion for the larger `/dpm/outcomes` command-center route remains forbidden until that route is
+implemented and proven.
 
 Workbench must consume these Gateway routes:
 

--- a/scripts/live/Capture-LotusFrontOfficeEvidence.ps1
+++ b/scripts/live/Capture-LotusFrontOfficeEvidence.ps1
@@ -11,6 +11,11 @@ $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $captureStartedAt = (Get-Date).ToUniversalTime().ToString("o")
 $validationSummaryPath = Join-Path $repoRoot "output\playwright\live-canonical\live-validation-summary.json"
+$canonicalCallerContextHeaders = @{
+  "X-Actor-Id" = "workbench-system"
+  "X-Tenant-Id" = "tenant-sg"
+  "X-Region" = "APAC"
+}
 
 if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
   $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
@@ -42,7 +47,8 @@ function Write-HttpArtifact {
   param(
     [string]$Name,
     [string]$Url,
-    [string]$RelativePath
+    [string]$RelativePath,
+    [hashtable]$Headers = @{}
   )
 
   $target = Resolve-ArtifactPath $RelativePath
@@ -55,7 +61,7 @@ function Write-HttpArtifact {
   }
 
   try {
-    $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 45
+    $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 45 -Headers $Headers
     $contentType = ($response.Headers["Content-Type"] -join ",")
     Set-Content -Path $target -Value $response.Content -Encoding UTF8
     $record.status = $response.StatusCode
@@ -187,11 +193,11 @@ $apiChecks += Write-HttpArtifact "manage-ready" "http://manage.dev.lotus/health/
 $apiChecks += Write-HttpArtifact "report-ready" "http://report.dev.lotus/health/ready" "api\report-ready.json"
 $apiChecks += Write-HttpArtifact "archive-ready" "http://archive.dev.lotus/health/ready" "api\archive-ready.json"
 $apiChecks += Write-HttpArtifact "render-ready" "http://render.dev.lotus/health/ready" "api\render-ready.json"
-$apiChecks += Write-HttpArtifact "gateway-platform-capabilities" "http://gateway.dev.lotus/api/v1/platform/capabilities" "api\gateway-platform-capabilities.json"
-$apiChecks += Write-HttpArtifact "gateway-workbench-overview" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/overview" "api\gateway-workbench-overview.json"
-$apiChecks += Write-HttpArtifact "gateway-performance-summary" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "api\gateway-performance-summary.json"
-$apiChecks += Write-HttpArtifact "gateway-risk-summary" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/risk/summary?period=YTD&detail_basis=NET&benchmark_code=$BenchmarkCode" "api\gateway-risk-summary.json"
-$apiChecks += Write-HttpArtifact "gateway-advisor-brief" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "api\gateway-advisor-brief.json"
+$apiChecks += Write-HttpArtifact "gateway-platform-capabilities" "http://gateway.dev.lotus/api/v1/platform/capabilities" "api\gateway-platform-capabilities.json" -Headers $canonicalCallerContextHeaders
+$apiChecks += Write-HttpArtifact "gateway-workbench-overview" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/overview" "api\gateway-workbench-overview.json" -Headers $canonicalCallerContextHeaders
+$apiChecks += Write-HttpArtifact "gateway-performance-summary" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "api\gateway-performance-summary.json" -Headers $canonicalCallerContextHeaders
+$apiChecks += Write-HttpArtifact "gateway-risk-summary" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/risk/summary?period=YTD&detail_basis=NET&benchmark_code=$BenchmarkCode" "api\gateway-risk-summary.json" -Headers $canonicalCallerContextHeaders
+$apiChecks += Write-HttpArtifact "gateway-advisor-brief" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "api\gateway-advisor-brief.json" -Headers $canonicalCallerContextHeaders
 $apiChecks += Write-HttpArtifact "manage-supportability-summary" "http://manage.dev.lotus/api/v1/rebalance/supportability/summary" "api\manage-supportability-summary.json"
 $apiChecks += Write-HttpArtifact "report-integration-capabilities" "http://report.dev.lotus/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default" "api\report-integration-capabilities.json"
 

--- a/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
@@ -8,6 +8,11 @@ param(
 
 $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$canonicalCallerContextHeaders = @{
+  "X-Actor-Id" = "workbench-system"
+  "X-Tenant-Id" = "tenant-sg"
+  "X-Region" = "APAC"
+}
 
 function Test-CanonicalHost {
   param(
@@ -31,6 +36,7 @@ function Test-Endpoint {
   param(
     [string]$Url,
     [string]$Label,
+    [hashtable]$Headers = @{},
     [int]$Attempts = 8,
     [int]$DelaySeconds = 3
   )
@@ -38,7 +44,7 @@ function Test-Endpoint {
   $lastError = $null
   for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
     try {
-      $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 45
+      $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 45 -Headers $Headers
       if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
         Write-Host "[ok] $Label -> $Url"
         return
@@ -88,12 +94,12 @@ Test-Endpoint "http://archive.dev.lotus/health/ready" "lotus-archive readiness"
 Test-Endpoint "http://render.dev.lotus/health/ready" "lotus-render readiness"
 Test-Endpoint "http://manage.dev.lotus/api/v1/rebalance/supportability/summary" "lotus-manage supportability summary"
 Test-Endpoint "http://report.dev.lotus/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default" "lotus-report integration capabilities"
-Test-Endpoint "$GatewayBaseUrl/api/v1/foundation/portfolios/$PortfolioId/workspace" "Gateway foundation workspace"
-Test-Endpoint "$GatewayBaseUrl/api/v1/platform/capabilities" "Gateway platform capabilities"
-Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/overview" "Gateway workbench overview"
-Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "Gateway performance summary"
-Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/risk/summary?period=YTD&detail_basis=NET&benchmark_code=$BenchmarkCode" "Gateway risk summary"
-Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "Gateway advisor brief"
+Test-Endpoint "$GatewayBaseUrl/api/v1/foundation/portfolios/$PortfolioId/workspace" "Gateway foundation workspace" -Headers $canonicalCallerContextHeaders
+Test-Endpoint "$GatewayBaseUrl/api/v1/platform/capabilities" "Gateway platform capabilities" -Headers $canonicalCallerContextHeaders
+Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/overview" "Gateway workbench overview" -Headers $canonicalCallerContextHeaders
+Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "Gateway performance summary" -Headers $canonicalCallerContextHeaders
+Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/risk/summary?period=YTD&detail_basis=NET&benchmark_code=$BenchmarkCode" "Gateway risk summary" -Headers $canonicalCallerContextHeaders
+Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "Gateway advisor brief" -Headers $canonicalCallerContextHeaders
 
 Push-Location $repoRoot
 try {

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -24,6 +24,7 @@ import {
   validatePerformanceAnalysisPanel,
   validatePerformanceSummaryPanel,
   validatePortfolioPanels,
+  validateOutcomeReviewPanel,
   validateRiskPanel,
 } from "./validation/browser-workflows.mjs";
 import { createPanelGovernance } from "./validation/panel-governance.mjs";
@@ -207,6 +208,17 @@ async function run() {
     throw new Error("lotus-manage supportability summary returned non-ready supportability.");
   }
 
+  const outcomeReviews = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/dpm/command-center/outcome-reviews?portfolio_id=${portfolioId}&limit=5`,
+    "DPM outcome reviews",
+    timeoutMs
+  );
+  const outcomeReviewItems = outcomeReviews?.data?.items ?? outcomeReviews?.items ?? [];
+  if (!Array.isArray(outcomeReviewItems) || outcomeReviewItems.length < 1) {
+    throw new Error("DPM outcome-review list returned no manage-backed reviews.");
+  }
+
   const reportCapabilities = await fetchJson(
     summary,
     "http://report.dev.lotus/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default",
@@ -263,6 +275,10 @@ async function run() {
   });
   panelGovernance.recordPanelClassification("performance.advisor_brief", "ready", "lotus-performance", {
     sourceMetricMinimum: 3,
+  });
+  panelGovernance.recordPanelClassification("dpm.outcome_review", "ready", "lotus-manage", {
+    route: `/workbench/${portfolioId}`,
+    outcomeReviewMinimum: 1,
   });
   panelGovernance.assertNoUnsupportedBlankPanels();
   panelGovernance.assertPanelSupportabilityAlignment();
@@ -345,6 +361,13 @@ async function run() {
       portfolioId,
       benchmarkCode,
       timeoutMs,
+      screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
+    });
+    await validateOutcomeReviewPanel(page, {
+      workbenchBaseUrl,
+      portfolioId,
+      timeoutMs,
+      assertTableHasRows: browserHelpers.assertTableHasRows,
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });
   } finally {

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -60,6 +60,7 @@ export function createBrowserValidationHelpers({
   function resolveRegistryRoute(routeTemplate) {
     return routeTemplate
       .replaceAll("{portfolioId}", portfolioId)
+      .replaceAll("{portfolio_id}", portfolioId)
       .replaceAll("{benchmarkCode}", benchmarkCode);
   }
 
@@ -361,4 +362,42 @@ export async function validateEvidencePanel(
   await screenshotRegisteredPanel(page, "performance.evidence", {
     state: "truthfully_degraded",
   });
+}
+
+export async function validateOutcomeReviewPanel(
+  page,
+  {
+    workbenchBaseUrl,
+    portfolioId,
+    timeoutMs,
+    assertTableHasRows,
+    screenshotRegisteredPanel,
+  }
+) {
+  await page.goto(`${workbenchBaseUrl}/workbench/${portfolioId}`, {
+    waitUntil: "networkidle",
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Post-Trade Outcome Review" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByLabel("Status lotus-manage")).toBeVisible({ timeout: timeoutMs });
+  await assertTableHasRows(
+    tableByExactLabel(page, "Post-trade outcome reviews"),
+    1,
+    "Post-trade outcome reviews"
+  );
+  await assertTableHasRows(
+    tableByExactLabel(page, "Outcome review dimensions"),
+    1,
+    "Outcome review dimensions"
+  );
+  await assertTableHasRows(
+    tableByExactLabel(page, "Outcome review source lineage"),
+    1,
+    "Outcome review source lineage"
+  );
+  await expect(page.getByText("Report Input")).toBeVisible({ timeout: timeoutMs });
+  await expect(page.getByText("AI Evidence")).toBeVisible({ timeout: timeoutMs });
+  await screenshotRegisteredPanel(page, "dpm.outcome_review");
 }

--- a/scripts/live/validation/contract-metadata.mjs
+++ b/scripts/live/validation/contract-metadata.mjs
@@ -151,6 +151,19 @@ export const DEFAULT_PANEL_REGISTRY = {
       knownLimitations: ["full evidence and lineage support is deferred pending RFC-0079"],
       ownerFollowUpRfc: "RFC-0079",
     },
+    {
+      panelId: "dpm.outcome_review",
+      owningService: "lotus-manage",
+      gatewayEndpoint: "/api/v1/dpm/command-center/outcome-reviews",
+      requiredSupportState: "ready",
+      route: "/workbench/{portfolioId}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "dpm-outcome-review-live.png",
+      knownLimitations: [
+        "embedded /workbench/{portfolioId} panel is implemented before the dedicated /dpm/outcomes workspace",
+      ],
+      ownerFollowUpRfc: "RFC-0098",
+    },
   ],
 };
 

--- a/scripts/live/validation/probes.mjs
+++ b/scripts/live/validation/probes.mjs
@@ -1,5 +1,11 @@
 import dns from "node:dns/promises";
 
+export const CANONICAL_CALLER_CONTEXT_HEADERS = {
+  "X-Actor-Id": "workbench-system",
+  "X-Tenant-Id": "tenant-sg",
+  "X-Region": "APAC",
+};
+
 export async function checkDns(summary, hostname, { required = true, lookup = dns.lookup } = {}) {
   try {
     const resolution = await lookup(hostname);
@@ -67,9 +73,13 @@ export async function sendJson(
       signal: controller.signal,
       headers:
         requestBody === undefined
-          ? headers
+          ? {
+              ...CANONICAL_CALLER_CONTEXT_HEADERS,
+              ...headers,
+            }
           : {
               "Content-Type": "application/json",
+              ...CANONICAL_CALLER_CONTEXT_HEADERS,
               ...headers,
             },
       body: requestBody === undefined ? undefined : JSON.stringify(requestBody),

--- a/src/app/api/bff/[...path]/route.ts
+++ b/src/app/api/bff/[...path]/route.ts
@@ -1,44 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveGatewayBaseUrl } from "@/features/platform-runtime/service-addressing";
 import { prepareAnalyticsUiProxyHeaders } from "@/features/analytics-observability/correlation";
-
-const DEFAULT_CALLER_CONTEXT_HEADERS = {
-  "X-Actor-Id": "workbench-system",
-  "X-Caller-Application": "lotus-workbench",
-  "X-Tenant-Id": "tenant-sg",
-  "X-Region": "APAC",
-  "X-Booking-Center-Code": "SG",
-  "X-Role": "advisor",
-} as const;
-
-const CALLER_CONTEXT_ENV_OVERRIDES: Record<
-  keyof typeof DEFAULT_CALLER_CONTEXT_HEADERS,
-  string
-> = {
-  "X-Actor-Id": "WORKBENCH_BFF_ACTOR_ID",
-  "X-Caller-Application": "WORKBENCH_BFF_CALLER_APPLICATION",
-  "X-Tenant-Id": "WORKBENCH_BFF_TENANT_ID",
-  "X-Region": "WORKBENCH_BFF_REGION",
-  "X-Booking-Center-Code": "WORKBENCH_BFF_BOOKING_CENTER_CODE",
-  "X-Role": "WORKBENCH_BFF_ROLE",
-};
-
-function defaultCallerContextValue(
-  headerName: keyof typeof DEFAULT_CALLER_CONTEXT_HEADERS
-) {
-  const configured = process.env[CALLER_CONTEXT_ENV_OVERRIDES[headerName]]?.trim();
-  return configured || DEFAULT_CALLER_CONTEXT_HEADERS[headerName];
-}
-
-function applyDefaultCallerContextHeaders(headers: Headers) {
-  for (const headerName of Object.keys(DEFAULT_CALLER_CONTEXT_HEADERS) as Array<
-    keyof typeof DEFAULT_CALLER_CONTEXT_HEADERS
-  >) {
-    if (!headers.get(headerName)?.trim()) {
-      headers.set(headerName, defaultCallerContextValue(headerName));
-    }
-  }
-}
+import { applyDefaultCallerContextHeaders } from "@/features/workbench/caller-context";
 
 async function proxy(request: NextRequest, params: { path: string[] }) {
   const upstreamPath = params.path.join("/");

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -190,6 +190,35 @@
   overflow-wrap: anywhere;
 }
 
+.outcome-review-panel .section-block-body {
+  gap: 0.75rem;
+}
+
+.outcome-review-badge-row,
+.outcome-review-reason-row,
+.outcome-review-hash-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.outcome-review-status-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.outcome-review-hash-strip {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+.outcome-review-hash-strip span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -1,4 +1,5 @@
 import {
+  getDpmOutcomeReviews,
   getPortfolio360,
   getReportingSnapshot,
   getWorkbenchAnalytics,
@@ -20,6 +21,7 @@ import DeltaAnalyticsPanel from "@/features/workbench/components/delta-analytics
 import DecisionReadinessPanel from "@/features/workbench/components/decision-readiness-panel";
 import ExceptionQueue from "@/features/workbench/components/exception-queue";
 import OverviewCards from "@/features/workbench/components/overview-cards";
+import OutcomeReviewPanel from "@/features/workbench/components/outcome-review-panel";
 import PartialFailureBanner from "@/features/workbench/components/partial-failure-banner";
 import PerformanceSnapshot from "@/features/workbench/components/performance-snapshot";
 import RebalanceStatus from "@/features/workbench/components/rebalance-status";
@@ -72,6 +74,8 @@ export default async function WorkbenchPage({
   let data: Awaited<ReturnType<typeof getPortfolio360>>;
   let analytics: Awaited<ReturnType<typeof getWorkbenchAnalytics>> | null = null;
   let reportingSnapshot: Awaited<ReturnType<typeof getReportingSnapshot>> | null = null;
+  let outcomeReviews: Awaited<ReturnType<typeof getDpmOutcomeReviews>> | null = null;
+  let outcomeReviewError: string | null = null;
   try {
     data = await getPortfolio360(portfolioId, sessionId);
   } catch (error) {
@@ -118,6 +122,17 @@ export default async function WorkbenchPage({
     );
   } catch {
     reportingSnapshot = null;
+  }
+
+  try {
+    outcomeReviews = await getDpmOutcomeReviews({
+      portfolioId: data.portfolio.portfolio_id,
+      limit: 10,
+    });
+  } catch (error) {
+    outcomeReviews = null;
+    outcomeReviewError =
+      error instanceof Error ? error.message : "Outcome review endpoint unavailable.";
   }
 
   const projectedCoveragePct =
@@ -238,6 +253,12 @@ export default async function WorkbenchPage({
               <RebalanceStatus
                 status={data.rebalance_snapshot?.status ?? "UNKNOWN"}
                 lastRunId={data.rebalance_snapshot?.last_rebalance_run_id ?? null}
+              />
+
+              <OutcomeReviewPanel
+                portfolioId={data.portfolio.portfolio_id}
+                response={outcomeReviews}
+                errorMessage={outcomeReviewError}
               />
 
               {reportingSnapshot ? (

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -140,6 +140,21 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     operation: "reporting.archive-document.metadata",
   },
   {
+    route: "workbench.dpm-command-center",
+    panel: "outcome-review-list",
+    operation: "dpm.outcome-reviews.list",
+  },
+  {
+    route: "workbench.dpm-command-center",
+    panel: "outcome-review-report-input",
+    operation: "dpm.outcome-review.report-input",
+  },
+  {
+    route: "workbench.dpm-command-center",
+    panel: "outcome-review-ai-evidence",
+    operation: "dpm.outcome-review.ai-evidence",
+  },
+  {
     route: "workbench.legacy-advisor",
     panel: "advisor-overview",
     operation: "workbench.overview",

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -28,6 +28,7 @@ import {
   type ServiceRequestTarget,
 } from "@/features/platform-runtime/service-addressing";
 import { buildAnalyticsUiCorrelationHeaders } from "@/features/analytics-observability/correlation";
+import { applyDefaultCallerContextHeaders } from "./caller-context";
 import {
   WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES,
   observeWorkbenchAnalyticsRequest,
@@ -156,6 +157,12 @@ function buildWorkbenchUrl(
   return suffix ? `${baseUrl}${path}?${suffix}` : `${baseUrl}${path}`;
 }
 
+function buildServerGatewayHeaders(initialHeaders?: HeadersInit): Headers {
+  const headers = buildAnalyticsUiCorrelationHeaders(initialHeaders);
+  applyDefaultCallerContextHeaders(headers);
+  return headers;
+}
+
 async function fetchWorkbenchResource<T>(
   target: WorkbenchRequestTarget,
   path: string,
@@ -165,7 +172,9 @@ async function fetchWorkbenchResource<T>(
   return await fetchWorkbenchJson<T>(
     buildWorkbenchUrl(target, path, query),
     errorLabel,
-    target === "client" ? { headers: buildAnalyticsUiCorrelationHeaders() } : undefined
+    target === "client"
+      ? { headers: buildAnalyticsUiCorrelationHeaders() }
+      : { headers: buildServerGatewayHeaders() }
   );
 }
 
@@ -319,7 +328,8 @@ export async function getWorkbenchPerformanceWorkspaceSummary(
     async () =>
       await fetchWorkbenchJson<WorkbenchPerformanceWorkspaceSummary>(
         buildPerformanceWorkspaceUrl(portfolioId, params, "/summary", "server"),
-        "performance workspace summary"
+        "performance workspace summary",
+        { headers: buildServerGatewayHeaders() }
       )
   );
 }
@@ -339,7 +349,8 @@ export async function getWorkbenchPerformanceWorkspaceDetails(
 ): Promise<WorkbenchPerformanceWorkspaceDetails> {
   return await fetchWorkbenchJson<WorkbenchPerformanceWorkspaceDetails>(
     buildPerformanceWorkspaceUrl(portfolioId, params, "/details", "server"),
-    "performance workspace details"
+    "performance workspace details",
+    { headers: buildServerGatewayHeaders() }
   );
 }
 

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -13,6 +13,8 @@ import {
   WorkbenchPerformanceWorkspaceDetails,
   WorkbenchPerformanceWorkspaceSummary,
   WorkbenchPortfolio360,
+  DpmOutcomeReviewGatewayResponse,
+  DpmOutcomeReviewHandoffResponse,
   ReportBatchHandleResponse,
   ReportBatchStatusResponse,
   ReportBatchWorkerRunResponse,
@@ -727,6 +729,61 @@ export async function getReportingSnapshot(
         `/reports/${portfolioId}/snapshot`,
         "reporting snapshot",
         query
+      )
+  );
+}
+
+export async function getDpmOutcomeReviews(params: {
+  portfolioId: string;
+  state?: string;
+  limit?: number;
+  cursor?: string;
+}): Promise<DpmOutcomeReviewGatewayResponse> {
+  const query = new URLSearchParams();
+  query.set("portfolio_id", params.portfolioId);
+  query.set("limit", String(params.limit ?? 10));
+  if (params.state) {
+    query.set("state", params.state);
+  }
+  if (params.cursor) {
+    query.set("cursor", params.cursor);
+  }
+  return await observeWorkbenchResource(
+    "dpm.outcome-reviews.list",
+    async () =>
+      await fetchWorkbenchResource<DpmOutcomeReviewGatewayResponse>(
+        "server",
+        "/dpm/command-center/outcome-reviews",
+        "DPM outcome reviews",
+        query
+      )
+  );
+}
+
+export async function getDpmOutcomeReviewReportInput(
+  outcomeReviewId: string
+): Promise<DpmOutcomeReviewHandoffResponse> {
+  return await observeWorkbenchResource(
+    "dpm.outcome-review.report-input",
+    async () =>
+      await fetchWorkbenchResource<DpmOutcomeReviewHandoffResponse>(
+        "client",
+        `/dpm/command-center/outcome-reviews/${encodeURIComponent(outcomeReviewId)}/report-input`,
+        "DPM outcome review report input"
+      )
+  );
+}
+
+export async function getDpmOutcomeReviewAiEvidenceInput(
+  outcomeReviewId: string
+): Promise<DpmOutcomeReviewHandoffResponse> {
+  return await observeWorkbenchResource(
+    "dpm.outcome-review.ai-evidence",
+    async () =>
+      await fetchWorkbenchResource<DpmOutcomeReviewHandoffResponse>(
+        "client",
+        `/dpm/command-center/outcome-reviews/${encodeURIComponent(outcomeReviewId)}/ai-evidence-input`,
+        "DPM outcome review AI evidence input"
       )
   );
 }

--- a/src/features/workbench/caller-context.ts
+++ b/src/features/workbench/caller-context.ts
@@ -1,0 +1,37 @@
+const DEFAULT_CALLER_CONTEXT_HEADERS = {
+  "X-Actor-Id": "workbench-system",
+  "X-Caller-Application": "lotus-workbench",
+  "X-Tenant-Id": "tenant-sg",
+  "X-Region": "APAC",
+  "X-Booking-Center-Code": "SG",
+  "X-Role": "advisor",
+} as const;
+
+const CALLER_CONTEXT_ENV_OVERRIDES: Record<
+  keyof typeof DEFAULT_CALLER_CONTEXT_HEADERS,
+  string
+> = {
+  "X-Actor-Id": "WORKBENCH_BFF_ACTOR_ID",
+  "X-Caller-Application": "WORKBENCH_BFF_CALLER_APPLICATION",
+  "X-Tenant-Id": "WORKBENCH_BFF_TENANT_ID",
+  "X-Region": "WORKBENCH_BFF_REGION",
+  "X-Booking-Center-Code": "WORKBENCH_BFF_BOOKING_CENTER_CODE",
+  "X-Role": "WORKBENCH_BFF_ROLE",
+};
+
+function defaultCallerContextValue(
+  headerName: keyof typeof DEFAULT_CALLER_CONTEXT_HEADERS
+) {
+  const configured = process.env[CALLER_CONTEXT_ENV_OVERRIDES[headerName]]?.trim();
+  return configured || DEFAULT_CALLER_CONTEXT_HEADERS[headerName];
+}
+
+export function applyDefaultCallerContextHeaders(headers: Headers) {
+  for (const headerName of Object.keys(DEFAULT_CALLER_CONTEXT_HEADERS) as Array<
+    keyof typeof DEFAULT_CALLER_CONTEXT_HEADERS
+  >) {
+    if (!headers.get(headerName)?.trim()) {
+      headers.set(headerName, defaultCallerContextValue(headerName));
+    }
+  }
+}

--- a/src/features/workbench/components/outcome-review-panel.tsx
+++ b/src/features/workbench/components/outcome-review-panel.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import {
+  AnalyticsTable,
+  MetricRow,
+  ScreenStatePanel,
+  SectionBlock,
+  SemanticBadge,
+  Text,
+} from "@/design-system";
+import type { DpmOutcomeReviewGatewayResponse } from "@/features/workbench/types";
+import {
+  buildOutcomeReviewPanelModel,
+  type OutcomeReviewPanelState,
+} from "@/features/workbench/outcome-review-view-model";
+
+type Props = {
+  portfolioId: string;
+  response: DpmOutcomeReviewGatewayResponse | null;
+  errorMessage?: string | null;
+};
+
+function badgeTone(state: string): "default" | "success" | "warn" | "danger" {
+  const normalized = state.toUpperCase();
+  if (normalized === "SUPPORTED" || normalized === "READY" || normalized === "WITHIN_TOLERANCE") {
+    return "success";
+  }
+  if (normalized === "DEGRADED" || normalized === "PARTIAL" || normalized.includes("REVIEW")) {
+    return "warn";
+  }
+  if (normalized === "BLOCKED" || normalized === "UNSUPPORTED" || normalized.includes("BREACH")) {
+    return "danger";
+  }
+  return "default";
+}
+
+function statePanelCopy(state: OutcomeReviewPanelState, portfolioId: string) {
+  if (state === "empty") {
+    return {
+      kind: "empty" as const,
+      title: "No outcome reviews for this portfolio",
+      body: `No RFC-0042 outcome review has been materialized for ${portfolioId}.`,
+    };
+  }
+  if (state === "blocked") {
+    return {
+      kind: "permission_blocked" as const,
+      title: "Outcome review handoff is blocked",
+      body: "Manage has blocked one or more downstream handoff actions for this review set.",
+    };
+  }
+  if (state === "unsupported") {
+    return {
+      kind: "unavailable" as const,
+      title: "Outcome review is not supported",
+      body: "The authoritative manage supportability state says this outcome-review path is unsupported.",
+    };
+  }
+  return {
+    kind: "partial" as const,
+    title: "Outcome review data is unavailable",
+    body: "Gateway did not return a usable manage outcome-review payload for this portfolio.",
+  };
+}
+
+function handoffLabel(blocked: boolean | undefined): string {
+  if (blocked === undefined) {
+    return "N/A";
+  }
+  return blocked ? "Blocked" : "Available";
+}
+
+function handoffTone(blocked: boolean | undefined): "default" | "success" | "danger" {
+  if (blocked === undefined) {
+    return "default";
+  }
+  return blocked ? "danger" : "success";
+}
+
+export default function OutcomeReviewPanel({ portfolioId, response, errorMessage }: Props) {
+  const model = buildOutcomeReviewPanelModel(response);
+  const primaryReview = model.items[0] ?? null;
+  const hasItems = model.items.length > 0;
+  const shouldShowStatePanel =
+    Boolean(errorMessage) || model.state === "empty" || model.state === "blocked" || model.state === "unsupported" || model.state === "unavailable";
+  const stateCopy = statePanelCopy(model.state, portfolioId);
+
+  return (
+    <SectionBlock
+      title="Post-Trade Outcome Review"
+      subtitle={`Manage authority: ${model.authority}. Correlation: ${model.correlationId}`}
+      className="outcome-review-panel"
+      actions={
+        <div className="outcome-review-badge-row">
+          <SemanticBadge tone={badgeTone(model.supportabilityState)}>
+            {model.supportabilityState}
+          </SemanticBadge>
+          <SemanticBadge>{model.sourceService}</SemanticBadge>
+        </div>
+      }
+    >
+      {shouldShowStatePanel ? (
+        <ScreenStatePanel
+          kind={errorMessage ? "partial" : stateCopy.kind}
+          surface="portfolio"
+          title={errorMessage ? "Outcome review endpoint is unavailable" : stateCopy.title}
+          body={errorMessage ?? stateCopy.body}
+        />
+      ) : null}
+
+      <div className="outcome-review-status-strip">
+        <MetricRow label="Reviews" value={model.items.length.toString()} />
+        <MetricRow
+          label="Report Input"
+          value={
+            <SemanticBadge tone={handoffTone(primaryReview?.reportInputBlocked)}>
+              {handoffLabel(primaryReview?.reportInputBlocked)}
+            </SemanticBadge>
+          }
+        />
+        <MetricRow
+          label="AI Evidence"
+          value={
+            <SemanticBadge tone={handoffTone(primaryReview?.aiEvidenceBlocked)}>
+              {handoffLabel(primaryReview?.aiEvidenceBlocked)}
+            </SemanticBadge>
+          }
+        />
+        <MetricRow label="Remediation Owner" value={model.remediationOwner} />
+      </div>
+
+      {model.supportabilityReasons.length > 0 || model.blockedActions.length > 0 ? (
+        <div className="outcome-review-reason-row">
+          {[...model.supportabilityReasons, ...model.blockedActions].map((reason) => (
+            <SemanticBadge key={reason} tone={reason.startsWith("CREATE") || reason.startsWith("REQUEST") ? "danger" : "warn"}>
+              {reason}
+            </SemanticBadge>
+          ))}
+        </div>
+      ) : null}
+
+      <AnalyticsTable
+        ariaLabel="Post-trade outcome reviews"
+        variant="portfolio"
+        density="compact"
+        columns={[
+          { key: "review", label: "Review" },
+          { key: "state", label: "State" },
+          { key: "run", label: "Run" },
+          { key: "proof-pack", label: "Proof Pack" },
+          { key: "updated", label: "Updated" },
+        ]}
+        rows={model.items.map((item) => ({
+          key: item.outcomeReviewId,
+          cells: [
+            item.outcomeReviewId,
+            <SemanticBadge key={`${item.outcomeReviewId}-state`} tone={badgeTone(item.state)}>
+              {item.state}
+            </SemanticBadge>,
+            item.rebalanceRunId,
+            item.proofPackId,
+            item.updatedAt,
+          ],
+        }))}
+        emptyState={{
+          title: "No outcome reviews returned",
+          body: "The Gateway BFF returned no manage outcome-review records for this portfolio.",
+        }}
+      />
+
+      {primaryReview && hasItems ? (
+        <>
+          <div className="outcome-review-hash-strip">
+            <span>Expected {primaryReview.expectedSnapshotHash}</span>
+            <span>Realized {primaryReview.realizedSnapshotHash}</span>
+            <span>Retention {primaryReview.retentionUntil}</span>
+          </div>
+
+          <AnalyticsTable
+            ariaLabel="Outcome review dimensions"
+            variant="analysis"
+            density="compact"
+            columns={[
+              { key: "dimension", label: "Dimension" },
+              { key: "expected", label: "Expected", align: "right" },
+              { key: "realized", label: "Realized", align: "right" },
+              { key: "variance", label: "Variance", align: "right" },
+              { key: "state", label: "State" },
+            ]}
+            rows={primaryReview.dimensions.map((row) => ({
+              key: row.key,
+              cells: [
+                row.dimension,
+                row.expected,
+                row.realized,
+                row.variance,
+                <SemanticBadge key={`${row.key}-state`} tone={badgeTone(row.state)}>
+                  {row.state}
+                </SemanticBadge>,
+              ],
+            }))}
+            emptyState={{
+              title: "No dimension results returned",
+              body: "The review exists, but manage did not return expected-versus-realized dimension rows.",
+            }}
+          />
+
+          <AnalyticsTable
+            ariaLabel="Outcome review source lineage"
+            variant="observation"
+            density="compact"
+            columns={[
+              { key: "source", label: "Source" },
+              { key: "reference", label: "Reference" },
+              { key: "freshness", label: "Freshness" },
+              { key: "hash", label: "Hash" },
+            ]}
+            rows={primaryReview.lineage.map((row) => ({
+              key: row.key,
+              cells: [row.source, row.reference, row.freshness, row.hash],
+            }))}
+            emptyState={{
+              title: "No source lineage returned",
+              body: "Manage returned the review without lineage rows in the list payload.",
+            }}
+          />
+        </>
+      ) : null}
+
+      <Text variant="secondary" className="muted">
+        Report and AI handoff availability is derived from manage-published blocked actions and
+        the Gateway outcome-review contract.
+      </Text>
+    </SectionBlock>
+  );
+}

--- a/src/features/workbench/outcome-review-view-model.ts
+++ b/src/features/workbench/outcome-review-view-model.ts
@@ -1,0 +1,215 @@
+import type { DpmOutcomeReviewGatewayResponse } from "./types";
+
+export type OutcomeReviewPanelState =
+  | "ready"
+  | "empty"
+  | "partial"
+  | "blocked"
+  | "unsupported"
+  | "unavailable";
+
+export type OutcomeReviewDimensionRow = {
+  key: string;
+  dimension: string;
+  expected: string;
+  realized: string;
+  variance: string;
+  state: string;
+};
+
+export type OutcomeReviewLineageRow = {
+  key: string;
+  source: string;
+  reference: string;
+  freshness: string;
+  hash: string;
+};
+
+export type OutcomeReviewListItem = {
+  outcomeReviewId: string;
+  state: string;
+  portfolioId: string;
+  rebalanceRunId: string;
+  waveId: string;
+  proofPackId: string;
+  expectedSnapshotHash: string;
+  realizedSnapshotHash: string;
+  retentionUntil: string;
+  updatedAt: string;
+  reportInputBlocked: boolean;
+  aiEvidenceBlocked: boolean;
+  dimensions: OutcomeReviewDimensionRow[];
+  lineage: OutcomeReviewLineageRow[];
+};
+
+export type OutcomeReviewPanelModel = {
+  state: OutcomeReviewPanelState;
+  supportabilityState: string;
+  supportabilityReasons: string[];
+  blockedActions: string[];
+  remediationOwner: string;
+  sourceService: string;
+  authority: string;
+  correlationId: string;
+  items: OutcomeReviewListItem[];
+};
+
+export function buildOutcomeReviewPanelModel(
+  response: DpmOutcomeReviewGatewayResponse | null
+): OutcomeReviewPanelModel {
+  if (!response) {
+    return {
+      state: "unavailable",
+      supportabilityState: "UNAVAILABLE",
+      supportabilityReasons: ["GATEWAY_OUTCOME_REVIEW_UNAVAILABLE"],
+      blockedActions: ["CREATE_REPORT_INPUT", "REQUEST_AI_NARRATIVE"],
+      remediationOwner: "Front Office Platform",
+      sourceService: "lotus-gateway",
+      authority: "lotus-manage:RFC-0042",
+      correlationId: "N/A",
+      items: [],
+    };
+  }
+
+  const supportabilityState = normalizeState(response.supportability.state);
+  const items = extractOutcomeReviewRecords(response.data).map((record, index) =>
+    buildOutcomeReviewListItem(record, response.supportability.blocked_actions, index)
+  );
+  return {
+    state: resolvePanelState(supportabilityState, items.length),
+    supportabilityState,
+    supportabilityReasons: response.supportability.reason_codes,
+    blockedActions: response.supportability.blocked_actions,
+    remediationOwner: response.supportability.remediation_owner ?? "N/A",
+    sourceService: response.supportability.source_service || response.source_service,
+    authority: response.supportability.authority,
+    correlationId: response.correlation_id,
+    items,
+  };
+}
+
+function resolvePanelState(
+  supportabilityState: string,
+  itemCount: number
+): OutcomeReviewPanelState {
+  if (supportabilityState === "BLOCKED") {
+    return "blocked";
+  }
+  if (supportabilityState === "UNSUPPORTED") {
+    return "unsupported";
+  }
+  if (supportabilityState === "DEGRADED" || supportabilityState === "UNKNOWN") {
+    return itemCount > 0 ? "partial" : "unavailable";
+  }
+  return itemCount > 0 ? "ready" : "empty";
+}
+
+function buildOutcomeReviewListItem(
+  record: Record<string, unknown>,
+  blockedActions: string[],
+  fallbackIndex: number
+): OutcomeReviewListItem {
+  const outcomeReviewId = readString(record, "outcome_review_id") || `outcome-review-${fallbackIndex + 1}`;
+  return {
+    outcomeReviewId,
+    state: readString(record, "state") || "UNKNOWN",
+    portfolioId: readString(record, "portfolio_id") || "N/A",
+    rebalanceRunId: readString(record, "rebalance_run_id") || "N/A",
+    waveId: readString(record, "wave_id") || "N/A",
+    proofPackId: readString(record, "proof_pack_id") || "N/A",
+    expectedSnapshotHash: readString(record, "expected_snapshot_hash") || "N/A",
+    realizedSnapshotHash: readString(record, "realized_snapshot_hash") || "N/A",
+    retentionUntil: readString(record, "retain_until") || readString(record, "retention_until") || "N/A",
+    updatedAt: readString(record, "updated_at") || readString(record, "created_at") || "N/A",
+    reportInputBlocked: blockedActions.includes("CREATE_REPORT_INPUT"),
+    aiEvidenceBlocked: blockedActions.includes("REQUEST_AI_NARRATIVE"),
+    dimensions: extractRecordArray(record.dimension_results).map((dimension, index) =>
+      buildDimensionRow(dimension, index)
+    ),
+    lineage: [
+      ...extractRecordArray(record.source_lineage),
+      ...extractRecordArray(record.lineage),
+      ...extractRecordArray(record.evidence_lineage),
+    ].map((lineage, index) => buildLineageRow(lineage, index)),
+  };
+}
+
+function buildDimensionRow(
+  record: Record<string, unknown>,
+  index: number
+): OutcomeReviewDimensionRow {
+  const dimension = readString(record, "dimension") || readString(record, "metric") || `dimension_${index + 1}`;
+  return {
+    key: `${dimension}-${index}`,
+    dimension,
+    expected: formatOutcomeValue(record.expected),
+    realized: formatOutcomeValue(record.realized),
+    variance: formatOutcomeValue(record.variance),
+    state: readString(record, "state") || readString(record, "status") || "UNKNOWN",
+  };
+}
+
+function buildLineageRow(record: Record<string, unknown>, index: number): OutcomeReviewLineageRow {
+  const source = readString(record, "source_service") || readString(record, "source") || "N/A";
+  const reference = readString(record, "source_ref") || readString(record, "reference") || readString(record, "id") || "N/A";
+  return {
+    key: `${source}-${reference}-${index}`,
+    source,
+    reference,
+    freshness: readString(record, "freshness") || readString(record, "freshness_bucket") || "N/A",
+    hash: readString(record, "hash") || readString(record, "payload_hash") || "N/A",
+  };
+}
+
+function extractOutcomeReviewRecords(data: Record<string, unknown>): Record<string, unknown>[] {
+  const items = extractRecordArray(data.items);
+  if (items.length > 0) {
+    return items;
+  }
+  return typeof data.outcome_review_id === "string" ? [data] : [];
+}
+
+function extractRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isRecord);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+function formatOutcomeValue(value: unknown): string {
+  if (isRecord(value)) {
+    const nestedValue = value.value;
+    const unit = typeof value.unit === "string" ? value.unit : "";
+    const formatted = formatOutcomeValue(nestedValue);
+    return unit && formatted !== "N/A" ? `${formatted} ${unit}` : formatted;
+  }
+  if (typeof value === "number") {
+    return value.toLocaleString(undefined, { maximumFractionDigits: 6 });
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return "N/A";
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeState(state: string): string {
+  return state.trim().toUpperCase() || "UNKNOWN";
+}

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1127,6 +1127,26 @@ export type WorkbenchReportingSnapshot = {
   rows: Array<Record<string, unknown>>;
 };
 
+export type DpmOutcomeReviewSupportability = {
+  source_service: string;
+  authority: string;
+  state: string;
+  reason_codes: string[];
+  blocked_actions: string[];
+  remediation_owner?: string | null;
+};
+
+export type DpmOutcomeReviewGatewayResponse = {
+  correlation_id: string;
+  contract_version: string;
+  source_service: string;
+  upstream_status: number;
+  supportability: DpmOutcomeReviewSupportability;
+  data: Record<string, unknown>;
+};
+
+export type DpmOutcomeReviewHandoffResponse = DpmOutcomeReviewGatewayResponse;
+
 export type ReportBatchHandleResponse = {
   batch_id: string;
   status: string;

--- a/tests/integration/workbench-page.test.tsx
+++ b/tests/integration/workbench-page.test.tsx
@@ -122,6 +122,47 @@ describe("WorkbenchPage", () => {
           } as Response;
         }
 
+        if (url.includes("/api/v1/dpm/command-center/outcome-reviews?portfolio_id=PF_1001")) {
+          return {
+            ok: true,
+            json: async () => ({
+              correlation_id: "corr_rfc42",
+              contract_version: "v1",
+              source_service: "lotus-manage",
+              upstream_status: 200,
+              supportability: {
+                source_service: "lotus-manage",
+                authority: "lotus-manage:RFC-0042",
+                state: "SUPPORTED",
+                reason_codes: ["READY_FOR_REPORT_INPUT"],
+                blocked_actions: [],
+              },
+              data: {
+                items: [
+                  {
+                    outcome_review_id: "or_1",
+                    state: "READY",
+                    portfolio_id: "PF_1001",
+                    rebalance_run_id: "run_001",
+                    proof_pack_id: "ppack_1",
+                    expected_snapshot_hash: "sha256:expected",
+                    realized_snapshot_hash: "sha256:realized",
+                    dimension_results: [
+                      {
+                        dimension: "cash_weight",
+                        expected: { value: "0.0340", unit: "ratio" },
+                        realized: { value: "0.0342", unit: "ratio" },
+                        variance: { value: "0.0002", unit: "ratio" },
+                        state: "WITHIN_TOLERANCE",
+                      },
+                    ],
+                  },
+                ],
+              },
+            }),
+          } as Response;
+        }
+
         return { ok: false, json: async () => ({}) } as Response;
       })
     );
@@ -145,6 +186,9 @@ describe("WorkbenchPage", () => {
     expect(screen.getByText("ATTENTION")).toBeInTheDocument();
     expect(screen.getByText("Partial Data Warning")).toBeInTheDocument();
     expect(screen.getAllByText(/UPSTREAM_TIMEOUT/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole("heading", { name: "Post-Trade Outcome Review" })).toBeInTheDocument();
+    expect(screen.getByText("or_1")).toBeInTheDocument();
+    expect(screen.getByText("cash_weight")).toBeInTheDocument();
   });
 
   it("falls back to the degraded route shell when the portfolio overview cannot be loaded", async () => {

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -289,6 +289,21 @@ describe("analytics UI observability metrics", () => {
         "archive-document-metadata",
         "reporting.archive-document.metadata",
       ],
+      [
+        "workbench.dpm-command-center",
+        "outcome-review-list",
+        "dpm.outcome-reviews.list",
+      ],
+      [
+        "workbench.dpm-command-center",
+        "outcome-review-report-input",
+        "dpm.outcome-review.report-input",
+      ],
+      [
+        "workbench.dpm-command-center",
+        "outcome-review-ai-evidence",
+        "dpm.outcome-review.ai-evidence",
+      ],
       ["workbench.legacy-advisor", "advisor-overview", "workbench.overview"],
       ["workbench.legacy-advisor", "portfolio-360", "workbench.portfolio-360"],
       ["workbench.legacy-advisor", "portfolio-analytics", "workbench.analytics"],

--- a/tests/unit/live-validation-probes.test.ts
+++ b/tests/unit/live-validation-probes.test.ts
@@ -142,6 +142,11 @@ describe("live validation probe helpers", () => {
       expect.objectContaining({
         url: "http://gateway.dev.lotus/api/v1/example",
         method: "POST",
+        headers: expect.objectContaining({
+          "X-Actor-Id": "workbench-system",
+          "X-Tenant-Id": "tenant-sg",
+          "X-Region": "APAC",
+        }),
         body: JSON.stringify({ ok: true }),
       }),
     ]);

--- a/tests/unit/outcome-review-panel.test.tsx
+++ b/tests/unit/outcome-review-panel.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import OutcomeReviewPanel from "../../src/features/workbench/components/outcome-review-panel";
+import type { DpmOutcomeReviewGatewayResponse } from "../../src/features/workbench/types";
+
+const readyResponse: DpmOutcomeReviewGatewayResponse = {
+  correlation_id: "corr-rfc42",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0042",
+    state: "SUPPORTED",
+    reason_codes: ["READY_FOR_REPORT_INPUT"],
+    blocked_actions: [],
+    remediation_owner: null,
+  },
+  data: {
+    items: [
+      {
+        outcome_review_id: "or_1",
+        state: "READY",
+        portfolio_id: "PB_SG_GLOBAL_BAL_001",
+        rebalance_run_id: "rr_1",
+        proof_pack_id: "ppack_1",
+        expected_snapshot_hash: "sha256:expected",
+        realized_snapshot_hash: "sha256:realized",
+        dimension_results: [
+          {
+            dimension: "tracking_error",
+            expected: { value: 0.012, unit: "ratio" },
+            realized: { value: 0.011, unit: "ratio" },
+            variance: { value: -0.001, unit: "ratio" },
+            state: "WITHIN_TOLERANCE",
+          },
+        ],
+        source_lineage: [
+          {
+            source_service: "lotus-risk",
+            source_ref: "risk_1",
+            freshness_bucket: "fresh",
+            hash: "sha256:risk",
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe("OutcomeReviewPanel", () => {
+  it("renders manage-backed outcome review state and evidence posture", () => {
+    render(<OutcomeReviewPanel portfolioId="PB_SG_GLOBAL_BAL_001" response={readyResponse} />);
+
+    expect(screen.getByRole("heading", { name: "Post-Trade Outcome Review" })).toBeInTheDocument();
+    expect(screen.getByText("SUPPORTED")).toBeInTheDocument();
+    expect(screen.getByText("or_1")).toBeInTheDocument();
+    expect(screen.getByText("rr_1")).toBeInTheDocument();
+    expect(screen.getByText("tracking_error")).toBeInTheDocument();
+    expect(screen.getByText("sha256:risk")).toBeInTheDocument();
+    expect(screen.getAllByText("Available").length).toBe(2);
+  });
+
+  it("renders blocked handoff posture from Gateway supportability", () => {
+    render(
+      <OutcomeReviewPanel
+        portfolioId="PB_SG_GLOBAL_BAL_001"
+        response={{
+          ...readyResponse,
+          supportability: {
+            ...readyResponse.supportability,
+            state: "BLOCKED",
+            blocked_actions: ["CREATE_REPORT_INPUT", "REQUEST_AI_NARRATIVE"],
+            remediation_owner: "Portfolio Operations",
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText("Outcome review handoff is blocked")).toBeInTheDocument();
+    expect(screen.getAllByText("Blocked").length).toBe(2);
+    expect(screen.getByText("Portfolio Operations")).toBeInTheDocument();
+  });
+
+  it("renders unavailable state without claiming support", () => {
+    render(
+      <OutcomeReviewPanel
+        portfolioId="PB_SG_GLOBAL_BAL_001"
+        response={null}
+        errorMessage="Failed to fetch DPM outcome reviews (503)"
+      />
+    );
+
+    expect(screen.getByText("Outcome review endpoint is unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Failed to fetch DPM outcome reviews (503)")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/outcome-review-view-model.test.ts
+++ b/tests/unit/outcome-review-view-model.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import { buildOutcomeReviewPanelModel } from "../../src/features/workbench/outcome-review-view-model";
+import type { DpmOutcomeReviewGatewayResponse } from "../../src/features/workbench/types";
+
+function response(
+  data: Record<string, unknown>,
+  supportability: Partial<DpmOutcomeReviewGatewayResponse["supportability"]> = {}
+): DpmOutcomeReviewGatewayResponse {
+  return {
+    correlation_id: "corr-rfc42",
+    contract_version: "v1",
+    source_service: "lotus-manage",
+    upstream_status: 200,
+    supportability: {
+      source_service: "lotus-manage",
+      authority: "lotus-manage:RFC-0042",
+      state: "SUPPORTED",
+      reason_codes: [],
+      blocked_actions: [],
+      remediation_owner: null,
+      ...supportability,
+    },
+    data,
+  };
+}
+
+describe("outcome review view model", () => {
+  it("normalizes list payloads into review, variance, lineage, and handoff posture", () => {
+    const model = buildOutcomeReviewPanelModel(
+      response({
+        items: [
+          {
+            outcome_review_id: "or_1",
+            state: "READY",
+            portfolio_id: "PB_SG_GLOBAL_BAL_001",
+            rebalance_run_id: "rr_1",
+            wave_id: "wave_1",
+            proof_pack_id: "ppack_1",
+            expected_snapshot_hash: "sha256:expected",
+            realized_snapshot_hash: "sha256:realized",
+            retain_until: "2033-02-24",
+            updated_at: "2026-02-24T10:00:00Z",
+            dimension_results: [
+              {
+                dimension: "cash_weight",
+                expected: { value: "0.0340", unit: "ratio" },
+                realized: { value: "0.0342", unit: "ratio" },
+                variance: { value: "0.0002", unit: "ratio" },
+                state: "WITHIN_TOLERANCE",
+              },
+            ],
+            source_lineage: [
+              {
+                source_service: "lotus-performance",
+                source_ref: "perf_1",
+                freshness_bucket: "fresh",
+                hash: "sha256:perf",
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    expect(model.state).toBe("ready");
+    expect(model.items[0]).toEqual(
+      expect.objectContaining({
+        outcomeReviewId: "or_1",
+        rebalanceRunId: "rr_1",
+        proofPackId: "ppack_1",
+        expectedSnapshotHash: "sha256:expected",
+        realizedSnapshotHash: "sha256:realized",
+        reportInputBlocked: false,
+        aiEvidenceBlocked: false,
+      })
+    );
+    expect(model.items[0].dimensions[0]).toEqual(
+      expect.objectContaining({
+        dimension: "cash_weight",
+        expected: "0.0340 ratio",
+        realized: "0.0342 ratio",
+        variance: "0.0002 ratio",
+      })
+    );
+    expect(model.items[0].lineage[0]).toEqual(
+      expect.objectContaining({
+        source: "lotus-performance",
+        reference: "perf_1",
+        freshness: "fresh",
+        hash: "sha256:perf",
+      })
+    );
+  });
+
+  it("marks blocked handoffs from manage supportability without inventing UI support", () => {
+    const model = buildOutcomeReviewPanelModel(
+      response(
+        {
+          items: [{ outcome_review_id: "or_2", state: "SOURCE_STALE" }],
+        },
+        {
+          state: "BLOCKED",
+          reason_codes: ["EXECUTION_EVIDENCE_PENDING"],
+          blocked_actions: ["CREATE_REPORT_INPUT", "REQUEST_AI_NARRATIVE"],
+          remediation_owner: "Portfolio Operations",
+        }
+      )
+    );
+
+    expect(model.state).toBe("blocked");
+    expect(model.remediationOwner).toBe("Portfolio Operations");
+    expect(model.items[0].reportInputBlocked).toBe(true);
+    expect(model.items[0].aiEvidenceBlocked).toBe(true);
+  });
+
+  it("keeps empty and unavailable states explicit", () => {
+    expect(buildOutcomeReviewPanelModel(response({ items: [] })).state).toBe("empty");
+    expect(buildOutcomeReviewPanelModel(null)).toEqual(
+      expect.objectContaining({
+        state: "unavailable",
+        supportabilityState: "UNAVAILABLE",
+        items: [],
+      })
+    );
+  });
+});

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -283,6 +283,81 @@ describe("workbench api", () => {
     expect(requestedUrl).not.toContain("benchmark_code=");
   });
 
+  it("adds governed caller context to server-side Gateway performance reads", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr",
+            contract_version: "v1",
+            portfolio_id: "PF_1001",
+            as_of_date: "2026-03-26",
+            period: "YTD",
+            chart_frequency: "monthly",
+            contribution_dimension: "asset_class",
+            attribution_dimension: "asset_class",
+            detail_basis: "NET",
+            benchmark_code: null,
+            portfolio: {
+              portfolio_id: "PF_1001",
+              client_id: "CIF_1",
+              base_currency: "USD",
+              booking_center_code: "SG",
+            },
+            overview: {
+              market_value_base: 1000000,
+              cash_weight_pct: 5,
+              position_count: 10,
+            },
+            net_performance: {
+              metric_basis: "NET",
+              portfolio_return_pct: 2.1,
+              benchmark_return_pct: null,
+              active_return_pct: 0.5,
+              annualized_return_pct: 2.1,
+              benchmark_id: null,
+              benchmark_return_source: null,
+            },
+            gross_performance: {
+              metric_basis: "GROSS",
+              portfolio_return_pct: 2.4,
+              benchmark_return_pct: null,
+              active_return_pct: 0.8,
+              annualized_return_pct: 2.4,
+              benchmark_id: null,
+              benchmark_return_source: null,
+            },
+            money_weighted_return: null,
+            net_chart: [],
+            gross_chart: [],
+            contribution: null,
+            attribution: null,
+            warnings: [],
+            partial_failures: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await getWorkbenchPerformanceWorkspaceSummary("PF_1001", {
+      period: "YTD",
+      chartFrequency: "monthly",
+      contributionDimension: "asset_class",
+      attributionDimension: "asset_class",
+      detailBasis: "NET",
+    });
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(headers.get("X-Actor-Id")).toBe("workbench-system");
+    expect(headers.get("X-Caller-Application")).toBe("lotus-workbench");
+    expect(headers.get("X-Tenant-Id")).toBe("tenant-sg");
+    expect(headers.get("X-Region")).toBe("APAC");
+    expect(headers.get("X-Correlation-Id")).toMatch(/^corr-workbench-/);
+  });
+
   it("includes benchmark code when performance details are requested with a selected benchmark", async () => {
     vi.stubGlobal(
       "fetch",

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -5,6 +5,9 @@ import {
   buildArchivedDocumentDownloadUrl,
   createPortfolioReportBatch,
   createSandboxSession,
+  getDpmOutcomeReviewAiEvidenceInput,
+  getDpmOutcomeReviewReportInput,
+  getDpmOutcomeReviews,
   getArchivedDocumentMetadata,
   getPortfolio360,
   getReportBatchStatus,
@@ -1647,6 +1650,87 @@ describe("workbench api", () => {
     expect(buildArchivedDocumentDownloadUrl("doc_1")).toBe(
       `${expectedBaseUrl}/documents/doc_1/download`
     );
+  });
+
+  it("loads DPM outcome reviews through the gateway BFF with portfolio filters", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr-rfc42",
+            contract_version: "v1",
+            source_service: "lotus-manage",
+            upstream_status: 200,
+            supportability: {
+              source_service: "lotus-manage",
+              authority: "lotus-manage:RFC-0042",
+              state: "SUPPORTED",
+              reason_codes: ["READY_FOR_REPORT_INPUT"],
+              blocked_actions: [],
+            },
+            data: { items: [{ outcome_review_id: "or_1", state: "READY" }] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await getDpmOutcomeReviews({
+      portfolioId: "PB_SG_GLOBAL_BAL_001",
+      state: "READY",
+      limit: 5,
+      cursor: "cursor_1",
+    });
+
+    const requestedUrl = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].toString();
+    expect(requestedUrl).toContain(
+      "/api/v1/dpm/command-center/outcome-reviews?portfolio_id=PB_SG_GLOBAL_BAL_001&limit=5&state=READY&cursor=cursor_1"
+    );
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("outcome-review-list");
+    expect(metricEventsJson).not.toContain("PB_SG_GLOBAL_BAL_001");
+    expect(metricEventsJson).not.toContain("or_1");
+  });
+
+  it("loads DPM report and AI handoff inputs through gateway-only client endpoints", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr-rfc42-handoff",
+            contract_version: "v1",
+            source_service: "lotus-manage",
+            upstream_status: 200,
+            supportability: {
+              source_service: "lotus-manage",
+              authority: "lotus-manage:RFC-0042",
+              state: "SUPPORTED",
+              reason_codes: [],
+              blocked_actions: [],
+            },
+            data: { outcome_review_id: "or_1" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await getDpmOutcomeReviewReportInput("or_1");
+    await getDpmOutcomeReviewAiEvidenceInput("or_1");
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/outcome-reviews/or_1/report-input`
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/outcome-reviews/or_1/ai-evidence-input`
+    );
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("outcome-review-report-input");
+    expect(metricEventsJson).toContain("outcome-review-ai-evidence");
+    expect(metricEventsJson).not.toContain("or_1");
   });
 
   it("raises a labeled error when the split summary endpoint fails", async () => {

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -49,13 +49,12 @@ promote dormant labels into product ownership just because historical route file
   route yet; promotion requires Gateway `/api/v1/dpm/command-center/waves*` implementation,
   Workbench BFF/browser implementation, canonical `PB_SG_GLOBAL_BAL_001` live validation, visual
   and accessibility evidence, and implementation-backed wiki/support wording.
-- RFC-0098 now also defines the future DPM post-trade outcome-review workspace. It is not an
-  active supported route yet; promotion requires Gateway
-  `/api/v1/dpm/command-center/outcome-reviews*` implementation, Workbench BFF/browser
-  implementation, canonical `PB_SG_GLOBAL_BAL_001` live validation, visual/accessibility
-  evidence, and implementation-backed wiki/support wording. Workbench must not calculate
-  expected-versus-realized values, source freshness, supportability, report-input posture, or
-  AI-evidence posture client-side.
+- RFC-0098/RFC-0042 post-trade outcome-review rendering is implemented on
+  `/workbench/{portfolioId}` through Gateway `/api/v1/dpm/command-center/outcome-reviews*`.
+  Workbench renders manage-owned review state, expected-versus-realized dimensions, hashes,
+  source lineage, supportability, report-input posture, and AI-evidence posture without
+  calculating those values client-side. Demo promotion still requires the canonical
+  `PB_SG_GLOBAL_BAL_001` live evidence pack and screenshot review in the implementation ledger.
 
 ## Route examples
 
@@ -81,6 +80,12 @@ Data products:
 
 ```txt
 http://workbench.dev.lotus/data-products
+```
+
+Workbench outcome review:
+
+```txt
+http://workbench.dev.lotus/workbench/PB_SG_GLOBAL_BAL_001
 ```
 
 Capability-gated navigation truth:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -56,21 +56,19 @@ must travel through Gateway-shaped contracts.
     emit bounded route, panel, operation, freshness, and supportability labels only; portfolio,
     intake payload, document, session, trace, request, response, and screen-content identifiers
     must not appear in metric labels.
-11. `lotus-manage` is not a proposal/advisory upstream for Workbench. Current Workbench proof uses
-    Manage only for readiness and supportability evidence through
-    `GET /api/v1/rebalance/supportability/summary`; any future discretionary mandate management
-    product surface must be backed by new strategic Gateway APIs before it is exposed in Workbench.
-    RFC-0098 defines that future DPM command-center experience and keeps Workbench as a renderer of
-    Gateway-composed mandate and proof-pack truth, not a direct caller of manage, risk,
+11. `lotus-manage` is not a proposal/advisory upstream for Workbench. DPM product surfaces must be
+    backed by strategic Gateway APIs before Workbench exposes them. RFC-0098 keeps Workbench as a
+    renderer of Gateway-composed mandate and proof-pack truth, not a direct caller of manage, risk,
     performance, core, report, archive, or AI. RFC-0040 proof-pack JSON, hashes, Markdown,
     report-input payloads, and AI-evidence payloads remain manage-owned and must reach Workbench
     through Gateway composition. RFC-0041 rebalance-wave preview, create, source-check,
     simulation, selection, approval, staging, handoff, and supportability also remain
     manage-owned and must reach Workbench through Gateway wave composition only. RFC-0042
     outcome-review search, detail, supportability, report-input, AI-evidence, preview, create, and
-    source-refresh posture also remains manage-owned and must reach Workbench through Gateway
-    outcome-review composition only; Workbench must not calculate expected-versus-realized values
-    or infer PM quality.
+    source-refresh posture also remain manage-owned and must reach Workbench through Gateway
+    outcome-review composition only; the implemented Workbench panel consumes the Gateway
+    outcome-review list contract and must not calculate expected-versus-realized values or infer
+    PM quality.
 12. `lotus-advise` owns advisor-led proposal workflows. Workbench proposal compatibility routes are
     not the active RFC-0108 product surface and should not be used as current client-demo evidence.
 
@@ -87,14 +85,15 @@ flowchart TB
   Report[Report materialization and report supportability]
   Archive[Document metadata and downloads]
   Render[PDF render readiness]
-  Manage[Strategic DPM run lookup, supportability, and proof packs]
+  Manage[Strategic DPM proof packs, waves, and outcome reviews]
   Waves[Future rebalance-wave workspace]
-  Outcomes[Future post-trade outcome workspace]
+  Outcomes[Post-trade outcome panel]
   Advise[Advisor-led proposal workflows]
   DpmCenter[Future DPM command center UI]
 
   Workbench -->|/api/bff/api/v1/workbench/*| Gateway
   Workbench --> DpmCenter
+  Workbench -->|/api/bff/api/v1/dpm/command-center/outcome-reviews*| Gateway
   DpmCenter --> Waves
   DpmCenter --> Outcomes
   DpmCenter -->|Gateway RFC-0098 contract| Gateway

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -14,7 +14,7 @@
   proposed DPM mandate command-center product experience backed by Gateway RFC-0098, including
   manage-owned RFC-0040 proof-pack evidence and RFC-0041 rebalance-wave orchestration rendered
   through Gateway without direct Workbench service calls or client-side readiness calculation. It
-  now also includes RFC-0042 post-trade outcome-review workspace realization for
+  now includes implemented RFC-0042 post-trade outcome-review rendering for
   expected-versus-realized dimensions, source lineage, supportability, report-input posture, and
   AI-evidence posture without client-side outcome calculation.
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -13,9 +13,8 @@
 ## Next priorities
 
 1. keep strengthening Portfolio and Performance truth and density
-2. implement RFC-0098 as the Gateway-backed DPM mandate command-center experience once Gateway
-   RFC-0098 provides the certified composition contract, including manage-owned RFC-0040
-   proof-pack evidence, RFC-0041 rebalance-wave orchestration, and RFC-0042 post-trade
-   outcome-review evidence rendered through Gateway
+2. promote the RFC-0042 outcome-review panel with canonical live evidence and screenshots, then
+   continue RFC-0098 DPM command-center realization for proof packs and rebalance-wave
+   orchestration as Gateway contracts mature
 3. preserve gateway-first integration discipline
 4. continue aligning route ownership to the product architecture blueprint


### PR DESCRIPTION
## Summary
- Add Gateway-backed RFC-0042 outcome-review APIs, types, deterministic Workbench view-model normalization, and the `/workbench/{portfolioId}` post-trade outcome-review panel.
- Render manage-owned outcome-review state, expected-versus-realized dimensions, source lineage, hashes, supportability, and report/AI handoff posture without client-side outcome calculation.
- Harden canonical caller-context propagation for server-side Gateway reads and live validation probes.
- Extend the governed live validator to certify `dpm.outcome_review` with API proof, panel classification, and screenshot evidence.

## Cross-repo dependencies raised from live proof
- lotus-gateway PR #187 fixes platform-capabilities live fanout and manage capability contract routing.
- lotus-platform PR #300 registers `dpm.outcome_review` in the governed Workbench panel registry and rollout-readiness contracts.
- lotus-core PR #336 passes canonical caller context in front-office seed validation.

## Validation
- `npm test -- --run tests/unit/outcome-review-view-model.test.ts tests/unit/outcome-review-panel.test.tsx tests/unit/workbench-api.test.ts tests/integration/workbench-page.test.tsx`
- `npm test -- --run tests/unit/workbench-api.test.ts tests/unit/bff-route.test.ts tests/unit/live-validation-probes.test.ts`
- `npm test -- --run tests/unit/live-canonical-validation-script.test.ts tests/unit/live-validation-browser-workflows.test.ts tests/unit/live-validation-contract-modules.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `make check`
- `git diff --check`

## Live proof
- `powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1 -ScreenshotDirectory output/playwright/live-canonical-rfc42-outcome-review`
- Result: passed for `PB_SG_GLOBAL_BAL_001`.
- Evidence summary: `output/playwright/live-canonical-rfc42-outcome-review/live-validation-summary.json`.
- Screenshot index: `output/playwright/live-canonical-rfc42-outcome-review/SHOT-INDEX.md`.
- Outcome-review panel proof: `dpm.outcome_review` classified `ready`, owner `lotus-manage`, route `/workbench/PB_SG_GLOBAL_BAL_001`, API `GET /api/v1/dpm/command-center/outcome-reviews?...` status 200, screenshot `dpm-outcome-review-live.png`.

## Wiki
- Repo-authored wiki source is updated. Publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-workbench`.
