### PR TITLE
feat: request RFC42 outcome review report jobs

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -196,11 +196,16 @@
 
 .outcome-review-badge-row,
 .outcome-review-reason-row,
+.outcome-review-report-actions,
 .outcome-review-hash-strip {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem;
+}
+
+.outcome-review-report-actions {
+  justify-content: flex-start;
 }
 
 .outcome-review-status-strip {

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -151,6 +151,11 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
   },
   {
     route: "workbench.dpm-command-center",
+    panel: "outcome-review-report-job",
+    operation: "dpm.outcome-review.report-job.submit",
+  },
+  {
+    route: "workbench.dpm-command-center",
     panel: "outcome-review-ai-evidence",
     operation: "dpm.outcome-review.ai-evidence",
   },

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -15,6 +15,7 @@ import {
   WorkbenchPortfolio360,
   DpmOutcomeReviewGatewayResponse,
   DpmOutcomeReviewHandoffResponse,
+  ReportJobHandleResponse,
   ReportBatchHandleResponse,
   ReportBatchStatusResponse,
   ReportBatchWorkerRunResponse,
@@ -795,6 +796,47 @@ export async function getDpmOutcomeReviewAiEvidenceInput(
         "client",
         `/dpm/command-center/outcome-reviews/${encodeURIComponent(outcomeReviewId)}/ai-evidence-input`,
         "DPM outcome review AI evidence input"
+      )
+  );
+}
+
+export async function submitDpmOutcomeReviewReportJob(params: {
+  outcomeReviewId: string;
+  outcomeReportInput: Record<string, unknown>;
+  requestedOutputFormats?: string[];
+  tenantId?: string;
+  region?: string;
+  bookingCenterCode?: string | null;
+  actorId?: string;
+}): Promise<ReportJobHandleResponse> {
+  const tenantId = params.tenantId ?? "tenant-sg";
+  const region = params.region ?? "APAC";
+  const actorId = params.actorId ?? "workbench-outcome-review-operator";
+  const idempotencyKey = `outcome-review-${params.outcomeReviewId}-pdf`;
+  return await observeWorkbenchMutation(
+    "dpm.outcome-review.report-job.submit",
+    async () =>
+      await fetchWorkbenchMutation<ReportJobHandleResponse>(
+        buildWorkbenchUrl("client", "/reports/outcome-reviews"),
+        "submit outcome-review report job",
+        {
+          method: "POST",
+          headers: {
+            ...buildReportBatchCallerHeaders({
+              actorId,
+              tenantId,
+              region,
+              bookingCenterCode: params.bookingCenterCode,
+              correlationId: `corr-workbench-outcome-report-${params.outcomeReviewId}`,
+            }),
+            "Idempotency-Key": idempotencyKey,
+          },
+          body: JSON.stringify({
+            outcome_report_input: params.outcomeReportInput,
+            requested_output_formats: params.requestedOutputFormats ?? ["pdf"],
+            options: { retention_policy_id: "generated-report-standard" },
+          }),
+        }
       )
   );
 }

--- a/src/features/workbench/components/outcome-review-panel.tsx
+++ b/src/features/workbench/components/outcome-review-panel.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import {
+  ActionButton,
   AnalyticsTable,
   MetricRow,
   ScreenStatePanel,
@@ -8,6 +10,10 @@ import {
   SemanticBadge,
   Text,
 } from "@/design-system";
+import {
+  getDpmOutcomeReviewReportInput,
+  submitDpmOutcomeReviewReportJob,
+} from "@/features/workbench/api";
 import type { DpmOutcomeReviewGatewayResponse } from "@/features/workbench/types";
 import {
   buildOutcomeReviewPanelModel,
@@ -78,12 +84,36 @@ function handoffTone(blocked: boolean | undefined): "default" | "success" | "dan
 }
 
 export default function OutcomeReviewPanel({ portfolioId, response, errorMessage }: Props) {
+  const [reportJobStatus, setReportJobStatus] = useState<string | null>(null);
+  const [reportJobError, setReportJobError] = useState<string | null>(null);
+  const [reportJobPending, setReportJobPending] = useState(false);
   const model = buildOutcomeReviewPanelModel(response);
   const primaryReview = model.items[0] ?? null;
   const hasItems = model.items.length > 0;
   const shouldShowStatePanel =
     Boolean(errorMessage) || model.state === "empty" || model.state === "blocked" || model.state === "unsupported" || model.state === "unavailable";
   const stateCopy = statePanelCopy(model.state, portfolioId);
+  const reportJobAvailable = Boolean(primaryReview && !primaryReview.reportInputBlocked);
+
+  async function requestOutcomeReportJob() {
+    if (!primaryReview || primaryReview.reportInputBlocked || reportJobPending) {
+      return;
+    }
+    setReportJobPending(true);
+    setReportJobError(null);
+    try {
+      const reportInput = await getDpmOutcomeReviewReportInput(primaryReview.outcomeReviewId);
+      const handle = await submitDpmOutcomeReviewReportJob({
+        outcomeReviewId: primaryReview.outcomeReviewId,
+        outcomeReportInput: reportInput.data,
+      });
+      setReportJobStatus(`${handle.status} / ${handle.report_job_id}`);
+    } catch (error) {
+      setReportJobError(error instanceof Error ? error.message : "Outcome report job failed");
+    } finally {
+      setReportJobPending(false);
+    }
+  }
 
   return (
     <SectionBlock
@@ -128,6 +158,21 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
         />
         <MetricRow label="Remediation Owner" value={model.remediationOwner} />
       </div>
+
+      {primaryReview ? (
+        <div className="outcome-review-report-actions">
+          <ActionButton
+            priority="secondary"
+            onClick={requestOutcomeReportJob}
+            disabled={!reportJobAvailable || reportJobPending}
+          >
+            {reportJobPending ? "Requesting report" : "Request report"}
+          </ActionButton>
+          <Text variant="secondary" className="muted">
+            {reportJobError ?? reportJobStatus ?? "Creates a Gateway-backed governed PDF job."}
+          </Text>
+        </div>
+      ) : null}
 
       {model.supportabilityReasons.length > 0 || model.blockedActions.length > 0 ? (
         <div className="outcome-review-reason-row">

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1147,6 +1147,14 @@ export type DpmOutcomeReviewGatewayResponse = {
 
 export type DpmOutcomeReviewHandoffResponse = DpmOutcomeReviewGatewayResponse;
 
+export type ReportJobHandleResponse = {
+  report_request_id: string;
+  report_job_id: string;
+  status: string;
+  status_url: string;
+  idempotency_key: string;
+};
+
 export type ReportBatchHandleResponse = {
   batch_id: string;
   status: string;

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -301,6 +301,11 @@ describe("analytics UI observability metrics", () => {
       ],
       [
         "workbench.dpm-command-center",
+        "outcome-review-report-job",
+        "dpm.outcome-review.report-job.submit",
+      ],
+      [
+        "workbench.dpm-command-center",
         "outcome-review-ai-evidence",
         "dpm.outcome-review.ai-evidence",
       ],

--- a/tests/unit/outcome-review-panel.test.tsx
+++ b/tests/unit/outcome-review-panel.test.tsx
@@ -1,8 +1,17 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import OutcomeReviewPanel from "../../src/features/workbench/components/outcome-review-panel";
 import type { DpmOutcomeReviewGatewayResponse } from "../../src/features/workbench/types";
+import {
+  getDpmOutcomeReviewReportInput,
+  submitDpmOutcomeReviewReportJob,
+} from "../../src/features/workbench/api";
+
+vi.mock("../../src/features/workbench/api", () => ({
+  getDpmOutcomeReviewReportInput: vi.fn(),
+  submitDpmOutcomeReviewReportJob: vi.fn(),
+}));
 
 const readyResponse: DpmOutcomeReviewGatewayResponse = {
   correlation_id: "corr-rfc42",
@@ -50,6 +59,10 @@ const readyResponse: DpmOutcomeReviewGatewayResponse = {
 };
 
 describe("OutcomeReviewPanel", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders manage-backed outcome review state and evidence posture", () => {
     render(<OutcomeReviewPanel portfolioId="PB_SG_GLOBAL_BAL_001" response={readyResponse} />);
 
@@ -60,6 +73,33 @@ describe("OutcomeReviewPanel", () => {
     expect(screen.getByText("tracking_error")).toBeInTheDocument();
     expect(screen.getByText("sha256:risk")).toBeInTheDocument();
     expect(screen.getAllByText("Available").length).toBe(2);
+    expect(screen.getByRole("button", { name: "Request report" })).toBeEnabled();
+  });
+
+  it("requests a governed outcome-review report job from manage report input", async () => {
+    vi.mocked(getDpmOutcomeReviewReportInput).mockResolvedValue({
+      ...readyResponse,
+      data: { outcome_review_id: "or_1", content_hash: "sha256:report-input" },
+    });
+    vi.mocked(submitDpmOutcomeReviewReportJob).mockResolvedValue({
+      report_request_id: "rrq_outcome_1",
+      report_job_id: "rjob_outcome_1",
+      status: "accepted",
+      status_url: "/api/v1/report-jobs/rjob_outcome_1",
+      idempotency_key: "outcome-review-or_1-pdf",
+    });
+
+    render(<OutcomeReviewPanel portfolioId="PB_SG_GLOBAL_BAL_001" response={readyResponse} />);
+    fireEvent.click(screen.getByRole("button", { name: "Request report" }));
+
+    await waitFor(() => {
+      expect(getDpmOutcomeReviewReportInput).toHaveBeenCalledWith("or_1");
+      expect(submitDpmOutcomeReviewReportJob).toHaveBeenCalledWith({
+        outcomeReviewId: "or_1",
+        outcomeReportInput: { outcome_review_id: "or_1", content_hash: "sha256:report-input" },
+      });
+    });
+    expect(screen.getByText("accepted / rjob_outcome_1")).toBeInTheDocument();
   });
 
   it("renders blocked handoff posture from Gateway supportability", () => {

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -28,6 +28,7 @@ import {
   getWorkbenchPerformanceWorkspaceSummary,
   postWorkbenchPerformanceAdvisorBriefReviewActionClient,
   runReportBatchOnce,
+  submitDpmOutcomeReviewReportJob,
 } from "../../src/features/workbench/api";
 import {
   getAnalyticsUiMetricEvents,
@@ -1805,6 +1806,47 @@ describe("workbench api", () => {
     const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
     expect(metricEventsJson).toContain("outcome-review-report-input");
     expect(metricEventsJson).toContain("outcome-review-ai-evidence");
+    expect(metricEventsJson).not.toContain("or_1");
+  });
+
+  it("submits DPM outcome-review report jobs through the gateway BFF", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            report_request_id: "rrq_outcome_1",
+            report_job_id: "rjob_outcome_1",
+            status: "accepted",
+            status_url: "/api/v1/report-jobs/rjob_outcome_1",
+            idempotency_key: "outcome-review-or_1-pdf",
+          }),
+          { status: 202, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    const handle = await submitDpmOutcomeReviewReportJob({
+      outcomeReviewId: "or_1",
+      outcomeReportInput: { outcome_review_id: "or_1", content_hash: "sha256:report-input" },
+    });
+
+    expect(handle.report_job_id).toBe("rjob_outcome_1");
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock.mock.calls[0][0]).toBe(`${expectedBaseUrl}/reports/outcome-reviews`);
+    expect(fetchMock.mock.calls[0][1].headers["Idempotency-Key"]).toBe(
+      "outcome-review-or_1-pdf"
+    );
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      outcome_report_input: {
+        outcome_review_id: "or_1",
+        content_hash: "sha256:report-input",
+      },
+      requested_output_formats: ["pdf"],
+      options: { retention_policy_id: "generated-report-standard" },
+    });
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("outcome-review-report-job");
     expect(metricEventsJson).not.toContain("or_1");
   });
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -53,7 +53,10 @@ promote dormant labels into product ownership just because historical route file
   `/workbench/{portfolioId}` through Gateway `/api/v1/dpm/command-center/outcome-reviews*`.
   Workbench renders manage-owned review state, expected-versus-realized dimensions, hashes,
   source lineage, supportability, report-input posture, and AI-evidence posture without
-  calculating those values client-side. Demo promotion still requires the canonical
+  calculating those values client-side. The panel can request a governed outcome-review PDF job by
+  loading manage report input through Gateway and then submitting Gateway
+  `POST /api/v1/reports/outcome-reviews`; report rendering and archive lifecycle remain owned by
+  `lotus-report`, `lotus-render`, and `lotus-archive`. Demo promotion still requires the canonical
   `PB_SG_GLOBAL_BAL_001` live evidence pack and screenshot review in the implementation ledger.
 
 ## Route examples

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -50,13 +50,17 @@ must travel through Gateway-shaped contracts.
    `/api/v1/documents/{document_id}/download` through `/api/bff/api/v1/documents/*`; Workbench
    does not call `lotus-archive` directly, and the BFF preserves binary responses and integrity
    headers for PDF downloads
-10. RFC-0108 analytics UI observability is centralized in
+10. Outcome-review report job requests use Gateway `POST /api/v1/reports/outcome-reviews` through
+    `/api/bff/api/v1/reports/outcome-reviews` after loading manage-owned `DpmOutcomeReportInput`.
+    Workbench does not call `lotus-report`, `lotus-render`, or `lotus-archive` directly for
+    report materialization.
+11. RFC-0108 analytics UI observability is centralized in
     `src/features/analytics-observability/metrics.ts`. Supported Portfolio, Intake, Performance,
     Risk, Reporting, Data Products, and legacy advisor Workbench gateway-backed reads/mutations
     emit bounded route, panel, operation, freshness, and supportability labels only; portfolio,
     intake payload, document, session, trace, request, response, and screen-content identifiers
     must not appear in metric labels.
-11. `lotus-manage` is not a proposal/advisory upstream for Workbench. DPM product surfaces must be
+12. `lotus-manage` is not a proposal/advisory upstream for Workbench. DPM product surfaces must be
     backed by strategic Gateway APIs before Workbench exposes them. RFC-0098 keeps Workbench as a
     renderer of Gateway-composed mandate and proof-pack truth, not a direct caller of manage, risk,
     performance, core, report, archive, or AI. RFC-0040 proof-pack JSON, hashes, Markdown,
@@ -69,7 +73,7 @@ must travel through Gateway-shaped contracts.
     outcome-review composition only; the implemented Workbench panel consumes the Gateway
     outcome-review list contract and must not calculate expected-versus-realized values or infer
     PM quality.
-12. `lotus-advise` owns advisor-led proposal workflows. Workbench proposal compatibility routes are
+13. `lotus-advise` owns advisor-led proposal workflows. Workbench proposal compatibility routes are
     not the active RFC-0108 product surface and should not be used as current client-demo evidence.
 
 ## Ownership Diagram


### PR DESCRIPTION
## Summary
- add Workbench BFF API for outcome-review report job creation
- add outcome-review panel action that loads manage report input before requesting the report job
- update observability metrics, tests, and wiki integration posture

## Validation
- npm test -- --run tests/unit/workbench-api.test.ts tests/unit/outcome-review-panel.test.tsx
- git diff --check