### PR TITLE
feat: add RFC42 outcome AI narrative action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ Always:
 7. keep commits small, meaningful, and truthful,
 8. remove dead code, duplicate logic, and stale non-standard handling when encountered,
 9. ensure every UI feature is genuinely backed by supported backend functionality,
-10. ensure RFC/docs/wiki/context/contract closure truth is present on `main`, not stranded on an
+10. treat "merged to `main` and validated" as the definition of done; ensure
+    RFC/docs/wiki/context/contract closure truth is present on `main`, not stranded on an
     unmerged side branch.
 
 For RFC, documentation, wiki, context, contract, supported-features, API-governance, migration, or

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -50,8 +50,9 @@ Current repository posture:
    Gateway `/api/v1/documents` via the Workbench BFF rather than calling `lotus-archive` directly,
 7. `/workbench/{portfolioId}` renders the RFC-0042 DPM outcome-review panel from Gateway
    `/api/v1/dpm/command-center/outcome-reviews*`, preserving manage-owned expected-versus-realized
-   dimensions, source lineage, supportability, report-input posture, and AI-evidence posture
-   without client-side outcome calculation,
+   dimensions, source lineage, supportability, report-input posture, AI-evidence posture, and
+   Gateway-backed governed AI narrative requests without client-side outcome calculation or direct
+   `lotus-manage`/`lotus-ai` calls,
 8. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map
@@ -150,6 +151,10 @@ Important validation expectations:
    must identify only governed route, panel, operation, freshness, supportability, and status
    classes; outcome review ids, portfolio ids, proof-pack ids, rebalance run ids, request payloads,
    response payloads, hashes, and lineage references must stay out of metric labels.
+10. DPM outcome-review AI narrative requests are Workbench state-changing mutations through
+    Gateway only. Workbench may display bounded workflow-pack run status returned by Gateway/AI,
+    but it must not construct AI prompts, generate recommendations, score PMs, or treat a narrative
+    run as autonomous approval.
 
 ### Visual Review Gate
 

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -391,9 +391,13 @@ Implementation note as of 2026-05-05: the first RFC-0042 outcome-review realizat
 `GET /api/v1/dpm/command-center/outcome-reviews`. It includes typed Workbench API wrappers,
 bounded analytics UI observability surfaces, deterministic view-model normalization, and a
 portfolio-linked panel that renders manage-owned review state, dimension rows, lineage rows,
-snapshot hashes, supportability reasons, blocked actions, and report/AI handoff posture. Dedicated
-`/dpm/outcomes` routing, mutation actions, drawers, and canonical live screenshot proof remain
-future RFC-0098 command-center work unless separately promoted by implementation evidence.
+snapshot hashes, supportability reasons, blocked actions, report handoff posture, and
+Gateway-backed governed AI narrative request posture. Workbench does not call `lotus-ai` or
+construct prompts; the narrative action uses Gateway
+`POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`, which composes
+manage-owned AI evidence with `lotus-ai` workflow-pack execution. Dedicated `/dpm/outcomes`
+routing, preview/create/source-refresh mutations, drawers, and canonical live screenshot proof
+remain future RFC-0098 command-center work unless separately promoted by implementation evidence.
 
 Target user journey:
 
@@ -406,9 +410,11 @@ Target user journey:
    and remediation routes from Gateway/manage truth only.
 5. Operations opens the supportability drawer and sees dimension counts, source-owner families,
    freshness counts, support refs, and remediation routes without raw source payloads.
-6. Sales/pre-sales can demonstrate a closed-loop outcome story while clearly stating that reports,
-   archive artifacts, AI narrative, external execution, and PM scoring are not claimed unless the
-   owning apps have implemented and proven them.
+6. Sales/pre-sales can demonstrate a closed-loop outcome story while clearly stating that report
+   rendering/archive artifacts, external execution, PM scoring, and autonomous AI recommendations
+   are not claimed unless the owning apps have implemented and proven them. The implemented AI
+   narrative action is a governed Gateway/AI workflow-pack request over manage-owned evidence, not
+   an approval, client contact, or PM score.
 
 Required outcome panels:
 
@@ -419,7 +425,7 @@ Required outcome panels:
 | Source Lineage Drawer | Support audit and operations. | Show source owners, source refs, hashes, timestamps, freshness, and supportability without raw payloads. |
 | Supportability Drawer | Support operator triage. | Show dimension counts, source-owner families, freshness counts, remediation routes, and safe diagnostics. |
 | Report Input Panel | Explain downstream report readiness. | Show report-input availability only; do not imply rendered report or archive completion. |
-| AI Evidence Panel | Explain downstream AI readiness. | Show AI-evidence permitted use and forbidden actions only; do not generate prompts, memos, or recommendations. |
+| AI Evidence Panel | Explain downstream AI readiness. | Show AI-evidence permitted use and forbidden actions only; request governed narrative execution through Gateway only and show bounded run status. Do not generate prompts, autonomous recommendations, approvals, or PM scores. |
 | Action Rail | Guide preview, create, source refresh, and handoff reads. | Buttons are enabled only from Gateway action eligibility; unsupported report, AI, archive, execution, and PM-scoring actions remain disabled or absent. |
 
 Required UI states:
@@ -434,7 +440,7 @@ Required UI states:
 8. not-supported dimension,
 9. source refresh available,
 10. report input available but rendered report unavailable,
-11. AI evidence available but AI memo unavailable,
+11. AI evidence available and governed AI narrative request available,
 12. Gateway unavailable,
 13. manage outcome authority unavailable,
 14. supportability blocked/degraded/not found.
@@ -460,6 +466,7 @@ Workbench must consume these Gateway outcome routes when implemented:
 | `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/supportability` | supportability drawer |
 | `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/report-input` | report-input panel |
 | `GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-evidence-input` | AI-evidence panel |
+| `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` | governed AI narrative action from embedded outcome panel |
 | `POST /api/v1/dpm/command-center/outcome-reviews/preview` | non-durable preview workflow |
 | `POST /api/v1/dpm/command-center/outcome-reviews` | durable outcome-review creation |
 | `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/refresh-sources` | source refresh action |

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -160,6 +160,11 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     operation: "dpm.outcome-review.ai-evidence",
   },
   {
+    route: "workbench.dpm-command-center",
+    panel: "outcome-review-ai-narrative",
+    operation: "dpm.outcome-review.ai-narrative",
+  },
+  {
     route: "workbench.legacy-advisor",
     panel: "advisor-overview",
     operation: "workbench.overview",

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -15,6 +15,7 @@ import {
   WorkbenchPortfolio360,
   DpmOutcomeReviewGatewayResponse,
   DpmOutcomeReviewHandoffResponse,
+  DpmOutcomeReviewNarrativeResponse,
   ReportJobHandleResponse,
   ReportBatchHandleResponse,
   ReportBatchStatusResponse,
@@ -796,6 +797,44 @@ export async function getDpmOutcomeReviewAiEvidenceInput(
         "client",
         `/dpm/command-center/outcome-reviews/${encodeURIComponent(outcomeReviewId)}/ai-evidence-input`,
         "DPM outcome review AI evidence input"
+      )
+  );
+}
+
+export async function requestDpmOutcomeReviewAiNarrative(params: {
+  outcomeReviewId: string;
+  requestedOutputs?: string[];
+  audience?: string[];
+}): Promise<DpmOutcomeReviewNarrativeResponse> {
+  return await observeWorkbenchMutation(
+    "dpm.outcome-review.ai-narrative",
+    async () =>
+      await fetchWorkbenchMutation<DpmOutcomeReviewNarrativeResponse>(
+        buildWorkbenchUrl(
+          "client",
+          `/dpm/command-center/outcome-reviews/${encodeURIComponent(params.outcomeReviewId)}/ai-narrative`
+        ),
+        "request DPM outcome review AI narrative",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Correlation-Id": `corr-workbench-outcome-ai-${params.outcomeReviewId}`,
+          },
+          body: JSON.stringify({
+            requested_outputs: params.requestedOutputs ?? [
+              "pm_summary",
+              "cio_summary",
+              "control_summary",
+              "evidence_gaps",
+            ],
+            audience: params.audience ?? [
+              "portfolio_manager",
+              "cio_office",
+              "investment_control",
+            ],
+          }),
+        }
       )
   );
 }

--- a/src/features/workbench/components/outcome-review-panel.tsx
+++ b/src/features/workbench/components/outcome-review-panel.tsx
@@ -11,6 +11,7 @@ import {
   Text,
 } from "@/design-system";
 import {
+  requestDpmOutcomeReviewAiNarrative,
   getDpmOutcomeReviewReportInput,
   submitDpmOutcomeReviewReportJob,
 } from "@/features/workbench/api";
@@ -87,6 +88,9 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
   const [reportJobStatus, setReportJobStatus] = useState<string | null>(null);
   const [reportJobError, setReportJobError] = useState<string | null>(null);
   const [reportJobPending, setReportJobPending] = useState(false);
+  const [aiNarrativeStatus, setAiNarrativeStatus] = useState<string | null>(null);
+  const [aiNarrativeError, setAiNarrativeError] = useState<string | null>(null);
+  const [aiNarrativePending, setAiNarrativePending] = useState(false);
   const model = buildOutcomeReviewPanelModel(response);
   const primaryReview = model.items[0] ?? null;
   const hasItems = model.items.length > 0;
@@ -94,6 +98,11 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
     Boolean(errorMessage) || model.state === "empty" || model.state === "blocked" || model.state === "unsupported" || model.state === "unavailable";
   const stateCopy = statePanelCopy(model.state, portfolioId);
   const reportJobAvailable = Boolean(primaryReview && !primaryReview.reportInputBlocked);
+  const aiNarrativeAvailable = Boolean(primaryReview && !primaryReview.aiEvidenceBlocked);
+  const handoffStatusMessages = [
+    reportJobError ?? reportJobStatus,
+    aiNarrativeError ?? aiNarrativeStatus,
+  ].filter((message): message is string => Boolean(message));
 
   async function requestOutcomeReportJob() {
     if (!primaryReview || primaryReview.reportInputBlocked || reportJobPending) {
@@ -112,6 +121,26 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
       setReportJobError(error instanceof Error ? error.message : "Outcome report job failed");
     } finally {
       setReportJobPending(false);
+    }
+  }
+
+  async function requestOutcomeAiNarrative() {
+    if (!primaryReview || primaryReview.aiEvidenceBlocked || aiNarrativePending) {
+      return;
+    }
+    setAiNarrativePending(true);
+    setAiNarrativeError(null);
+    try {
+      const narrative = await requestDpmOutcomeReviewAiNarrative({
+        outcomeReviewId: primaryReview.outcomeReviewId,
+      });
+      setAiNarrativeStatus(describeNarrativeRun(narrative.data));
+    } catch (error) {
+      setAiNarrativeError(
+        error instanceof Error ? error.message : "Outcome AI narrative request failed"
+      );
+    } finally {
+      setAiNarrativePending(false);
     }
   }
 
@@ -168,9 +197,24 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
           >
             {reportJobPending ? "Requesting report" : "Request report"}
           </ActionButton>
-          <Text variant="secondary" className="muted">
-            {reportJobError ?? reportJobStatus ?? "Creates a Gateway-backed governed PDF job."}
-          </Text>
+          <ActionButton
+            priority="secondary"
+            onClick={requestOutcomeAiNarrative}
+            disabled={!aiNarrativeAvailable || aiNarrativePending}
+          >
+            {aiNarrativePending ? "Requesting AI review" : "Request AI review"}
+          </ActionButton>
+          {handoffStatusMessages.length > 0 ? (
+            handoffStatusMessages.map((message) => (
+              <Text key={message} variant="secondary" className="muted">
+                {message}
+              </Text>
+            ))
+          ) : (
+            <Text variant="secondary" className="muted">
+              Creates Gateway-backed governed report and AI review handoffs.
+            </Text>
+          )}
         </div>
       ) : null}
 
@@ -278,4 +322,22 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
       </Text>
     </SectionBlock>
   );
+}
+
+function describeNarrativeRun(data: Record<string, unknown>): string {
+  const workflowPackRun = readRecord(data.workflow_pack_run);
+  const execution = readRecord(data.execution);
+  const runId = readString(workflowPackRun.run_id) ?? "workflow-pack run";
+  const status = readString(execution.status) ?? "submitted";
+  return `${status} / ${runId}`;
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
 }

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1147,6 +1147,19 @@ export type DpmOutcomeReviewGatewayResponse = {
 
 export type DpmOutcomeReviewHandoffResponse = DpmOutcomeReviewGatewayResponse;
 
+export type DpmOutcomeReviewNarrativeResponse = {
+  correlation_id: string;
+  contract_version: string;
+  source_service: "lotus-ai";
+  evidence_source_service: "lotus-manage";
+  manage_upstream_status: number;
+  ai_upstream_status: number;
+  supportability: DpmOutcomeReviewSupportability;
+  ai_evidence_input: Record<string, unknown>;
+  narrative_request: Record<string, unknown>;
+  data: Record<string, unknown>;
+};
+
 export type ReportJobHandleResponse = {
   report_request_id: string;
   report_job_id: string;

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -309,6 +309,11 @@ describe("analytics UI observability metrics", () => {
         "outcome-review-ai-evidence",
         "dpm.outcome-review.ai-evidence",
       ],
+      [
+        "workbench.dpm-command-center",
+        "outcome-review-ai-narrative",
+        "dpm.outcome-review.ai-narrative",
+      ],
       ["workbench.legacy-advisor", "advisor-overview", "workbench.overview"],
       ["workbench.legacy-advisor", "portfolio-360", "workbench.portfolio-360"],
       ["workbench.legacy-advisor", "portfolio-analytics", "workbench.analytics"],

--- a/tests/unit/outcome-review-panel.test.tsx
+++ b/tests/unit/outcome-review-panel.test.tsx
@@ -5,11 +5,13 @@ import OutcomeReviewPanel from "../../src/features/workbench/components/outcome-
 import type { DpmOutcomeReviewGatewayResponse } from "../../src/features/workbench/types";
 import {
   getDpmOutcomeReviewReportInput,
+  requestDpmOutcomeReviewAiNarrative,
   submitDpmOutcomeReviewReportJob,
 } from "../../src/features/workbench/api";
 
 vi.mock("../../src/features/workbench/api", () => ({
   getDpmOutcomeReviewReportInput: vi.fn(),
+  requestDpmOutcomeReviewAiNarrative: vi.fn(),
   submitDpmOutcomeReviewReportJob: vi.fn(),
 }));
 
@@ -74,6 +76,7 @@ describe("OutcomeReviewPanel", () => {
     expect(screen.getByText("sha256:risk")).toBeInTheDocument();
     expect(screen.getAllByText("Available").length).toBe(2);
     expect(screen.getByRole("button", { name: "Request report" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Request AI review" })).toBeEnabled();
   });
 
   it("requests a governed outcome-review report job from manage report input", async () => {
@@ -102,6 +105,79 @@ describe("OutcomeReviewPanel", () => {
     expect(screen.getByText("accepted / rjob_outcome_1")).toBeInTheDocument();
   });
 
+  it("requests a governed outcome-review AI narrative through Gateway", async () => {
+    vi.mocked(requestDpmOutcomeReviewAiNarrative).mockResolvedValue({
+      correlation_id: "corr-ai",
+      contract_version: "v1",
+      source_service: "lotus-ai",
+      evidence_source_service: "lotus-manage",
+      manage_upstream_status: 200,
+      ai_upstream_status: 200,
+      supportability: readyResponse.supportability,
+      ai_evidence_input: {
+        outcome_review_id: "or_1",
+        content_hash: "sha256:ai-evidence",
+      },
+      narrative_request: {
+        requested_outputs: ["pm_summary", "cio_summary", "control_summary", "evidence_gaps"],
+        audience: ["portfolio_manager", "cio_office", "investment_control"],
+      },
+      data: {
+        execution: { status: "COMPLETED" },
+        workflow_pack_run: { run_id: "packrun_or_1", workflow_authority_owner: "lotus-manage" },
+      },
+    });
+
+    render(<OutcomeReviewPanel portfolioId="PB_SG_GLOBAL_BAL_001" response={readyResponse} />);
+    fireEvent.click(screen.getByRole("button", { name: "Request AI review" }));
+
+    await waitFor(() => {
+      expect(requestDpmOutcomeReviewAiNarrative).toHaveBeenCalledWith({
+        outcomeReviewId: "or_1",
+      });
+    });
+    expect(screen.getByText("COMPLETED / packrun_or_1")).toBeInTheDocument();
+  });
+
+  it("keeps report and AI handoff run posture visible after both actions", async () => {
+    vi.mocked(getDpmOutcomeReviewReportInput).mockResolvedValue({
+      ...readyResponse,
+      data: { outcome_review_id: "or_1", content_hash: "sha256:report-input" },
+    });
+    vi.mocked(submitDpmOutcomeReviewReportJob).mockResolvedValue({
+      report_request_id: "rrq_outcome_1",
+      report_job_id: "rjob_outcome_1",
+      status: "accepted",
+      status_url: "/api/v1/report-jobs/rjob_outcome_1",
+      idempotency_key: "outcome-review-or_1-pdf",
+    });
+    vi.mocked(requestDpmOutcomeReviewAiNarrative).mockResolvedValue({
+      correlation_id: "corr-ai",
+      contract_version: "v1",
+      source_service: "lotus-ai",
+      evidence_source_service: "lotus-manage",
+      manage_upstream_status: 200,
+      ai_upstream_status: 200,
+      supportability: readyResponse.supportability,
+      ai_evidence_input: { outcome_review_id: "or_1" },
+      narrative_request: {
+        requested_outputs: ["pm_summary", "cio_summary", "control_summary", "evidence_gaps"],
+        audience: ["portfolio_manager", "cio_office", "investment_control"],
+      },
+      data: {
+        execution: { status: "COMPLETED" },
+        workflow_pack_run: { run_id: "packrun_or_1" },
+      },
+    });
+
+    render(<OutcomeReviewPanel portfolioId="PB_SG_GLOBAL_BAL_001" response={readyResponse} />);
+    fireEvent.click(screen.getByRole("button", { name: "Request report" }));
+    fireEvent.click(screen.getByRole("button", { name: "Request AI review" }));
+
+    expect(await screen.findByText("accepted / rjob_outcome_1")).toBeInTheDocument();
+    expect(screen.getByText("COMPLETED / packrun_or_1")).toBeInTheDocument();
+  });
+
   it("renders blocked handoff posture from Gateway supportability", () => {
     render(
       <OutcomeReviewPanel
@@ -121,6 +197,7 @@ describe("OutcomeReviewPanel", () => {
     expect(screen.getByText("Outcome review handoff is blocked")).toBeInTheDocument();
     expect(screen.getAllByText("Blocked").length).toBe(2);
     expect(screen.getByText("Portfolio Operations")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Request AI review" })).toBeDisabled();
   });
 
   it("renders unavailable state without claiming support", () => {

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -8,6 +8,7 @@ import {
   getDpmOutcomeReviewAiEvidenceInput,
   getDpmOutcomeReviewReportInput,
   getDpmOutcomeReviews,
+  requestDpmOutcomeReviewAiNarrative,
   getArchivedDocumentMetadata,
   getPortfolio360,
   getReportBatchStatus,
@@ -1807,6 +1808,54 @@ describe("workbench api", () => {
     expect(metricEventsJson).toContain("outcome-review-report-input");
     expect(metricEventsJson).toContain("outcome-review-ai-evidence");
     expect(metricEventsJson).not.toContain("or_1");
+  });
+
+  it("requests DPM outcome-review AI narrative through the Gateway BFF", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr-rfc42-ai-narrative",
+            contract_version: "v1",
+            source_service: "lotus-ai",
+            evidence_source_service: "lotus-manage",
+            manage_upstream_status: 200,
+            ai_upstream_status: 200,
+            supportability: {
+              source_service: "lotus-manage",
+              authority: "lotus-manage:RFC-0042",
+              state: "SUPPORTED",
+              reason_codes: [],
+              blocked_actions: [],
+            },
+            ai_evidence_input: { outcome_review_id: "or_1" },
+            narrative_request: { requested_outputs: ["pm_summary"], audience: ["pm"] },
+            data: { workflow_pack_run: { run_id: "packrun_or_1" } },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await requestDpmOutcomeReviewAiNarrative({
+      outcomeReviewId: "or_1",
+      requestedOutputs: ["pm_summary"],
+      audience: ["pm"],
+    });
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/outcome-reviews/or_1/ai-narrative`
+    );
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      requested_outputs: ["pm_summary"],
+      audience: ["pm"],
+    });
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("outcome-review-ai-narrative");
+    expect(metricEventsJson).not.toContain("or_1");
+    expect(metricEventsJson).not.toContain("packrun_or_1");
   });
 
   it("submits DPM outcome-review report jobs through the gateway BFF", async () => {

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -56,7 +56,11 @@ promote dormant labels into product ownership just because historical route file
   calculating those values client-side. The panel can request a governed outcome-review PDF job by
   loading manage report input through Gateway and then submitting Gateway
   `POST /api/v1/reports/outcome-reviews`; report rendering and archive lifecycle remain owned by
-  `lotus-report`, `lotus-render`, and `lotus-archive`. Demo promotion still requires the canonical
+  `lotus-report`, `lotus-render`, and `lotus-archive`. The panel can also request a governed
+  outcome-review AI narrative through Gateway
+  `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`; evidence
+  remains manage-owned, narrative execution remains `lotus-ai` owned, and Workbench shows only
+  bounded workflow-pack run posture. Demo promotion still requires the canonical
   `PB_SG_GLOBAL_BAL_001` live evidence pack and screenshot review in the implementation ledger.
 
 ## Route examples

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -54,13 +54,18 @@ must travel through Gateway-shaped contracts.
     `/api/bff/api/v1/reports/outcome-reviews` after loading manage-owned `DpmOutcomeReportInput`.
     Workbench does not call `lotus-report`, `lotus-render`, or `lotus-archive` directly for
     report materialization.
-11. RFC-0108 analytics UI observability is centralized in
+11. Outcome-review AI narrative requests use Gateway
+    `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative` through
+    `/api/bff/api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`.
+    Workbench does not call `lotus-manage` or `lotus-ai` directly, does not construct prompts, and
+    displays only bounded workflow-pack run posture returned by Gateway.
+12. RFC-0108 analytics UI observability is centralized in
     `src/features/analytics-observability/metrics.ts`. Supported Portfolio, Intake, Performance,
     Risk, Reporting, Data Products, and legacy advisor Workbench gateway-backed reads/mutations
     emit bounded route, panel, operation, freshness, and supportability labels only; portfolio,
     intake payload, document, session, trace, request, response, and screen-content identifiers
     must not appear in metric labels.
-12. `lotus-manage` is not a proposal/advisory upstream for Workbench. DPM product surfaces must be
+13. `lotus-manage` is not a proposal/advisory upstream for Workbench. DPM product surfaces must be
     backed by strategic Gateway APIs before Workbench exposes them. RFC-0098 keeps Workbench as a
     renderer of Gateway-composed mandate and proof-pack truth, not a direct caller of manage, risk,
     performance, core, report, archive, or AI. RFC-0040 proof-pack JSON, hashes, Markdown,
@@ -69,11 +74,12 @@ must travel through Gateway-shaped contracts.
     simulation, selection, approval, staging, handoff, and supportability also remain
     manage-owned and must reach Workbench through Gateway wave composition only. RFC-0042
     outcome-review search, detail, supportability, report-input, AI-evidence, preview, create, and
-    source-refresh posture also remain manage-owned and must reach Workbench through Gateway
-    outcome-review composition only; the implemented Workbench panel consumes the Gateway
-    outcome-review list contract and must not calculate expected-versus-realized values or infer
+    source-refresh posture also remain manage-owned, while AI narrative execution remains
+    `lotus-ai` owned; both must reach Workbench through Gateway outcome-review composition only.
+    The implemented Workbench panel consumes the Gateway outcome-review list and AI-narrative
+    contracts and must not calculate expected-versus-realized values, construct prompts, or infer
     PM quality.
-13. `lotus-advise` owns advisor-led proposal workflows. Workbench proposal compatibility routes are
+14. `lotus-advise` owns advisor-led proposal workflows. Workbench proposal compatibility routes are
     not the active RFC-0108 product surface and should not be used as current client-demo evidence.
 
 ## Ownership Diagram
@@ -98,6 +104,7 @@ flowchart TB
   Workbench -->|/api/bff/api/v1/workbench/*| Gateway
   Workbench --> DpmCenter
   Workbench -->|/api/bff/api/v1/dpm/command-center/outcome-reviews*| Gateway
+  Workbench -->|AI narrative action via Gateway only| Gateway
   DpmCenter --> Waves
   DpmCenter --> Outcomes
   DpmCenter -->|Gateway RFC-0098 contract| Gateway


### PR DESCRIPTION
## Summary
- Adds the RFC-0042 DPM outcome-review AI narrative action to the Workbench outcome panel through the Gateway BFF only.
- Preserves manage-owned evidence and lotus-ai-owned execution boundaries; Workbench does not construct prompts, score PMs, approve trades, or call raw domain services.
- Extends bounded analytics observability for the new mutation and updates RFC/wiki/context truth.

## Validation
- `npm test -- --run tests/unit/outcome-review-panel.test.tsx tests/unit/workbench-api.test.ts tests/unit/analytics-observability-metrics.test.ts` (58 passed)
- `make lint`
- `make typecheck`
- `make test-coverage` (153 files, 695 tests, 91.06% statement coverage)
- `make build`
- `git diff --check`

## Wiki
- Repo-local wiki source updated for Workbench API surface and integrations.
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` intentionally reports drift before merge because published wiki has not yet been updated with this PR's repo-authored wiki changes. Publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-workbench`.