### PR TITLE
fix: render RFC-0042 outcome lineage fields

### DIFF
--- a/src/features/workbench/outcome-review-view-model.ts
+++ b/src/features/workbench/outcome-review-view-model.ts
@@ -71,8 +71,12 @@ export function buildOutcomeReviewPanelModel(
     };
   }
 
-  const supportabilityState = normalizeState(response.supportability.state);
-  const items = extractOutcomeReviewRecords(response.data).map((record, index) =>
+  const records = extractOutcomeReviewRecords(response.data);
+  const supportabilityState = resolveSupportabilityState(
+    normalizeState(response.supportability.state),
+    records
+  );
+  const items = records.map((record, index) =>
     buildOutcomeReviewListItem(record, response.supportability.blocked_actions, index)
   );
   return {
@@ -102,6 +106,26 @@ function resolvePanelState(
     return itemCount > 0 ? "partial" : "unavailable";
   }
   return itemCount > 0 ? "ready" : "empty";
+}
+
+function resolveSupportabilityState(
+  gatewayState: string,
+  records: Record<string, unknown>[]
+): string {
+  if (gatewayState !== "UNKNOWN" || records.length === 0) {
+    return gatewayState;
+  }
+  const recordStates = records.map((record) => normalizeState(readString(record, "state")));
+  if (recordStates.every((state) => state === "READY")) {
+    return "READY";
+  }
+  if (recordStates.some((state) => state === "BLOCKED" || state === "UNSUPPORTED")) {
+    return recordStates.find((state) => state === "BLOCKED" || state === "UNSUPPORTED") ?? "UNKNOWN";
+  }
+  if (recordStates.some((state) => state === "DEGRADED" || state === "SOURCE_STALE")) {
+    return "DEGRADED";
+  }
+  return gatewayState;
 }
 
 function buildOutcomeReviewListItem(
@@ -150,14 +174,31 @@ function buildDimensionRow(
 }
 
 function buildLineageRow(record: Record<string, unknown>, index: number): OutcomeReviewLineageRow {
-  const source = readString(record, "source_service") || readString(record, "source") || "N/A";
-  const reference = readString(record, "source_ref") || readString(record, "reference") || readString(record, "id") || "N/A";
+  const source =
+    readString(record, "source_service") ||
+    readString(record, "source_system") ||
+    readString(record, "source") ||
+    "N/A";
+  const reference =
+    readString(record, "source_ref") ||
+    readString(record, "source_id") ||
+    readString(record, "reference") ||
+    readString(record, "id") ||
+    "N/A";
   return {
     key: `${source}-${reference}-${index}`,
     source,
     reference,
-    freshness: readString(record, "freshness") || readString(record, "freshness_bucket") || "N/A",
-    hash: readString(record, "hash") || readString(record, "payload_hash") || "N/A",
+    freshness:
+      readString(record, "freshness") ||
+      readString(record, "freshness_bucket") ||
+      readString(record, "freshness_state") ||
+      "N/A",
+    hash:
+      readString(record, "hash") ||
+      readString(record, "payload_hash") ||
+      readString(record, "content_hash") ||
+      "N/A",
   };
 }
 

--- a/tests/unit/outcome-review-view-model.test.ts
+++ b/tests/unit/outcome-review-view-model.test.ts
@@ -93,6 +93,51 @@ describe("outcome review view model", () => {
     );
   });
 
+  it("maps manage RFC-0042 source lineage fields without degrading them to N/A", () => {
+    const model = buildOutcomeReviewPanelModel(
+      response(
+        {
+          items: [
+            {
+              outcome_review_id: "dor_1",
+              state: "READY",
+              source_lineage: [
+                {
+                  source_system: "lotus-manage",
+                  source_type: "DPM_SELECTED_ALTERNATIVE_EXPECTED_OUTCOME",
+                  source_id: "selected-alternative-1",
+                  content_hash: "sha256:selected",
+                },
+                {
+                  source_system: "lotus-core",
+                  source_type: "POST_TRADE_HOLDINGS_WINDOW",
+                  source_id: "post-trade-holdings-1",
+                  content_hash: "sha256:realized",
+                },
+              ],
+            },
+          ],
+        },
+        { state: "UNKNOWN" }
+      )
+    );
+
+    expect(model.state).toBe("ready");
+    expect(model.supportabilityState).toBe("READY");
+    expect(model.items[0].lineage).toEqual([
+      expect.objectContaining({
+        source: "lotus-manage",
+        reference: "selected-alternative-1",
+        hash: "sha256:selected",
+      }),
+      expect.objectContaining({
+        source: "lotus-core",
+        reference: "post-trade-holdings-1",
+        hash: "sha256:realized",
+      }),
+    ]);
+  });
+
   it("marks blocked handoffs from manage supportability without inventing UI support", () => {
     const model = buildOutcomeReviewPanelModel(
       response(


### PR DESCRIPTION
## Summary
- maps manage RFC-0042 source_lineage fields from Gateway payloads into the Workbench outcome-review panel
- prevents source_system/source_id/content_hash from rendering as N/A when manage-backed evidence is present
- derives READY supportability from manage-backed outcome records when the envelope state is UNKNOWN

## Evidence
- npm test -- --run tests/unit/outcome-review-view-model.test.ts tests/unit/outcome-review-panel.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- canonical validation passed: output/playwright/rfc42-wtbd-audit-20260506-fixed/live-validation-summary.json

## Wiki
No repo-local wiki source change in this PR.