### PR TITLE
test: prove construction alternatives live flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ WORKBENCH_BFF_TENANT_ID=tenant-sg
 WORKBENCH_BFF_REGION=APAC
 WORKBENCH_BFF_BOOKING_CENTER_CODE=SG
 WORKBENCH_BFF_ROLE=advisor
+WORKBENCH_DPM_MANDATE_ID=MANDATE_PB_SG_GLOBAL_BAL_001
+WORKBENCH_DPM_MODEL_PORTFOLIO_ID=MODEL_PB_SG_GLOBAL_BAL_DPM
+WORKBENCH_DPM_BOOKING_CENTER_CODE=Singapore
+WORKBENCH_DPM_SOURCE_AS_OF_DATE=2026-04-10
 ```
 
 Canonical front-office runtime:
@@ -213,6 +217,8 @@ http://workbench.dev.lotus/data-products
   canonical front-office stack bring-up
 - `npm run live:validate`
   canonical front-office validation against the running stack
+- `npm run live:validate:construction`
+  focused live proof for the Gateway/manage-backed construction alternatives lab
 
 ## Validation And CI Lanes
 
@@ -232,6 +238,8 @@ Repo-native gate mapping:
   Docker parity
 - `npm run live:validate`
   canonical integrated product validation when cross-app flows change
+- `npm run live:validate:construction`
+  focused browser proof for RFC-0039 construction alternatives when the construction lab changes
 
 ## Product Contract Notes
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "live:stack:up:workbench-local": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -LocalApps workbench",
     "live:stack:up:validate": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -RunValidation",
     "live:validate": "powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1",
+    "live:validate:construction": "playwright test tests/live/construction-alternatives.live.spec.ts --config playwright.live.config.ts",
     "live:validate:ui": "node scripts/live/validate-canonical-workbench-live.mjs",
     "live:evidence": "powershell -ExecutionPolicy Bypass -File scripts/live/Capture-LotusFrontOfficeEvidence.ps1",
     "auto:pulse": "powershell -ExecutionPolicy Bypass -File scripts/automation/Platform-Pulse.ps1",

--- a/playwright.live.config.ts
+++ b/playwright.live.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/live",
+  fullyParallel: false,
+  forbidOnly: true,
+  retries: 0,
+  workers: 1,
+  reporter: [["list"], ["html", { open: "never", outputFolder: "output/playwright/live-report" }]],
+  use: {
+    baseURL: process.env.LOTUS_WORKBENCH_LIVE_BASE_URL ?? "http://workbench.dev.lotus",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+});

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -31,7 +31,11 @@ import {
   type ServiceRequestTarget,
 } from "@/features/platform-runtime/service-addressing";
 import { buildAnalyticsUiCorrelationHeaders } from "@/features/analytics-observability/correlation";
-import { applyDefaultCallerContextHeaders, resolveDefaultCallerContext } from "./caller-context";
+import {
+  applyDefaultCallerContextHeaders,
+  resolveDefaultCallerContext,
+  resolveDefaultDpmContext,
+} from "./caller-context";
 import {
   WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES,
   observeWorkbenchAnalyticsRequest,
@@ -781,6 +785,22 @@ export async function generateDpmConstructionAlternatives(params: {
 }): Promise<DpmConstructionGatewayResponse> {
   const portfolioId = params.portfolio.portfolio.portfolio_id;
   const actorId = params.actorId ?? "workbench-construction-operator";
+  const methods = params.methods ?? [
+    "DO_NOTHING_BASELINE",
+    "HEURISTIC_EXPLAINABLE",
+    "MIN_TURNOVER",
+  ];
+  const requestBody = buildConstructionAlternativeSetRequest(
+    params.portfolio,
+    methods
+  );
+  const statefulInput = requestBody.stateful_input as
+    | { as_of?: unknown }
+    | undefined;
+  const constructionAsOf =
+    typeof statefulInput?.as_of === "string"
+      ? statefulInput.as_of
+      : params.portfolio.as_of_date;
   return await observeWorkbenchMutation(
     "dpm.construction.alternatives.generate",
     async () =>
@@ -791,14 +811,11 @@ export async function generateDpmConstructionAlternatives(params: {
           method: "POST",
           headers: buildDpmConstructionCallerHeaders({
             actorId,
-            correlationId: `corr-workbench-construction-${portfolioId}-${params.portfolio.as_of_date}`,
+            correlationId: `corr-workbench-construction-${portfolioId}-${constructionAsOf}`,
           }),
           body: JSON.stringify({
-            idempotency_key: `workbench-construction-${portfolioId}-${params.portfolio.as_of_date}`,
-            body: buildConstructionAlternativeSetRequest(
-              params.portfolio,
-              params.methods ?? ["DO_NOTHING_BASELINE", "HEURISTIC_EXPLAINABLE", "MIN_TURNOVER"]
-            ),
+            idempotency_key: `workbench-construction-${portfolioId}-${constructionAsOf}`,
+            body: requestBody,
           }),
         }
       )
@@ -1004,15 +1021,21 @@ function buildConstructionAlternativeSetRequest(
   const portfolioId = portfolio.portfolio.portfolio_id;
   const baseCurrency = portfolio.portfolio.base_currency;
   const callerContext = resolveDefaultCallerContext();
+  const dpmContext = resolveDefaultDpmContext();
+  const sourceAsOfDate = dpmContext.sourceAsOfDate || portfolio.as_of_date;
   return {
     input_mode: "stateful",
     methods,
     stateful_input: {
       portfolio_id: portfolioId,
-      as_of: portfolio.as_of_date,
+      as_of: sourceAsOfDate,
+      mandate_id: dpmContext.mandateId,
+      model_portfolio_id: dpmContext.modelPortfolioId,
       tenant_id: callerContext.tenantId,
       booking_center_code:
-        portfolio.portfolio.booking_center_code || callerContext.bookingCenterCode,
+        dpmContext.bookingCenterCode ||
+        portfolio.portfolio.booking_center_code ||
+        callerContext.bookingCenterCode,
       include_tax_lots: true,
       include_settlement_profile: true,
       include_shelf: true,

--- a/src/features/workbench/caller-context.ts
+++ b/src/features/workbench/caller-context.ts
@@ -7,6 +7,13 @@ const DEFAULT_CALLER_CONTEXT_HEADERS = {
   "X-Role": "advisor",
 } as const;
 
+const DEFAULT_DPM_CONTEXT = {
+  mandateId: "MANDATE_PB_SG_GLOBAL_BAL_001",
+  modelPortfolioId: "MODEL_PB_SG_GLOBAL_BAL_DPM",
+  bookingCenterCode: "Singapore",
+  sourceAsOfDate: "2026-04-10",
+} as const;
+
 const CALLER_CONTEXT_ENV_OVERRIDES: Record<
   keyof typeof DEFAULT_CALLER_CONTEXT_HEADERS,
   string
@@ -34,6 +41,23 @@ export function resolveDefaultCallerContext() {
     region: defaultCallerContextValue("X-Region"),
     bookingCenterCode: defaultCallerContextValue("X-Booking-Center-Code"),
     role: defaultCallerContextValue("X-Role"),
+  };
+}
+
+export function resolveDefaultDpmContext() {
+  return {
+    mandateId:
+      process.env.WORKBENCH_DPM_MANDATE_ID?.trim() ||
+      DEFAULT_DPM_CONTEXT.mandateId,
+    modelPortfolioId:
+      process.env.WORKBENCH_DPM_MODEL_PORTFOLIO_ID?.trim() ||
+      DEFAULT_DPM_CONTEXT.modelPortfolioId,
+    bookingCenterCode:
+      process.env.WORKBENCH_DPM_BOOKING_CENTER_CODE?.trim() ||
+      DEFAULT_DPM_CONTEXT.bookingCenterCode,
+    sourceAsOfDate:
+      process.env.WORKBENCH_DPM_SOURCE_AS_OF_DATE?.trim() ||
+      DEFAULT_DPM_CONTEXT.sourceAsOfDate,
   };
 }
 

--- a/src/features/workbench/components/construction-alternatives-panel.tsx
+++ b/src/features/workbench/components/construction-alternatives-panel.tsx
@@ -214,16 +214,17 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
             ? "Generating alternatives"
             : "Generate alternatives"}
         </ActionButton>
-        {actionMessage ? (
+        <div>
+          {actionMessage ? (
+            <Text variant="secondary" className="muted">
+              {actionMessage}
+            </Text>
+          ) : null}
           <Text variant="secondary" className="muted">
-            {actionMessage}
+            LOTUS-GATEWAY forwards this request to manage and preserves the
+            returned construction truth.
           </Text>
-        ) : (
-          <Text variant="secondary" className="muted">
-            Gateway forwards this request to manage and preserves the returned
-            construction truth.
-          </Text>
-        )}
+        </div>
       </div>
 
       {model.supportabilityReasons.length > 0 ? (

--- a/tests/live/construction-alternatives.live.spec.ts
+++ b/tests/live/construction-alternatives.live.spec.ts
@@ -1,0 +1,103 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+
+const portfolioId = process.env.LOTUS_CANONICAL_PORTFOLIO_ID ?? "PB_SG_GLOBAL_BAL_001";
+const outputDir =
+  process.env.LOTUS_LIVE_EVIDENCE_DIR ??
+  "output/rfc39-wtbd002-construction-lab/construction-live";
+
+test("construction alternatives lab renders and exercises Gateway-backed generation", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(120_000);
+  await mkdir(outputDir, { recursive: true });
+
+  await page.goto(`/workbench/${portfolioId}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 60_000,
+  });
+
+  const panel = page.locator(".construction-alternatives-panel");
+  await expect(panel.getByRole("heading", { name: "Construction Alternatives" })).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(panel.getByText("Manage authority: lotus-manage:RFC-0039")).toBeVisible();
+  await expect(panel.getByLabel("Status lotus-gateway")).toBeVisible();
+  await expect(
+    panel.getByText("Construction alternatives have not been generated")
+  ).toBeVisible();
+
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response
+        .url()
+        .includes("/api/bff/api/v1/dpm/command-center/construction/alternative-sets/generate"),
+    { timeout: 90_000 }
+  );
+  await panel.getByRole("button", { name: "Generate alternatives" }).click();
+  const response = await responsePromise;
+  const responseText = await response.text().catch(() => "");
+  let responseBody: Record<string, any> | null = null;
+  try {
+    responseBody = responseText ? JSON.parse(responseText) : null;
+  } catch {
+    responseBody = null;
+  }
+
+  await expect(panel.getByRole("button", { name: "Generate alternatives" })).toBeEnabled({
+    timeout: 90_000,
+  });
+
+  const panelText = await panel.innerText();
+  const screenshotPath = path.join(outputDir, "construction-alternatives-live.png");
+  await panel.screenshot({ path: screenshotPath });
+
+  const evidence = {
+    generatedAt: new Date().toISOString(),
+    portfolioId,
+    baseUrl: testInfo.project.use.baseURL,
+    request: {
+      method: "POST",
+      path: "/api/bff/api/v1/dpm/command-center/construction/alternative-sets/generate",
+    },
+    response: {
+      status: response.status(),
+      ok: response.ok(),
+      body: responseBody ?? responseText,
+      supportabilityState: responseBody?.supportability?.state ?? null,
+      reasonCodes: responseBody?.supportability?.reason_codes ?? [],
+      sourceService:
+        responseBody?.supportability?.source_service ?? responseBody?.source_service ?? null,
+      authority: responseBody?.supportability?.authority ?? null,
+      correlationId: responseBody?.correlation_id ?? null,
+      alternativeSetId: responseBody?.data?.alternative_set_id ?? null,
+      alternativeCount: Array.isArray(responseBody?.data?.alternatives)
+        ? responseBody.data.alternatives.length
+        : 0,
+      selectedAlternativeId:
+        responseBody?.supportability?.selected_alternative_id ??
+        responseBody?.data?.selected_alternative_id ??
+        null,
+    },
+    ui: {
+      screenshotPath,
+      includesGatewaySource: panelText.includes("LOTUS-GATEWAY"),
+      includesManageAuthority: panelText.includes("lotus-manage:RFC-0039"),
+      includesNoLocalMethodologyClaim: !panelText.includes("local optimizer"),
+      textExcerpt: panelText.slice(0, 2000),
+    },
+  };
+  await writeFile(
+    path.join(outputDir, "construction-alternatives-live-summary.json"),
+    `${JSON.stringify(evidence, null, 2)}\n`,
+    "utf8"
+  );
+
+  expect(response.ok(), `generation response status ${response.status()}`).toBe(true);
+  expect(evidence.response.sourceService).toMatch(/lotus-(gateway|manage)/i);
+  expect(evidence.response.authority).toBe("lotus-manage:RFC-0039");
+  expect(evidence.ui.includesGatewaySource).toBe(true);
+  expect(evidence.ui.includesManageAuthority).toBe(true);
+  expect(evidence.ui.includesNoLocalMethodologyClaim).toBe(true);
+});

--- a/tests/unit/domain-product-discovery-client.test.tsx
+++ b/tests/unit/domain-product-discovery-client.test.tsx
@@ -28,11 +28,7 @@ describe("DomainProductDiscoveryClient", () => {
       screen.getByText("Loading governed catalog and trust certification from gateway.")
     ).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Domain Product Discovery" })).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("PortfolioStateSnapshot")).toBeInTheDocument();
+    expect(await screen.findByText("PortfolioStateSnapshot")).toBeInTheDocument();
     expect(screen.getAllByText("lotus-core").length).toBeGreaterThan(0);
     expect(screen.getByText("lotus-workbench, lotus-risk")).toBeInTheDocument();
     expect(screen.getByText("materialized")).toBeInTheDocument();

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -1851,7 +1851,7 @@ describe("workbench api", () => {
     expect(options.headers["X-Actor-Id"]).toBe("workbench-construction-operator");
     const body = JSON.parse(options.body);
     expect(body.idempotency_key).toBe(
-      "workbench-construction-PB_SG_GLOBAL_BAL_001-2026-02-24"
+      "workbench-construction-PB_SG_GLOBAL_BAL_001-2026-04-10"
     );
     expect(body.body.input_mode).toBe("stateful");
     expect(body.body.methods).toEqual([
@@ -1861,8 +1861,15 @@ describe("workbench api", () => {
     expect(body.body.stateful_input.portfolio_id).toBe(
       "PB_SG_GLOBAL_BAL_001"
     );
+    expect(body.body.stateful_input.as_of).toBe("2026-04-10");
+    expect(body.body.stateful_input.mandate_id).toBe(
+      "MANDATE_PB_SG_GLOBAL_BAL_001"
+    );
+    expect(body.body.stateful_input.model_portfolio_id).toBe(
+      "MODEL_PB_SG_GLOBAL_BAL_DPM"
+    );
     expect(body.body.stateful_input.tenant_id).toBe("tenant-sg");
-    expect(body.body.stateful_input.booking_center_code).toBe("SG");
+    expect(body.body.stateful_input.booking_center_code).toBe("Singapore");
     expect(body.body.stateful_input.include_model_portfolio).toBe(true);
     expect(body.body.options_override.valuation_mode).toBe("TRUST_SNAPSHOT");
     const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -18,6 +18,8 @@
   Docker parity
 - `npm run live:validate`
   canonical integrated product validation
+- `npm run live:validate:construction`
+  focused RFC-0039 construction alternatives proof against the running canonical stack
 - `npm run live:evidence`
   post-validation observability, logging, metrics, API, and dashboard evidence capture
 
@@ -32,6 +34,8 @@
 
 - canonical browser validation writes screenshots and structured summary output under
   `output/playwright/live-canonical/`
+- construction alternatives live proof writes focused machine-readable evidence and a panel
+  screenshot under `output/rfc39-wtbd002-construction-lab/construction-live/`
 - observability evidence capture writes local non-functional proof packs under
   `output/observability-live/<timestamp>/`
 - final visual review should use canonical validated captures, not pre-validation diagnostics


### PR DESCRIPTION
## Summary
- follows up PR #150 with the live-proof and hardening commit that remained on `feat/rfc39-wtbd002-construction-lab` after auto-merge completed early
- sends canonical governed DPM context and source as-of for construction generation
- adds `npm run live:validate:construction` and a focused Playwright live proof harness
- keeps Gateway mediation visible after manage-owned alternatives load
- hardens one async domain-product discovery test uncovered by the full Workbench gate

## Evidence
- `npx vitest run tests/unit/workbench-api.test.ts tests/unit/domain-product-discovery-client.test.tsx tests/unit/construction-alternatives-panel.test.tsx` passed: 3 files / 46 tests
- `npm run live:validate:construction` passed against canonical `PB_SG_GLOBAL_BAL_001`
- prior branch verification before PR #150 merge also passed: `make check` (lint, typecheck, coverage 155 files / 704 tests, Next production build), context validation, skill alignment validation, AGENTS sync, and wiki source check with expected unpublished-source warning

## Live evidence
- local artifact path: `output/rfc39-wtbd002-construction-lab/construction-live/construction-alternatives-live-summary.json`
- response status: 200
- source service: `lotus-manage`
- authority: `lotus-manage:RFC-0039`
- correlation: `corr-workbench-construction-PB_SG_GLOBAL_BAL_001-2026-04-10`
- generated alternatives: 3
- UI evidence includes Gateway mediation and no local optimizer/methodology claim

## Notes
- PR #150 merged at `c50f8ea`; this PR brings the remaining live-proof commit `2ed9616` into main so no durable implementation truth is stranded on the feature branch.
- Wiki source changed; publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-workbench`.