### PR TITLE
feat: surface manage rebalance supportability

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -58,7 +58,12 @@ Current repository posture:
    manage/core source selector through Gateway, preserves manage-owned alternatives,
    supportability, objective/constraint traces, and selected-alternative state, and must not build
    stateless source bundles, optimizer logic, prices, or selection truth in the browser,
-9. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
+9. `/workbench/{portfolioId}` also renders Gateway-provided rebalance action-register
+   supportability from the portfolio overview `rebalance_snapshot`, including source state,
+   freshness, run count, operation count, workflow decision count, last-run identity, and reason
+   posture. Missing Gateway supportability is shown as unknown/N/A rather than as verified zero
+   activity.
+10. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -194,6 +194,32 @@
   gap: 0.75rem;
 }
 
+.rebalance-status-panel .section-block-body {
+  gap: 0.75rem;
+}
+
+.rebalance-status-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.rebalance-status-detail-grid > span {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+  padding: 0.625rem;
+  border: var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-secondary);
+}
+
+.rebalance-status-detail-grid strong {
+  color: var(--color-text);
+  font-size: var(--text-md);
+  font-weight: 650;
+}
+
 .outcome-review-badge-row,
 .outcome-review-reason-row,
 .outcome-review-report-actions,

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -252,8 +252,7 @@ export default async function WorkbenchPage({
               />
 
               <RebalanceStatus
-                status={data.rebalance_snapshot?.status ?? "UNKNOWN"}
-                lastRunId={data.rebalance_snapshot?.last_rebalance_run_id ?? null}
+                snapshot={data.rebalance_snapshot}
               />
 
               <ConstructionAlternativesPanel portfolio={data} />

--- a/src/features/workbench/components/rebalance-status.tsx
+++ b/src/features/workbench/components/rebalance-status.tsx
@@ -1,22 +1,118 @@
 "use client";
 
 import { MetricRow, SectionBlock, SemanticBadge, Text } from "@/design-system";
+import type { WorkbenchOverview } from "@/features/workbench/types";
 
 type Props = {
-  status: string;
-  lastRunId: string | null;
+  snapshot: WorkbenchOverview["rebalance_snapshot"];
 };
 
 export default function RebalanceStatus(props: Props) {
-  const tone =
-    props.status === "READY" ? "success" : props.status.includes("REVIEW") ? "warn" : "danger";
+  const status = props.snapshot?.status ?? "UNKNOWN";
+  const supportability = props.snapshot?.supportability ?? null;
+  const supportabilityState = supportability?.state ?? "unknown";
+  const supportabilityFreshness = supportability?.freshness_bucket ?? "unknown";
+  const supportabilityReason = supportability?.reason ?? null;
+  const lastRunId = props.snapshot?.last_rebalance_run_id ?? null;
+  const lastRunAt = props.snapshot?.last_run_at_utc ?? null;
+  const hasSourceContext = supportability !== null;
+  const tone = badgeTone(status);
+  const missingEvidenceValue = hasSourceContext ? 0 : "N/A";
 
   return (
-    <SectionBlock title="Rebalance Status">
-      <MetricRow label="Status" value={<SemanticBadge tone={tone}>{props.status}</SemanticBadge>} />
+    <SectionBlock title="Rebalance Status" className="rebalance-status-panel">
+      <MetricRow
+        label="Status"
+        value={<SemanticBadge tone={tone}>{formatToken(status)}</SemanticBadge>}
+      />
+      <MetricRow
+        label="Source Support"
+        value={
+          <SemanticBadge tone={badgeTone(supportabilityState)}>
+            {formatToken(supportabilityState)}
+          </SemanticBadge>
+        }
+      />
+      <MetricRow
+        label="Freshness"
+        value={
+          <SemanticBadge tone={freshnessTone(supportabilityFreshness)}>
+            {formatToken(supportabilityFreshness)}
+          </SemanticBadge>
+        }
+      />
+      <div className="rebalance-status-detail-grid" aria-label="Rebalance execution evidence">
+        <span>
+          <strong>{supportability?.run_count ?? missingEvidenceValue}</strong>
+          <Text as="span" variant="bodySmall" className="muted">
+            Runs
+          </Text>
+        </span>
+        <span>
+          <strong>{supportability?.operation_count ?? missingEvidenceValue}</strong>
+          <Text as="span" variant="bodySmall" className="muted">
+            Operations
+          </Text>
+        </span>
+        <span>
+          <strong>{supportability?.workflow_decision_count ?? missingEvidenceValue}</strong>
+          <Text as="span" variant="bodySmall" className="muted">
+            Decisions
+          </Text>
+        </span>
+      </div>
       <Text variant="secondary" className="muted">
-        Last Run: {props.lastRunId ?? "N/A"}
+        Last run: {lastRunId ?? "N/A"}
+        {lastRunAt ? ` - ${lastRunAt}` : ""}
+      </Text>
+      <Text variant="secondary" className="muted">
+        {hasSourceContext
+          ? supportabilityReason ?? "Gateway is preserving manage-owned action-register posture."
+          : "Gateway did not return manage action-register supportability for this portfolio."}
       </Text>
     </SectionBlock>
   );
+}
+
+function badgeTone(state: string): "default" | "success" | "warn" | "danger" {
+  const normalized = state.toLowerCase();
+  if (["ready", "healthy", "supported", "fresh"].includes(normalized)) {
+    return "success";
+  }
+  if (
+    normalized.includes("review") ||
+    ["partial", "degraded", "stale", "unknown"].includes(normalized)
+  ) {
+    return "warn";
+  }
+  if (
+    ["blocked", "unsupported", "unavailable", "error"].some((token) =>
+      normalized.includes(token)
+    )
+  ) {
+    return "danger";
+  }
+  return "default";
+}
+
+function freshnessTone(state: string): "default" | "success" | "warn" | "danger" {
+  const normalized = state.toLowerCase();
+  if (["fresh", "current"].includes(normalized)) {
+    return "success";
+  }
+  if (["stale", "expired"].includes(normalized)) {
+    return "danger";
+  }
+  if (normalized === "unknown" || normalized === "partial") {
+    return "warn";
+  }
+  return "default";
+}
+
+function formatToken(value: string): string {
+  return value
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(" ");
 }

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -22,6 +22,15 @@ export type WorkbenchOverview = {
     status: string;
     last_rebalance_run_id: string | null;
     last_run_at_utc: string | null;
+    supportability?: {
+      feature_key?: string | null;
+      state?: string | null;
+      reason?: string | null;
+      freshness_bucket?: string | null;
+      run_count?: number | null;
+      operation_count?: number | null;
+      workflow_decision_count?: number | null;
+    } | null;
   } | null;
   warnings: string[];
   partial_failures: Array<{

--- a/tests/unit/rebalance-status.test.tsx
+++ b/tests/unit/rebalance-status.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import RebalanceStatus from "../../src/features/workbench/components/rebalance-status";
+
+function getPanel(container: HTMLElement): HTMLElement {
+  const panel = container.querySelector(".rebalance-status-panel");
+  expect(panel).not.toBeNull();
+  return panel as HTMLElement;
+}
+
+describe("RebalanceStatus", () => {
+  it("renders manage-owned stateful execution supportability", () => {
+    const { container } = render(
+      <RebalanceStatus
+        snapshot={{
+          status: "READY",
+          last_rebalance_run_id: "rr_100",
+          last_run_at_utc: "2026-03-27T12:00:00Z",
+          supportability: {
+            feature_key: "manage.observability.action_register_supportability",
+            state: "healthy",
+            reason: "action_register_current",
+            freshness_bucket: "fresh",
+            run_count: 4,
+            operation_count: 12,
+            workflow_decision_count: 3,
+          },
+        }}
+      />
+    );
+
+    const scope = within(getPanel(container));
+    expect(scope.getByText("Ready")).toBeInTheDocument();
+    expect(scope.getByText("Healthy")).toBeInTheDocument();
+    expect(scope.getByText("Fresh")).toBeInTheDocument();
+    expect(scope.getByLabelText("Rebalance execution evidence")).toHaveTextContent("4");
+    expect(scope.getByLabelText("Rebalance execution evidence")).toHaveTextContent("Runs");
+    expect(scope.getByLabelText("Rebalance execution evidence")).toHaveTextContent("12");
+    expect(scope.getByLabelText("Rebalance execution evidence")).toHaveTextContent("Operations");
+    expect(scope.getByLabelText("Rebalance execution evidence")).toHaveTextContent("3");
+    expect(scope.getByLabelText("Rebalance execution evidence")).toHaveTextContent("Decisions");
+    expect(scope.getByText("Last run: rr_100 - 2026-03-27T12:00:00Z")).toBeInTheDocument();
+    expect(scope.getByText("action_register_current")).toBeInTheDocument();
+  });
+
+  it("surfaces source-incomplete posture without inventing readiness", () => {
+    const { container } = render(
+      <RebalanceStatus
+        snapshot={{
+          status: "PENDING_REVIEW",
+          last_rebalance_run_id: null,
+          last_run_at_utc: null,
+          supportability: {
+            feature_key: "manage.observability.action_register_supportability",
+            state: "action_required",
+            reason: "SOURCE_READINESS_INCOMPLETE",
+            freshness_bucket: "stale",
+            run_count: 0,
+            operation_count: 0,
+            workflow_decision_count: 0,
+          },
+        }}
+      />
+    );
+
+    const scope = within(getPanel(container));
+    expect(scope.getByText("Pending Review")).toBeInTheDocument();
+    expect(scope.getByText("Action Required")).toBeInTheDocument();
+    expect(scope.getByText("Stale")).toBeInTheDocument();
+    expect(scope.getByText("Last run: N/A")).toBeInTheDocument();
+    expect(scope.getByText("SOURCE_READINESS_INCOMPLETE")).toBeInTheDocument();
+  });
+
+  it("marks missing Gateway supportability as unknown", () => {
+    const { container } = render(
+      <RebalanceStatus
+        snapshot={{
+          status: "UNKNOWN",
+          last_rebalance_run_id: null,
+          last_run_at_utc: null,
+        }}
+      />
+    );
+
+    const scope = within(getPanel(container));
+    expect(scope.getAllByText("Unknown").length).toBeGreaterThanOrEqual(2);
+    expect(scope.getByLabelText("Rebalance execution evidence")).toHaveTextContent("N/A");
+    expect(scope.getByLabelText("Rebalance execution evidence")).not.toHaveTextContent("0");
+    expect(
+      scope.getByText("Gateway did not return manage action-register supportability for this portfolio.")
+    ).toBeInTheDocument();
+  });
+});

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -56,6 +56,12 @@ promote dormant labels into product ownership just because historical route file
   method statuses, comparison metrics, objective/constraint trace counts, supportability, and
   selected-alternative state, and records PM selection through Gateway. It does not synthesize
   source snapshots, prices, optimizer results, supportability, or selection truth locally.
+- RFC-0098/RFC-0041 action-register supportability is rendered on `/workbench/{portfolioId}` from
+  the Gateway portfolio overview `rebalance_snapshot`. The rebalance status panel shows
+  manage-owned status, source support state, freshness, run count, operation count, workflow
+  decision count, last-run identity, and reason posture. When Gateway does not provide
+  supportability, Workbench renders unknown/N/A instead of implying verified zero activity or
+  calculating supportability locally.
 - RFC-0098/RFC-0042 post-trade outcome-review rendering is implemented on
   `/workbench/{portfolioId}` through Gateway `/api/v1/dpm/command-center/outcome-reviews*`.
   Workbench renders manage-owned review state, expected-versus-realized dimensions, hashes,

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -65,13 +65,18 @@ must travel through Gateway-shaped contracts.
     comparison and supportability truth, and records PM selection through Gateway; it does not call
     `lotus-manage` directly or invent stateless portfolio snapshots, prices, optimizer output, or
     selected-alternative state.
-13. RFC-0108 analytics UI observability is centralized in
+13. Rebalance action-register supportability is read from the Gateway portfolio overview
+    `rebalance_snapshot`. Workbench displays manage-owned status, source support state, freshness,
+    run count, operation count, workflow decision count, last-run identity, and reason posture; it
+    does not call `lotus-manage` directly and does not convert missing supportability into
+    apparently verified zero activity.
+14. RFC-0108 analytics UI observability is centralized in
     `src/features/analytics-observability/metrics.ts`. Supported Portfolio, Intake, Performance,
     Risk, Reporting, Data Products, and legacy advisor Workbench gateway-backed reads/mutations
     emit bounded route, panel, operation, freshness, and supportability labels only; portfolio,
     intake payload, document, session, trace, request, response, and screen-content identifiers
     must not appear in metric labels.
-14. `lotus-manage` is not a proposal/advisory upstream for Workbench. DPM product surfaces must be
+15. `lotus-manage` is not a proposal/advisory upstream for Workbench. DPM product surfaces must be
     backed by strategic Gateway APIs before Workbench exposes them. RFC-0098 keeps Workbench as a
     renderer of Gateway-composed mandate and proof-pack truth, not a direct caller of manage, risk,
     performance, core, report, archive, or AI. RFC-0040 proof-pack JSON, hashes, Markdown,

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -26,6 +26,9 @@ This repo does not own:
 - Portfolio and Performance are the active front-office paths
 - `/workbench/{portfolioId}` includes Gateway/manage-backed DPM construction alternatives and
   post-trade outcome-review panels without direct Workbench calls to manage, report, archive, or AI
+- `/workbench/{portfolioId}` surfaces Gateway-provided manage action-register supportability in the
+  rebalance status panel, including source state, freshness, run/operation/decision counts, last-run
+  identity, and explicit unknown/N/A handling when supportability is absent
 - risk is served through Performance route modes
 - recommendations and proposals remain compatibility entrypoints rather than active shell apps
 - shell navigation currently exposes disabled `Proposal` and `Advisory` items through normalized


### PR DESCRIPTION
## Summary

- expand the Workbench rebalance status panel to render Gateway/manage action-register supportability from `rebalance_snapshot`
- show source support, freshness, run/operation/decision counts, last-run identity, and reason posture without inventing supportability locally
- render missing Gateway supportability as `Unknown` / `N/A` instead of implying verified zero activity
- update Workbench repository context and wiki source for the shipped DPM/rebalance supportability behavior

## RFC / WTBD

- RFC36-WTBD-002: Workbench product surfaces over stateful manage execution

## Evidence

- `npx vitest run tests/unit/rebalance-status.test.tsx` -> 3 passed
- `npm run typecheck` -> passed
- `make check` -> lint passed, typecheck passed, 156 test files / 707 tests passed with coverage, production build passed
- canonical live proof: `powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -LocalApps workbench -RunValidation -ScreenshotDirectory output/playwright/rfc36-wtbd002-rebalance-status` -> passed for `PB_SG_GLOBAL_BAL_001`
- targeted live browser assertion against `http://workbench.dev.lotus/workbench/PB_SG_GLOBAL_BAL_001` proved the rebalance panel renders status/source support/freshness/evidence counts and the missing-supportability message
- evidence artifacts generated locally under `output/playwright/rfc36-wtbd002-rebalance-status/`, including `live-validation-summary.json`, `SHOT-INDEX.md`, `dpm-outcome-review-live.png`, and `rebalance-status-panel-live.png`
- `npm run live:stack:down` -> canonical runtime stopped cleanly

## Wiki

Repo-local wiki source was updated in this PR. `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` correctly reports drift for `API-Surface.md`, `Integrations.md`, and `Overview.md` until this PR is merged and wiki publish is run.