### PR TITLE
feat: add DPM operations dashboard

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -59,10 +59,11 @@ Current repository posture:
    supportability, objective/constraint traces, and selected-alternative state, and must not build
    stateless source bundles, optimizer logic, prices, or selection truth in the browser,
 9. `/workbench/{portfolioId}` also renders Gateway-provided rebalance action-register
-   supportability from the portfolio overview `rebalance_snapshot`, including source state,
-   freshness, run count, operation count, workflow decision count, last-run identity, and reason
-   posture. Missing Gateway supportability is shown as unknown/N/A rather than as verified zero
-   activity.
+   supportability and portfolio-level DPM operations posture from the portfolio overview
+   `rebalance_snapshot`, including source state, freshness, run count, operation count, workflow
+   decision count, last-run identity, bounded recent runs, workflow posture, run issue count, and
+   reason posture. Missing Gateway supportability is shown as unknown/N/A rather than as verified
+   zero activity.
 10. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -220,6 +220,70 @@
   font-weight: 650;
 }
 
+.rebalance-operations-dashboard {
+  display: grid;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.rebalance-operations-dashboard-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.rebalance-operations-dashboard-summary > span,
+.rebalance-operations-run-row {
+  min-width: 0;
+  padding: 0.625rem;
+  border: var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-secondary);
+}
+
+.rebalance-operations-dashboard-summary > span {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.rebalance-operations-dashboard-summary strong {
+  color: var(--color-text);
+  font-size: var(--text-md);
+  font-weight: 650;
+}
+
+.rebalance-operations-run-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.rebalance-operations-run-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.rebalance-operations-run-row > div:first-child {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.rebalance-operations-run-id {
+  color: var(--color-text);
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.rebalance-operations-run-state {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
 .outcome-review-badge-row,
 .outcome-review-reason-row,
 .outcome-review-report-actions,

--- a/src/features/workbench/components/rebalance-status.tsx
+++ b/src/features/workbench/components/rebalance-status.tsx
@@ -15,6 +15,8 @@ export default function RebalanceStatus(props: Props) {
   const supportabilityReason = supportability?.reason ?? null;
   const lastRunId = props.snapshot?.last_rebalance_run_id ?? null;
   const lastRunAt = props.snapshot?.last_run_at_utc ?? null;
+  const recentRuns = props.snapshot?.recent_runs ?? [];
+  const failedRunCount = recentRuns.filter((run) => isFailureStatus(run.status)).length;
   const hasSourceContext = supportability !== null;
   const tone = badgeTone(status);
   const missingEvidenceValue = hasSourceContext ? 0 : "N/A";
@@ -61,6 +63,56 @@ export default function RebalanceStatus(props: Props) {
           </Text>
         </span>
       </div>
+      <div className="rebalance-operations-dashboard" aria-label="DPM operations dashboard">
+        <div className="rebalance-operations-dashboard-summary">
+          <span>
+            <strong>{recentRuns.length}</strong>
+            <Text as="span" variant="bodySmall" className="muted">
+              Recent runs
+            </Text>
+          </span>
+          <span>
+            <strong>{failedRunCount}</strong>
+            <Text as="span" variant="bodySmall" className="muted">
+              Run issues
+            </Text>
+          </span>
+        </div>
+        {recentRuns.length > 0 ? (
+          <div className="rebalance-operations-run-list">
+            {recentRuns.map((run, index) => (
+              <div
+                className="rebalance-operations-run-row"
+                key={`${run.rebalance_run_id ?? "run"}-${index}`}
+              >
+                <div>
+                  <Text as="span" variant="bodySmall" className="rebalance-operations-run-id">
+                    {run.rebalance_run_id ?? "N/A"}
+                  </Text>
+                  <Text as="span" variant="bodySmall" className="muted">
+                    {run.created_at_utc ?? "Timestamp N/A"}
+                  </Text>
+                </div>
+                <div className="rebalance-operations-run-state">
+                  <SemanticBadge tone={badgeTone(run.status)}>{formatToken(run.status)}</SemanticBadge>
+                  {run.workflow_state ? (
+                    <SemanticBadge tone={badgeTone(run.workflow_state)}>
+                      {formatToken(run.workflow_state)}
+                    </SemanticBadge>
+                  ) : null}
+                  {run.error_code ? (
+                    <SemanticBadge tone="danger">{formatToken(run.error_code)}</SemanticBadge>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <Text variant="secondary" className="muted">
+            No recent manage rebalance runs were returned by Gateway for this portfolio.
+          </Text>
+        )}
+      </div>
       <Text variant="secondary" className="muted">
         Last run: {lastRunId ?? "N/A"}
         {lastRunAt ? ` - ${lastRunAt}` : ""}
@@ -72,6 +124,11 @@ export default function RebalanceStatus(props: Props) {
       </Text>
     </SectionBlock>
   );
+}
+
+function isFailureStatus(state: string): boolean {
+  const normalized = state.toLowerCase();
+  return ["failed", "error", "blocked", "rejected"].some((token) => normalized.includes(token));
 }
 
 function badgeTone(state: string): "default" | "success" | "warn" | "danger" {
@@ -113,6 +170,12 @@ function formatToken(value: string): string {
   return value
     .split(/[_\s-]+/)
     .filter(Boolean)
-    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .map((segment) => {
+      const upper = segment.toUpperCase();
+      if (["DPM", "PM", "CIO", "SLA", "SLO", "ID", "API"].includes(upper)) {
+        return upper;
+      }
+      return segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase();
+    })
     .join(" ");
 }

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -31,6 +31,13 @@ export type WorkbenchOverview = {
       operation_count?: number | null;
       workflow_decision_count?: number | null;
     } | null;
+    recent_runs?: Array<{
+      rebalance_run_id: string | null;
+      status: string;
+      created_at_utc: string | null;
+      error_code: string | null;
+      workflow_state: string | null;
+    }>;
   } | null;
   warnings: string[];
   partial_failures: Array<{

--- a/tests/integration/workbench-page.test.tsx
+++ b/tests/integration/workbench-page.test.tsx
@@ -49,6 +49,31 @@ describe("WorkbenchPage", () => {
                 status: "READY",
                 last_rebalance_run_id: "run_001",
                 last_run_at_utc: "2026-02-24T00:00:00Z",
+                supportability: {
+                  feature_key: "manage.observability.action_register_supportability",
+                  state: "healthy",
+                  reason: "action_register_current",
+                  freshness_bucket: "fresh",
+                  run_count: 2,
+                  operation_count: 4,
+                  workflow_decision_count: 1,
+                },
+                recent_runs: [
+                  {
+                    rebalance_run_id: "run_001",
+                    status: "PENDING_REVIEW",
+                    created_at_utc: "2026-02-24T00:00:00Z",
+                    error_code: null,
+                    workflow_state: "PM_REVIEW_REQUIRED",
+                  },
+                  {
+                    rebalance_run_id: "run_000",
+                    status: "FAILED",
+                    created_at_utc: "2026-02-23T00:00:00Z",
+                    error_code: "SOURCE_READINESS_BLOCKED",
+                    workflow_state: null,
+                  },
+                ],
               },
               current_positions: [
                 {
@@ -183,6 +208,13 @@ describe("WorkbenchPage", () => {
     );
     expect(screen.getAllByText(/RISK_BFF_NOT_IMPLEMENTED/).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Data Integrity")).toBeInTheDocument();
+    expect(screen.getByLabelText("DPM operations dashboard")).toHaveTextContent("Recent runs");
+    expect(screen.getByLabelText("DPM operations dashboard")).toHaveTextContent("Run issues");
+    expect(screen.getByLabelText("DPM operations dashboard")).toHaveTextContent("run_001");
+    expect(screen.getByLabelText("DPM operations dashboard")).toHaveTextContent("PM Review Required");
+    expect(screen.getByLabelText("DPM operations dashboard")).toHaveTextContent(
+      "Source Readiness Blocked"
+    );
     expect(screen.getByText("ATTENTION")).toBeInTheDocument();
     expect(screen.getByText("Partial Data Warning")).toBeInTheDocument();
     expect(screen.getAllByText(/UPSTREAM_TIMEOUT/).length).toBeGreaterThanOrEqual(1);

--- a/tests/unit/rebalance-status.test.tsx
+++ b/tests/unit/rebalance-status.test.tsx
@@ -26,6 +26,22 @@ describe("RebalanceStatus", () => {
             operation_count: 12,
             workflow_decision_count: 3,
           },
+          recent_runs: [
+            {
+              rebalance_run_id: "rr_100",
+              status: "PENDING_REVIEW",
+              created_at_utc: "2026-03-27T12:00:00Z",
+              error_code: null,
+              workflow_state: "PM_REVIEW_REQUIRED",
+            },
+            {
+              rebalance_run_id: "rr_099",
+              status: "FAILED",
+              created_at_utc: "2026-03-26T12:00:00Z",
+              error_code: "SOURCE_READINESS_BLOCKED",
+              workflow_state: null,
+            },
+          ],
         }}
       />
     );
@@ -42,6 +58,15 @@ describe("RebalanceStatus", () => {
     expect(scope.getByLabelText("Rebalance execution evidence")).toHaveTextContent("Decisions");
     expect(scope.getByText("Last run: rr_100 - 2026-03-27T12:00:00Z")).toBeInTheDocument();
     expect(scope.getByText("action_register_current")).toBeInTheDocument();
+    const dashboard = scope.getByLabelText("DPM operations dashboard");
+    expect(dashboard).toHaveTextContent("2");
+    expect(dashboard).toHaveTextContent("Recent runs");
+    expect(dashboard).toHaveTextContent("1");
+    expect(dashboard).toHaveTextContent("Run issues");
+    expect(dashboard).toHaveTextContent("rr_100");
+    expect(dashboard).toHaveTextContent("PM Review Required");
+    expect(dashboard).toHaveTextContent("rr_099");
+    expect(dashboard).toHaveTextContent("Source Readiness Blocked");
   });
 
   it("surfaces source-incomplete posture without inventing readiness", () => {
@@ -70,6 +95,9 @@ describe("RebalanceStatus", () => {
     expect(scope.getByText("Stale")).toBeInTheDocument();
     expect(scope.getByText("Last run: N/A")).toBeInTheDocument();
     expect(scope.getByText("SOURCE_READINESS_INCOMPLETE")).toBeInTheDocument();
+    expect(scope.getByLabelText("DPM operations dashboard")).toHaveTextContent(
+      "No recent manage rebalance runs were returned by Gateway for this portfolio."
+    );
   });
 
   it("marks missing Gateway supportability as unknown", () => {

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -59,8 +59,9 @@ promote dormant labels into product ownership just because historical route file
 - RFC-0098/RFC-0041 action-register supportability is rendered on `/workbench/{portfolioId}` from
   the Gateway portfolio overview `rebalance_snapshot`. The rebalance status panel shows
   manage-owned status, source support state, freshness, run count, operation count, workflow
-  decision count, last-run identity, and reason posture. When Gateway does not provide
-  supportability, Workbench renders unknown/N/A instead of implying verified zero activity or
+  decision count, last-run identity, bounded recent runs, workflow posture, run issue count, and
+  reason posture. When Gateway does not provide supportability or recent run detail, Workbench
+  renders unknown/N/A or an explicit empty run state instead of implying verified zero activity or
   calculating supportability locally.
 - RFC-0098/RFC-0042 post-trade outcome-review rendering is implemented on
   `/workbench/{portfolioId}` through Gateway `/api/v1/dpm/command-center/outcome-reviews*`.

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -67,9 +67,10 @@ must travel through Gateway-shaped contracts.
     selected-alternative state.
 13. Rebalance action-register supportability is read from the Gateway portfolio overview
     `rebalance_snapshot`. Workbench displays manage-owned status, source support state, freshness,
-    run count, operation count, workflow decision count, last-run identity, and reason posture; it
-    does not call `lotus-manage` directly and does not convert missing supportability into
-    apparently verified zero activity.
+    run count, operation count, workflow decision count, last-run identity, bounded recent runs,
+    workflow posture, run issue count, and reason posture; it does not call `lotus-manage`
+    directly and does not convert missing supportability or absent recent runs into apparently
+    verified zero activity.
 14. RFC-0108 analytics UI observability is centralized in
     `src/features/analytics-observability/metrics.ts`. Supported Portfolio, Intake, Performance,
     Risk, Reporting, Data Products, and legacy advisor Workbench gateway-backed reads/mutations

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -28,7 +28,8 @@ This repo does not own:
   post-trade outcome-review panels without direct Workbench calls to manage, report, archive, or AI
 - `/workbench/{portfolioId}` surfaces Gateway-provided manage action-register supportability in the
   rebalance status panel, including source state, freshness, run/operation/decision counts, last-run
-  identity, and explicit unknown/N/A handling when supportability is absent
+  identity, bounded recent runs, workflow posture, run issue count, and explicit unknown/N/A or
+  empty-run handling when supportability or recent runs are absent
 - risk is served through Performance route modes
 - recommendations and proposals remain compatibility entrypoints rather than active shell apps
 - shell navigation currently exposes disabled `Proposal` and `Advisory` items through normalized


### PR DESCRIPTION
## Summary

Implements RFC36-WTBD-003 Workbench slice for portfolio-level DPM operations dashboards.

- Extends the Workbench rebalance snapshot type with Gateway-provided recent run posture.
- Adds a DPM operations dashboard section to the rebalance panel with recent run count, issue count, run identity, timestamp, status, workflow posture, and bounded error codes.
- Keeps empty and missing-supportability states explicit; Workbench remains Gateway/BFF-only.
- Updates Workbench repository context and wiki source for implementation-backed product documentation.

## Evidence

- `npx vitest run tests/unit/rebalance-status.test.tsx` -> 3 passed
- `npx vitest run tests/unit/rebalance-status.test.tsx tests/integration/workbench-page.test.tsx` -> 7 passed
- `npm run typecheck` -> passed
- `make check` -> lint, typecheck, 156 test files / 707 tests with coverage, production build passed
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` -> expected pre-merge drift in authored wiki files: API-Surface.md, Integrations.md, Overview.md. Publish after merge.

## Boundary

Workbench renders Gateway truth only. It does not call `lotus-manage` directly, does not compute source readiness or supportability, and does not turn missing recent-run data into verified zero activity.