### PR TITLE
Register DPM command center live validation

### DIFF
--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -2,7 +2,7 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | IN PROGRESS - RFC-0038 COMMAND-CENTER COCKPIT, RFC-0039 CONSTRUCTION LAB, AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`; RFC-0038 LIVE PROOF PASSED WITH WTBD-003 SEED GAP RECORDED |
+| **Status** | IN PROGRESS - RFC-0038 COMMAND-CENTER COCKPIT, RFC-0039 CONSTRUCTION LAB, AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`; RFC-0038 POPULATED COMMAND-CENTER LIVE PROOF PASSED AFTER WTBD-003 SEED AUTOMATION |
 | **Created** | 2026-05-03 |
 | **Last Tightened** | 2026-05-06 |
 | **Owner** | `lotus-workbench` |
@@ -17,6 +17,14 @@ RFC-0038 command-center cockpit live proof passed on 2026-05-06 with local Workb
 The run proved Gateway command-center summary and exceptions responses, populated DPM command-center
 UI tables, and recorded the canonical `mandates/by-portfolio/PB_SG_GLOBAL_BAL_001` lookup as a
 `seed_gap` (`DPM_MANDATE_NOT_FOUND`) owned by WTBD-003 canonical seed automation.
+
+WTBD-003 populated seed automation was then completed locally on 2026-05-07 through
+`lotus-platform` canonical front-office QA. The governed runtime now refreshes
+`MANDATE_PB_SG_GLOBAL_BAL_001` from core through manage, verifies Gateway mandate lookup, health,
+and command-center summary, classifies `dpm.command_center` as `ready`, and captures the registered
+DPM command-center screenshot under `output/playwright/live-canonical/`. Workbench still preserves
+`seed_gap` for non-populated environments, but the governed canonical portfolio path is no longer
+gap-coded.
 
 ---
 

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -362,6 +362,10 @@ async function run() {
     route: `/workbench/${portfolioId}`,
     outcomeReviewMinimum: 1,
   });
+  panelGovernance.recordPanelClassification("dpm.command_center", "ready", "lotus-manage", {
+    route: `/workbench/${portfolioId}`,
+    source: "Gateway DPM command-center summary",
+  });
   panelGovernance.assertNoUnsupportedBlankPanels();
   panelGovernance.assertPanelSupportabilityAlignment();
 
@@ -457,6 +461,7 @@ async function run() {
       portfolioId,
       timeoutMs,
       assertTableHasRows: browserHelpers.assertTableHasRows,
+      screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });
   } finally {
     await browser.close();

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -409,7 +409,7 @@ export async function validateOutcomeReviewPanel(
 
 export async function validateDpmCommandCenterPanel(
   page,
-  { workbenchBaseUrl, portfolioId, timeoutMs, assertTableHasRows }
+  { workbenchBaseUrl, portfolioId, timeoutMs, assertTableHasRows, screenshotRegisteredPanel }
 ) {
   await page.goto(`${workbenchBaseUrl}/workbench/${portfolioId}`, {
     waitUntil: "networkidle",
@@ -441,4 +441,5 @@ export async function validateDpmCommandCenterPanel(
     0,
     "DPM mandate health dimensions"
   );
+  await screenshotRegisteredPanel(page, "dpm.command_center");
 }


### PR DESCRIPTION
## Summary

Completes the Workbench validation side of RFC38-WTBD-003 by registering the populated DPM command-center panel as canonical live proof.

## Scope

- Records `dpm.command_center` as a governed ready panel in canonical live validation.
- Captures the registered `dpm-command-center-live.png` screenshot during browser validation.
- Updates RFC-0098 to record the populated seed automation proof while preserving `seed_gap` for non-populated environments.

## Evidence

- `npm test -- --run tests/unit/live-canonical-validation-script.test.ts tests/unit/live-validation-browser-workflows.test.ts` -> 13 passed.
- `git diff --check` passed, with only normal LF-to-CRLF warnings.
- Prior governed runtime proof passed through platform canonical QA and produced `output/playwright/live-canonical/live-validation-summary.json`, `dpm-command-center-live.png`, and `SHOT-INDEX.md`.

## Generated Evidence

`output/` remains untracked generated evidence and is intentionally not part of this PR.