### PR TITLE
Implement DPM proof-pack review panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,21 +54,26 @@ Boundary rules that matter:
    `PB_SG_GLOBAL_BAL_001`.
 4. `Data Products` is available at `/data-products` for gateway-backed catalog, dependency, and
    live trust discovery.
-5. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0042 post-trade outcome-review
+5. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0040 proof-pack evidence panel
+   for manage-owned proof-pack identity, section posture, content hash, source hashes, Markdown,
+   report-input posture, and AI-evidence posture. Workbench renders Gateway/manage truth and does
+   not generate proof-pack sections, hashes, report inputs, AI evidence, narratives, or reports
+   locally.
+6. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0042 post-trade outcome-review
    panel for manage-owned expected-versus-realized dimensions, source lineage, supportability,
    and report/AI handoff posture. Workbench renders the Gateway contract and does not calculate
    outcome variance, freshness, supportability, or handoff eligibility locally.
-6. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0039 construction alternatives
+7. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0039 construction alternatives
    lab. Workbench sends stateful construction requests through Gateway
    `/api/v1/dpm/command-center/construction/alternative-sets*`, renders manage-owned
    alternatives, objective/constraint trace counts, supportability, and selected-alternative
    state, and does not create optimizer logic, source data, prices, or selection truth locally.
-7. Recommendations and proposals routes still exist as compatibility paths, but they are no longer
+8. Recommendations and proposals routes still exist as compatibility paths, but they are no longer
    the primary supported front-office app surfaces.
-8. Top-level shell navigation is capability-gated: `Portfolio`, `Performance`, and `Risk` are
+9. Top-level shell navigation is capability-gated: `Portfolio`, `Performance`, and `Risk` are
    active, while `Proposal` and `Advisory` remain disabled in the current normalized shell
    bootstrap contract.
-9. Canonical review-ready browser evidence comes from `npm run live:validate` artifacts under
+10. Canonical review-ready browser evidence comes from `npm run live:validate` artifacts under
    `output/playwright/live-canonical/`, not from ad hoc localhost screenshots.
 
 ## Architecture At A Glance
@@ -83,7 +88,7 @@ Current main surfaces:
   `/performance` with performance, risk, advisor-brief, and evidence modes
 - `workbench`
   `/workbench/*` compatibility and portfolio-linked workspace entry, including the Gateway-backed
-  DPM construction alternatives lab and outcome-review panel when Gateway/manage have
+  DPM construction alternatives lab, proof-pack evidence panel, and outcome-review panel when Gateway/manage have
   materialized the relevant DPM evidence
 - `data-products`
   `/data-products` self-serve catalog, dependency, and live trust discovery through gateway
@@ -267,6 +272,11 @@ Important current product and route truths:
    stateful source selector and option overrides through Gateway and must not synthesize
    stateless portfolio snapshots, prices, optimization results, objective scores, supportability,
    or PM selection truth.
+10. RFC-0040 proof-pack evidence rendering on `/workbench/{portfolioId}` is backed by Gateway
+   `/api/v1/dpm/command-center/proof-packs*`; Workbench may render Gateway/manage proof-pack
+   identity, sections, hashes, Markdown, report-input readiness, and AI-evidence readiness, but
+   must not rebuild proof-pack sections, compute hashes, synthesize Markdown, construct report
+   input, construct AI evidence, or call `lotus-manage`, `lotus-report`, or `lotus-ai` directly.
 
 Copy-paste route and runtime examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -59,18 +59,24 @@ Current repository posture:
    dimensions, source lineage, supportability, report-input posture, AI-evidence posture, and
    Gateway-backed governed AI narrative requests without client-side outcome calculation or direct
    `lotus-manage`/`lotus-ai` calls,
-9. `/workbench/{portfolioId}` renders the RFC-0039 DPM construction alternatives lab from Gateway
+9. `/workbench/{portfolioId}` renders the RFC-0040 proof-pack evidence panel from Gateway
+   `/api/v1/dpm/command-center/proof-packs*`, preserving manage-owned proof-pack identity,
+   section posture, content hash, source hashes, Markdown availability, report-input readiness,
+   and AI-evidence readiness without client-side proof-pack construction, hash generation,
+   Markdown synthesis, report-input synthesis, AI-evidence synthesis, or direct calls to
+   `lotus-manage`, `lotus-report`, or `lotus-ai`,
+10. `/workbench/{portfolioId}` renders the RFC-0039 DPM construction alternatives lab from Gateway
    `/api/v1/dpm/command-center/construction/alternative-sets*`. Workbench sends a stateful
    manage/core source selector through Gateway, preserves manage-owned alternatives,
    supportability, objective/constraint traces, and selected-alternative state, and must not build
    stateless source bundles, optimizer logic, prices, or selection truth in the browser,
-10. `/workbench/{portfolioId}` also renders Gateway-provided rebalance action-register
+11. `/workbench/{portfolioId}` also renders Gateway-provided rebalance action-register
    supportability and portfolio-level DPM operations posture from the portfolio overview
    `rebalance_snapshot`, including source state, freshness, run count, operation count, workflow
    decision count, last-run identity, bounded recent runs, workflow posture, run issue count, and
    reason posture. Missing Gateway supportability is shown as unknown/N/A rather than as verified
    zero activity.
-11. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
+12. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map
 
@@ -181,6 +187,11 @@ Important validation expectations:
     through Gateway only. Workbench may construct the stateful source selector needed to invoke the
     Gateway/manage contract, but it must not synthesize stateless portfolio snapshots, price
     payloads, target weights, optimization outcomes, supportability states, or selection decisions.
+13. DPM proof-pack generation, retrieval, Markdown, report-input, and AI-evidence reads/actions are
+    Workbench gateway-only operations. Observability labels must remain bounded to route, panel,
+    operation, freshness, supportability, status class, and error category; proof-pack ids,
+    rebalance run ids, mandate ids, portfolio ids, content hashes, source hashes, request bodies,
+    response bodies, and screen content must never be emitted as metric labels.
 
 ### Visual Review Gate
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -29,5 +29,5 @@ Governance boundary:
 | RFC-0021 | UI Architecture Hardening and Design-System Governance | IMPLEMENTED | `docs/rfcs/RFC-0021-ui-architecture-hardening-and-design-system-governance.md` |
 | RFC-0022 | Stateful Risk Workspace and lotus-risk UI Integration | IMPLEMENTED | `docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md` |
 | RFC-0023 | Risk Workspace UX Hardening and Production Readiness | IMPLEMENTED | `docs/rfcs/RFC-0023-risk-workspace-ux-hardening-and-production-readiness.md` |
-| RFC-0098 | DPM Mandate Command Center Experience | IN PROGRESS - RFC-0039 CONSTRUCTION LAB AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`, LIVE CANONICAL PROOF PENDING | `docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md` |
+| RFC-0098 | DPM Mandate Command Center Experience | IN PROGRESS - RFC-0039 CONSTRUCTION LAB, RFC-0040 PROOF-PACK PANEL, AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`, LIVE CANONICAL PROOF PENDING | `docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md` |
 

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -2,7 +2,7 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | IN PROGRESS - RFC-0038 COMMAND-CENTER COCKPIT, RFC-0039 CONSTRUCTION LAB, AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`; RFC-0038 POPULATED COMMAND-CENTER LIVE PROOF PASSED AFTER WTBD-003 SEED AUTOMATION |
+| **Status** | IN PROGRESS - RFC-0038 COMMAND-CENTER COCKPIT, RFC-0039 CONSTRUCTION LAB, RFC-0040 PROOF-PACK PANEL, AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`; RFC-0038 POPULATED COMMAND-CENTER LIVE PROOF PASSED AFTER WTBD-003 SEED AUTOMATION |
 | **Created** | 2026-05-03 |
 | **Last Tightened** | 2026-05-06 |
 | **Owner** | `lotus-workbench` |
@@ -308,6 +308,17 @@ Required UI states:
 
 Supported-feature promotion is forbidden until Gateway implementation, Workbench browser proof,
 canonical screenshots, accessibility checks, and live validation pass.
+
+Implementation note as of 2026-05-07: the first RFC-0040 proof-pack review realization is embedded
+in `/workbench/{portfolioId}` using Gateway `/api/v1/dpm/command-center/proof-packs*`.
+Workbench derives the launch context from Gateway outcome-review proof-pack and rebalance-run
+references, can trigger Gateway proof-pack generation for the linked run, and renders
+Gateway/manage proof-pack identity, status, content hash, section states, source hashes, Markdown
+availability, report-input readiness, and AI-evidence readiness. Browser code does not rebuild
+proof-pack sections, compute hashes, synthesize Markdown, construct report input, construct AI
+evidence, construct prompts, materialize reports, or call `lotus-manage`, `lotus-report`, or
+`lotus-ai` directly. The live canonical validator now registers the `dpm.proof_pack` panel against
+the governed Workbench panel registry.
 
 ### 7.0B Rebalance Wave Command Center Addendum
 

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -26,6 +26,7 @@ import {
   validatePerformanceSummaryPanel,
   validatePortfolioPanels,
   validateOutcomeReviewPanel,
+  validateProofPackPanel,
   validateRiskPanel,
 } from "./validation/browser-workflows.mjs";
 import { createPanelGovernance } from "./validation/panel-governance.mjs";
@@ -242,6 +243,27 @@ async function run() {
   if (!Array.isArray(outcomeReviewItems) || outcomeReviewItems.length < 1) {
     throw new Error("DPM outcome-review list returned no manage-backed reviews.");
   }
+  const proofPackId = outcomeReviewItems.find((item) => item?.proof_pack_id)?.proof_pack_id;
+  if (!proofPackId) {
+    throw new Error("DPM outcome-review list returned no proof-pack reference.");
+  }
+  const proofPack = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/dpm/command-center/proof-packs/${encodeURIComponent(proofPackId)}`,
+    "DPM proof-pack evidence",
+    timeoutMs
+  );
+  const proofPackPayload = proofPack?.data?.proof_pack ?? proofPack?.data ?? proofPack;
+  if (!proofPackPayload?.proof_pack_id) {
+    throw new Error("DPM proof-pack evidence returned no proof-pack identity.");
+  }
+  const proofPackSupportability = proofPack?.supportability;
+  if (
+    proofPackSupportability?.state &&
+    proofPackSupportability.state.toUpperCase() !== "READY"
+  ) {
+    throw new Error(`DPM proof-pack evidence returned non-ready state: ${proofPackSupportability.state}.`);
+  }
 
   const commandCenterParams = new URLSearchParams({
     tenant_id: dpmCommandCenterDefaults.tenantId,
@@ -362,6 +384,10 @@ async function run() {
     route: `/workbench/${portfolioId}`,
     outcomeReviewMinimum: 1,
   });
+  panelGovernance.recordPanelClassification("dpm.proof_pack", "ready", "lotus-manage", {
+    route: `/workbench/${portfolioId}`,
+    proofPackId,
+  });
   panelGovernance.recordPanelClassification("dpm.command_center", "ready", "lotus-manage", {
     route: `/workbench/${portfolioId}`,
     source: "Gateway DPM command-center summary",
@@ -450,6 +476,13 @@ async function run() {
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });
     await validateOutcomeReviewPanel(page, {
+      workbenchBaseUrl,
+      portfolioId,
+      timeoutMs,
+      assertTableHasRows: browserHelpers.assertTableHasRows,
+      screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
+    });
+    await validateProofPackPanel(page, {
       workbenchBaseUrl,
       portfolioId,
       timeoutMs,

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -443,3 +443,37 @@ export async function validateDpmCommandCenterPanel(
   );
   await screenshotRegisteredPanel(page, "dpm.command_center");
 }
+
+export async function validateProofPackPanel(
+  page,
+  { workbenchBaseUrl, portfolioId, timeoutMs, assertTableHasRows, screenshotRegisteredPanel }
+) {
+  await page.goto(`${workbenchBaseUrl}/workbench/${portfolioId}`, {
+    waitUntil: "networkidle",
+    timeout: timeoutMs,
+  });
+  const proofPackPanel = page.getByRole("group", { name: "Proof-Pack Evidence" });
+  await expect(proofPackPanel.getByRole("heading", { name: "Proof-Pack Evidence" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(proofPackPanel.getByText(/Markdown (Available|Unavailable)/)).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(proofPackPanel.getByText(/Report Input (Available|Unavailable)/)).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(proofPackPanel.getByText(/AI Evidence (Available|Unavailable)/)).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await assertTableHasRows(
+    tableByExactLabel(page, "Proof-pack sections"),
+    1,
+    "Proof-pack sections"
+  );
+  await assertTableHasRows(
+    tableByExactLabel(page, "Proof-pack source hashes"),
+    1,
+    "Proof-pack source hashes"
+  );
+  await screenshotRegisteredPanel(page, "dpm.proof_pack");
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -190,7 +190,8 @@
   overflow-wrap: anywhere;
 }
 
-.outcome-review-panel .section-block-body {
+.outcome-review-panel .section-block-body,
+.proof-pack-panel .section-block-body {
   gap: 0.75rem;
 }
 
@@ -311,6 +312,41 @@
 
 .outcome-review-hash-strip span {
   min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.proof-pack-badge-row,
+.proof-pack-action-row,
+.proof-pack-reason-row,
+.proof-pack-handoff-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.proof-pack-status-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.proof-pack-panel .analytics-table-frame {
+  margin-top: 0.35rem;
+}
+
+.proof-pack-markdown-preview {
+  max-height: 18rem;
+  min-width: 0;
+  overflow: auto;
+  padding: 0.75rem;
+  border: var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-secondary);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 
@@ -13855,7 +13891,8 @@ a:hover {
     padding: 0.78rem;
   }
 
-  .construction-alternatives-status-strip {
+  .construction-alternatives-status-strip,
+  .proof-pack-status-strip {
     grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -4,6 +4,7 @@ import {
   getDpmMandateByPortfolio,
   getDpmMandateHealth,
   getDpmOutcomeReviews,
+  getDpmProofPack,
   getPortfolio360,
   getReportingSnapshot,
   getWorkbenchAnalytics,
@@ -30,6 +31,7 @@ import OverviewCards from "@/features/workbench/components/overview-cards";
 import OutcomeReviewPanel from "@/features/workbench/components/outcome-review-panel";
 import PartialFailureBanner from "@/features/workbench/components/partial-failure-banner";
 import PerformanceSnapshot from "@/features/workbench/components/performance-snapshot";
+import ProofPackPanel from "@/features/workbench/components/proof-pack-panel";
 import RebalanceStatus from "@/features/workbench/components/rebalance-status";
 import ReportBatchOperationsPanel from "@/features/workbench/components/report-batch-operations-panel";
 import ReportingSnapshotPanel from "@/features/workbench/components/reporting-snapshot-panel";
@@ -87,6 +89,8 @@ export default async function WorkbenchPage({
   let dpmCommandCenterError: string | null = null;
   let outcomeReviews: Awaited<ReturnType<typeof getDpmOutcomeReviews>> | null = null;
   let outcomeReviewError: string | null = null;
+  let proofPack: Awaited<ReturnType<typeof getDpmProofPack>> | null = null;
+  let proofPackError: string | null = null;
   try {
     data = await getPortfolio360(portfolioId, sessionId);
   } catch (error) {
@@ -175,6 +179,18 @@ export default async function WorkbenchPage({
       error instanceof Error ? error.message : "Outcome review endpoint unavailable.";
   }
 
+  const primaryProofPackId = readPrimaryProofPackId(outcomeReviews?.data ?? null);
+  if (primaryProofPackId) {
+    try {
+      proofPack = await getDpmProofPack(primaryProofPackId, "server");
+    } catch (error) {
+      proofPack = null;
+      proofPackError =
+        error instanceof Error ? error.message : "Proof-pack endpoint unavailable.";
+    }
+  }
+
+  const dpmMandateId = readDpmMandateId(dpmMandate?.data ?? null);
   const projectedCoveragePct =
     data.projected_summary &&
     data.projected_summary.total_baseline_positions > 0
@@ -304,6 +320,14 @@ export default async function WorkbenchPage({
 
               <ConstructionAlternativesPanel portfolio={data} />
 
+              <ProofPackPanel
+                portfolioId={data.portfolio.portfolio_id}
+                mandateId={dpmMandateId}
+                outcomeReviews={outcomeReviews}
+                initialProofPack={proofPack}
+                errorMessage={proofPackError}
+              />
+
               <OutcomeReviewPanel
                 portfolioId={data.portfolio.portfolio_id}
                 response={outcomeReviews}
@@ -416,4 +440,37 @@ export default async function WorkbenchPage({
       </WorkbenchPageFrame>
     </main>
   );
+}
+
+function readPrimaryProofPackId(data: Record<string, unknown> | null): string | null {
+  if (!data) {
+    return null;
+  }
+  const items = Array.isArray(data.items) ? data.items : [];
+  for (const item of items) {
+    if (item && typeof item === "object" && !Array.isArray(item)) {
+      const proofPackId = (item as Record<string, unknown>).proof_pack_id;
+      if (typeof proofPackId === "string" && proofPackId.trim().length > 0) {
+        return proofPackId;
+      }
+    }
+  }
+  return typeof data.proof_pack_id === "string" && data.proof_pack_id.trim().length > 0
+    ? data.proof_pack_id
+    : null;
+}
+
+function readDpmMandateId(data: Record<string, unknown> | null): string | null {
+  if (!data) {
+    return null;
+  }
+  if (typeof data.mandate_id === "string" && data.mandate_id.trim().length > 0) {
+    return data.mandate_id;
+  }
+  const mandate = data.mandate;
+  if (mandate && typeof mandate === "object" && !Array.isArray(mandate)) {
+    const mandateId = (mandate as Record<string, unknown>).mandate_id;
+    return typeof mandateId === "string" && mandateId.trim().length > 0 ? mandateId : null;
+  }
+  return null;
 }

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -205,6 +205,31 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     operation: "dpm.construction.alternative.select",
   },
   {
+    route: "workbench.dpm-command-center",
+    panel: "proof-pack-generate",
+    operation: "dpm.proof-pack.generate",
+  },
+  {
+    route: "workbench.dpm-command-center",
+    panel: "proof-pack-detail",
+    operation: "dpm.proof-pack.get",
+  },
+  {
+    route: "workbench.dpm-command-center",
+    panel: "proof-pack-markdown",
+    operation: "dpm.proof-pack.markdown",
+  },
+  {
+    route: "workbench.dpm-command-center",
+    panel: "proof-pack-report-input",
+    operation: "dpm.proof-pack.report-input",
+  },
+  {
+    route: "workbench.dpm-command-center",
+    panel: "proof-pack-ai-evidence",
+    operation: "dpm.proof-pack.ai-evidence",
+  },
+  {
     route: "workbench.legacy-advisor",
     panel: "advisor-overview",
     operation: "workbench.overview",

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -18,6 +18,8 @@ import {
   DpmOutcomeReviewGatewayResponse,
   DpmOutcomeReviewHandoffResponse,
   DpmOutcomeReviewNarrativeResponse,
+  DpmProofPackGatewayResponse,
+  DpmProofPackMarkdownResponse,
   ReportJobHandleResponse,
   ReportBatchHandleResponse,
   ReportBatchStatusResponse,
@@ -1042,6 +1044,105 @@ export async function getDpmOutcomeReviewAiEvidenceInput(
   );
 }
 
+export async function generateDpmProofPackFromRun(params: {
+  rebalanceRunId: string;
+  mandateId?: string | null;
+  actorId?: string;
+  reason?: string;
+  includeMarkdown?: boolean;
+  includeReportInput?: boolean;
+  includeAiEvidenceInput?: boolean;
+}): Promise<DpmProofPackGatewayResponse> {
+  const actorId = params.actorId ?? "workbench-proof-pack-operator";
+  return await observeWorkbenchMutation(
+    "dpm.proof-pack.generate",
+    async () =>
+      await fetchWorkbenchMutation<DpmProofPackGatewayResponse>(
+        buildWorkbenchUrl("client", "/dpm/command-center/proof-packs"),
+        "generate DPM proof pack",
+        {
+          method: "POST",
+          headers: buildDpmProofPackCallerHeaders({
+            actorId,
+            correlationId: `corr-workbench-proof-pack-${params.rebalanceRunId}`,
+          }),
+          body: JSON.stringify({
+            idempotency_key: `workbench-proof-pack-${params.rebalanceRunId}`,
+            body: {
+              source_type: "REBALANCE_RUN",
+              rebalance_run_id: params.rebalanceRunId,
+              mandate_id: params.mandateId ?? undefined,
+              include_markdown: params.includeMarkdown ?? true,
+              include_report_input: params.includeReportInput ?? true,
+              include_ai_evidence_input: params.includeAiEvidenceInput ?? true,
+              actor_id: actorId,
+              reason:
+                params.reason ??
+                "Workbench PM generated proof pack from Gateway-backed rebalance run.",
+            },
+          }),
+        }
+      )
+  );
+}
+
+export async function getDpmProofPack(
+  proofPackId: string,
+  target: WorkbenchRequestTarget = "client"
+): Promise<DpmProofPackGatewayResponse> {
+  return await observeWorkbenchResource(
+    "dpm.proof-pack.get",
+    async () =>
+      await fetchWorkbenchResource<DpmProofPackGatewayResponse>(
+        target,
+        `/dpm/command-center/proof-packs/${encodeURIComponent(proofPackId)}`,
+        "DPM proof pack"
+      )
+  );
+}
+
+export async function getDpmProofPackMarkdown(
+  proofPackId: string
+): Promise<DpmProofPackMarkdownResponse> {
+  return await observeWorkbenchResource(
+    "dpm.proof-pack.markdown",
+    async () =>
+      await fetchWorkbenchResource<DpmProofPackMarkdownResponse>(
+        "client",
+        `/dpm/command-center/proof-packs/${encodeURIComponent(proofPackId)}/summary.md`,
+        "DPM proof pack Markdown"
+      )
+  );
+}
+
+export async function getDpmProofPackReportInput(
+  proofPackId: string
+): Promise<DpmProofPackGatewayResponse> {
+  return await observeWorkbenchResource(
+    "dpm.proof-pack.report-input",
+    async () =>
+      await fetchWorkbenchResource<DpmProofPackGatewayResponse>(
+        "client",
+        `/dpm/command-center/proof-packs/${encodeURIComponent(proofPackId)}/report-input`,
+        "DPM proof pack report input"
+      )
+  );
+}
+
+export async function getDpmProofPackAiEvidenceInput(
+  proofPackId: string
+): Promise<DpmProofPackGatewayResponse> {
+  return await observeWorkbenchResource(
+    "dpm.proof-pack.ai-evidence",
+    async () =>
+      await fetchWorkbenchResource<DpmProofPackGatewayResponse>(
+        "client",
+        `/dpm/command-center/proof-packs/${encodeURIComponent(proofPackId)}/ai-evidence-input`,
+        "DPM proof pack AI evidence input"
+      )
+  );
+}
+
 export async function requestDpmOutcomeReviewAiNarrative(params: {
   outcomeReviewId: string;
   requestedOutputs?: string[];
@@ -1157,6 +1258,18 @@ function buildDpmConstructionCallerHeaders(params: {
 }
 
 function buildDpmCommandCenterCallerHeaders(params: {
+  actorId: string;
+  correlationId: string;
+}): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    "X-Actor-Id": params.actorId,
+    "X-Caller-Application": "lotus-workbench",
+    "X-Correlation-Id": params.correlationId,
+  };
+}
+
+function buildDpmProofPackCallerHeaders(params: {
   actorId: string;
   correlationId: string;
 }): Record<string, string> {

--- a/src/features/workbench/components/proof-pack-panel.tsx
+++ b/src/features/workbench/components/proof-pack-panel.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ActionButton,
+  AnalyticsTable,
+  MetricRow,
+  ScreenStatePanel,
+  SectionBlock,
+  SemanticBadge,
+  Text,
+} from "@/design-system";
+import {
+  generateDpmProofPackFromRun,
+  getDpmProofPack,
+  getDpmProofPackAiEvidenceInput,
+  getDpmProofPackMarkdown,
+  getDpmProofPackReportInput,
+} from "@/features/workbench/api";
+import type {
+  DpmOutcomeReviewGatewayResponse,
+  DpmProofPackGatewayResponse,
+} from "@/features/workbench/types";
+import {
+  buildProofPackPanelModel,
+  deriveProofPackContext,
+  type ProofPackPanelState,
+} from "@/features/workbench/proof-pack-view-model";
+
+type Props = {
+  portfolioId: string;
+  mandateId?: string | null;
+  outcomeReviews: DpmOutcomeReviewGatewayResponse | null;
+  initialProofPack: DpmProofPackGatewayResponse | null;
+  errorMessage?: string | null;
+};
+
+function badgeTone(state: string): "default" | "success" | "warn" | "danger" {
+  const normalized = state.toUpperCase();
+  if (normalized === "SUPPORTED" || normalized === "READY" || normalized === "COMPLETE") {
+    return "success";
+  }
+  if (normalized === "DEGRADED" || normalized === "PARTIAL" || normalized.includes("PENDING")) {
+    return "warn";
+  }
+  if (normalized === "BLOCKED" || normalized === "UNSUPPORTED" || normalized === "FAILED") {
+    return "danger";
+  }
+  return "default";
+}
+
+function statePanelCopy(state: ProofPackPanelState, portfolioId: string) {
+  if (state === "empty") {
+    return {
+      kind: "empty" as const,
+      title: "No proof pack linked to this portfolio",
+      body: `Gateway did not return a manage proof-pack reference for ${portfolioId}.`,
+    };
+  }
+  if (state === "blocked") {
+    return {
+      kind: "permission_blocked" as const,
+      title: "Proof-pack handoff is blocked",
+      body: "Manage has blocked proof-pack evidence actions for this rebalance run.",
+    };
+  }
+  if (state === "unsupported") {
+    return {
+      kind: "unavailable" as const,
+      title: "Proof-pack evidence is not supported",
+      body: "The authoritative manage supportability state says this proof-pack path is unsupported.",
+    };
+  }
+  return {
+    kind: "partial" as const,
+    title: "Proof-pack evidence is unavailable",
+    body: "Gateway did not return a usable manage proof-pack payload for this portfolio.",
+  };
+}
+
+function availabilityLabel(available: boolean): string {
+  return available ? "Available" : "Unavailable";
+}
+
+export default function ProofPackPanel({
+  portfolioId,
+  mandateId,
+  outcomeReviews,
+  initialProofPack,
+  errorMessage,
+}: Props) {
+  const context = deriveProofPackContext(outcomeReviews);
+  const [proofPack, setProofPack] = useState<DpmProofPackGatewayResponse | null>(initialProofPack);
+  const [markdown, setMarkdown] = useState<string | null>(null);
+  const [handoffStatus, setHandoffStatus] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const model = buildProofPackPanelModel(proofPack);
+  const proofPackId = model.proofPackId !== "N/A" ? model.proofPackId : context.proofPackId;
+  const rebalanceRunId =
+    context.rebalanceRunId ?? (model.rebalanceRunId !== "N/A" ? model.rebalanceRunId : null);
+  const resolvedMandateId =
+    mandateId ?? context.mandateId ?? (model.mandateId !== "N/A" ? model.mandateId : null);
+  const shouldShowStatePanel =
+    Boolean(errorMessage) ||
+    model.state === "empty" ||
+    model.state === "blocked" ||
+    model.state === "unsupported" ||
+    model.state === "unavailable";
+  const stateCopy = statePanelCopy(model.state, portfolioId);
+
+  async function runAction(label: string, action: () => Promise<void>) {
+    if (pendingAction) {
+      return;
+    }
+    setPendingAction(label);
+    setActionError(null);
+    try {
+      await action();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : `${label} failed`);
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  function loadProofPack() {
+    if (!proofPackId) {
+      return;
+    }
+    void runAction("Load proof pack", async () => {
+      setProofPack(await getDpmProofPack(proofPackId));
+      setHandoffStatus("Proof-pack payload loaded from Gateway.");
+    });
+  }
+
+  function generateProofPack() {
+    if (!rebalanceRunId) {
+      return;
+    }
+    void runAction("Generate proof pack", async () => {
+      const generated = await generateDpmProofPackFromRun({
+        rebalanceRunId,
+        mandateId: resolvedMandateId,
+      });
+      setProofPack(generated);
+      setHandoffStatus("Proof-pack generation completed through Gateway.");
+    });
+  }
+
+  function loadMarkdown() {
+    if (!proofPackId) {
+      return;
+    }
+    void runAction("Load Markdown", async () => {
+      const response = await getDpmProofPackMarkdown(proofPackId);
+      setMarkdown(readMarkdown(response));
+      setHandoffStatus("Markdown summary loaded from Gateway.");
+    });
+  }
+
+  function loadReportInput() {
+    if (!proofPackId) {
+      return;
+    }
+    void runAction("Load Report Input", async () => {
+      const response = await getDpmProofPackReportInput(proofPackId);
+      setHandoffStatus(`Report input ${response.supportability.report_input_available ? "available" : "unavailable"}.`);
+    });
+  }
+
+  function loadAiEvidence() {
+    if (!proofPackId) {
+      return;
+    }
+    void runAction("Load AI Evidence", async () => {
+      const response = await getDpmProofPackAiEvidenceInput(proofPackId);
+      setHandoffStatus(
+        `AI evidence input ${response.supportability.ai_evidence_input_available ? "available" : "unavailable"}.`
+      );
+    });
+  }
+
+  return (
+    <SectionBlock
+      title="Proof-Pack Evidence"
+      subtitle={`Manage authority: ${model.authority}. Correlation: ${model.correlationId}`}
+      className="proof-pack-panel"
+      actions={
+        <div className="proof-pack-badge-row">
+          <SemanticBadge tone={badgeTone(model.supportabilityState)}>
+            {model.supportabilityState}
+          </SemanticBadge>
+          <SemanticBadge>{model.sourceService}</SemanticBadge>
+        </div>
+      }
+    >
+      {shouldShowStatePanel ? (
+        <ScreenStatePanel
+          kind={errorMessage ? "partial" : stateCopy.kind}
+          surface="portfolio"
+          title={errorMessage ? "Proof-pack endpoint is unavailable" : stateCopy.title}
+          body={errorMessage ?? stateCopy.body}
+        />
+      ) : null}
+
+      <div className="proof-pack-status-strip">
+        <MetricRow label="Proof Pack" value={model.proofPackId} />
+        <MetricRow
+          label="Status"
+          value={<SemanticBadge tone={badgeTone(model.status)}>{model.status}</SemanticBadge>}
+        />
+        <MetricRow label="Sections" value={model.sectionStateSummary} />
+        <MetricRow label="Content Hash" value={model.contentHash} />
+      </div>
+
+      <div className="proof-pack-action-row" aria-label="Proof-pack actions">
+        <ActionButton priority="secondary" onClick={generateProofPack} disabled={!rebalanceRunId || Boolean(pendingAction)}>
+          {pendingAction === "Generate proof pack" ? "Generating" : "Generate proof pack"}
+        </ActionButton>
+        <ActionButton priority="secondary" onClick={loadProofPack} disabled={!proofPackId || Boolean(pendingAction)}>
+          {pendingAction === "Load proof pack" ? "Loading" : "Load proof pack"}
+        </ActionButton>
+        <ActionButton
+          priority="secondary"
+          onClick={loadMarkdown}
+          disabled={!proofPackId || !model.markdownAvailable || Boolean(pendingAction)}
+        >
+          {pendingAction === "Load Markdown" ? "Loading Markdown" : "Load Markdown"}
+        </ActionButton>
+        <ActionButton
+          priority="secondary"
+          onClick={loadReportInput}
+          disabled={!proofPackId || !model.reportInputAvailable || Boolean(pendingAction)}
+        >
+          Report Input
+        </ActionButton>
+        <ActionButton
+          priority="secondary"
+          onClick={loadAiEvidence}
+          disabled={!proofPackId || !model.aiEvidenceInputAvailable || Boolean(pendingAction)}
+        >
+          AI Evidence
+        </ActionButton>
+      </div>
+
+      {actionError || handoffStatus ? (
+        <Text variant="secondary" className="muted">
+          {actionError ?? handoffStatus}
+        </Text>
+      ) : (
+        <Text variant="secondary" className="muted">
+          Shows Gateway-composed proof-pack identity, sections, hashes, Markdown, report-input, and AI-evidence posture.
+        </Text>
+      )}
+
+      {model.supportabilityReasons.length > 0 ? (
+        <div className="proof-pack-reason-row">
+          {model.supportabilityReasons.map((reason) => (
+            <SemanticBadge key={reason} tone={badgeTone(reason)}>
+              {reason}
+            </SemanticBadge>
+          ))}
+        </div>
+      ) : null}
+
+      <AnalyticsTable
+        ariaLabel="Proof-pack sections"
+        variant="analysis"
+        density="compact"
+        columns={[
+          { key: "section", label: "Section" },
+          { key: "state", label: "State" },
+          { key: "source", label: "Source" },
+          { key: "hash", label: "Hash" },
+        ]}
+        rows={model.sections.map((section) => ({
+          key: section.key,
+          cells: [
+            section.section,
+            <SemanticBadge key={`${section.key}-state`} tone={badgeTone(section.state)}>
+              {section.state}
+            </SemanticBadge>,
+            section.source,
+            section.hash,
+          ],
+        }))}
+        emptyState={{
+          title: "No proof-pack sections returned",
+          body: "Gateway did not return section posture for this manage proof pack.",
+        }}
+      />
+
+      <AnalyticsTable
+        ariaLabel="Proof-pack source hashes"
+        variant="observation"
+        density="compact"
+        columns={[
+          { key: "source", label: "Source" },
+          { key: "reference", label: "Reference" },
+          { key: "hash", label: "Hash" },
+        ]}
+        rows={model.sourceHashes.map((source) => ({
+          key: source.key,
+          cells: [source.source, source.reference, source.hash],
+        }))}
+        emptyState={{
+          title: "No source hashes returned",
+          body: "Manage returned the proof pack without source-hash lineage rows.",
+        }}
+      />
+
+      <div className="proof-pack-handoff-row" aria-label="Proof-pack handoff posture">
+        <SemanticBadge tone={model.markdownAvailable ? "success" : "default"}>
+          Markdown {availabilityLabel(model.markdownAvailable)}
+        </SemanticBadge>
+        <SemanticBadge tone={model.reportInputAvailable ? "success" : "default"}>
+          Report Input {availabilityLabel(model.reportInputAvailable)}
+        </SemanticBadge>
+        <SemanticBadge tone={model.aiEvidenceInputAvailable ? "success" : "default"}>
+          AI Evidence {availabilityLabel(model.aiEvidenceInputAvailable)}
+        </SemanticBadge>
+      </div>
+
+      {markdown ? (
+        <pre className="proof-pack-markdown-preview" aria-label="Proof-pack Markdown preview">
+          {markdown}
+        </pre>
+      ) : null}
+    </SectionBlock>
+  );
+}
+
+function readMarkdown(response: DpmProofPackGatewayResponse & { markdown?: unknown }): string {
+  if (typeof response.markdown === "string") {
+    return response.markdown;
+  }
+  if (typeof response.data.markdown === "string") {
+    return response.data.markdown;
+  }
+  if (typeof response.data.content === "string") {
+    return response.data.content;
+  }
+  return "Gateway returned no Markdown content for this proof pack.";
+}

--- a/src/features/workbench/proof-pack-view-model.ts
+++ b/src/features/workbench/proof-pack-view-model.ts
@@ -1,0 +1,277 @@
+import type {
+  DpmOutcomeReviewGatewayResponse,
+  DpmProofPackGatewayResponse,
+} from "./types";
+
+export type ProofPackPanelState =
+  | "ready"
+  | "empty"
+  | "partial"
+  | "blocked"
+  | "unsupported"
+  | "unavailable";
+
+export type ProofPackContext = {
+  proofPackId: string | null;
+  rebalanceRunId: string | null;
+  mandateId: string | null;
+};
+
+export type ProofPackSectionRow = {
+  key: string;
+  section: string;
+  state: string;
+  source: string;
+  hash: string;
+};
+
+export type ProofPackSourceHashRow = {
+  key: string;
+  source: string;
+  reference: string;
+  hash: string;
+};
+
+export type ProofPackPanelModel = {
+  state: ProofPackPanelState;
+  supportabilityState: string;
+  supportabilityReasons: string[];
+  sourceService: string;
+  authority: string;
+  correlationId: string;
+  proofPackId: string;
+  portfolioId: string;
+  mandateId: string;
+  rebalanceRunId: string;
+  alternativeSetId: string;
+  selectedAlternativeId: string;
+  asOfDate: string;
+  status: string;
+  contentHash: string;
+  createdAt: string;
+  sectionStateSummary: string;
+  markdownAvailable: boolean;
+  reportInputAvailable: boolean;
+  aiEvidenceInputAvailable: boolean;
+  sections: ProofPackSectionRow[];
+  sourceHashes: ProofPackSourceHashRow[];
+};
+
+export function deriveProofPackContext(
+  outcomeReviews: DpmOutcomeReviewGatewayResponse | null
+): ProofPackContext {
+  const review = extractOutcomeReviewRecords(outcomeReviews?.data ?? {}).find(
+    (record) => readString(record, "proof_pack_id") || readString(record, "rebalance_run_id")
+  );
+  return {
+    proofPackId: review ? readString(review, "proof_pack_id") || null : null,
+    rebalanceRunId: review ? readString(review, "rebalance_run_id") || null : null,
+    mandateId: review ? readString(review, "mandate_id") || null : null,
+  };
+}
+
+export function buildProofPackPanelModel(
+  response: DpmProofPackGatewayResponse | null
+): ProofPackPanelModel {
+  if (!response) {
+    return {
+      state: "unavailable",
+      supportabilityState: "UNAVAILABLE",
+      supportabilityReasons: ["GATEWAY_PROOF_PACK_UNAVAILABLE"],
+      sourceService: "lotus-gateway",
+      authority: "lotus-manage:RFC-0040",
+      correlationId: "N/A",
+      proofPackId: "N/A",
+      portfolioId: "N/A",
+      mandateId: "N/A",
+      rebalanceRunId: "N/A",
+      alternativeSetId: "N/A",
+      selectedAlternativeId: "N/A",
+      asOfDate: "N/A",
+      status: "UNAVAILABLE",
+      contentHash: "N/A",
+      createdAt: "N/A",
+      sectionStateSummary: "N/A",
+      markdownAvailable: false,
+      reportInputAvailable: false,
+      aiEvidenceInputAvailable: false,
+      sections: [],
+      sourceHashes: [],
+    };
+  }
+
+  const proofPack = extractProofPackRecord(response.data);
+  const supportabilityState = normalizeState(response.supportability.state);
+  const sections = extractRecordArray(
+    proofPack.sections ?? proofPack.section_posture ?? response.data.sections
+  ).map(buildSectionRow);
+  const sourceHashes = [
+    ...extractRecordArray(proofPack.source_hashes),
+    ...extractRecordArray(proofPack.source_lineage),
+    ...extractRecordArray(response.data.source_hashes),
+  ].map(buildSourceHashRow);
+  const contentHash =
+    readString(proofPack, "content_hash") ||
+    readString(response.data, "content_hash") ||
+    response.supportability.content_hash ||
+    "N/A";
+  const proofPackId =
+    readString(proofPack, "proof_pack_id") ||
+    readString(response.data, "proof_pack_id") ||
+    response.supportability.proof_pack_id ||
+    "N/A";
+
+  return {
+    state: resolvePanelState(supportabilityState, proofPackId, sections.length),
+    supportabilityState,
+    supportabilityReasons: response.supportability.reason_codes ?? [],
+    sourceService: response.supportability.source_service || response.source_service,
+    authority: response.supportability.authority,
+    correlationId: response.correlation_id,
+    proofPackId,
+    portfolioId: readString(proofPack, "portfolio_id") || readString(response.data, "portfolio_id") || "N/A",
+    mandateId: readString(proofPack, "mandate_id") || readString(response.data, "mandate_id") || "N/A",
+    rebalanceRunId:
+      readString(proofPack, "rebalance_run_id") ||
+      readString(response.data, "rebalance_run_id") ||
+      "N/A",
+    alternativeSetId:
+      readString(proofPack, "alternative_set_id") ||
+      readString(response.data, "alternative_set_id") ||
+      "N/A",
+    selectedAlternativeId:
+      readString(proofPack, "selected_alternative_id") ||
+      readString(response.data, "selected_alternative_id") ||
+      "N/A",
+    asOfDate: readString(proofPack, "as_of_date") || readString(response.data, "as_of_date") || "N/A",
+    status: readString(proofPack, "status") || supportabilityState,
+    contentHash,
+    createdAt: readString(proofPack, "created_at") || readString(response.data, "created_at") || "N/A",
+    sectionStateSummary: formatSectionStateCounts(response.supportability.section_state_counts),
+    markdownAvailable: Boolean(response.supportability.markdown_available),
+    reportInputAvailable: Boolean(response.supportability.report_input_available),
+    aiEvidenceInputAvailable: Boolean(response.supportability.ai_evidence_input_available),
+    sections,
+    sourceHashes,
+  };
+}
+
+function resolvePanelState(
+  supportabilityState: string,
+  proofPackId: string,
+  sectionCount: number
+): ProofPackPanelState {
+  if (supportabilityState === "BLOCKED") {
+    return "blocked";
+  }
+  if (supportabilityState === "UNSUPPORTED") {
+    return "unsupported";
+  }
+  if (supportabilityState === "DEGRADED" || supportabilityState === "PARTIAL") {
+    return proofPackId !== "N/A" ? "partial" : "unavailable";
+  }
+  if (proofPackId === "N/A") {
+    return "empty";
+  }
+  return sectionCount > 0 || supportabilityState === "READY" ? "ready" : "partial";
+}
+
+function extractProofPackRecord(data: Record<string, unknown>): Record<string, unknown> {
+  const proofPack = data.proof_pack;
+  if (isRecord(proofPack)) {
+    return proofPack;
+  }
+  return data;
+}
+
+function extractOutcomeReviewRecords(data: Record<string, unknown>): Record<string, unknown>[] {
+  const items = extractRecordArray(data.items);
+  if (items.length > 0) {
+    return items;
+  }
+  return typeof data.outcome_review_id === "string" ? [data] : [];
+}
+
+function buildSectionRow(record: Record<string, unknown>, index: number): ProofPackSectionRow {
+  const section =
+    readString(record, "section") ||
+    readString(record, "section_name") ||
+    readString(record, "name") ||
+    `section_${index + 1}`;
+  const source =
+    readString(record, "source_service") ||
+    readString(record, "source") ||
+    readString(record, "authority") ||
+    "N/A";
+  return {
+    key: `${section}-${index}`,
+    section,
+    state: readString(record, "state") || readString(record, "status") || "UNKNOWN",
+    source,
+    hash:
+      readString(record, "content_hash") ||
+      readString(record, "payload_hash") ||
+      readString(record, "hash") ||
+      "N/A",
+  };
+}
+
+function buildSourceHashRow(record: Record<string, unknown>, index: number): ProofPackSourceHashRow {
+  const source =
+    readString(record, "source_service") ||
+    readString(record, "source_system") ||
+    readString(record, "source") ||
+    "N/A";
+  const reference =
+    readString(record, "source_ref") ||
+    readString(record, "reference") ||
+    readString(record, "source_id") ||
+    readString(record, "id") ||
+    "N/A";
+  return {
+    key: `${source}-${reference}-${index}`,
+    source,
+    reference,
+    hash:
+      readString(record, "content_hash") ||
+      readString(record, "payload_hash") ||
+      readString(record, "hash") ||
+      "N/A",
+  };
+}
+
+function formatSectionStateCounts(counts: Record<string, number> | null | undefined): string {
+  if (!counts || Object.keys(counts).length === 0) {
+    return "N/A";
+  }
+  return Object.entries(counts)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([state, count]) => `${state}: ${count}`)
+    .join(", ");
+}
+
+function extractRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isRecord);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+function normalizeState(state: string): string {
+  return state.trim().toUpperCase() || "UNKNOWN";
+}

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1199,6 +1199,33 @@ export type DpmConstructionGatewayResponse = {
   data: Record<string, unknown>;
 };
 
+export type DpmProofPackSupportability = {
+  source_service: string;
+  authority: string;
+  state: string;
+  proof_pack_id?: string | null;
+  reason_codes: string[];
+  section_state_counts?: Record<string, number> | null;
+  content_hash?: string | null;
+  markdown_available: boolean;
+  report_input_available: boolean;
+  ai_evidence_input_available: boolean;
+  remediation_owner?: string | null;
+};
+
+export type DpmProofPackGatewayResponse = {
+  correlation_id: string;
+  contract_version: string;
+  source_service: string;
+  upstream_status: number;
+  supportability: DpmProofPackSupportability;
+  data: Record<string, unknown>;
+};
+
+export type DpmProofPackMarkdownResponse = DpmProofPackGatewayResponse & {
+  markdown?: string;
+};
+
 export type DpmOutcomeReviewNarrativeResponse = {
   correlation_id: string;
   contract_version: string;

--- a/tests/integration/workbench-page.test.tsx
+++ b/tests/integration/workbench-page.test.tsx
@@ -188,6 +188,54 @@ describe("WorkbenchPage", () => {
           } as Response;
         }
 
+        if (url.includes("/api/v1/dpm/command-center/proof-packs/ppack_1")) {
+          return {
+            ok: true,
+            json: async () => ({
+              correlation_id: "corr_rfc40",
+              contract_version: "v1",
+              source_service: "lotus-manage",
+              upstream_status: 200,
+              supportability: {
+                source_service: "lotus-manage",
+                authority: "lotus-manage:RFC-0040",
+                state: "READY",
+                proof_pack_id: "ppack_1",
+                reason_codes: ["PROOF_PACK_READY"],
+                section_state_counts: { READY: 1 },
+                content_hash: "sha256:proof-pack",
+                markdown_available: true,
+                report_input_available: true,
+                ai_evidence_input_available: true,
+              },
+              data: {
+                proof_pack: {
+                  proof_pack_id: "ppack_1",
+                  portfolio_id: "PF_1001",
+                  rebalance_run_id: "run_001",
+                  status: "READY",
+                  content_hash: "sha256:proof-pack",
+                  sections: [
+                    {
+                      section: "investment_policy",
+                      state: "READY",
+                      source_service: "lotus-manage",
+                      content_hash: "sha256:policy",
+                    },
+                  ],
+                  source_hashes: [
+                    {
+                      source_service: "lotus-risk",
+                      source_ref: "risk_snapshot_1",
+                      hash: "sha256:risk",
+                    },
+                  ],
+                },
+              },
+            }),
+          } as Response;
+        }
+
         return { ok: false, json: async () => ({}) } as Response;
       })
     );
@@ -215,6 +263,9 @@ describe("WorkbenchPage", () => {
     expect(screen.getByLabelText("DPM operations dashboard")).toHaveTextContent(
       "Source Readiness Blocked"
     );
+    expect(screen.getByRole("heading", { name: "Proof-Pack Evidence" })).toBeInTheDocument();
+    expect(screen.getByText("investment_policy")).toBeInTheDocument();
+    expect(screen.getAllByText("sha256:proof-pack").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("ATTENTION")).toBeInTheDocument();
     expect(screen.getByText("Partial Data Warning")).toBeInTheDocument();
     expect(screen.getAllByText(/UPSTREAM_TIMEOUT/).length).toBeGreaterThanOrEqual(1);

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -354,6 +354,31 @@ describe("analytics UI observability metrics", () => {
         "construction-selection",
         "dpm.construction.alternative.select",
       ],
+      [
+        "workbench.dpm-command-center",
+        "proof-pack-generate",
+        "dpm.proof-pack.generate",
+      ],
+      [
+        "workbench.dpm-command-center",
+        "proof-pack-detail",
+        "dpm.proof-pack.get",
+      ],
+      [
+        "workbench.dpm-command-center",
+        "proof-pack-markdown",
+        "dpm.proof-pack.markdown",
+      ],
+      [
+        "workbench.dpm-command-center",
+        "proof-pack-report-input",
+        "dpm.proof-pack.report-input",
+      ],
+      [
+        "workbench.dpm-command-center",
+        "proof-pack-ai-evidence",
+        "dpm.proof-pack.ai-evidence",
+      ],
       ["workbench.legacy-advisor", "advisor-overview", "workbench.overview"],
       ["workbench.legacy-advisor", "portfolio-360", "workbench.portfolio-360"],
       ["workbench.legacy-advisor", "portfolio-analytics", "workbench.analytics"],

--- a/tests/unit/proof-pack-panel.test.tsx
+++ b/tests/unit/proof-pack-panel.test.tsx
@@ -1,0 +1,185 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import ProofPackPanel from "../../src/features/workbench/components/proof-pack-panel";
+import type {
+  DpmOutcomeReviewGatewayResponse,
+  DpmProofPackGatewayResponse,
+} from "../../src/features/workbench/types";
+import {
+  generateDpmProofPackFromRun,
+  getDpmProofPack,
+  getDpmProofPackAiEvidenceInput,
+  getDpmProofPackMarkdown,
+  getDpmProofPackReportInput,
+} from "../../src/features/workbench/api";
+
+vi.mock("../../src/features/workbench/api", () => ({
+  generateDpmProofPackFromRun: vi.fn(),
+  getDpmProofPack: vi.fn(),
+  getDpmProofPackAiEvidenceInput: vi.fn(),
+  getDpmProofPackMarkdown: vi.fn(),
+  getDpmProofPackReportInput: vi.fn(),
+}));
+
+const outcomeReviews: DpmOutcomeReviewGatewayResponse = {
+  correlation_id: "corr-rfc42",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0042",
+    state: "SUPPORTED",
+    reason_codes: [],
+    blocked_actions: [],
+  },
+  data: {
+    items: [
+      {
+        outcome_review_id: "or_1",
+        proof_pack_id: "ppack_1",
+        rebalance_run_id: "rr_1",
+        mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001",
+      },
+    ],
+  },
+};
+
+const readyProofPack: DpmProofPackGatewayResponse = {
+  correlation_id: "corr-rfc40",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0040",
+    state: "READY",
+    proof_pack_id: "ppack_1",
+    reason_codes: ["PROOF_PACK_READY"],
+    section_state_counts: { READY: 1 },
+    content_hash: "sha256:proof-pack",
+    markdown_available: true,
+    report_input_available: true,
+    ai_evidence_input_available: true,
+  },
+  data: {
+    proof_pack: {
+      proof_pack_id: "ppack_1",
+      portfolio_id: "PB_SG_GLOBAL_BAL_001",
+      mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001",
+      rebalance_run_id: "rr_1",
+      status: "READY",
+      content_hash: "sha256:proof-pack",
+      sections: [
+        {
+          section: "investment_policy",
+          state: "READY",
+          source_service: "lotus-manage",
+          content_hash: "sha256:policy",
+        },
+      ],
+      source_hashes: [
+        {
+          source_service: "lotus-risk",
+          source_ref: "risk_snapshot_1",
+          hash: "sha256:risk",
+        },
+      ],
+    },
+  },
+};
+
+describe("ProofPackPanel", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders manage-backed proof-pack evidence posture", () => {
+    render(
+      <ProofPackPanel
+        portfolioId="PB_SG_GLOBAL_BAL_001"
+        mandateId="MANDATE_PB_SG_GLOBAL_BAL_001"
+        outcomeReviews={outcomeReviews}
+        initialProofPack={readyProofPack}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "Proof-Pack Evidence" })).toBeInTheDocument();
+    expect(screen.getAllByText("READY").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("ppack_1")).toBeInTheDocument();
+    expect(screen.getAllByText("sha256:proof-pack").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("investment_policy")).toBeInTheDocument();
+    expect(screen.getByText("sha256:risk")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Generate proof pack" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Load Markdown" })).toBeEnabled();
+  });
+
+  it("generates a proof pack from the outcome-review rebalance run", async () => {
+    vi.mocked(generateDpmProofPackFromRun).mockResolvedValue(readyProofPack);
+
+    render(
+      <ProofPackPanel
+        portfolioId="PB_SG_GLOBAL_BAL_001"
+        mandateId="MANDATE_PB_SG_GLOBAL_BAL_001"
+        outcomeReviews={outcomeReviews}
+        initialProofPack={null}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Generate proof pack" }));
+
+    await waitFor(() => {
+      expect(generateDpmProofPackFromRun).toHaveBeenCalledWith({
+        rebalanceRunId: "rr_1",
+        mandateId: "MANDATE_PB_SG_GLOBAL_BAL_001",
+      });
+    });
+    expect(screen.getByText("Proof-pack generation completed through Gateway.")).toBeInTheDocument();
+    expect(screen.getByText("ppack_1")).toBeInTheDocument();
+  });
+
+  it("loads proof-pack detail and handoff payloads through Gateway", async () => {
+    vi.mocked(getDpmProofPack).mockResolvedValue(readyProofPack);
+    vi.mocked(getDpmProofPackMarkdown).mockResolvedValue({
+      ...readyProofPack,
+      data: { markdown: "# Proof Pack\n\nReady." },
+    });
+    vi.mocked(getDpmProofPackReportInput).mockResolvedValue(readyProofPack);
+    vi.mocked(getDpmProofPackAiEvidenceInput).mockResolvedValue(readyProofPack);
+
+    render(
+      <ProofPackPanel
+        portfolioId="PB_SG_GLOBAL_BAL_001"
+        outcomeReviews={outcomeReviews}
+        initialProofPack={readyProofPack}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Load proof pack" }));
+    await waitFor(() => expect(getDpmProofPack).toHaveBeenCalledWith("ppack_1"));
+    fireEvent.click(screen.getByRole("button", { name: "Load Markdown" }));
+    await waitFor(() => expect(getDpmProofPackMarkdown).toHaveBeenCalledWith("ppack_1"));
+    expect(await screen.findByLabelText("Proof-pack Markdown preview")).toHaveTextContent(
+      "Ready."
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Report Input" }));
+    await waitFor(() => expect(getDpmProofPackReportInput).toHaveBeenCalledWith("ppack_1"));
+    fireEvent.click(screen.getByRole("button", { name: "AI Evidence" }));
+    await waitFor(() => expect(getDpmProofPackAiEvidenceInput).toHaveBeenCalledWith("ppack_1"));
+  });
+
+  it("renders unavailable state without claiming generated proof", () => {
+    render(
+      <ProofPackPanel
+        portfolioId="PB_SG_GLOBAL_BAL_001"
+        outcomeReviews={null}
+        initialProofPack={null}
+        errorMessage="Failed to fetch DPM proof pack (503)"
+      />
+    );
+
+    expect(screen.getByText("Proof-pack endpoint is unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Failed to fetch DPM proof pack (503)")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Generate proof pack" })).toBeDisabled();
+  });
+});

--- a/tests/unit/proof-pack-view-model.test.ts
+++ b/tests/unit/proof-pack-view-model.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildProofPackPanelModel,
+  deriveProofPackContext,
+} from "../../src/features/workbench/proof-pack-view-model";
+import type {
+  DpmOutcomeReviewGatewayResponse,
+  DpmProofPackGatewayResponse,
+} from "../../src/features/workbench/types";
+
+const proofPackResponse: DpmProofPackGatewayResponse = {
+  correlation_id: "corr-rfc40",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0040",
+    state: "READY",
+    proof_pack_id: "ppack_1",
+    reason_codes: ["PROOF_PACK_READY"],
+    section_state_counts: { READY: 2 },
+    content_hash: "sha256:proof-pack",
+    markdown_available: true,
+    report_input_available: true,
+    ai_evidence_input_available: true,
+  },
+  data: {
+    proof_pack: {
+      proof_pack_id: "ppack_1",
+      portfolio_id: "PB_SG_GLOBAL_BAL_001",
+      mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001",
+      rebalance_run_id: "rr_1",
+      alternative_set_id: "cas_1",
+      selected_alternative_id: "alt_1",
+      status: "READY",
+      as_of_date: "2026-05-03",
+      content_hash: "sha256:proof-pack",
+      sections: [
+        {
+          section: "investment_policy",
+          state: "READY",
+          source_service: "lotus-manage",
+          content_hash: "sha256:policy",
+        },
+      ],
+      source_hashes: [
+        {
+          source_service: "lotus-risk",
+          source_ref: "risk_snapshot_1",
+          hash: "sha256:risk",
+        },
+      ],
+    },
+  },
+};
+
+describe("proof pack view model", () => {
+  it("keeps manage proof-pack identity, section posture, and hashes visible", () => {
+    const model = buildProofPackPanelModel(proofPackResponse);
+
+    expect(model.state).toBe("ready");
+    expect(model.proofPackId).toBe("ppack_1");
+    expect(model.portfolioId).toBe("PB_SG_GLOBAL_BAL_001");
+    expect(model.mandateId).toBe("MANDATE_PB_SG_GLOBAL_BAL_001");
+    expect(model.rebalanceRunId).toBe("rr_1");
+    expect(model.contentHash).toBe("sha256:proof-pack");
+    expect(model.sectionStateSummary).toBe("READY: 2");
+    expect(model.sections).toEqual([
+      {
+        key: "investment_policy-0",
+        section: "investment_policy",
+        state: "READY",
+        source: "lotus-manage",
+        hash: "sha256:policy",
+      },
+    ]);
+    expect(model.sourceHashes).toEqual([
+      {
+        key: "lotus-risk-risk_snapshot_1-0",
+        source: "lotus-risk",
+        reference: "risk_snapshot_1",
+        hash: "sha256:risk",
+      },
+    ]);
+    expect(model.markdownAvailable).toBe(true);
+    expect(model.reportInputAvailable).toBe(true);
+    expect(model.aiEvidenceInputAvailable).toBe(true);
+  });
+
+  it("derives proof-pack launch context from outcome reviews", () => {
+    const outcomeReviews: DpmOutcomeReviewGatewayResponse = {
+      correlation_id: "corr-rfc42",
+      contract_version: "v1",
+      source_service: "lotus-manage",
+      upstream_status: 200,
+      supportability: {
+        source_service: "lotus-manage",
+        authority: "lotus-manage:RFC-0042",
+        state: "SUPPORTED",
+        reason_codes: [],
+        blocked_actions: [],
+      },
+      data: {
+        items: [
+          {
+            outcome_review_id: "or_1",
+            proof_pack_id: "ppack_1",
+            rebalance_run_id: "rr_1",
+            mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001",
+          },
+        ],
+      },
+    };
+
+    expect(deriveProofPackContext(outcomeReviews)).toEqual({
+      proofPackId: "ppack_1",
+      rebalanceRunId: "rr_1",
+      mandateId: "MANDATE_PB_SG_GLOBAL_BAL_001",
+    });
+  });
+
+  it("does not claim support before Gateway returns a proof pack", () => {
+    const model = buildProofPackPanelModel(null);
+
+    expect(model.state).toBe("unavailable");
+    expect(model.supportabilityState).toBe("UNAVAILABLE");
+    expect(model.proofPackId).toBe("N/A");
+    expect(model.markdownAvailable).toBe(false);
+  });
+
+  it("preserves blocked supportability from manage", () => {
+    const model = buildProofPackPanelModel({
+      ...proofPackResponse,
+      supportability: {
+        ...proofPackResponse.supportability,
+        state: "BLOCKED",
+        reason_codes: ["PROOF_PACK_SOURCE_BLOCKED"],
+      },
+    });
+
+    expect(model.state).toBe("blocked");
+    expect(model.supportabilityReasons).toEqual(["PROOF_PACK_SOURCE_BLOCKED"]);
+  });
+});

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -11,11 +11,15 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     integrations = (ROOT / "wiki" / "Integrations.md").read_text(encoding="utf-8")
     roadmap = (ROOT / "wiki" / "Roadmap.md").read_text(encoding="utf-8")
 
-    assert "RFC-0041/0042 WAVE AND OUTCOME EXPERIENCE ALIGNED" in rfc
-    assert "RFC-0041/0042 WAVE AND OUTCOME EXPERIENCE ALIGNED" in index
+    assert "RFC-0040 PROOF-PACK PANEL" in rfc
+    assert "RFC-0040 PROOF-PACK PANEL" in index
     assert "`lotus-manage` RFC-0040" in rfc
     assert "`lotus-manage` RFC-0042" in rfc
     assert "proof_pack_evidence" in rfc
+    assert "first RFC-0040 proof-pack review realization is embedded" in rfc
+    assert "`/api/v1/dpm/command-center/proof-packs*`" in rfc
+    assert "`dpm.proof_pack`" in rfc
+    assert "RFC-0040 PROOF-PACK PANEL" in index
     assert "Post-Trade Outcome Review Workspace Addendum" in rfc
     assert "`GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}`" in rfc
     assert "Dimension Matrix" in rfc
@@ -30,6 +34,8 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     assert "outcome-review search, detail, supportability" in integrations
     assert "must not calculate expected-versus-realized values" in integrations
     assert "proof-pack truth" in integrations
+    assert "proof-pack generation" in integrations
+    assert "proof-pack sections" in integrations
     assert "manage-owned RFC-0040" in roadmap
-    assert "RFC-0042 post-trade\n   outcome-review evidence" in roadmap
-    assert "proof-pack evidence, RFC-0041 rebalance-wave orchestration" in roadmap
+    assert "RFC-0042 outcome-review panel" in roadmap
+    assert "RFC-0040 proof-pack evidence" in roadmap

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -6,6 +6,7 @@ import {
   createPortfolioReportBatch,
   createSandboxSession,
   generateDpmConstructionAlternatives,
+  generateDpmProofPackFromRun,
   getDpmCommandCenter,
   getDpmCommandCenterExceptions,
   getDpmMandateByPortfolio,
@@ -14,6 +15,10 @@ import {
   getDpmOutcomeReviewReportInput,
   getDpmOutcomeReviews,
   getDpmConstructionAlternativeSet,
+  getDpmProofPack,
+  getDpmProofPackAiEvidenceInput,
+  getDpmProofPackMarkdown,
+  getDpmProofPackReportInput,
   requestDpmOutcomeReviewAiNarrative,
   getArchivedDocumentMetadata,
   getPortfolio360,
@@ -2086,6 +2091,93 @@ describe("workbench api", () => {
     expect(metricEventsJson).toContain("construction-selection");
     expect(metricEventsJson).not.toContain("cas_1");
     expect(metricEventsJson).not.toContain("alt_1");
+  });
+
+  it("generates and loads DPM proof packs through Gateway endpoints", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr-rfc40",
+            contract_version: "v1",
+            source_service: "lotus-manage",
+            upstream_status: 200,
+            supportability: {
+              source_service: "lotus-manage",
+              authority: "lotus-manage:RFC-0040",
+              state: "READY",
+              proof_pack_id: "ppack_1",
+              reason_codes: [],
+              section_state_counts: { READY: 3 },
+              content_hash: "sha256:proof-pack",
+              markdown_available: true,
+              report_input_available: true,
+              ai_evidence_input_available: true,
+            },
+            data: { proof_pack_id: "ppack_1", content_hash: "sha256:proof-pack" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await generateDpmProofPackFromRun({
+      rebalanceRunId: "rr_1",
+      mandateId: "MANDATE_PB_SG_GLOBAL_BAL_001",
+      actorId: "pm_1",
+    });
+    await getDpmProofPack("ppack_1");
+    await getDpmProofPackMarkdown("ppack_1");
+    await getDpmProofPackReportInput("ppack_1");
+    await getDpmProofPackAiEvidenceInput("ppack_1");
+    await getDpmProofPack("ppack_1", "server");
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/proof-packs`
+    );
+    expect(fetchMock.mock.calls[0][1].headers["X-Caller-Application"]).toBe(
+      "lotus-workbench"
+    );
+    expect(fetchMock.mock.calls[0][1].headers["X-Actor-Id"]).toBe("pm_1");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      idempotency_key: "workbench-proof-pack-rr_1",
+      body: {
+        source_type: "REBALANCE_RUN",
+        rebalance_run_id: "rr_1",
+        mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001",
+        include_markdown: true,
+        include_report_input: true,
+        include_ai_evidence_input: true,
+        actor_id: "pm_1",
+        reason: "Workbench PM generated proof pack from Gateway-backed rebalance run.",
+      },
+    });
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/proof-packs/ppack_1`
+    );
+    expect(fetchMock.mock.calls[2][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/proof-packs/ppack_1/summary.md`
+    );
+    expect(fetchMock.mock.calls[3][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/proof-packs/ppack_1/report-input`
+    );
+    expect(fetchMock.mock.calls[4][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/proof-packs/ppack_1/ai-evidence-input`
+    );
+    expect(fetchMock.mock.calls[5][0]).toBe(
+      `${resolveGatewayBaseUrl()}/api/v1/dpm/command-center/proof-packs/ppack_1`
+    );
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("proof-pack-generate");
+    expect(metricEventsJson).toContain("proof-pack-detail");
+    expect(metricEventsJson).toContain("proof-pack-markdown");
+    expect(metricEventsJson).toContain("proof-pack-report-input");
+    expect(metricEventsJson).toContain("proof-pack-ai-evidence");
+    expect(metricEventsJson).not.toContain("ppack_1");
+    expect(metricEventsJson).not.toContain("sha256:proof-pack");
+    expect(metricEventsJson).not.toContain("rr_1");
   });
 
   it("requests DPM outcome-review AI narrative through the Gateway BFF", async () => {

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -66,6 +66,14 @@ promote dormant labels into product ownership just because historical route file
   method statuses, comparison metrics, objective/constraint trace counts, supportability, and
   selected-alternative state, and records PM selection through Gateway. It does not synthesize
   source snapshots, prices, optimizer results, supportability, or selection truth locally.
+- RFC-0098/RFC-0040 proof-pack evidence rendering is implemented on `/workbench/{portfolioId}`
+  through Gateway `/api/v1/dpm/command-center/proof-packs*`. Workbench renders manage-owned
+  proof-pack id, status, content hash, section states, source hashes, Markdown availability,
+  report-input readiness, and AI-evidence readiness. Browser code may trigger Gateway proof-pack
+  generation from a linked rebalance run and load Gateway-provided Markdown/report/AI evidence
+  payload posture, but it does not rebuild proof-pack sections, compute hashes, synthesize
+  Markdown, construct report input, construct AI evidence, construct AI prompts, materialize PDF
+  reports, or call `lotus-manage`, `lotus-report`, or `lotus-ai` directly.
 - RFC-0098/RFC-0041 action-register supportability is rendered on `/workbench/{portfolioId}` from
   the Gateway portfolio overview `rebalance_snapshot`. The rebalance status panel shows
   manage-owned status, source support state, freshness, run count, operation count, workflow
@@ -113,7 +121,7 @@ Data products:
 http://workbench.dev.lotus/data-products
 ```
 
-Workbench construction alternatives and outcome review:
+Workbench construction alternatives, proof-pack evidence, and outcome review:
 
 ```txt
 http://workbench.dev.lotus/workbench/PB_SG_GLOBAL_BAL_001

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -16,8 +16,8 @@
 - primary product client for Lotus
 - Portfolio and Performance are the most mature active front-office surfaces
 - `/data-products` provides gateway-backed domain-product discovery and live trust posture
-- `/workbench/{portfolioId}` includes Gateway-backed DPM construction alternatives and
-  outcome-review panels for manage-owned operating evidence
+- `/workbench/{portfolioId}` includes Gateway-backed DPM construction alternatives, proof-pack
+  evidence, and outcome-review panels for manage-owned operating evidence
 - recommendations and proposals remain compatibility routes, not the main supported shell apps
 - shell navigation currently treats `Proposal` and `Advisory` as disabled capability-gated entries
 

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -91,9 +91,10 @@ must travel through Gateway-shaped contracts.
     source-refresh posture also remain manage-owned, while AI narrative execution remains
     `lotus-ai` owned; both must reach Workbench through Gateway outcome-review composition only.
     The implemented Workbench construction panel consumes the Gateway construction alternative-set
-    contracts, and the implemented outcome panel consumes the Gateway outcome-review list and
-    AI-narrative contracts. Workbench must not calculate expected-versus-realized values, construct
-    prompts, infer PM quality, or optimize construction alternatives.
+    contracts, the implemented proof-pack panel consumes the Gateway proof-pack generation,
+    detail, Markdown, report-input, and AI-evidence contracts, and the implemented outcome panel
+    consumes the Gateway outcome-review list and AI-narrative contracts. Workbench must not calculate expected-versus-realized values. It must not rebuild proof-pack sections, compute
+    proof-pack hashes, construct prompts, infer PM quality, or optimize construction alternatives.
 16. The implemented RFC-0038 mandate command-center cockpit consumes Gateway
     `/api/v1/dpm/command-center`, `/monitoring/run-once`, `/exceptions`, and `/mandates*`
     contracts. Workbench renders manage-owned health distribution, source readiness,
@@ -118,6 +119,7 @@ flowchart TB
   Render[PDF render readiness]
   Manage[Strategic DPM proof packs, waves, and outcome reviews]
   Construction[Construction alternatives lab]
+  ProofPacks[Proof-pack evidence panel]
   Waves[Future rebalance-wave workspace]
   Outcomes[Post-trade outcome panel]
   Advise[Advisor-led proposal workflows]
@@ -127,10 +129,12 @@ flowchart TB
   Workbench --> DpmCenter
   Workbench -->|/api/bff/api/v1/dpm/command-center*| Gateway
   Workbench -->|/api/bff/api/v1/dpm/command-center/construction/alternative-sets*| Gateway
+  Workbench -->|/api/bff/api/v1/dpm/command-center/proof-packs*| Gateway
   Workbench -->|/api/bff/api/v1/dpm/command-center/outcome-reviews*| Gateway
   Workbench -->|AI narrative action via Gateway only| Gateway
   DpmCenter --> Waves
   DpmCenter --> Construction
+  DpmCenter --> ProofPacks
   DpmCenter --> Outcomes
   DpmCenter -->|Gateway RFC-0098 contract| Gateway
   Gateway --> Core

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -24,8 +24,9 @@ This repo does not own:
 
 - gateway-first product client
 - Portfolio and Performance are the active front-office paths
-- `/workbench/{portfolioId}` includes Gateway/manage-backed DPM construction alternatives and
-  post-trade outcome-review panels without direct Workbench calls to manage, report, archive, or AI
+- `/workbench/{portfolioId}` includes Gateway/manage-backed DPM construction alternatives,
+  proof-pack evidence, and post-trade outcome-review panels without direct Workbench calls to
+  manage, report, archive, or AI
 - `/workbench/{portfolioId}` surfaces Gateway-provided manage action-register supportability in the
   rebalance status panel, including source state, freshness, run/operation/decision counts, last-run
   identity, bounded recent runs, workflow posture, run issue count, and explicit unknown/N/A or

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -13,8 +13,11 @@
 ## Next priorities
 
 1. keep strengthening Portfolio and Performance truth and density
-2. promote the embedded RFC-0039 construction alternatives lab and RFC-0042 outcome-review panel
-   with canonical live evidence and screenshots, then continue RFC-0098 DPM command-center
-   realization for proof packs and rebalance-wave orchestration as Gateway contracts mature
+2. promote the embedded RFC-0039 construction alternatives lab, RFC-0040 proof-pack evidence
+   panel, and RFC-0042 outcome-review panel with canonical live evidence and screenshots, then
+   continue RFC-0098 DPM command-center realization for rebalance-wave orchestration as Gateway
+   contracts mature
+   - manage-owned RFC-0040 proof-pack evidence is now rendered through Gateway in Workbench; the
+     remaining roadmap focus is canonical proof promotion and wave orchestration.
 3. preserve gateway-first integration discipline
 4. continue aligning route ownership to the product architecture blueprint


### PR DESCRIPTION
## Summary
- add Gateway-backed RFC-0040 proof-pack API wrappers, typed view model, and Proof-Pack Evidence panel on `/workbench/{portfolioId}`
- wire proof-pack validation into canonical live Workbench browser workflows and bounded analytics UI observability
- update RFC-0098, README, repo context, and wiki source to describe the implementation-backed proof-pack panel

## Evidence
- `npm test -- --run tests/unit/proof-pack-view-model.test.ts tests/unit/proof-pack-panel.test.tsx tests/unit/workbench-api.test.ts tests/unit/analytics-observability-metrics.test.ts tests/integration/workbench-page.test.tsx` - 70 passed
- `python -m pytest tests/unit/test_rfc0098_documentation.py -q` - 1 passed
- `npm run typecheck` - passed
- `npm run lint` - passed
- `git diff --check` - passed; normal LF-to-CRLF warnings only
- `make check` - passed: lint, typecheck, 725 coverage-backed tests, production build
- `C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` - expected drift on API-Surface.md, Home.md, Integrations.md, Overview.md, Roadmap.md because repo-local wiki source changed and must be published after merge

## Stranded Truth
- `git fetch origin --prune; git branch -r --no-merged origin/main` returned no unmerged governance branches in lotus-workbench before implementation and before PR.

## Coordination
- Requires sgajbi/lotus-platform PR for `dpm.proof_pack` panel registry and canonical invariant updates before live canonical proof can classify the panel.