### PR TITLE
Fix proof-pack live validation identity boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Boundary rules that matter:
    for manage-owned proof-pack identity, section posture, content hash, source hashes, Markdown,
    report-input posture, and AI-evidence posture. Workbench renders Gateway/manage truth and does
    not generate proof-pack sections, hashes, report inputs, AI evidence, narratives, or reports
-   locally.
+   locally. It generates RFC-0040 proof packs from Gateway-linked rebalance-run references and does
+   not treat RFC-0042 outcome-review `dpp_*` proof ids as RFC-0040 proof-pack ids.
 6. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0042 post-trade outcome-review
    panel for manage-owned expected-versus-realized dimensions, source lineage, supportability,
    and report/AI handoff posture. Workbench renders the Gateway contract and does not calculate

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -62,7 +62,9 @@ Current repository posture:
 9. `/workbench/{portfolioId}` renders the RFC-0040 proof-pack evidence panel from Gateway
    `/api/v1/dpm/command-center/proof-packs*`, preserving manage-owned proof-pack identity,
    section posture, content hash, source hashes, Markdown availability, report-input readiness,
-   and AI-evidence readiness without client-side proof-pack construction, hash generation,
+   and AI-evidence readiness after Gateway generates or returns an RFC-0040 proof pack for a
+   linked rebalance run. Workbench does not treat RFC-0042 outcome-review `dpp_*` proof ids as
+   RFC-0040 proof-pack ids, and it avoids client-side proof-pack construction, hash generation,
    Markdown synthesis, report-input synthesis, AI-evidence synthesis, or direct calls to
    `lotus-manage`, `lotus-report`, or `lotus-ai`,
 10. `/workbench/{portfolioId}` renders the RFC-0039 DPM construction alternatives lab from Gateway

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -311,14 +311,16 @@ canonical screenshots, accessibility checks, and live validation pass.
 
 Implementation note as of 2026-05-07: the first RFC-0040 proof-pack review realization is embedded
 in `/workbench/{portfolioId}` using Gateway `/api/v1/dpm/command-center/proof-packs*`.
-Workbench derives the launch context from Gateway outcome-review proof-pack and rebalance-run
-references, can trigger Gateway proof-pack generation for the linked run, and renders
+Workbench derives the launch context from Gateway outcome-review rebalance-run references and can
+trigger Gateway proof-pack generation for the linked run. Outcome-review proof ids such as
+RFC-0042 `dpp_*` references are not treated as RFC-0040 proof-pack ids. Workbench renders
 Gateway/manage proof-pack identity, status, content hash, section states, source hashes, Markdown
-availability, report-input readiness, and AI-evidence readiness. Browser code does not rebuild
-proof-pack sections, compute hashes, synthesize Markdown, construct report input, construct AI
-evidence, construct prompts, materialize reports, or call `lotus-manage`, `lotus-report`, or
-`lotus-ai` directly. The live canonical validator now registers the `dpm.proof_pack` panel against
-the governed Workbench panel registry.
+availability, report-input readiness, and AI-evidence readiness only after Gateway returns the
+generated proof-pack payload. Browser code does not rebuild proof-pack sections, compute hashes,
+synthesize Markdown, construct report input, construct AI evidence, construct prompts, materialize
+reports, or call `lotus-manage`, `lotus-report`, or `lotus-ai` directly. The live canonical
+validator now generates an RFC-0040 proof pack from the Gateway-linked rebalance run before
+registering the `dpm.proof_pack` panel against the governed Workbench panel registry.
 
 ### 7.0B Rebalance Wave Command Center Addendum
 

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -79,6 +79,19 @@ async function fetchOptionalJson(description, url) {
   }
 }
 
+function readString(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function extractGeneratedProofPackId(response) {
+  return (
+    readString(response?.data?.proof_pack?.proof_pack_id) ||
+    readString(response?.data?.proof_pack_id) ||
+    readString(response?.supportability?.proof_pack_id) ||
+    null
+  );
+}
+
 async function run() {
   await ensureDirectory(outputDir);
 
@@ -243,9 +256,33 @@ async function run() {
   if (!Array.isArray(outcomeReviewItems) || outcomeReviewItems.length < 1) {
     throw new Error("DPM outcome-review list returned no manage-backed reviews.");
   }
-  const proofPackId = outcomeReviewItems.find((item) => item?.proof_pack_id)?.proof_pack_id;
+  const proofPackSourceReview = outcomeReviewItems.find((item) => item?.rebalance_run_id);
+  const rebalanceRunId = readString(proofPackSourceReview?.rebalance_run_id);
+  if (!rebalanceRunId) {
+    throw new Error("DPM outcome-review list returned no rebalance-run reference for proof-pack generation.");
+  }
+  const generatedProofPack = await postJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/dpm/command-center/proof-packs`,
+    "Generate DPM proof-pack evidence",
+    timeoutMs,
+    {
+      idempotency_key: `live-canonical-proof-pack-${rebalanceRunId}`,
+      body: {
+        source_type: "REBALANCE_RUN",
+        rebalance_run_id: rebalanceRunId,
+        mandate_id: readString(proofPackSourceReview?.mandate_id) ?? undefined,
+        include_markdown: true,
+        include_report_input: true,
+        include_ai_evidence_input: true,
+        actor_id: "workbench-live-validator",
+        reason: "Canonical Workbench live validation generated an RFC-0040 proof pack from Gateway truth.",
+      },
+    }
+  );
+  const proofPackId = extractGeneratedProofPackId(generatedProofPack);
   if (!proofPackId) {
-    throw new Error("DPM outcome-review list returned no proof-pack reference.");
+    throw new Error("DPM proof-pack generation returned no proof-pack reference.");
   }
   const proofPack = await fetchJson(
     summary,

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -465,6 +465,12 @@ export async function validateProofPackPanel(
   await expect(proofPackPanel.getByText(/AI Evidence (Available|Unavailable)/)).toBeVisible({
     timeout: timeoutMs,
   });
+  await proofPackPanel.getByRole("button", { name: "Generate proof pack" }).click({
+    timeout: timeoutMs,
+  });
+  await expect(proofPackPanel.getByText("Proof-pack generation completed through Gateway.")).toBeVisible({
+    timeout: timeoutMs,
+  });
   await assertTableHasRows(
     tableByExactLabel(page, "Proof-pack sections"),
     1,

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -4,7 +4,6 @@ import {
   getDpmMandateByPortfolio,
   getDpmMandateHealth,
   getDpmOutcomeReviews,
-  getDpmProofPack,
   getPortfolio360,
   getReportingSnapshot,
   getWorkbenchAnalytics,
@@ -89,8 +88,6 @@ export default async function WorkbenchPage({
   let dpmCommandCenterError: string | null = null;
   let outcomeReviews: Awaited<ReturnType<typeof getDpmOutcomeReviews>> | null = null;
   let outcomeReviewError: string | null = null;
-  let proofPack: Awaited<ReturnType<typeof getDpmProofPack>> | null = null;
-  let proofPackError: string | null = null;
   try {
     data = await getPortfolio360(portfolioId, sessionId);
   } catch (error) {
@@ -177,17 +174,6 @@ export default async function WorkbenchPage({
     outcomeReviews = null;
     outcomeReviewError =
       error instanceof Error ? error.message : "Outcome review endpoint unavailable.";
-  }
-
-  const primaryProofPackId = readPrimaryProofPackId(outcomeReviews?.data ?? null);
-  if (primaryProofPackId) {
-    try {
-      proofPack = await getDpmProofPack(primaryProofPackId, "server");
-    } catch (error) {
-      proofPack = null;
-      proofPackError =
-        error instanceof Error ? error.message : "Proof-pack endpoint unavailable.";
-    }
   }
 
   const dpmMandateId = readDpmMandateId(dpmMandate?.data ?? null);
@@ -324,8 +310,8 @@ export default async function WorkbenchPage({
                 portfolioId={data.portfolio.portfolio_id}
                 mandateId={dpmMandateId}
                 outcomeReviews={outcomeReviews}
-                initialProofPack={proofPack}
-                errorMessage={proofPackError}
+                initialProofPack={null}
+                errorMessage={null}
               />
 
               <OutcomeReviewPanel
@@ -440,24 +426,6 @@ export default async function WorkbenchPage({
       </WorkbenchPageFrame>
     </main>
   );
-}
-
-function readPrimaryProofPackId(data: Record<string, unknown> | null): string | null {
-  if (!data) {
-    return null;
-  }
-  const items = Array.isArray(data.items) ? data.items : [];
-  for (const item of items) {
-    if (item && typeof item === "object" && !Array.isArray(item)) {
-      const proofPackId = (item as Record<string, unknown>).proof_pack_id;
-      if (typeof proofPackId === "string" && proofPackId.trim().length > 0) {
-        return proofPackId;
-      }
-    }
-  }
-  return typeof data.proof_pack_id === "string" && data.proof_pack_id.trim().length > 0
-    ? data.proof_pack_id
-    : null;
 }
 
 function readDpmMandateId(data: Record<string, unknown> | null): string | null {

--- a/src/features/workbench/proof-pack-view-model.ts
+++ b/src/features/workbench/proof-pack-view-model.ts
@@ -61,10 +61,10 @@ export function deriveProofPackContext(
   outcomeReviews: DpmOutcomeReviewGatewayResponse | null
 ): ProofPackContext {
   const review = extractOutcomeReviewRecords(outcomeReviews?.data ?? {}).find(
-    (record) => readString(record, "proof_pack_id") || readString(record, "rebalance_run_id")
+    (record) => readString(record, "rebalance_run_id")
   );
   return {
-    proofPackId: review ? readString(review, "proof_pack_id") || null : null,
+    proofPackId: null,
     rebalanceRunId: review ? readString(review, "rebalance_run_id") || null : null,
     mandateId: review ? readString(review, "mandate_id") || null : null,
   };

--- a/tests/integration/workbench-page.test.tsx
+++ b/tests/integration/workbench-page.test.tsx
@@ -169,7 +169,7 @@ describe("WorkbenchPage", () => {
                     state: "READY",
                     portfolio_id: "PF_1001",
                     rebalance_run_id: "run_001",
-                    proof_pack_id: "ppack_1",
+                    proof_pack_id: "dpp_rfc0042_1",
                     expected_snapshot_hash: "sha256:expected",
                     realized_snapshot_hash: "sha256:realized",
                     dimension_results: [
@@ -264,8 +264,8 @@ describe("WorkbenchPage", () => {
       "Source Readiness Blocked"
     );
     expect(screen.getByRole("heading", { name: "Proof-Pack Evidence" })).toBeInTheDocument();
-    expect(screen.getByText("investment_policy")).toBeInTheDocument();
-    expect(screen.getAllByText("sha256:proof-pack").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Proof-pack evidence is unavailable")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Generate proof pack" })).toBeEnabled();
     expect(screen.getByText("ATTENTION")).toBeInTheDocument();
     expect(screen.getByText("Partial Data Warning")).toBeInTheDocument();
     expect(screen.getAllByText(/UPSTREAM_TIMEOUT/).length).toBeGreaterThanOrEqual(1);

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -323,7 +323,11 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain("DPM Command Center");
     expect(browserWorkflowModule).toContain("DPM attention queue");
     expect(browserWorkflowModule).toContain("DPM mandate health dimensions");
+    expect(script).toContain("Generate DPM proof-pack evidence");
+    expect(script).toContain("live-canonical-proof-pack");
+    expect(script).toContain("source_type: \"REBALANCE_RUN\"");
     expect(browserWorkflowModule).toContain("screenshotRegisteredPanel");
+    expect(browserWorkflowModule).toContain("Proof-pack generation completed through Gateway.");
     expect(browserWorkflowModule).toContain("resolveRegistryRoute");
     expect(browserWorkflowModule).toContain("assertRailModeActive");
     expect(browserWorkflowModule).toContain("tableByExactLabel");

--- a/tests/unit/proof-pack-panel.test.tsx
+++ b/tests/unit/proof-pack-panel.test.tsx
@@ -38,7 +38,7 @@ const outcomeReviews: DpmOutcomeReviewGatewayResponse = {
     items: [
       {
         outcome_review_id: "or_1",
-        proof_pack_id: "ppack_1",
+        proof_pack_id: "dpp_rfc0042_1",
         rebalance_run_id: "rr_1",
         mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001",
       },

--- a/tests/unit/proof-pack-view-model.test.ts
+++ b/tests/unit/proof-pack-view-model.test.ts
@@ -106,7 +106,7 @@ describe("proof pack view model", () => {
         items: [
           {
             outcome_review_id: "or_1",
-            proof_pack_id: "ppack_1",
+            proof_pack_id: "dpp_rfc0042_1",
             rebalance_run_id: "rr_1",
             mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001",
           },
@@ -115,7 +115,7 @@ describe("proof pack view model", () => {
     };
 
     expect(deriveProofPackContext(outcomeReviews)).toEqual({
-      proofPackId: "ppack_1",
+      proofPackId: null,
       rebalanceRunId: "rr_1",
       mandateId: "MANDATE_PB_SG_GLOBAL_BAL_001",
     });

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -18,6 +18,10 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     assert "proof_pack_evidence" in rfc
     assert "first RFC-0040 proof-pack review realization is embedded" in rfc
     assert "`/api/v1/dpm/command-center/proof-packs*`" in rfc
+    assert "Outcome-review proof ids such as" in rfc
+    assert "does not treat RFC-0042 outcome-review `dpp_*` proof ids as RFC-0040" in (
+        ROOT / "wiki" / "API-Surface.md"
+    ).read_text(encoding="utf-8")
     assert "`dpm.proof_pack`" in rfc
     assert "RFC-0040 PROOF-PACK PANEL" in index
     assert "Post-Trade Outcome Review Workspace Addendum" in rfc

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -71,9 +71,10 @@ promote dormant labels into product ownership just because historical route file
   proof-pack id, status, content hash, section states, source hashes, Markdown availability,
   report-input readiness, and AI-evidence readiness. Browser code may trigger Gateway proof-pack
   generation from a linked rebalance run and load Gateway-provided Markdown/report/AI evidence
-  payload posture, but it does not rebuild proof-pack sections, compute hashes, synthesize
-  Markdown, construct report input, construct AI evidence, construct AI prompts, materialize PDF
-  reports, or call `lotus-manage`, `lotus-report`, or `lotus-ai` directly.
+  payload posture; it does not treat RFC-0042 outcome-review `dpp_*` proof ids as RFC-0040
+  proof-pack ids. It does not rebuild proof-pack sections, compute hashes, synthesize Markdown,
+  construct report input, construct AI evidence, construct AI prompts, materialize PDF reports, or
+  call `lotus-manage`, `lotus-report`, or `lotus-ai` directly.
 - RFC-0098/RFC-0041 action-register supportability is rendered on `/workbench/{portfolioId}` from
   the Gateway portfolio overview `rebalance_snapshot`. The rebalance status panel shows
   manage-owned status, source support state, freshness, run count, operation count, workflow


### PR DESCRIPTION
## Summary
- generate RFC-0040 DPM proof-pack evidence from the Gateway-linked rebalance run during canonical live validation
- stop treating RFC-0042 outcome-review `dpp_*` ids as RFC-0040 proof-pack ids in the Workbench server render path
- update README, RFC-0098, repository context, wiki API truth, and regression tests for the proof-pack identity boundary

## Validation
- `npm test -- --run tests/unit/proof-pack-view-model.test.ts tests/unit/proof-pack-panel.test.tsx tests/integration/workbench-page.test.tsx tests/unit/live-canonical-validation-script.test.ts` -> 23 passed
- `python -m pytest tests/unit/test_rfc0098_documentation.py -q` -> 1 passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `git diff --check` -> passed; only normal LF-to-CRLF warnings
- `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` -> expected drift for repo-local `wiki/API-Surface.md` until merge/publish

## Diagnostic Context
- Previous governed canonical proof failed in `lotus-platform/output/front-office-qa/canonical-front-office-qa-20260507-090516.json` because validation fetched `/api/v1/dpm/command-center/proof-packs/dpp_rfc0042_3e86b870ef` and correctly received 404. This PR fixes that identity boundary before rerunning canonical proof with rebuilt images.