### PR TITLE
Use Workbench rebalance run for proof-pack generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Boundary rules that matter:
    for manage-owned proof-pack identity, section posture, content hash, source hashes, Markdown,
    report-input posture, and AI-evidence posture. Workbench renders Gateway/manage truth and does
    not generate proof-pack sections, hashes, report inputs, AI evidence, narratives, or reports
-   locally. It generates RFC-0040 proof packs from Gateway-linked rebalance-run references and does
-   not treat RFC-0042 outcome-review `dpp_*` proof ids as RFC-0040 proof-pack ids.
+   locally. It generates RFC-0040 proof packs from the Gateway Workbench rebalance snapshot's
+   manage run id and does not treat RFC-0042 outcome-review `dpp_*` proof ids or expected-snapshot
+   run ids as RFC-0040 proof-pack sources.
 6. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0042 post-trade outcome-review
    panel for manage-owned expected-versus-realized dimensions, source lineage, supportability,
    and report/AI handoff posture. Workbench renders the Gateway contract and does not calculate

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -63,8 +63,9 @@ Current repository posture:
    `/api/v1/dpm/command-center/proof-packs*`, preserving manage-owned proof-pack identity,
    section posture, content hash, source hashes, Markdown availability, report-input readiness,
    and AI-evidence readiness after Gateway generates or returns an RFC-0040 proof pack for a
-   linked rebalance run. Workbench does not treat RFC-0042 outcome-review `dpp_*` proof ids as
-   RFC-0040 proof-pack ids, and it avoids client-side proof-pack construction, hash generation,
+   manage rebalance run surfaced by the Gateway Workbench rebalance snapshot. Workbench does not
+   treat RFC-0042 outcome-review `dpp_*` proof ids or expected-snapshot run ids as RFC-0040
+   proof-pack ids or proof-pack generation sources, and it avoids client-side proof-pack construction, hash generation,
    Markdown synthesis, report-input synthesis, AI-evidence synthesis, or direct calls to
    `lotus-manage`, `lotus-report`, or `lotus-ai`,
 10. `/workbench/{portfolioId}` renders the RFC-0039 DPM construction alternatives lab from Gateway

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -312,14 +312,16 @@ canonical screenshots, accessibility checks, and live validation pass.
 Implementation note as of 2026-05-07: the first RFC-0040 proof-pack review realization is embedded
 in `/workbench/{portfolioId}` using Gateway `/api/v1/dpm/command-center/proof-packs*`.
 Workbench derives the launch context from Gateway outcome-review rebalance-run references and can
-trigger Gateway proof-pack generation for the linked run. Outcome-review proof ids such as
-RFC-0042 `dpp_*` references are not treated as RFC-0040 proof-pack ids. Workbench renders
+trigger Gateway proof-pack generation for the linked run. The generation source is the manage
+rebalance run surfaced by the Gateway Workbench rebalance snapshot, not an RFC-0042
+expected-snapshot run id. Outcome-review proof ids such as RFC-0042 `dpp_*` references are not
+treated as RFC-0040 proof-pack ids. Workbench renders
 Gateway/manage proof-pack identity, status, content hash, section states, source hashes, Markdown
 availability, report-input readiness, and AI-evidence readiness only after Gateway returns the
 generated proof-pack payload. Browser code does not rebuild proof-pack sections, compute hashes,
 synthesize Markdown, construct report input, construct AI evidence, construct prompts, materialize
 reports, or call `lotus-manage`, `lotus-report`, or `lotus-ai` directly. The live canonical
-validator now generates an RFC-0040 proof pack from the Gateway-linked rebalance run before
+validator now generates an RFC-0040 proof pack from the Gateway Workbench rebalance snapshot before
 registering the `dpm.proof_pack` panel against the governed Workbench panel registry.
 
 ### 7.0B Rebalance Wave Command Center Addendum

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -92,6 +92,17 @@ function extractGeneratedProofPackId(response) {
   );
 }
 
+function extractWorkbenchRebalanceRunId(gatewayOverview) {
+  const snapshot = gatewayOverview?.rebalance_snapshot;
+  const latestRunId = readString(snapshot?.last_rebalance_run_id);
+  if (latestRunId) {
+    return latestRunId;
+  }
+  const recentRuns = Array.isArray(snapshot?.recent_runs) ? snapshot.recent_runs : [];
+  const recentRun = recentRuns.find((item) => readString(item?.rebalance_run_id));
+  return readString(recentRun?.rebalance_run_id);
+}
+
 async function run() {
   await ensureDirectory(outputDir);
 
@@ -256,10 +267,19 @@ async function run() {
   if (!Array.isArray(outcomeReviewItems) || outcomeReviewItems.length < 1) {
     throw new Error("DPM outcome-review list returned no manage-backed reviews.");
   }
-  const proofPackSourceReview = outcomeReviewItems.find((item) => item?.rebalance_run_id);
-  const rebalanceRunId = readString(proofPackSourceReview?.rebalance_run_id);
+  const gatewayOverview = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/overview`,
+    "Gateway workbench overview",
+    timeoutMs
+  );
+  if (gatewayOverview?.portfolio?.portfolio_id !== portfolioId) {
+    throw new Error("Gateway workbench overview returned no portfolio payload.");
+  }
+  const proofPackSourceReview = outcomeReviewItems.find((item) => readString(item?.mandate_id));
+  const rebalanceRunId = extractWorkbenchRebalanceRunId(gatewayOverview);
   if (!rebalanceRunId) {
-    throw new Error("DPM outcome-review list returned no rebalance-run reference for proof-pack generation.");
+    throw new Error("Gateway workbench overview returned no manage rebalance-run reference for proof-pack generation.");
   }
   const generatedProofPack = await postJson(
     summary,
@@ -276,7 +296,7 @@ async function run() {
         include_report_input: true,
         include_ai_evidence_input: true,
         actor_id: "workbench-live-validator",
-        reason: "Canonical Workbench live validation generated an RFC-0040 proof pack from Gateway truth.",
+        reason: "Canonical Workbench live validation generated an RFC-0040 proof pack from the Gateway Workbench rebalance snapshot.",
       },
     }
   );
@@ -399,15 +419,6 @@ async function run() {
     }
   }
 
-  const gatewayOverview = await fetchJson(
-    summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/overview`,
-    "Gateway workbench overview",
-    timeoutMs
-  );
-  if (gatewayOverview?.portfolio?.portfolio_id !== portfolioId) {
-    throw new Error("Gateway workbench overview returned no portfolio payload.");
-  }
   panelGovernance.recordPanelClassification("portfolio.summary", "ready", "lotus-gateway", {
     portfolioId,
   });

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -310,6 +310,7 @@ export default async function WorkbenchPage({
                 portfolioId={data.portfolio.portfolio_id}
                 mandateId={dpmMandateId}
                 outcomeReviews={outcomeReviews}
+                rebalanceSnapshot={data.rebalance_snapshot}
                 initialProofPack={null}
                 errorMessage={null}
               />

--- a/src/features/workbench/components/proof-pack-panel.tsx
+++ b/src/features/workbench/components/proof-pack-panel.tsx
@@ -20,6 +20,7 @@ import {
 import type {
   DpmOutcomeReviewGatewayResponse,
   DpmProofPackGatewayResponse,
+  WorkbenchOverview,
 } from "@/features/workbench/types";
 import {
   buildProofPackPanelModel,
@@ -31,6 +32,7 @@ type Props = {
   portfolioId: string;
   mandateId?: string | null;
   outcomeReviews: DpmOutcomeReviewGatewayResponse | null;
+  rebalanceSnapshot?: WorkbenchOverview["rebalance_snapshot"] | null;
   initialProofPack: DpmProofPackGatewayResponse | null;
   errorMessage?: string | null;
 };
@@ -86,10 +88,11 @@ export default function ProofPackPanel({
   portfolioId,
   mandateId,
   outcomeReviews,
+  rebalanceSnapshot,
   initialProofPack,
   errorMessage,
 }: Props) {
-  const context = deriveProofPackContext(outcomeReviews);
+  const context = deriveProofPackContext(outcomeReviews, rebalanceSnapshot ?? null);
   const [proofPack, setProofPack] = useState<DpmProofPackGatewayResponse | null>(initialProofPack);
   const [markdown, setMarkdown] = useState<string | null>(null);
   const [handoffStatus, setHandoffStatus] = useState<string | null>(null);

--- a/src/features/workbench/proof-pack-view-model.ts
+++ b/src/features/workbench/proof-pack-view-model.ts
@@ -1,6 +1,7 @@
 import type {
   DpmOutcomeReviewGatewayResponse,
   DpmProofPackGatewayResponse,
+  WorkbenchOverview,
 } from "./types";
 
 export type ProofPackPanelState =
@@ -58,14 +59,15 @@ export type ProofPackPanelModel = {
 };
 
 export function deriveProofPackContext(
-  outcomeReviews: DpmOutcomeReviewGatewayResponse | null
+  outcomeReviews: DpmOutcomeReviewGatewayResponse | null,
+  rebalanceSnapshot: WorkbenchOverview["rebalance_snapshot"] | null = null
 ): ProofPackContext {
   const review = extractOutcomeReviewRecords(outcomeReviews?.data ?? {}).find(
-    (record) => readString(record, "rebalance_run_id")
+    (record) => readString(record, "mandate_id")
   );
   return {
     proofPackId: null,
-    rebalanceRunId: review ? readString(review, "rebalance_run_id") || null : null,
+    rebalanceRunId: readRebalanceRunId(rebalanceSnapshot),
     mandateId: review ? readString(review, "mandate_id") || null : null,
   };
 }
@@ -190,6 +192,19 @@ function extractOutcomeReviewRecords(data: Record<string, unknown>): Record<stri
     return items;
   }
   return typeof data.outcome_review_id === "string" ? [data] : [];
+}
+
+function readRebalanceRunId(
+  snapshot: WorkbenchOverview["rebalance_snapshot"] | null
+): string | null {
+  if (!snapshot) {
+    return null;
+  }
+  if (snapshot.last_rebalance_run_id?.trim()) {
+    return snapshot.last_rebalance_run_id;
+  }
+  const recentRun = snapshot.recent_runs?.find((run) => run.rebalance_run_id?.trim());
+  return recentRun?.rebalance_run_id ?? null;
 }
 
 function buildSectionRow(record: Record<string, unknown>, index: number): ProofPackSectionRow {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -325,6 +325,8 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain("DPM mandate health dimensions");
     expect(script).toContain("Generate DPM proof-pack evidence");
     expect(script).toContain("live-canonical-proof-pack");
+    expect(script).toContain("extractWorkbenchRebalanceRunId");
+    expect(script).toContain("Gateway workbench overview returned no manage rebalance-run reference");
     expect(script).toContain("source_type: \"REBALANCE_RUN\"");
     expect(browserWorkflowModule).toContain("screenshotRegisteredPanel");
     expect(browserWorkflowModule).toContain("Proof-pack generation completed through Gateway.");

--- a/tests/unit/proof-pack-panel.test.tsx
+++ b/tests/unit/proof-pack-panel.test.tsx
@@ -90,6 +90,21 @@ const readyProofPack: DpmProofPackGatewayResponse = {
   },
 };
 
+const rebalanceSnapshot = {
+  status: "READY",
+  last_rebalance_run_id: "run_001",
+  last_run_at_utc: "2026-05-07T01:00:00Z",
+  recent_runs: [
+    {
+      rebalance_run_id: "run_001",
+      status: "READY",
+      created_at_utc: "2026-05-07T01:00:00Z",
+      error_code: null,
+      workflow_state: "REVIEW_READY",
+    },
+  ],
+};
+
 describe("ProofPackPanel", () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -101,6 +116,7 @@ describe("ProofPackPanel", () => {
         portfolioId="PB_SG_GLOBAL_BAL_001"
         mandateId="MANDATE_PB_SG_GLOBAL_BAL_001"
         outcomeReviews={outcomeReviews}
+        rebalanceSnapshot={rebalanceSnapshot}
         initialProofPack={readyProofPack}
       />
     );
@@ -115,7 +131,7 @@ describe("ProofPackPanel", () => {
     expect(screen.getByRole("button", { name: "Load Markdown" })).toBeEnabled();
   });
 
-  it("generates a proof pack from the outcome-review rebalance run", async () => {
+  it("generates a proof pack from the Workbench rebalance snapshot run", async () => {
     vi.mocked(generateDpmProofPackFromRun).mockResolvedValue(readyProofPack);
 
     render(
@@ -123,6 +139,7 @@ describe("ProofPackPanel", () => {
         portfolioId="PB_SG_GLOBAL_BAL_001"
         mandateId="MANDATE_PB_SG_GLOBAL_BAL_001"
         outcomeReviews={outcomeReviews}
+        rebalanceSnapshot={rebalanceSnapshot}
         initialProofPack={null}
       />
     );
@@ -130,7 +147,7 @@ describe("ProofPackPanel", () => {
 
     await waitFor(() => {
       expect(generateDpmProofPackFromRun).toHaveBeenCalledWith({
-        rebalanceRunId: "rr_1",
+        rebalanceRunId: "run_001",
         mandateId: "MANDATE_PB_SG_GLOBAL_BAL_001",
       });
     });
@@ -151,6 +168,7 @@ describe("ProofPackPanel", () => {
       <ProofPackPanel
         portfolioId="PB_SG_GLOBAL_BAL_001"
         outcomeReviews={outcomeReviews}
+        rebalanceSnapshot={rebalanceSnapshot}
         initialProofPack={readyProofPack}
       />
     );

--- a/tests/unit/proof-pack-view-model.test.ts
+++ b/tests/unit/proof-pack-view-model.test.ts
@@ -7,6 +7,7 @@ import {
 import type {
   DpmOutcomeReviewGatewayResponse,
   DpmProofPackGatewayResponse,
+  WorkbenchOverview,
 } from "../../src/features/workbench/types";
 
 const proofPackResponse: DpmProofPackGatewayResponse = {
@@ -89,7 +90,7 @@ describe("proof pack view model", () => {
     expect(model.aiEvidenceInputAvailable).toBe(true);
   });
 
-  it("derives proof-pack launch context from outcome reviews", () => {
+  it("derives proof-pack launch context from the Workbench rebalance snapshot", () => {
     const outcomeReviews: DpmOutcomeReviewGatewayResponse = {
       correlation_id: "corr-rfc42",
       contract_version: "v1",
@@ -113,10 +114,56 @@ describe("proof pack view model", () => {
         ],
       },
     };
+    const rebalanceSnapshot: WorkbenchOverview["rebalance_snapshot"] = {
+      status: "READY",
+      last_rebalance_run_id: "run_001",
+      last_run_at_utc: "2026-05-07T01:00:00Z",
+      recent_runs: [
+        {
+          rebalance_run_id: "run_001",
+          status: "READY",
+          created_at_utc: "2026-05-07T01:00:00Z",
+          error_code: null,
+          workflow_state: "REVIEW_READY",
+        },
+      ],
+    };
+
+    expect(deriveProofPackContext(outcomeReviews, rebalanceSnapshot)).toEqual({
+      proofPackId: null,
+      rebalanceRunId: "run_001",
+      mandateId: "MANDATE_PB_SG_GLOBAL_BAL_001",
+    });
+  });
+
+  it("does not use outcome-review run ids as proof-pack generation sources", () => {
+    const outcomeReviews: DpmOutcomeReviewGatewayResponse = {
+      correlation_id: "corr-rfc42",
+      contract_version: "v1",
+      source_service: "lotus-manage",
+      upstream_status: 200,
+      supportability: {
+        source_service: "lotus-manage",
+        authority: "lotus-manage:RFC-0042",
+        state: "SUPPORTED",
+        reason_codes: [],
+        blocked_actions: [],
+      },
+      data: {
+        items: [
+          {
+            outcome_review_id: "or_1",
+            proof_pack_id: "dpp_rfc0042_1",
+            rebalance_run_id: "rr_rfc0042_expected_snapshot",
+            mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001",
+          },
+        ],
+      },
+    };
 
     expect(deriveProofPackContext(outcomeReviews)).toEqual({
       proofPackId: null,
-      rebalanceRunId: "rr_1",
+      rebalanceRunId: null,
       mandateId: "MANDATE_PB_SG_GLOBAL_BAL_001",
     });
   });

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -19,7 +19,11 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     assert "first RFC-0040 proof-pack review realization is embedded" in rfc
     assert "`/api/v1/dpm/command-center/proof-packs*`" in rfc
     assert "Outcome-review proof ids such as" in rfc
-    assert "does not treat RFC-0042 outcome-review `dpp_*` proof ids as RFC-0040" in (
+    assert "Gateway Workbench rebalance snapshot" in rfc
+    assert "expected-snapshot run ids" in (
+        ROOT / "wiki" / "API-Surface.md"
+    ).read_text(encoding="utf-8")
+    assert "outcome-review `dpp_*` proof ids or expected-snapshot run ids as RFC-0040" in (
         ROOT / "wiki" / "API-Surface.md"
     ).read_text(encoding="utf-8")
     assert "`dpm.proof_pack`" in rfc

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -70,9 +70,10 @@ promote dormant labels into product ownership just because historical route file
   through Gateway `/api/v1/dpm/command-center/proof-packs*`. Workbench renders manage-owned
   proof-pack id, status, content hash, section states, source hashes, Markdown availability,
   report-input readiness, and AI-evidence readiness. Browser code may trigger Gateway proof-pack
-  generation from a linked rebalance run and load Gateway-provided Markdown/report/AI evidence
-  payload posture; it does not treat RFC-0042 outcome-review `dpp_*` proof ids as RFC-0040
-  proof-pack ids. It does not rebuild proof-pack sections, compute hashes, synthesize Markdown,
+  generation from the manage rebalance run surfaced by the Gateway Workbench rebalance snapshot and
+  load Gateway-provided Markdown/report/AI evidence payload posture; it does not treat RFC-0042
+  outcome-review `dpp_*` proof ids or expected-snapshot run ids as RFC-0040 proof-pack ids or
+  generation sources. It does not rebuild proof-pack sections, compute hashes, synthesize Markdown,
   construct report input, construct AI evidence, construct AI prompts, materialize PDF reports, or
   call `lotus-manage`, `lotus-report`, or `lotus-ai` directly.
 - RFC-0098/RFC-0041 action-register supportability is rendered on `/workbench/{portfolioId}` from


### PR DESCRIPTION
## Summary
- generate RFC-0040 proof packs from the Manage rebalance run exposed by Gateway Workbench overview/rebalance snapshot
- keep RFC-0042 outcome reviews as post-trade context only; do not use `dpp_*` proof ids or expected-snapshot run ids as proof-pack sources
- update Workbench proof-pack context, live validator, docs/wiki guardrails, and regression tests

## Validation
- `npm test -- --run tests/unit/proof-pack-view-model.test.ts tests/unit/proof-pack-panel.test.tsx tests/integration/workbench-page.test.tsx tests/unit/live-canonical-validation-script.test.ts` -> 24 passed
- `python -m pytest tests/unit/test_rfc0098_documentation.py -q` -> 1 passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `git diff --check` -> passed; only normal LF-to-CRLF warnings
- `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` -> expected drift for repo-local `wiki/API-Surface.md` until merge/publish

## Diagnostic Context
- Governed canonical proof after PR #157 reached the proof-pack POST path but failed with `DPM_RUN_NOT_FOUND` because live validation still used an RFC-0042 outcome-review run id. Evidence: `lotus-platform/output/front-office-qa/canonical-front-office-qa-20260507-093113.json`.