### PR TITLE
Accept reviewable proof-pack states in live validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Boundary rules that matter:
    not generate proof-pack sections, hashes, report inputs, AI evidence, narratives, or reports
    locally. It generates RFC-0040 proof packs from the Gateway Workbench rebalance snapshot's
    manage run id and does not treat RFC-0042 outcome-review `dpp_*` proof ids or expected-snapshot
-   run ids as RFC-0040 proof-pack sources.
+   run ids as RFC-0040 proof-pack sources. Reviewable Manage states such as `PENDING_REVIEW` are
+   displayed truthfully when the proof pack includes identity, sections, hashes/lineage, and handoff
+   posture.
 6. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0042 post-trade outcome-review
    panel for manage-owned expected-versus-realized dimensions, source lineage, supportability,
    and report/AI handoff posture. Workbench renders the Gateway contract and does not calculate

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -68,6 +68,8 @@ Current repository posture:
    proof-pack ids or proof-pack generation sources, and it avoids client-side proof-pack construction, hash generation,
    Markdown synthesis, report-input synthesis, AI-evidence synthesis, or direct calls to
    `lotus-manage`, `lotus-report`, or `lotus-ai`,
+   while preserving reviewable Manage business states such as `PENDING_REVIEW` when sections,
+   hashes/lineage, and handoff posture are present,
 10. `/workbench/{portfolioId}` renders the RFC-0039 DPM construction alternatives lab from Gateway
    `/api/v1/dpm/command-center/construction/alternative-sets*`. Workbench sends a stateful
    manage/core source selector through Gateway, preserves manage-owned alternatives,

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -323,6 +323,10 @@ synthesize Markdown, construct report input, construct AI evidence, construct pr
 reports, or call `lotus-manage`, `lotus-report`, or `lotus-ai` directly. The live canonical
 validator now generates an RFC-0040 proof pack from the Gateway Workbench rebalance snapshot before
 registering the `dpm.proof_pack` panel against the governed Workbench panel registry.
+Populated proof packs with manage business state `PENDING_REVIEW` or `DEGRADED` are valid product
+evidence when they include proof-pack identity, reviewable sections, source hashes or lineage, and
+handoff posture; Workbench must preserve that business state instead of relabelling it as fully
+ready.
 
 ### 7.0B Rebalance Wave Command Center Addendum
 

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -103,6 +103,15 @@ function extractWorkbenchRebalanceRunId(gatewayOverview) {
   return readString(recentRun?.rebalance_run_id);
 }
 
+function recordArrayCount(value) {
+  return Array.isArray(value) ? value.filter((item) => item && typeof item === "object").length : 0;
+}
+
+function isReviewableProofPackState(state) {
+  const normalized = readString(state)?.toUpperCase();
+  return normalized === "READY" || normalized === "PENDING_REVIEW" || normalized === "DEGRADED";
+}
+
 async function run() {
   await ensureDirectory(outputDir);
 
@@ -314,12 +323,19 @@ async function run() {
   if (!proofPackPayload?.proof_pack_id) {
     throw new Error("DPM proof-pack evidence returned no proof-pack identity.");
   }
+  const proofPackSectionCount = recordArrayCount(proofPackPayload.sections ?? proofPackPayload.section_posture);
+  const proofPackSourceHashCount = recordArrayCount(
+    proofPackPayload.source_hashes ?? proofPackPayload.source_lineage
+  );
+  if (proofPackSectionCount < 1) {
+    throw new Error("DPM proof-pack evidence returned no reviewable proof-pack sections.");
+  }
+  if (proofPackSourceHashCount < 1) {
+    throw new Error("DPM proof-pack evidence returned no source hashes or lineage references.");
+  }
   const proofPackSupportability = proofPack?.supportability;
-  if (
-    proofPackSupportability?.state &&
-    proofPackSupportability.state.toUpperCase() !== "READY"
-  ) {
-    throw new Error(`DPM proof-pack evidence returned non-ready state: ${proofPackSupportability.state}.`);
+  if (proofPackSupportability?.state && !isReviewableProofPackState(proofPackSupportability.state)) {
+    throw new Error(`DPM proof-pack evidence returned non-reviewable state: ${proofPackSupportability.state}.`);
   }
 
   const commandCenterParams = new URLSearchParams({
@@ -435,6 +451,9 @@ async function run() {
   panelGovernance.recordPanelClassification("dpm.proof_pack", "ready", "lotus-manage", {
     route: `/workbench/${portfolioId}`,
     proofPackId,
+    proofPackBusinessState: proofPackSupportability?.state ?? proofPackPayload.status ?? "UNKNOWN",
+    sectionCount: proofPackSectionCount,
+    sourceHashCount: proofPackSourceHashCount,
   });
   panelGovernance.recordPanelClassification("dpm.command_center", "ready", "lotus-manage", {
     route: `/workbench/${portfolioId}`,

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -326,6 +326,9 @@ describe("canonical live validation script", () => {
     expect(script).toContain("Generate DPM proof-pack evidence");
     expect(script).toContain("live-canonical-proof-pack");
     expect(script).toContain("extractWorkbenchRebalanceRunId");
+    expect(script).toContain("isReviewableProofPackState");
+    expect(script).toContain("PENDING_REVIEW");
+    expect(script).toContain("DPM proof-pack evidence returned no reviewable proof-pack sections.");
     expect(script).toContain("Gateway workbench overview returned no manage rebalance-run reference");
     expect(script).toContain("source_type: \"REBALANCE_RUN\"");
     expect(browserWorkflowModule).toContain("screenshotRegisteredPanel");

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -20,6 +20,7 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     assert "`/api/v1/dpm/command-center/proof-packs*`" in rfc
     assert "Outcome-review proof ids such as" in rfc
     assert "Gateway Workbench rebalance snapshot" in rfc
+    assert "Populated proof packs with manage business state `PENDING_REVIEW`" in rfc
     assert "expected-snapshot run ids" in (
         ROOT / "wiki" / "API-Surface.md"
     ).read_text(encoding="utf-8")

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -73,7 +73,9 @@ promote dormant labels into product ownership just because historical route file
   generation from the manage rebalance run surfaced by the Gateway Workbench rebalance snapshot and
   load Gateway-provided Markdown/report/AI evidence payload posture; it does not treat RFC-0042
   outcome-review `dpp_*` proof ids or expected-snapshot run ids as RFC-0040 proof-pack ids or
-  generation sources. It does not rebuild proof-pack sections, compute hashes, synthesize Markdown,
+  generation sources. Reviewable Manage business states such as `PENDING_REVIEW` remain valid
+  populated product evidence when proof-pack identity, sections, hashes/lineage, and handoff posture
+  are present. It does not rebuild proof-pack sections, compute hashes, synthesize Markdown,
   construct report input, construct AI evidence, construct AI prompts, materialize PDF reports, or
   call `lotus-manage`, `lotus-report`, or `lotus-ai` directly.
 - RFC-0098/RFC-0041 action-register supportability is rendered on `/workbench/{portfolioId}` from


### PR DESCRIPTION
## Summary
- accept populated Manage proof packs in reviewable business states (`READY`, `PENDING_REVIEW`, `DEGRADED`) during canonical validation
- continue rejecting empty proof-pack payloads by requiring proof-pack identity, reviewable sections, and source hashes or lineage
- update RFC, README, repository context, wiki API truth, and regression tests for review-state semantics

## Validation
- `npm test -- --run tests/unit/live-canonical-validation-script.test.ts` -> 11 passed
- `python -m pytest tests/unit/test_rfc0098_documentation.py -q` -> 1 passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `git diff --check` -> passed; only normal LF-to-CRLF warnings
- `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` -> expected drift for repo-local `wiki/API-Surface.md` until merge/publish

## Diagnostic Context
- After PR #158, canonical proof generated and retrieved a Manage proof pack but failed because the live validator rejected truthful `PENDING_REVIEW` business state. Evidence: `lotus-platform/output/front-office-qa/canonical-front-office-qa-20260507-095644.json`.