### PR TITLE
Normalize proof-pack source hash evidence

### DIFF
--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -107,6 +107,25 @@ function recordArrayCount(value) {
   return Array.isArray(value) ? value.filter((item) => item && typeof item === "object").length : 0;
 }
 
+function recordMapCount(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return 0;
+  }
+  return Object.values(value).filter((item) => {
+    if (typeof item === "string") {
+      return item.trim().length > 0;
+    }
+    return item !== null && item !== undefined;
+  }).length;
+}
+
+function sourceEvidenceCount(proofPackPayload) {
+  const sourceHashCount =
+    recordArrayCount(proofPackPayload.source_hashes) || recordMapCount(proofPackPayload.source_hashes);
+  const lineageCount = recordArrayCount(proofPackPayload.source_lineage);
+  return sourceHashCount + lineageCount;
+}
+
 function isReviewableProofPackState(state) {
   const normalized = readString(state)?.toUpperCase();
   return normalized === "READY" || normalized === "PENDING_REVIEW" || normalized === "DEGRADED";
@@ -324,9 +343,7 @@ async function run() {
     throw new Error("DPM proof-pack evidence returned no proof-pack identity.");
   }
   const proofPackSectionCount = recordArrayCount(proofPackPayload.sections ?? proofPackPayload.section_posture);
-  const proofPackSourceHashCount = recordArrayCount(
-    proofPackPayload.source_hashes ?? proofPackPayload.source_lineage
-  );
+  const proofPackSourceHashCount = sourceEvidenceCount(proofPackPayload);
   if (proofPackSectionCount < 1) {
     throw new Error("DPM proof-pack evidence returned no reviewable proof-pack sections.");
   }

--- a/src/features/workbench/proof-pack-view-model.ts
+++ b/src/features/workbench/proof-pack-view-model.ts
@@ -108,9 +108,9 @@ export function buildProofPackPanelModel(
     proofPack.sections ?? proofPack.section_posture ?? response.data.sections
   ).map(buildSectionRow);
   const sourceHashes = [
-    ...extractRecordArray(proofPack.source_hashes),
+    ...extractSourceHashRecords(proofPack.source_hashes),
     ...extractRecordArray(proofPack.source_lineage),
-    ...extractRecordArray(response.data.source_hashes),
+    ...extractSourceHashRecords(response.data.source_hashes),
   ].map(buildSourceHashRow);
   const contentHash =
     readString(proofPack, "content_hash") ||
@@ -270,6 +270,21 @@ function extractRecordArray(value: unknown): Record<string, unknown>[] {
     return [];
   }
   return value.filter(isRecord);
+}
+
+function extractSourceHashRecords(value: unknown): Record<string, unknown>[] {
+  if (Array.isArray(value)) {
+    return value.filter(isRecord);
+  }
+  if (!isRecord(value)) {
+    return [];
+  }
+  return Object.entries(value)
+    .filter(([, hash]) => typeof hash === "string" && hash.trim().length > 0)
+    .map(([sourceRef, hash]) => ({
+      source_ref: sourceRef,
+      hash,
+    }));
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -327,6 +327,8 @@ describe("canonical live validation script", () => {
     expect(script).toContain("live-canonical-proof-pack");
     expect(script).toContain("extractWorkbenchRebalanceRunId");
     expect(script).toContain("isReviewableProofPackState");
+    expect(script).toContain("recordMapCount");
+    expect(script).toContain("sourceEvidenceCount");
     expect(script).toContain("PENDING_REVIEW");
     expect(script).toContain("DPM proof-pack evidence returned no reviewable proof-pack sections.");
     expect(script).toContain("Gateway workbench overview returned no manage rebalance-run reference");

--- a/tests/unit/proof-pack-panel.test.tsx
+++ b/tests/unit/proof-pack-panel.test.tsx
@@ -79,13 +79,9 @@ const readyProofPack: DpmProofPackGatewayResponse = {
           content_hash: "sha256:policy",
         },
       ],
-      source_hashes: [
-        {
-          source_service: "lotus-risk",
-          source_ref: "risk_snapshot_1",
-          hash: "sha256:risk",
-        },
-      ],
+      source_hashes: {
+        risk_snapshot_1: "sha256:risk",
+      },
     },
   },
 };

--- a/tests/unit/proof-pack-view-model.test.ts
+++ b/tests/unit/proof-pack-view-model.test.ts
@@ -46,13 +46,9 @@ const proofPackResponse: DpmProofPackGatewayResponse = {
           content_hash: "sha256:policy",
         },
       ],
-      source_hashes: [
-        {
-          source_service: "lotus-risk",
-          source_ref: "risk_snapshot_1",
-          hash: "sha256:risk",
-        },
-      ],
+      source_hashes: {
+        risk_snapshot_1: "sha256:risk",
+      },
     },
   },
 };
@@ -79,8 +75,8 @@ describe("proof pack view model", () => {
     ]);
     expect(model.sourceHashes).toEqual([
       {
-        key: "lotus-risk-risk_snapshot_1-0",
-        source: "lotus-risk",
+        key: "N/A-risk_snapshot_1-0",
+        source: "N/A",
         reference: "risk_snapshot_1",
         hash: "sha256:risk",
       },


### PR DESCRIPTION
## Summary
- normalize Manage RFC-0040 source_hashes dictionaries into Workbench proof-pack source-hash rows
- count dictionary-shaped source hashes as source evidence in canonical live validation
- cover dictionary source hashes in proof-pack panel/view-model and live-validator tests

## Validation
- npm test -- --run tests/unit/proof-pack-view-model.test.ts tests/unit/proof-pack-panel.test.tsx tests/unit/live-canonical-validation-script.test.ts
- npm run typecheck
- npm run lint
- git diff --check