### PR TITLE
Scope outcome review live selectors

### DIFF
--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -402,8 +402,12 @@ export async function validateOutcomeReviewPanel(
     1,
     "Outcome review source lineage"
   );
-  await expect(page.getByText("Report Input")).toBeVisible({ timeout: timeoutMs });
-  await expect(page.getByText("AI Evidence")).toBeVisible({ timeout: timeoutMs });
+  await expect(outcomeReviewPanel.getByText("Report Input", { exact: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(outcomeReviewPanel.getByText("AI Evidence", { exact: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
   await screenshotRegisteredPanel(page, "dpm.outcome_review");
 }
 

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -340,6 +340,7 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain("tableByExactLabel");
     expect(browserWorkflowModule).toContain("requireVisible");
     expect(browserWorkflowModule).toContain("Observation Trail");
+    expect(browserWorkflowModule).toContain('outcomeReviewPanel.getByText("Report Input", { exact: true })');
     expect(browserWorkflowModule).toContain("performAcceptReviewActionProof");
     expect(browserWorkflowModule).toContain("Accept Brief");
     expect(browserWorkflowModule).toContain("hasAcceptedAdvisorBriefReviewPosture");


### PR DESCRIPTION
## Summary
- scope outcome-review Report Input and AI Evidence assertions to the outcome-review panel
- use exact text matching so proof-pack controls and table headers do not create strict-mode ambiguity
- add live-validator coverage for the scoped selector pattern

## Validation
- npm test -- --run tests/unit/live-canonical-validation-script.test.ts
- npm run typecheck
- npm run lint
- git diff --check