### PR TITLE
Stabilize DPM live panel locators

### DIFF
--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -98,6 +98,10 @@ function tableByExactLabel(page, label) {
   return page.locator(`table[aria-label="${label}"]`);
 }
 
+function workbenchPanelByClass(page, className) {
+  return page.locator(`article.${className}`).first();
+}
+
 export async function validatePortfolioPanels(
   page,
   {
@@ -378,7 +382,7 @@ export async function validateOutcomeReviewPanel(
     waitUntil: "networkidle",
     timeout: timeoutMs,
   });
-  const outcomeReviewPanel = page.getByRole("group", { name: "Post-Trade Outcome Review" });
+  const outcomeReviewPanel = workbenchPanelByClass(page, "outcome-review-panel");
   await expect(
     outcomeReviewPanel.getByRole("heading", { name: "Post-Trade Outcome Review" })
   ).toBeVisible({
@@ -456,7 +460,7 @@ export async function validateProofPackPanel(
     waitUntil: "networkidle",
     timeout: timeoutMs,
   });
-  const proofPackPanel = page.getByRole("group", { name: "Proof-Pack Evidence" });
+  const proofPackPanel = workbenchPanelByClass(page, "proof-pack-panel");
   await expect(proofPackPanel.getByRole("heading", { name: "Proof-Pack Evidence" })).toBeVisible({
     timeout: timeoutMs,
   });

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -338,6 +338,9 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain("resolveRegistryRoute");
     expect(browserWorkflowModule).toContain("assertRailModeActive");
     expect(browserWorkflowModule).toContain("tableByExactLabel");
+    expect(browserWorkflowModule).toContain("workbenchPanelByClass");
+    expect(browserWorkflowModule).toContain('workbenchPanelByClass(page, "outcome-review-panel")');
+    expect(browserWorkflowModule).toContain('workbenchPanelByClass(page, "proof-pack-panel")');
     expect(browserWorkflowModule).toContain("requireVisible");
     expect(browserWorkflowModule).toContain("Observation Trail");
     expect(browserWorkflowModule).toContain('outcomeReviewPanel.getByText("Report Input", { exact: true })');
@@ -349,6 +352,8 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain("/^Performance Overview/");
     expect(browserWorkflowModule).toContain("/^Performance Analysis/");
     expect(browserWorkflowModule).toContain('"Asset Class attribution table"');
+    expect(browserWorkflowModule).not.toContain('getByRole("group", { name: "Post-Trade Outcome Review"');
+    expect(browserWorkflowModule).not.toContain('getByRole("group", { name: "Proof-Pack Evidence"');
     expect(browserWorkflowModule).not.toContain('getByRole("tab", { name: "Summary"');
     expect(contractModule).toContain('panelId: "performance.risk.snapshot"');
     expect(contractModule).toContain('screenshotName: "performance-risk-live.png"');


### PR DESCRIPTION
## Summary
- Replace accidental ARIA group lookup for DPM outcome-review and proof-pack panels with stable Workbench panel-class locators.
- Add live-validator regression assertions so DPM proof browser validation stays aligned to the actual SectionBlock/Panel markup.

## Evidence
- npm test -- --run tests/unit/live-canonical-validation-script.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Notes
- No wiki/source documentation change in this PR.
- Generated output/ evidence remains untracked.