### PR TITLE
Send JSON content type for Workbench mutations

### DIFF
--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -120,11 +120,41 @@ async function fetchWorkbenchMutation<T>(
   errorLabel: string,
   init: RequestInit
 ): Promise<T> {
-  const response = await fetch(url, { cache: "no-store", ...init });
+  const response = await fetch(url, { cache: "no-store", ...withJsonMutationHeaders(init) });
   if (!response.ok) {
     throw new WorkbenchApiError(errorLabel, response.status);
   }
   return (await response.json()) as T;
+}
+
+function withJsonMutationHeaders(init: RequestInit): RequestInit {
+  if (typeof init.body !== "string") {
+    return init;
+  }
+
+  const headers = init.headers;
+  if (headers instanceof Headers) {
+    const nextHeaders = new Headers(headers);
+    if (!nextHeaders.has("Content-Type")) {
+      nextHeaders.set("Content-Type", "application/json");
+    }
+    return { ...init, headers: nextHeaders };
+  }
+
+  if (Array.isArray(headers)) {
+    const hasContentType = headers.some(([key]) => key.toLowerCase() === "content-type");
+    return {
+      ...init,
+      headers: hasContentType ? headers : [["Content-Type", "application/json"], ...headers],
+    };
+  }
+
+  const nextHeaders: Record<string, string> = { ...(headers as Record<string, string> | undefined) };
+  const hasContentType = Object.keys(nextHeaders).some((key) => key.toLowerCase() === "content-type");
+  if (!hasContentType) {
+    nextHeaders["Content-Type"] = "application/json";
+  }
+  return { ...init, headers: nextHeaders };
 }
 
 function observedSurface(

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -2141,6 +2141,7 @@ describe("workbench api", () => {
       "lotus-workbench"
     );
     expect(fetchMock.mock.calls[0][1].headers["X-Actor-Id"]).toBe("pm_1");
+    expect(fetchMock.mock.calls[0][1].headers["Content-Type"]).toBe("application/json");
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
       idempotency_key: "workbench-proof-pack-rr_1",
       body: {


### PR DESCRIPTION
## Summary
- add JSON Content-Type for string-bodied Workbench mutation requests
- preserve existing caller headers while fixing Gateway/BFF proof-pack generation requests
- add proof-pack API regression coverage for the JSON mutation header

## Evidence
- npm test -- --run tests/unit/workbench-api.test.ts tests/unit/proof-pack-panel.test.tsx tests/unit/live-canonical-validation-script.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Notes
- No wiki/source documentation change in this slice; this is a runtime mutation-header defect fix needed before governed platform proof can pass.
- Generated output/ evidence remains untracked.