### PR TITLE
Align proof-pack live validation idempotency

### DIFF
--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -309,13 +309,14 @@ async function run() {
   if (!rebalanceRunId) {
     throw new Error("Gateway workbench overview returned no manage rebalance-run reference for proof-pack generation.");
   }
+  const proofPackIdempotencyKey = `workbench-proof-pack-${rebalanceRunId}`;
   const generatedProofPack = await postJson(
     summary,
     `${gatewayBaseUrl}/api/v1/dpm/command-center/proof-packs`,
     "Generate DPM proof-pack evidence",
     timeoutMs,
     {
-      idempotency_key: `live-canonical-proof-pack-${rebalanceRunId}`,
+      idempotency_key: proofPackIdempotencyKey,
       body: {
         source_type: "REBALANCE_RUN",
         rebalance_run_id: rebalanceRunId,
@@ -323,8 +324,8 @@ async function run() {
         include_markdown: true,
         include_report_input: true,
         include_ai_evidence_input: true,
-        actor_id: "workbench-live-validator",
-        reason: "Canonical Workbench live validation generated an RFC-0040 proof pack from the Gateway Workbench rebalance snapshot.",
+        actor_id: "workbench-proof-pack-operator",
+        reason: "Workbench PM generated proof pack from Gateway-backed rebalance run.",
       },
     }
   );

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -324,7 +324,9 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain("DPM attention queue");
     expect(browserWorkflowModule).toContain("DPM mandate health dimensions");
     expect(script).toContain("Generate DPM proof-pack evidence");
-    expect(script).toContain("live-canonical-proof-pack");
+    expect(script).toContain("workbench-proof-pack");
+    expect(script).toContain("workbench-proof-pack-operator");
+    expect(script).toContain("Workbench PM generated proof pack from Gateway-backed rebalance run.");
     expect(script).toContain("extractWorkbenchRebalanceRunId");
     expect(script).toContain("isReviewableProofPackState");
     expect(script).toContain("recordMapCount");


### PR DESCRIPTION
## Summary
- align the live proof-pack API preflight with the Workbench browser action idempotency key
- use the same Workbench actor and rationale as the UI-generated proof-pack request
- preserve the browser click as an idempotent Gateway replay instead of a duplicate immutable proof-pack write

## Evidence
- npm test -- --run tests/unit/live-canonical-validation-script.test.ts tests/unit/workbench-api.test.ts tests/unit/proof-pack-panel.test.tsx
- npm run typecheck
- npm run lint
- git diff --check

## Notes
- No wiki/source documentation change in this slice; this fixes live validation orchestration for the RFC40 proof-pack runtime proof.
- Generated output/ evidence remains untracked.