### PR TITLE
Implement DPM portfolio memory panel

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -76,7 +76,13 @@ Current repository posture:
    manage/core source selector through Gateway, preserves manage-owned alternatives,
    supportability, objective/constraint traces, and selected-alternative state, and must not build
    stateless source bundles, optimizer logic, prices, or selection truth in the browser,
-11. `/workbench/{portfolioId}` renders the RFC-0041 DPM rebalance-wave command-center panel
+11. `/workbench/{portfolioId}` renders the RFC40-WTBD-010 portfolio-memory panel through Gateway
+   `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`. Workbench preserves
+   manage-owned timeline order, event type counts, source systems, source refs, artifact refs,
+   reason codes, supportability state, and content hash without reconstructing timeline nodes from
+   proof-pack, wave, outcome-review, report, archive, or AI payloads and without direct
+   `lotus-manage` calls.
+12. `/workbench/{portfolioId}` renders the RFC-0041 DPM rebalance-wave command-center panel
    through Gateway `/api/v1/dpm/command-center/waves*`. Workbench lists explicit portfolio-list
    waves, previews and creates canonical portfolio waves, opens wave detail and item posture, and
    sends source-check and simulation through Gateway only. It preserves manage-owned wave state,
@@ -84,13 +90,13 @@ Current repository posture:
    handoff refs, blocked actions, and `external_execution_claimed` posture without calling
    `lotus-manage` directly, calculating readiness, claiming external execution, or inferring
    PM-book discovery.
-12. `/workbench/{portfolioId}` also renders Gateway-provided rebalance action-register
+13. `/workbench/{portfolioId}` also renders Gateway-provided rebalance action-register
    supportability and portfolio-level DPM operations posture from the portfolio overview
    `rebalance_snapshot`, including source state, freshness, run count, operation count, workflow
    decision count, last-run identity, bounded recent runs, workflow posture, run issue count, and
    reason posture. Missing Gateway supportability is shown as unknown/N/A rather than as verified
    zero activity.
-13. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
+14. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map
 
@@ -211,6 +217,10 @@ Important validation expectations:
     labels must remain bounded to route, panel, operation, freshness, supportability, status class,
     and error category; wave ids, wave item ids, portfolio ids, proof-pack ids, handoff refs,
     request bodies, response bodies, and screen content must never be emitted as metric labels.
+15. DPM portfolio-memory reads are Workbench gateway-only operations. Observability labels must
+    remain bounded to route, panel, operation, freshness, supportability, status class, and error
+    category; portfolio ids, event ids, source refs, artifact refs, content hashes, request bodies,
+    response bodies, and screen content must never be emitted as metric labels.
 
 ### Visual Review Gate
 

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -230,7 +230,8 @@ Validation layers:
    - `lotus-report`
    - `lotus-archive`
    - `lotus-render`
-   - `lotus-manage` supportability summary through `GET /api/v1/rebalance/supportability/summary`
+   - `lotus-manage` action-register supportability summary through
+     `GET /api/v1/rebalance/supportability/summary`
 3. Gateway and Workbench route readiness
 4. live Gateway contracts for:
    - foundation workspace
@@ -334,8 +335,11 @@ monolithic validation script.
 
 The validation script runs the browser validator from the `lotus-workbench` repository root so
 these artifact paths are stable even when `lotus-platform` or another orchestrator calls the
-script. Browser validation failures must fail the PowerShell command; do not treat stale summaries
-or partial screenshot output as successful evidence.
+script. Browser validation failures must fail the PowerShell command. The Manage action-register
+supportability summary is recorded as source-supportability evidence, including stale state and
+reason when present; DPM panel proof is gated by the command-center, wave, outcome-review, proof-pack,
+and portfolio-memory contracts instead of failing on unrelated historical action-register freshness.
+Do not treat partial screenshot output as successful evidence.
 
 The summary includes `calculationChecks` for canonical performance and risk sanity. These checks
 assert numeric ranges, contribution reconciliation, governed attribution fallback posture, risk

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -29,5 +29,5 @@ Governance boundary:
 | RFC-0021 | UI Architecture Hardening and Design-System Governance | IMPLEMENTED | `docs/rfcs/RFC-0021-ui-architecture-hardening-and-design-system-governance.md` |
 | RFC-0022 | Stateful Risk Workspace and lotus-risk UI Integration | IMPLEMENTED | `docs/rfcs/RFC-0022-stateful-risk-workspace-and-lotus-risk-ui-integration.md` |
 | RFC-0023 | Risk Workspace UX Hardening and Production Readiness | IMPLEMENTED | `docs/rfcs/RFC-0023-risk-workspace-ux-hardening-and-production-readiness.md` |
-| RFC-0098 | DPM Mandate Command Center Experience | IN PROGRESS - RFC-0038 COMMAND-CENTER COCKPIT, RFC-0039 CONSTRUCTION LAB, RFC-0040 PROOF-PACK PANEL, RFC-0041 REBALANCE-WAVE PANEL, AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`, CANONICAL LIVE WAVE PROOF PENDING | `docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md` |
+| RFC-0098 | DPM Mandate Command Center Experience | IN PROGRESS - RFC-0038 COMMAND-CENTER COCKPIT, RFC-0039 CONSTRUCTION LAB, RFC-0040 PROOF-PACK PANEL, RFC-0040/RFC-0041/RFC-0042 PORTFOLIO-MEMORY PANEL, RFC-0041 REBALANCE-WAVE PANEL, AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`, CANONICAL LIVE MEMORY/WAVE PROOF PENDING | `docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md` |
 

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -2,7 +2,7 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | IN PROGRESS - RFC-0038 COMMAND-CENTER COCKPIT, RFC-0039 CONSTRUCTION LAB, RFC-0040 PROOF-PACK PANEL, RFC-0041 REBALANCE-WAVE PANEL, AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`; CANONICAL LIVE WAVE PROOF PENDING |
+| **Status** | IN PROGRESS - RFC-0038 COMMAND-CENTER COCKPIT, RFC-0039 CONSTRUCTION LAB, RFC-0040 PROOF-PACK PANEL, RFC-0040/RFC-0041/RFC-0042 PORTFOLIO-MEMORY PANEL, RFC-0041 REBALANCE-WAVE PANEL, AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`; CANONICAL LIVE MEMORY/WAVE PROOF PENDING |
 | **Created** | 2026-05-03 |
 | **Last Tightened** | 2026-05-06 |
 | **Owner** | `lotus-workbench` |
@@ -10,7 +10,7 @@
 | **Business Sponsor Persona** | DPM head, portfolio manager, CIO desk, investment control, operations, sales/pre-sales |
 | **Depends On** | `lotus-gateway` RFC-0098, `lotus-manage` RFC-0037, `lotus-manage` RFC-0038, `lotus-manage` RFC-0040, `lotus-manage` RFC-0041, `lotus-manage` RFC-0042, `lotus-core` RFC-0087, Workbench RFC-0076/RFC-0077 canonical proof contracts |
 | **Doc Location** | `docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md` |
-| **Implementation Branch** | `feat/rfc38-wtbd002-dpm-command-center-cockpit` for RFC-0038 command-center cockpit realization |
+| **Implementation Branch** | `wtbd-rfc40-portfolio-memory-workbench` for the RFC40-WTBD-010 portfolio-memory Workbench realization |
 
 RFC-0038 command-center cockpit live proof passed on 2026-05-06 with local Workbench and Gateway:
 `output/rfc38-wtbd002-command-center-cockpit-command-center-validated/live-validation-summary.json`.
@@ -31,6 +31,13 @@ RFC41-WTBD-006 implementation is now in progress on the
 embedded in `/workbench/{portfolioId}` and consumes Gateway
 `/api/v1/dpm/command-center/waves*` routes only. Promotion remains pending focused CI, canonical
 front-office proof, PR merge, wiki publication, and Manage WTBD closure.
+
+RFC40-WTBD-010 portfolio-memory product realization is now implemented locally on
+`wtbd-rfc40-portfolio-memory-workbench`. `/workbench/{portfolioId}` consumes Gateway
+`GET /api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`, renders manage-owned event
+order, event types, source systems, source refs, artifact refs, reason codes, supportability, and
+content hash, and does not reconstruct timeline nodes in the browser. Promotion remains pending
+focused CI, canonical front-office proof, PR merge, wiki publication, and final WTBD closure.
 
 ---
 
@@ -218,6 +225,32 @@ construction module backed by `lotus-manage` RFC-0039. This belongs inside the c
 experience because the portfolio manager reaches construction alternatives from mandate attention,
 rebalance readiness, and action posture. It must not become a separate decorative optimizer page.
 
+### 7.1 Portfolio Memory Timeline Addendum
+
+Workbench RFC-0098 must include a portfolio-memory timeline panel once Gateway exposes the
+manage-owned RFC40-WTBD-010 route. The panel is the product-readable event trail across RFC-0040
+proof packs, RFC-0041 waves and handoffs, and RFC-0042 outcome reviews.
+
+The implemented panel:
+
+1. consumes only Gateway
+   `GET /api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`,
+2. renders manage-owned supportability state, event count, event type counts, source systems,
+   reason codes, and content hash,
+3. preserves upstream event order, event type, event time, source refs, artifact refs, and reason
+   codes,
+4. shows empty, partial, unsupported, unavailable, and error states explicitly,
+5. emits bounded `dpm.portfolio-memory.get` observability without portfolio ids, event ids, content
+   hashes, source refs, request payloads, response payloads, or screen content as metric labels,
+6. must not call `lotus-manage` directly,
+7. must not reconstruct timeline nodes from proof-pack, wave, outcome-review, report, archive, or
+   AI responses.
+
+This panel is intentionally read-only in the current slice. Dedicated timeline filters, event
+detail drawers, retention/audit policy controls, cross-app lifecycle export, and client-demo
+timeline scripts remain follow-up scope until the owning services and Workbench browser proof
+promote them.
+
 Business outcome:
 
 1. PMs compare `do nothing`, explainable rebalance, minimum-turnover, and tax-aware choices before
@@ -309,7 +342,7 @@ Required UI states:
 5. proof pack degraded or pending review,
 6. proof pack blocked,
 7. report-input ready but report output unavailable,
-8. AI-evidence ready but AI PM memo unavailable or waiting for review,
+8. AI-evidence ready but AI memo unavailable, including AI PM memo unavailable or waiting for review,
 9. Gateway or manage unavailable.
 
 Supported-feature promotion is forbidden until Gateway implementation, Workbench browser proof,

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -21,6 +21,7 @@ import {
   createBrowserValidationHelpers,
   validateAdvisorBriefPanel,
   validateDpmCommandCenterPanel,
+  validatePortfolioMemoryPanel,
   validateDpmWaveCommandCenterPanel,
   validateEvidencePanel,
   validatePerformanceAnalysisPanel,
@@ -133,7 +134,12 @@ function sourceEvidenceCount(proofPackPayload) {
 
 function isReviewableProofPackState(state) {
   const normalized = readString(state)?.toUpperCase();
-  return normalized === "READY" || normalized === "PENDING_REVIEW" || normalized === "DEGRADED";
+  return (
+    normalized === "READY" ||
+    normalized === "PENDING_REVIEW" ||
+    normalized === "DEGRADED" ||
+    normalized === "BLOCKED"
+  );
 }
 
 function extractWorkflowPackRunId(payload) {
@@ -295,9 +301,24 @@ async function run() {
     "lotus-manage supportability summary",
     timeoutMs
   );
-  if (manageSupportabilitySummary?.supportability?.state !== "ready") {
-    throw new Error("lotus-manage supportability summary returned non-ready supportability.");
+  const manageSupportabilityState = readSupportabilityState(
+    manageSupportabilitySummary?.supportability
+  );
+  if (!manageSupportabilityState) {
+    throw new Error("lotus-manage supportability summary returned no bounded supportability state.");
   }
+  summary.sourceSupportability = {
+    ...(summary.sourceSupportability ?? {}),
+    lotusManageActionRegister: {
+      state: manageSupportabilityState,
+      reason: readString(manageSupportabilitySummary?.supportability?.reason),
+      freshnessBucket: readString(manageSupportabilitySummary?.supportability?.freshness_bucket),
+      runCount: manageSupportabilitySummary?.supportability?.run_count ?? null,
+      operationCount: manageSupportabilitySummary?.supportability?.operation_count ?? null,
+      workflowDecisionCount:
+        manageSupportabilitySummary?.supportability?.workflow_decision_count ?? null,
+    },
+  };
 
   const outcomeReviews = await fetchJson(
     summary,
@@ -420,6 +441,33 @@ async function run() {
   const dpmCommandCenterPayload = dpmCommandCenter?.data ?? dpmCommandCenter;
   if (!dpmCommandCenterPayload?.supportability) {
     throw new Error("DPM command-center summary returned no manage supportability envelope.");
+  }
+
+  const portfolioMemory = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/dpm/command-center/portfolios/${encodeURIComponent(portfolioId)}/memory?limit=100`,
+    "DPM portfolio memory",
+    timeoutMs
+  );
+  const portfolioMemorySupportability = portfolioMemory?.supportability;
+  const portfolioMemoryPayload = portfolioMemory?.data ?? portfolioMemory;
+  const portfolioMemoryEvents = Array.isArray(portfolioMemoryPayload?.events)
+    ? portfolioMemoryPayload.events
+    : [];
+  const portfolioMemoryState = readSupportabilityState(portfolioMemorySupportability);
+  const supportedPortfolioMemoryStates = new Set(["ready", "partial", "blocked"]);
+  if (!supportedPortfolioMemoryStates.has(portfolioMemoryState?.toLowerCase())) {
+    throw new Error(
+      `DPM portfolio memory did not return populated manage supportability; observed ${
+        portfolioMemoryState ?? "missing"
+      }.`
+    );
+  }
+  if (portfolioMemoryEvents.length < 1) {
+    throw new Error("DPM portfolio memory returned no manage-owned timeline events.");
+  }
+  if (!readString(portfolioMemorySupportability?.content_hash)) {
+    throw new Error("DPM portfolio memory returned no content hash.");
   }
 
   const dpmExceptions = await fetchJson(
@@ -567,6 +615,11 @@ async function run() {
     route: `/workbench/${portfolioId}`,
     source: "Gateway DPM command-center summary",
   });
+  panelGovernance.recordPanelClassification("dpm.portfolio_memory", "ready", "lotus-manage", {
+    route: `/workbench/${portfolioId}`,
+    eventCount: portfolioMemoryEvents.length,
+    source: "Gateway DPM portfolio-memory composition",
+  });
   panelGovernance.recordPanelClassification("dpm.wave_command_center", "ready", "lotus-manage", {
     route: `/workbench/${portfolioId}`,
     source: "Gateway DPM rebalance-wave composition",
@@ -669,6 +722,13 @@ async function run() {
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });
     await validateDpmCommandCenterPanel(page, {
+      workbenchBaseUrl,
+      portfolioId,
+      timeoutMs,
+      assertTableHasRows: browserHelpers.assertTableHasRows,
+      screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
+    });
+    await validatePortfolioMemoryPanel(page, {
       workbenchBaseUrl,
       portfolioId,
       timeoutMs,

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -494,6 +494,37 @@ export async function validateDpmWaveCommandCenterPanel(
   await screenshotRegisteredPanel(page, "dpm.wave_command_center");
 }
 
+export async function validatePortfolioMemoryPanel(
+  page,
+  { workbenchBaseUrl, portfolioId, timeoutMs, assertTableHasRows, screenshotRegisteredPanel }
+) {
+  await page.goto(`${workbenchBaseUrl}/workbench/${portfolioId}`, {
+    waitUntil: "networkidle",
+    timeout: timeoutMs,
+  });
+  const memoryPanel = workbenchPanelByClass(page, "portfolio-memory-panel");
+  await expect(memoryPanel.getByRole("heading", { name: "Portfolio Memory" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(memoryPanel.getByLabel("Status lotus-manage")).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(memoryPanel.getByText(/sha256:/)).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await assertTableHasRows(
+    tableByExactLabel(page, "DPM portfolio-memory event type counts"),
+    1,
+    "DPM portfolio-memory event type counts"
+  );
+  await assertTableHasRows(
+    tableByExactLabel(page, "DPM portfolio-memory event timeline"),
+    1,
+    "DPM portfolio-memory event timeline"
+  );
+  await screenshotRegisteredPanel(page, "dpm.portfolio_memory");
+}
+
 export async function validateProofPackPanel(
   page,
   { workbenchBaseUrl, portfolioId, timeoutMs, assertTableHasRows, screenshotRegisteredPanel }

--- a/scripts/live/validation/contract-metadata.mjs
+++ b/scripts/live/validation/contract-metadata.mjs
@@ -177,6 +177,19 @@ export const DEFAULT_PANEL_REGISTRY = {
       ],
       ownerFollowUpRfc: "RFC-0098",
     },
+    {
+      panelId: "dpm.portfolio_memory",
+      owningService: "lotus-manage",
+      gatewayEndpoint: "/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory",
+      requiredSupportState: "ready",
+      route: "/workbench/{portfolioId}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "dpm-portfolio-memory-live.png",
+      knownLimitations: [
+        "embedded /workbench/{portfolioId} timeline is implemented before event filters and detail drawers",
+      ],
+      ownerFollowUpRfc: "RFC-0098",
+    },
   ],
 };
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -401,6 +401,41 @@
   margin-top: 0.75rem;
 }
 
+.portfolio-memory-panel .analytics-table-frame {
+  margin-top: 0.85rem;
+}
+
+.portfolio-memory-badge-row,
+.portfolio-memory-reason-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.portfolio-memory-status-strip,
+.portfolio-memory-summary-grid {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.85rem;
+}
+
+.portfolio-memory-status-strip {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.portfolio-memory-summary-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.portfolio-memory-subsection {
+  min-width: 0;
+}
+
+.portfolio-memory-reason-row {
+  margin-top: 0.75rem;
+}
+
 .dpm-wave-command-center-panel .analytics-table-frame {
   margin-top: 0.85rem;
 }

--- a/src/app/workbench/[portfolioId]/page.tsx
+++ b/src/app/workbench/[portfolioId]/page.tsx
@@ -4,6 +4,7 @@ import {
   getDpmMandateByPortfolio,
   getDpmMandateHealth,
   getDpmOutcomeReviews,
+  getDpmPortfolioMemory,
   listDpmWaves,
   getPortfolio360,
   getReportingSnapshot,
@@ -32,6 +33,7 @@ import OverviewCards from "@/features/workbench/components/overview-cards";
 import OutcomeReviewPanel from "@/features/workbench/components/outcome-review-panel";
 import PartialFailureBanner from "@/features/workbench/components/partial-failure-banner";
 import PerformanceSnapshot from "@/features/workbench/components/performance-snapshot";
+import PortfolioMemoryPanel from "@/features/workbench/components/portfolio-memory-panel";
 import ProofPackPanel from "@/features/workbench/components/proof-pack-panel";
 import RebalanceStatus from "@/features/workbench/components/rebalance-status";
 import ReportBatchOperationsPanel from "@/features/workbench/components/report-batch-operations-panel";
@@ -88,6 +90,8 @@ export default async function WorkbenchPage({
   let dpmMandate: Awaited<ReturnType<typeof getDpmMandateByPortfolio>> | null = null;
   let dpmMandateHealth: Awaited<ReturnType<typeof getDpmMandateHealth>> | null = null;
   let dpmCommandCenterError: string | null = null;
+  let portfolioMemory: Awaited<ReturnType<typeof getDpmPortfolioMemory>> | null = null;
+  let portfolioMemoryError: string | null = null;
   let dpmWaves: Awaited<ReturnType<typeof listDpmWaves>> | null = null;
   let dpmWavesError: string | null = null;
   let outcomeReviews: Awaited<ReturnType<typeof getDpmOutcomeReviews>> | null = null;
@@ -167,6 +171,17 @@ export default async function WorkbenchPage({
   } catch {
     dpmMandate = null;
     dpmMandateHealth = null;
+  }
+
+  try {
+    portfolioMemory = await getDpmPortfolioMemory({
+      portfolioId: data.portfolio.portfolio_id,
+      limit: 100,
+    });
+  } catch (error) {
+    portfolioMemory = null;
+    portfolioMemoryError =
+      error instanceof Error ? error.message : "Portfolio-memory endpoint unavailable.";
   }
 
   try {
@@ -317,6 +332,11 @@ export default async function WorkbenchPage({
                 mandate={dpmMandate}
                 mandateHealth={dpmMandateHealth}
                 errorMessage={dpmCommandCenterError}
+              />
+
+              <PortfolioMemoryPanel
+                response={portfolioMemory}
+                errorMessage={portfolioMemoryError}
               />
 
               <ConstructionAlternativesPanel portfolio={data} />

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -166,6 +166,11 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
   },
   {
     route: "workbench.dpm-command-center",
+    panel: "portfolio-memory",
+    operation: "dpm.portfolio-memory.get",
+  },
+  {
+    route: "workbench.dpm-command-center",
     panel: "outcome-review-list",
     operation: "dpm.outcome-reviews.list",
   },

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -18,6 +18,7 @@ import {
   DpmOutcomeReviewGatewayResponse,
   DpmOutcomeReviewHandoffResponse,
   DpmOutcomeReviewNarrativeResponse,
+  DpmPortfolioMemoryGatewayResponse,
   DpmProofPackAiPmMemoResponse,
   DpmProofPackGatewayResponse,
   DpmProofPackMarkdownResponse,
@@ -925,6 +926,24 @@ export async function getDpmMandateHealth(
         "server",
         `/dpm/command-center/mandates/${encodeURIComponent(mandateId)}/health`,
         "DPM mandate health"
+      )
+  );
+}
+
+export async function getDpmPortfolioMemory(params: {
+  portfolioId: string;
+  limit?: number;
+}): Promise<DpmPortfolioMemoryGatewayResponse> {
+  const query = new URLSearchParams();
+  query.set("limit", String(params.limit ?? 100));
+  return await observeWorkbenchResource(
+    "dpm.portfolio-memory.get",
+    async () =>
+      await fetchWorkbenchResource<DpmPortfolioMemoryGatewayResponse>(
+        "server",
+        `/dpm/command-center/portfolios/${encodeURIComponent(params.portfolioId)}/memory`,
+        "DPM portfolio memory",
+        query
       )
   );
 }

--- a/src/features/workbench/components/portfolio-memory-panel.tsx
+++ b/src/features/workbench/components/portfolio-memory-panel.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import {
+  AnalyticsTable,
+  MetricRow,
+  ScreenStatePanel,
+  SectionBlock,
+  SemanticBadge,
+  Text,
+} from "@/design-system";
+import type { DpmPortfolioMemoryGatewayResponse } from "@/features/workbench/types";
+import {
+  buildPortfolioMemoryPanelModel,
+  type PortfolioMemoryPanelState,
+} from "@/features/workbench/portfolio-memory-view-model";
+
+type Props = {
+  response: DpmPortfolioMemoryGatewayResponse | null;
+  errorMessage?: string | null;
+};
+
+function badgeTone(state: string): "default" | "success" | "warn" | "danger" {
+  const normalized = state.toUpperCase();
+  if (normalized === "READY" || normalized === "COMPLETE" || normalized === "SUPPORTED") {
+    return "success";
+  }
+  if (normalized === "PARTIAL" || normalized === "DEGRADED" || normalized === "EMPTY" || normalized === "UNKNOWN") {
+    return "warn";
+  }
+  if (normalized === "BLOCKED" || normalized === "UNSUPPORTED" || normalized === "UNAVAILABLE") {
+    return "danger";
+  }
+  return "default";
+}
+
+function statePanelCopy(state: PortfolioMemoryPanelState) {
+  if (state === "empty") {
+    return {
+      kind: "empty" as const,
+      title: "No portfolio-memory events returned",
+      body: "Manage returned an empty portfolio-memory timeline for this portfolio.",
+    };
+  }
+  if (state === "partial") {
+    return {
+      kind: "partial" as const,
+      title: "Portfolio memory is partial",
+      body: "Gateway preserved a non-ready manage supportability state. Some proof-pack, wave, handoff, or outcome-review lineage may still be unavailable.",
+    };
+  }
+  if (state === "unsupported") {
+    return {
+      kind: "unavailable" as const,
+      title: "Portfolio memory is not supported",
+      body: "Manage reported that this portfolio-memory path is not available for the selected portfolio.",
+    };
+  }
+  return {
+    kind: "partial" as const,
+    title: "Portfolio memory is unavailable",
+    body: "Gateway did not return a usable manage portfolio-memory payload.",
+  };
+}
+
+export default function PortfolioMemoryPanel({ response, errorMessage = null }: Props) {
+  const model = buildPortfolioMemoryPanelModel(response);
+  const shouldShowStatePanel =
+    Boolean(errorMessage) ||
+    model.state === "empty" ||
+    model.state === "partial" ||
+    model.state === "unsupported" ||
+    model.state === "unavailable";
+  const stateCopy = statePanelCopy(model.state);
+
+  return (
+    <SectionBlock
+      title="Portfolio Memory"
+      subtitle={`Manage authority: ${model.authority}. Correlation: ${model.correlationId}`}
+      className="portfolio-memory-panel"
+      actions={
+        <div className="portfolio-memory-badge-row">
+          <SemanticBadge tone={badgeTone(model.supportabilityState)}>
+            {model.supportabilityState}
+          </SemanticBadge>
+          <SemanticBadge>{model.sourceService}</SemanticBadge>
+        </div>
+      }
+    >
+      {shouldShowStatePanel ? (
+        <ScreenStatePanel
+          kind={errorMessage ? "partial" : stateCopy.kind}
+          surface="portfolio"
+          title={errorMessage ? "Portfolio-memory endpoint is unavailable" : stateCopy.title}
+          body={errorMessage ?? stateCopy.body}
+        />
+      ) : null}
+
+      <div className="portfolio-memory-status-strip">
+        <MetricRow label="Portfolio" value={model.portfolioId} />
+        <MetricRow label="Events" value={model.eventCount} />
+        <MetricRow label="Source Systems" value={model.sourceSystems} />
+        <MetricRow label="Content Hash" value={model.contentHash} />
+      </div>
+
+      {model.reasonCodes.length > 0 ? (
+        <div className="portfolio-memory-reason-row">
+          {model.reasonCodes.map((reason) => (
+            <SemanticBadge key={reason} tone={badgeTone(reason)}>
+              {reason}
+            </SemanticBadge>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="portfolio-memory-summary-grid">
+        <div className="portfolio-memory-subsection">
+          <Text as="h3" variant="subsectionTitle">
+            Event Mix
+          </Text>
+          <AnalyticsTable
+            ariaLabel="DPM portfolio-memory event type counts"
+            variant="portfolio"
+            density="compact"
+            columns={[
+              { key: "event-type", label: "Event Type" },
+              { key: "count", label: "Count", align: "right" },
+            ]}
+            rows={model.eventTypeRows.map((row) => ({
+              key: row.key,
+              cells: [row.eventType, row.count],
+            }))}
+            emptyState={{
+              title: "No event counts returned",
+              body: "Manage did not publish portfolio-memory event type counts for this portfolio.",
+            }}
+          />
+        </div>
+      </div>
+
+      <AnalyticsTable
+        ariaLabel="DPM portfolio-memory event timeline"
+        variant="analysis"
+        density="compact"
+        columns={[
+          { key: "time", label: "Event Time" },
+          { key: "type", label: "Event Type" },
+          { key: "source-systems", label: "Sources" },
+          { key: "source-refs", label: "Source Refs" },
+          { key: "artifact-refs", label: "Artifact Refs" },
+          { key: "reasons", label: "Reasons" },
+        ]}
+        rows={model.events.map((row) => ({
+          key: row.key,
+          cells: [
+            row.eventTime,
+            row.eventType,
+            row.sourceSystems,
+            row.sourceRefs,
+            row.artifactRefs,
+            row.reasonCodes,
+          ],
+        }))}
+        emptyState={{
+          title: "No memory events returned",
+          body: "Workbench does not reconstruct portfolio-memory timeline rows locally.",
+        }}
+      />
+
+      <Text variant="secondary" className="muted">
+        Event order, event types, source refs, artifact refs, reason codes, source systems, and
+        content hash are Gateway-preserved manage truth.
+      </Text>
+    </SectionBlock>
+  );
+}

--- a/src/features/workbench/portfolio-memory-view-model.ts
+++ b/src/features/workbench/portfolio-memory-view-model.ts
@@ -1,0 +1,213 @@
+import type { DpmPortfolioMemoryGatewayResponse } from "./types";
+
+export type PortfolioMemoryPanelState =
+  | "complete"
+  | "partial"
+  | "empty"
+  | "unsupported"
+  | "unavailable";
+
+export type PortfolioMemoryEventRow = {
+  key: string;
+  eventId: string;
+  eventType: string;
+  eventTime: string;
+  sourceSystems: string;
+  sourceRefs: string;
+  artifactRefs: string;
+  reasonCodes: string;
+};
+
+export type PortfolioMemoryCountRow = {
+  key: string;
+  eventType: string;
+  count: string;
+};
+
+export type PortfolioMemoryPanelModel = {
+  state: PortfolioMemoryPanelState;
+  supportabilityState: string;
+  sourceService: string;
+  authority: string;
+  correlationId: string;
+  portfolioId: string;
+  eventCount: string;
+  contentHash: string;
+  sourceSystems: string;
+  reasonCodes: string[];
+  eventTypeRows: PortfolioMemoryCountRow[];
+  events: PortfolioMemoryEventRow[];
+};
+
+export function buildPortfolioMemoryPanelModel(
+  response: DpmPortfolioMemoryGatewayResponse | null,
+): PortfolioMemoryPanelModel {
+  if (!response) {
+    return {
+      state: "unavailable",
+      supportabilityState: "UNAVAILABLE",
+      sourceService: "lotus-gateway",
+      authority: "lotus-manage:RFC-0040/RFC-0041/RFC-0042",
+      correlationId: "N/A",
+      portfolioId: "N/A",
+      eventCount: "N/A",
+      contentHash: "N/A",
+      sourceSystems: "N/A",
+      reasonCodes: ["GATEWAY_PORTFOLIO_MEMORY_UNAVAILABLE"],
+      eventTypeRows: [],
+      events: [],
+    };
+  }
+
+  const supportability = response.supportability;
+  const supportabilityState = normalizeState(supportability.state);
+  const data = response.data;
+  const events = extractRecordArray(data.events);
+  return {
+    state: resolvePanelState(supportabilityState, supportability.event_count, events.length),
+    supportabilityState,
+    sourceService: supportability.source_service || response.source_service,
+    authority: supportability.authority,
+    correlationId: response.correlation_id,
+    portfolioId: readString(data, "portfolio_id") || "N/A",
+    eventCount: formatValue(supportability.event_count),
+    contentHash:
+      supportability.content_hash ||
+      readString(data, "content_hash") ||
+      "N/A",
+    sourceSystems: supportability.source_systems.join(", ") || "N/A",
+    reasonCodes: supportability.reason_codes,
+    eventTypeRows: Object.entries(supportability.event_type_counts).map(
+      ([eventType, count]) => ({
+        key: eventType,
+        eventType,
+        count: formatValue(count),
+      }),
+    ),
+    events: events.map(buildEventRow),
+  };
+}
+
+function resolvePanelState(
+  supportabilityState: string,
+  supportabilityEventCount: number,
+  renderedEventCount: number,
+): PortfolioMemoryPanelState {
+  if (supportabilityState === "EMPTY" || (supportabilityEventCount === 0 && renderedEventCount === 0)) {
+    return "empty";
+  }
+  if (
+    supportabilityState === "PARTIAL" ||
+    supportabilityState === "DEGRADED" ||
+    supportabilityState === "BLOCKED" ||
+    supportabilityState === "UNKNOWN"
+  ) {
+    return "partial";
+  }
+  if (supportabilityState === "UNSUPPORTED" || supportabilityState === "UNAVAILABLE") {
+    return "unsupported";
+  }
+  return "complete";
+}
+
+function buildEventRow(record: Record<string, unknown>, index: number): PortfolioMemoryEventRow {
+  const eventId = readString(record, "event_id") || `portfolio-memory-event-${index + 1}`;
+  return {
+    key: eventId,
+    eventId,
+    eventType: readString(record, "event_type") || "N/A",
+    eventTime:
+      readString(record, "event_time") ||
+      readString(record, "occurred_at") ||
+      readString(record, "created_at") ||
+      "N/A",
+    sourceSystems: extractSourceSystems(record).join(", ") || "N/A",
+    sourceRefs: formatRefs(record.source_refs),
+    artifactRefs: formatRefs(record.artifact_refs),
+    reasonCodes: extractStringArray(record.reason_codes).join(", ") || "N/A",
+  };
+}
+
+function extractSourceSystems(record: Record<string, unknown>): string[] {
+  const explicit = extractStringArray(record.source_systems);
+  if (explicit.length > 0) {
+    return explicit;
+  }
+  return extractRecordArray(record.source_refs)
+    .map((ref) => readString(ref, "source_system"))
+    .filter((value) => value.length > 0);
+}
+
+function formatRefs(value: unknown): string {
+  const records = extractRecordArray(value);
+  if (records.length === 0) {
+    return "N/A";
+  }
+  return records
+    .map((record) => {
+      const system =
+        readString(record, "source_system") ||
+        readString(record, "artifact_type") ||
+        readString(record, "type") ||
+        "ref";
+      const id =
+        readString(record, "source_id") ||
+        readString(record, "artifact_id") ||
+        readString(record, "id") ||
+        readString(record, "uri") ||
+        "N/A";
+      return `${system}:${id}`;
+    })
+    .join(", ");
+}
+
+function extractRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isRecord);
+}
+
+function extractStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (item): item is string => typeof item === "string" && item.length > 0,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "number") {
+    return value.toLocaleString(undefined, { maximumFractionDigits: 6 });
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return "N/A";
+  }
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeState(state: string): string {
+  return state.trim().toUpperCase() || "UNKNOWN";
+}

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1162,6 +1162,26 @@ export type DpmCommandCenterGatewayResponse = {
   data: Record<string, unknown>;
 };
 
+export type DpmPortfolioMemorySupportability = {
+  source_service: string;
+  authority: string;
+  state: string;
+  event_count: number;
+  event_type_counts: Record<string, number>;
+  source_systems: string[];
+  reason_codes: string[];
+  content_hash?: string | null;
+};
+
+export type DpmPortfolioMemoryGatewayResponse = {
+  correlation_id: string;
+  contract_version: string;
+  source_service: string;
+  upstream_status: number;
+  supportability: DpmPortfolioMemorySupportability;
+  data: Record<string, unknown>;
+};
+
 export type DpmOutcomeReviewSupportability = {
   source_service: string;
   authority: string;

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -316,6 +316,11 @@ describe("analytics UI observability metrics", () => {
       ],
       [
         "workbench.dpm-command-center",
+        "portfolio-memory",
+        "dpm.portfolio-memory.get",
+      ],
+      [
+        "workbench.dpm-command-center",
         "outcome-review-list",
         "dpm.outcome-reviews.list",
       ],

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -33,7 +33,8 @@ describe("canonical live validation script", () => {
 
     expect(runbook).toContain("runs the browser validator from the `lotus-workbench` repository root");
     expect(runbook).toContain("Browser validation failures must fail the PowerShell command");
-    expect(runbook).toContain("stale summaries");
+    expect(runbook).toContain("recorded as source-supportability evidence");
+    expect(runbook).toContain("historical action-register freshness");
     expect(runbook).toContain("-CleanCoreState");
     expect(runbook).toContain("1000`-portfolio load scenario");
     expect(runbook).toContain("Docker is the default for every canonical front-office app");
@@ -63,7 +64,16 @@ describe("canonical live validation script", () => {
     }
 
     expect(browserValidator).toContain("readSupportabilityState");
+    expect(browserValidator).toContain("summary.sourceSupportability");
+    expect(browserValidator).toContain(
+      "lotus-manage supportability summary returned no bounded supportability state"
+    );
+    expect(browserValidator).not.toContain(
+      "lotus-manage supportability summary returned non-ready supportability"
+    );
     expect(browserValidator).toContain("DPM rebalance-wave preview did not return ready manage supportability");
+    expect(browserValidator).toContain("supportedPortfolioMemoryStates");
+    expect(browserValidator).toContain("DPM portfolio memory did not return populated manage supportability");
     expect(browserValidator).toContain("gatewayModuleHealth.lotus_manage");
     expect(browserValidator).toContain("/api/v1/dpm/command-center?");
     expect(browserValidator).toContain("DPM command-center summary");
@@ -320,7 +330,16 @@ describe("canonical live validation script", () => {
 
     expect(script).toContain("canonicalAsOfDate");
     expect(script).toContain("createBrowserValidationHelpers");
+    expect(script).toContain("validatePortfolioMemoryPanel");
     expect(browserWorkflowModule).toContain("validateDpmCommandCenterPanel");
+    expect(browserWorkflowModule).toContain("Portfolio Memory");
+    expect(browserWorkflowModule).toContain("DPM portfolio-memory event timeline");
+    expect(browserWorkflowModule).toContain('workbenchPanelByClass(page, "portfolio-memory-panel")');
+    expect(browserWorkflowModule).toContain('screenshotRegisteredPanel(page, "dpm.portfolio_memory")');
+    expect(script).toContain("DPM portfolio memory");
+    expect(script).toContain("/memory?limit=100");
+    expect(script).toContain("DPM portfolio memory returned no manage-owned timeline events.");
+    expect(script).toContain('recordPanelClassification("dpm.portfolio_memory"');
     expect(browserWorkflowModule).toContain("DPM Command Center");
     expect(browserWorkflowModule).toContain("DPM attention queue");
     expect(browserWorkflowModule).toContain("DPM mandate health dimensions");
@@ -335,6 +354,7 @@ describe("canonical live validation script", () => {
     expect(script).toContain("extractWorkflowPackRunId");
     expect(script).toContain("PENDING_REVIEW");
     expect(script).toContain("DPM proof-pack evidence returned no reviewable proof-pack sections.");
+    expect(script).toContain('normalized === "BLOCKED"');
     expect(script).toContain("DPM proof-pack AI PM memo");
     expect(script).toContain("/ai-pm-memo");
     expect(script).toContain("DPM proof-pack AI PM memo did not return lotus-ai source authority.");

--- a/tests/unit/live-validation-contract-modules.test.ts
+++ b/tests/unit/live-validation-contract-modules.test.ts
@@ -84,6 +84,13 @@ describe("live validation contract modules", () => {
       expect(shotIndex).toContain(summaryPath);
       expect(shotIndex).toContain("2026-04-10");
       expect(persistedSummary.workflowPackChecks).toEqual([]);
+      expect(
+        DEFAULT_PANEL_REGISTRY.panels.some(
+          (panel) =>
+            panel.panelId === "dpm.portfolio_memory" &&
+            panel.gatewayEndpoint === "/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory"
+        )
+      ).toBe(true);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/tests/unit/portfolio-memory-panel.test.tsx
+++ b/tests/unit/portfolio-memory-panel.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import PortfolioMemoryPanel from "../../src/features/workbench/components/portfolio-memory-panel";
+import type { DpmPortfolioMemoryGatewayResponse } from "../../src/features/workbench/types";
+
+const readyResponse: DpmPortfolioMemoryGatewayResponse = {
+  correlation_id: "corr-memory",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0040/RFC-0041/RFC-0042",
+    state: "READY",
+    event_count: 1,
+    event_type_counts: { OUTCOME_REVIEW_CREATED: 1 },
+    source_systems: ["lotus-manage", "lotus-risk"],
+    reason_codes: ["SOURCE_READY"],
+    content_hash: "sha256:portfolio-memory",
+  },
+  data: {
+    portfolio_id: "PB_SG_GLOBAL_BAL_001",
+    events: [
+      {
+        event_id: "memory:outcome-review:or_1",
+        event_type: "OUTCOME_REVIEW_CREATED",
+        event_time: "2026-05-07T10:05:00Z",
+        source_refs: [{ source_system: "lotus-manage", source_id: "or_1" }],
+        artifact_refs: [{ artifact_type: "outcome_review", artifact_id: "or_1" }],
+        reason_codes: ["OUTCOME_REVIEW_READY"],
+      },
+    ],
+  },
+};
+
+describe("PortfolioMemoryPanel", () => {
+  it("renders Gateway-backed portfolio-memory supportability and timeline", () => {
+    render(<PortfolioMemoryPanel response={readyResponse} />);
+
+    expect(screen.getByRole("heading", { name: "Portfolio Memory" })).toBeInTheDocument();
+    expect(screen.getAllByText("READY").length).toBeGreaterThan(0);
+    expect(screen.getByText("sha256:portfolio-memory")).toBeInTheDocument();
+    expect(screen.getAllByText("OUTCOME_REVIEW_CREATED").length).toBeGreaterThan(1);
+    expect(screen.getByText("lotus-manage:or_1")).toBeInTheDocument();
+    expect(screen.getByText("outcome_review:or_1")).toBeInTheDocument();
+    expect(screen.getByText("OUTCOME_REVIEW_READY")).toBeInTheDocument();
+  });
+
+  it("renders endpoint errors without claiming local reconstruction", () => {
+    render(
+      <PortfolioMemoryPanel
+        response={null}
+        errorMessage="Failed to fetch DPM portfolio memory (503)"
+      />,
+    );
+
+    expect(screen.getByText("Portfolio-memory endpoint is unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Failed to fetch DPM portfolio memory (503)")).toBeInTheDocument();
+    expect(
+      screen.getByText("Workbench does not reconstruct portfolio-memory timeline rows locally."),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/unit/portfolio-memory-view-model.test.ts
+++ b/tests/unit/portfolio-memory-view-model.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPortfolioMemoryPanelModel } from "../../src/features/workbench/portfolio-memory-view-model";
+import type { DpmPortfolioMemoryGatewayResponse } from "../../src/features/workbench/types";
+
+const memoryResponse: DpmPortfolioMemoryGatewayResponse = {
+  correlation_id: "corr-memory",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0040/RFC-0041/RFC-0042",
+    state: "READY",
+    event_count: 2,
+    event_type_counts: {
+      PROOF_PACK_CREATED: 1,
+      OUTCOME_REVIEW_CREATED: 1,
+    },
+    source_systems: ["lotus-manage", "lotus-core"],
+    reason_codes: ["SOURCE_READY"],
+    content_hash: "sha256:portfolio-memory",
+  },
+  data: {
+    portfolio_id: "PB_SG_GLOBAL_BAL_001",
+    events: [
+      {
+        event_id: "memory:proof-pack:ppack_1",
+        event_type: "PROOF_PACK_CREATED",
+        event_time: "2026-05-07T10:00:00Z",
+        source_refs: [{ source_system: "lotus-manage", source_id: "ppack_1" }],
+        artifact_refs: [{ artifact_type: "proof_pack", artifact_id: "ppack_1" }],
+        reason_codes: ["PROOF_READY"],
+      },
+      {
+        event_id: "memory:outcome-review:or_1",
+        event_type: "OUTCOME_REVIEW_CREATED",
+        event_time: "2026-05-07T10:05:00Z",
+        source_refs: [{ source_system: "lotus-manage", source_id: "or_1" }],
+        artifact_refs: [{ artifact_type: "outcome_review", artifact_id: "or_1" }],
+        reason_codes: ["OUTCOME_REVIEW_READY"],
+      },
+    ],
+  },
+};
+
+describe("portfolio-memory view model", () => {
+  it("preserves manage event order, supportability, refs, and content hash", () => {
+    const model = buildPortfolioMemoryPanelModel(memoryResponse);
+
+    expect(model.state).toBe("complete");
+    expect(model.supportabilityState).toBe("READY");
+    expect(model.portfolioId).toBe("PB_SG_GLOBAL_BAL_001");
+    expect(model.eventCount).toBe("2");
+    expect(model.contentHash).toBe("sha256:portfolio-memory");
+    expect(model.eventTypeRows.map((row) => row.eventType)).toEqual([
+      "PROOF_PACK_CREATED",
+      "OUTCOME_REVIEW_CREATED",
+    ]);
+    expect(model.events.map((row) => row.eventId)).toEqual([
+      "memory:proof-pack:ppack_1",
+      "memory:outcome-review:or_1",
+    ]);
+    expect(model.events[0]).toMatchObject({
+      sourceRefs: "lotus-manage:ppack_1",
+      artifactRefs: "proof_pack:ppack_1",
+      reasonCodes: "PROOF_READY",
+    });
+  });
+
+  it("does not infer readiness from populated events when manage supportability is partial", () => {
+    const model = buildPortfolioMemoryPanelModel({
+      ...memoryResponse,
+      supportability: {
+        ...memoryResponse.supportability,
+        state: "PARTIAL",
+        reason_codes: ["SOURCE_PARTIAL"],
+      },
+    });
+
+    expect(model.state).toBe("partial");
+    expect(model.supportabilityState).toBe("PARTIAL");
+    expect(model.events).toHaveLength(2);
+  });
+
+  it("treats blocked portfolio-memory supportability as action-required timeline truth", () => {
+    const model = buildPortfolioMemoryPanelModel({
+      ...memoryResponse,
+      supportability: {
+        ...memoryResponse.supportability,
+        state: "BLOCKED",
+        reason_codes: ["DPM_OPERATIONS_REVIEW_REQUIRED"],
+      },
+    });
+
+    expect(model.state).toBe("partial");
+    expect(model.supportabilityState).toBe("BLOCKED");
+    expect(model.reasonCodes).toEqual(["DPM_OPERATIONS_REVIEW_REQUIRED"]);
+  });
+});

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -32,6 +32,12 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     assert "RFC-0040 PROOF-PACK PANEL" in index
     assert "Post-Trade Outcome Review Workspace Addendum" in rfc
     assert "RFC-0041 REBALANCE-WAVE PANEL" in rfc
+    assert "PORTFOLIO-MEMORY PANEL" in rfc
+    assert "Portfolio Memory Timeline Addendum" in rfc
+    assert "`GET /api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`" in rfc
+    assert "must not reconstruct timeline nodes" in rfc
+    assert "DPM portfolio memory" in supported_features
+    assert "source refs, artifact refs, reason codes" in supported_features
     assert "first RFC-0041 rebalance-wave command-center" in rfc
     assert "`/api/v1/dpm/command-center/waves*`" in rfc
     assert "approval, staging, handoff" in rfc

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -15,6 +15,7 @@ import {
   getDpmOutcomeReviewAiEvidenceInput,
   getDpmOutcomeReviewReportInput,
   getDpmOutcomeReviews,
+  getDpmPortfolioMemory,
   getDpmConstructionAlternativeSet,
   getDpmProofPack,
   getDpmProofPackAiEvidenceInput,
@@ -1904,6 +1905,51 @@ describe("workbench api", () => {
     expect(metricEventsJson).toContain("mandate-command-center-health");
     expect(metricEventsJson).not.toContain("PB_SG_GLOBAL_BAL_001");
     expect(metricEventsJson).not.toContain("MANDATE_PB_SG_GLOBAL_BAL_001");
+  });
+
+  it("loads DPM portfolio memory through Gateway without leaking portfolio identifiers into metrics", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr-memory",
+            contract_version: "v1",
+            source_service: "lotus-manage",
+            upstream_status: 200,
+            supportability: {
+              source_service: "lotus-manage",
+              authority: "lotus-manage:RFC-0040/RFC-0041/RFC-0042",
+              state: "READY",
+              event_count: 1,
+              event_type_counts: { OUTCOME_REVIEW_CREATED: 1 },
+              source_systems: ["lotus-manage"],
+              reason_codes: ["SOURCE_READY"],
+              content_hash: "sha256:portfolio-memory",
+            },
+            data: {
+              portfolio_id: "PB_SG_GLOBAL_BAL_001",
+              events: [{ event_id: "memory:or_1", event_type: "OUTCOME_REVIEW_CREATED" }],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await getDpmPortfolioMemory({
+      portfolioId: "PB_SG_GLOBAL_BAL_001",
+      limit: 100,
+    });
+
+    const requestedUrl = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].toString();
+    expect(requestedUrl).toContain(
+      "/api/v1/dpm/command-center/portfolios/PB_SG_GLOBAL_BAL_001/memory?limit=100"
+    );
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("portfolio-memory");
+    expect(metricEventsJson).not.toContain("PB_SG_GLOBAL_BAL_001");
+    expect(metricEventsJson).not.toContain("sha256:portfolio-memory");
   });
 
   it("loads DPM rebalance waves through Gateway without leaking wave identifiers into metrics", async () => {

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -84,6 +84,14 @@ promote dormant labels into product ownership just because historical route file
   are present. It does not rebuild proof-pack sections, compute hashes, synthesize Markdown,
   construct report input, construct AI evidence, construct PM memo prompts, materialize PDF
   reports, or call `lotus-manage`, `lotus-report`, or `lotus-ai` directly.
+- RFC40-WTBD-010 portfolio-memory timeline rendering is implemented on
+  `/workbench/{portfolioId}` through Gateway
+  `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`. Workbench renders manage-owned
+  event order, event type counts, event time, source systems, source refs, artifact refs, reason
+  codes, supportability state, and content hash. It does not reconstruct timeline nodes from
+  proof-pack, wave, outcome-review, report, archive, or AI payloads; direct `lotus-manage` calls
+  remain forbidden. Dedicated timeline filters, event drawers, lifecycle export, and retention or
+  audit-policy controls remain future scope until separately implemented and proven.
 - RFC-0098/RFC-0041 action-register supportability is rendered on `/workbench/{portfolioId}` from
   the Gateway portfolio overview `rebalance_snapshot`. The rebalance status panel shows
   manage-owned status, source support state, freshness, run count, operation count, workflow
@@ -131,7 +139,7 @@ Data products:
 http://workbench.dev.lotus/data-products
 ```
 
-Workbench DPM command-center, waves, construction alternatives, proof-pack evidence, and outcome review:
+Workbench DPM command-center, portfolio memory, waves, construction alternatives, proof-pack evidence, and outcome review:
 
 ```txt
 http://workbench.dev.lotus/workbench/PB_SG_GLOBAL_BAL_001

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -91,15 +91,21 @@ must travel through Gateway-shaped contracts.
     outcome-review search, detail, supportability, report-input, AI-evidence, preview, create, and
     source-refresh posture also remain manage-owned, while AI narrative execution remains
     `lotus-ai` owned; both must reach Workbench through Gateway outcome-review composition only.
+    RFC40-WTBD-010 portfolio-memory timeline events, source refs, artifact refs, event counts,
+    source systems, reason codes, supportability, and content hashes remain manage-owned and must
+    reach Workbench through Gateway portfolio-memory composition only.
     The implemented Workbench construction panel consumes the Gateway construction alternative-set
     contracts, the implemented wave command-center panel consumes Gateway wave list, preview,
     create, detail, item, source-check, simulation, approval, staging, handoff, proof-posture, and
     supportability contracts, the implemented proof-pack panel consumes the Gateway proof-pack
     generation, detail, Markdown, report-input, AI-evidence, and AI PM memo contracts, and the
     implemented outcome panel consumes the Gateway outcome-review list and AI-narrative contracts.
+    The implemented portfolio-memory panel consumes the Gateway portfolio-memory contract and
+    preserves manage event order without reconstructing timeline nodes.
     Workbench must not calculate expected-versus-realized values. It must not rebuild proof-pack
-    sections, compute proof-pack hashes, construct prompts, infer PM quality, calculate wave
-    readiness, claim external execution, or optimize construction alternatives.
+    sections, compute proof-pack hashes, construct prompts, infer PM quality, calculate wave readiness,
+    reconstruct portfolio-memory events, claim external execution, or optimize construction
+    alternatives; proof-pack sections remain manage-owned evidence.
 16. The implemented RFC-0038 mandate command-center cockpit consumes Gateway
     `/api/v1/dpm/command-center`, `/monitoring/run-once`, `/exceptions`, and `/mandates*`
     contracts. Workbench renders manage-owned health distribution, source readiness,
@@ -135,6 +141,7 @@ flowchart TB
   Workbench -->|/api/bff/api/v1/dpm/command-center*| Gateway
   Workbench -->|/api/bff/api/v1/dpm/command-center/construction/alternative-sets*| Gateway
   Workbench -->|/api/bff/api/v1/dpm/command-center/proof-packs*| Gateway
+  Workbench -->|/api/bff/api/v1/dpm/command-center/portfolios/*/memory| Gateway
   Workbench -->|/api/bff/api/v1/dpm/command-center/waves*| Gateway
   Workbench -->|/api/bff/api/v1/dpm/command-center/outcome-reviews*| Gateway
   Workbench -->|AI narrative action via Gateway only| Gateway

--- a/wiki/Observability-Evidence.md
+++ b/wiki/Observability-Evidence.md
@@ -54,7 +54,8 @@ Use the API samples to show that the UI is backed by live services rather than s
 - performance summary
 - risk summary
 - advisor brief
-- Manage supportability summary through `GET /api/v1/rebalance/supportability/summary`
+- Manage action-register supportability summary through
+  `GET /api/v1/rebalance/supportability/summary`
 - Report integration capabilities
 - Archive and Render readiness
 
@@ -189,7 +190,10 @@ The 2026-05-02 RFC-0108 Workbench gold-pass run produced these local artifacts:
 The canonical validation recorded 24 API checks, 8 UI checks, 7 governed screenshots, 12 panel
 classifications, and 4 advisor-brief workflow-pack checks for `PB_SG_GLOBAL_BAL_001` against
 `BMK_PB_GLOBAL_BALANCED_60_40`. All application API samples in the companion observability pack
-returned HTTP `200`, including Manage readiness and Manage supportability summary.
+returned HTTP `200`, including Manage readiness and Manage action-register supportability summary.
+The canonical Workbench validator records the bounded Manage supportability state and reason as
+source-supportability evidence; stale action-register freshness is not treated as DPM panel failure
+when command-center, wave, outcome-review, proof-pack, and portfolio-memory contracts are ready.
 
 ## Suggested Offline Demo Flow
 

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -14,7 +14,32 @@ It is intended for developers, business users, operations, sales/pre-sales, and 
 | DPM rebalance-wave command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/waves*` | Implemented for wave queue, preview, create, detail, items, source-check, simulation, approval, staging, handoff, proof posture, and supportability through Gateway only; canonical live wave proof pending. |
 | DPM construction alternatives | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/construction/alternative-sets*` | Implemented for generation, comparison, and PM selection through Gateway only. |
 | DPM proof-pack evidence | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/proof-packs*` | Implemented for generation from Gateway rebalance-run reference, proof-pack identity, sections, hashes, Markdown/report/AI posture, and governed PM memo request posture. |
+| DPM portfolio memory | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory` | Implemented for manage-owned timeline event order, event mix, source systems, source refs, artifact refs, reason codes, supportability, and content hash; canonical live memory proof pending. |
 | DPM outcome review | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/outcome-reviews*` | Implemented for review list, dimensions, source lineage, report input, AI evidence, report job, and AI narrative request. |
+
+## DPM Portfolio Memory
+
+The RFC40-WTBD-010 portfolio-memory panel gives portfolio managers, operations, audit, and
+sales/pre-sales a single readable event trail for DPM evidence.
+
+Implemented:
+
+1. loads portfolio memory through Gateway only,
+2. renders manage-owned supportability, event count, event type counts, source systems, reason
+   codes, and content hash,
+3. preserves event order, event type, event time, source refs, artifact refs, and reason codes,
+4. handles empty, partial, unsupported, unavailable, and endpoint error states without implying
+   local reconstruction,
+5. emits bounded observability for `dpm.portfolio-memory.get` without portfolio ids, event ids,
+   source refs, content hashes, request bodies, response bodies, or screen content as labels.
+
+Not yet supported:
+
+1. event detail drawers,
+2. timeline filtering and search,
+3. retention or audit-policy controls,
+4. cross-app lifecycle export,
+5. client-demo script steps beyond the canonical Workbench screenshot after live validation.
 
 ## DPM Wave Command Center
 
@@ -53,6 +78,7 @@ flowchart LR
   Manage --> Waves[RFC-0041 waves]
   Manage --> Construction[RFC-0039 alternatives]
   Manage --> ProofPacks[RFC-0040 proof packs]
+  Manage --> Memory[RFC40-WTBD-010 portfolio memory]
   Manage --> Outcomes[RFC-0042 outcomes]
   GW --> Report[lotus-report via Gateway]
   GW --> AI[lotus-ai via Gateway]


### PR DESCRIPTION
## Summary\n- Add Gateway-backed DPM portfolio-memory API consumption and Workbench panel rendering\n- Extend canonical live validation to API-check, browser-check, classify, and screenshot dpm.portfolio_memory\n- Record Manage source-supportability evidence without treating unrelated action-register staleness as DPM panel failure\n- Update RFC/context/wiki docs for implementation-backed feature coverage\n\n## Validation\n- npm test -- --run tests/unit/portfolio-memory-view-model.test.ts tests/unit/portfolio-memory-panel.test.tsx tests/unit/live-canonical-validation-script.test.ts tests/unit/live-validation-browser-workflows.test.ts\n- make check\n- npm run live:validate with local workbench,gateway,manage after DPM seed\n- git diff --check\n- wiki check-only: expected drift in API-Surface.md, Integrations.md, Observability-Evidence.md, Supported-Features.md until post-merge wiki publication\n\n## Evidence\n- output/playwright/live-canonical/live-validation-summary.json\n- output/playwright/live-canonical/dpm-portfolio-memory-live.png\n- output/playwright/live-canonical/SHOT-INDEX.md\n\n## Dependency\n- Companion platform registry PR should merge first.