### PR TITLE
Add Workbench wave AI memo proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ Boundary rules that matter:
    run ids as RFC-0040 proof-pack sources. Reviewable Manage states such as `PENDING_REVIEW` are
    displayed truthfully when the proof pack includes identity, sections, hashes/lineage, and handoff
    posture.
-6. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0042 post-trade outcome-review
+6. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0041 rebalance-wave command
+   center for wave queue, preview, create, detail, items, source-check, simulation, approval,
+   staging, handoff, report-input, and governed AI PM memo request posture. Workbench renders
+   Gateway/manage/lotus-ai workflow-pack truth and does not calculate wave readiness, build report
+   input, construct AI prompts, generate memo narrative locally, claim external execution, or call
+   `lotus-manage` or `lotus-ai` directly.
+7. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0042 post-trade outcome-review
    panel for manage-owned expected-versus-realized dimensions, source lineage, supportability,
    and report/AI handoff posture. Workbench renders the Gateway contract and does not calculate
    outcome variance, freshness, supportability, or handoff eligibility locally.
@@ -283,6 +289,11 @@ Important current product and route truths:
    lotus-ai PM memo workflow-pack posture through Gateway, but must not rebuild proof-pack
    sections, compute hashes, synthesize Markdown, construct report input, construct AI evidence,
    construct PM memo prompts, or call `lotus-manage`, `lotus-report`, or `lotus-ai` directly.
+11. RFC-0041 rebalance-wave rendering on `/workbench/{portfolioId}` is backed by Gateway
+   `/api/v1/dpm/command-center/waves*`; Workbench may render Gateway/manage wave state,
+   report-input readiness, and lotus-ai wave PM memo workflow-pack posture through Gateway, but
+   must not build report input, construct AI prompts, generate memo text locally, score PMs,
+   approve trades independently, contact clients, place orders, or call upstream services directly.
 
 Copy-paste route and runtime examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -85,11 +85,13 @@ Current repository posture:
 12. `/workbench/{portfolioId}` renders the RFC-0041 DPM rebalance-wave command-center panel
    through Gateway `/api/v1/dpm/command-center/waves*`. Workbench lists explicit portfolio-list
    waves, previews and creates canonical portfolio waves, opens wave detail and item posture, and
-   sends source-check and simulation through Gateway only. It preserves manage-owned wave state,
-   item state, source-readiness state, supportability, aggregate metrics, proof-pack refs,
-   handoff refs, blocked actions, and `external_execution_claimed` posture without calling
-   `lotus-manage` directly, calculating readiness, claiming external execution, or inferring
-   PM-book discovery.
+   sends source-check, simulation, approval, staging, handoff, report-input, and governed AI PM
+   memo requests through Gateway only. It preserves manage-owned wave state, item state,
+   source-readiness state, supportability, aggregate metrics, report-input refs, proof-pack refs,
+   handoff refs, blocked actions, lotus-ai workflow-pack run posture, and
+   `external_execution_claimed` posture without calling `lotus-manage` or `lotus-ai` directly,
+   calculating readiness, constructing report input, constructing AI prompts, generating memo
+   narrative locally, claiming external execution, or inferring PM-book discovery.
 13. `/workbench/{portfolioId}` also renders Gateway-provided rebalance action-register
    supportability and portfolio-level DPM operations posture from the portfolio overview
    `rebalance_snapshot`, including source state, freshness, run count, operation count, workflow
@@ -216,7 +218,8 @@ Important validation expectations:
 14. DPM rebalance-wave reads and mutations are Workbench gateway-only operations. Observability
     labels must remain bounded to route, panel, operation, freshness, supportability, status class,
     and error category; wave ids, wave item ids, portfolio ids, proof-pack ids, handoff refs,
-    request bodies, response bodies, and screen content must never be emitted as metric labels.
+    report-input refs, workflow-pack run ids, request bodies, response bodies, and screen content
+    must never be emitted as metric labels.
 15. DPM portfolio-memory reads are Workbench gateway-only operations. Observability labels must
     remain bounded to route, panel, operation, freshness, supportability, status class, and error
     category; portfolio ids, event ids, source refs, artifact refs, content hashes, request bodies,

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -2,7 +2,7 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | IN PROGRESS - RFC-0038 COMMAND-CENTER COCKPIT, RFC-0039 CONSTRUCTION LAB, RFC-0040 PROOF-PACK PANEL, RFC-0040/RFC-0041/RFC-0042 PORTFOLIO-MEMORY PANEL, RFC-0041 REBALANCE-WAVE PANEL, AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`; CANONICAL LIVE MEMORY/WAVE PROOF PENDING |
+| **Status** | IN PROGRESS - RFC-0038 COMMAND-CENTER COCKPIT, RFC-0039 CONSTRUCTION LAB, RFC-0040 PROOF-PACK PANEL, RFC-0040/RFC-0041/RFC-0042 PORTFOLIO-MEMORY PANEL, RFC-0041 REBALANCE-WAVE PANEL, AND RFC-0042 OUTCOME PANEL IMPLEMENTED ON `/workbench/{portfolioId}`; CANONICAL LIVE WAVE AI MEMO PROOF IN PROGRESS |
 | **Created** | 2026-05-03 |
 | **Last Tightened** | 2026-05-06 |
 | **Owner** | `lotus-workbench` |
@@ -32,12 +32,14 @@ embedded in `/workbench/{portfolioId}` and consumes Gateway
 `/api/v1/dpm/command-center/waves*` routes only. Promotion remains pending focused CI, canonical
 front-office proof, PR merge, wiki publication, and Manage WTBD closure.
 
-RFC40-WTBD-010 portfolio-memory product realization is now implemented locally on
-`wtbd-rfc40-portfolio-memory-workbench`. `/workbench/{portfolioId}` consumes Gateway
+RFC40-WTBD-010 portfolio-memory product realization is implemented on
+`/workbench/{portfolioId}`. The panel consumes Gateway
 `GET /api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`, renders manage-owned event
 order, event types, source systems, source refs, artifact refs, reason codes, supportability, and
-content hash, and does not reconstruct timeline nodes in the browser. Promotion remains pending
-focused CI, canonical front-office proof, PR merge, wiki publication, and final WTBD closure.
+content hash, and does not reconstruct timeline nodes in the browser. Canonical live validation
+accepts populated `READY`, `PARTIAL`, `DEGRADED`, and `BLOCKED` source truth because the panel is
+responsible for surfacing source-owner readiness gaps; it still fails empty, unsupported,
+unavailable, or content-hash-missing memory.
 
 ---
 
@@ -239,7 +241,7 @@ The implemented panel:
    reason codes, and content hash,
 3. preserves upstream event order, event type, event time, source refs, artifact refs, and reason
    codes,
-4. shows empty, partial, unsupported, unavailable, and error states explicitly,
+4. shows empty, partial, degraded, unsupported, unavailable, and error states explicitly,
 5. emits bounded `dpm.portfolio-memory.get` observability without portfolio ids, event ids, content
    hashes, source refs, request payloads, response payloads, or screen content as metric labels,
 6. must not call `lotus-manage` directly,
@@ -452,19 +454,23 @@ Workbench must consume these Gateway wave routes when implemented:
 | `POST /api/v1/dpm/command-center/waves/{wave_id}/approve` | approval action |
 | `POST /api/v1/dpm/command-center/waves/{wave_id}/stage` | staging action |
 | `POST /api/v1/dpm/command-center/waves/{wave_id}/handoff` | internal operations handoff action |
+| `GET /api/v1/dpm/command-center/waves/{wave_id}/report-input` | report-input evidence drawer |
+| `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo` | governed AI PM memo request |
 
-Implementation note as of 2026-05-07: the first RFC-0041 rebalance-wave command-center
+Implementation note as of 2026-05-08: the first RFC-0041 rebalance-wave command-center
 realization is embedded in `/workbench/{portfolioId}` through Gateway
 `/api/v1/dpm/command-center/waves*`. Workbench loads the explicit portfolio-list wave queue,
 previews and creates canonical portfolio waves, opens wave detail and item posture, and calls
-source-check, simulation, approval, staging, handoff, proof-posture, and supportability through the
-Workbench BFF/Gateway boundary. The panel renders manage-owned wave id, lifecycle state, item
-count, issue count, supportability reason codes, blocked actions, aggregate metrics, item states,
-source-readiness state, alternative refs, proof-pack refs, handoff refs, and
-`external_execution_claimed` posture without direct `lotus-manage` calls or client-side readiness
-calculation. Item-selection drawers, richer supportability drawers, dedicated `/dpm/waves` routes,
-PM-book discovery, CIO approval workflow, and external OMS execution remain future scope until
-Gateway/Manage and Workbench proof promote them.
+source-check, simulation, approval, staging, handoff, proof-posture, supportability, report-input,
+and governed AI PM memo requests through the Workbench BFF/Gateway boundary. The panel renders
+manage-owned wave id, lifecycle state, item count, issue count, supportability reason codes,
+blocked actions, aggregate metrics, item states, source-readiness state, alternative refs,
+report-input refs, proof-pack refs, handoff refs, lotus-ai workflow-pack run posture, and
+`external_execution_claimed` posture without direct `lotus-manage` or `lotus-ai` calls,
+client-side readiness calculation, report-input construction, prompt construction, or local memo
+narrative generation. Item-selection drawers, richer supportability drawers, dedicated
+`/dpm/waves` routes, PM-book discovery, CIO approval workflow, and external OMS execution remain
+future scope until Gateway/Manage and Workbench proof promote them.
 
 Supported-feature promotion is forbidden until the Workbench BFF and browser implementation is
 complete, canonical `PB_SG_GLOBAL_BAL_001` live validation passes, visual and accessibility

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -98,6 +98,17 @@ function extractGeneratedProofPackId(response) {
   );
 }
 
+function extractDpmWaveId(response) {
+  const payload = response?.data ?? response;
+  return (
+    readString(payload?.wave?.wave_id) ||
+    readString(payload?.wave_id) ||
+    readString(payload?.items?.[0]?.wave_id) ||
+    readString(response?.supportability?.wave_id) ||
+    null
+  );
+}
+
 function extractWorkbenchRebalanceRunId(gatewayOverview) {
   const snapshot = gatewayOverview?.rebalance_snapshot;
   const latestRunId = readString(snapshot?.last_rebalance_run_id);
@@ -144,6 +155,8 @@ function isReviewableProofPackState(state) {
 
 function extractWorkflowPackRunId(payload) {
   return (
+    readString(payload?.run_id) ||
+    readString(payload?.workflow_run_id) ||
     readString(payload?.workflow_pack_run?.run_id) ||
     readString(payload?.execution?.audit?.workflow_pack_run_id) ||
     readString(payload?.audit?.workflow_pack_run_id) ||
@@ -455,7 +468,7 @@ async function run() {
     ? portfolioMemoryPayload.events
     : [];
   const portfolioMemoryState = readSupportabilityState(portfolioMemorySupportability);
-  const supportedPortfolioMemoryStates = new Set(["ready", "partial", "blocked"]);
+  const supportedPortfolioMemoryStates = new Set(["ready", "partial", "degraded", "blocked"]);
   if (!supportedPortfolioMemoryStates.has(portfolioMemoryState?.toLowerCase())) {
     throw new Error(
       `DPM portfolio memory did not return populated manage supportability; observed ${
@@ -526,6 +539,8 @@ async function run() {
   if (!readSupportabilityState(dpmWaveSupportability)) {
     throw new Error("DPM rebalance-wave list returned no manage supportability state.");
   }
+  const dpmWavePayload = dpmWaves?.data ?? dpmWaves;
+  let dpmWaveId = extractDpmWaveId(dpmWavePayload);
   const dpmWavePreview = await postJson(
     summary,
     `${gatewayBaseUrl}/api/v1/dpm/command-center/waves/preview`,
@@ -551,6 +566,77 @@ async function run() {
       }.`
     );
   }
+  if (!dpmWaveId) {
+    const dpmWaveCreate = await postJson(
+      summary,
+      `${gatewayBaseUrl}/api/v1/dpm/command-center/waves`,
+      "DPM rebalance-wave create",
+      timeoutMs,
+      {
+        idempotency_key: [
+          "workbench-live-validation-wave",
+          portfolioId,
+          dpmCommandCenterDefaults.asOfDate,
+        ].join("-"),
+        body: {
+          trigger_type: "EXPLICIT_PORTFOLIO_LIST",
+          trigger_id: `live-validation-wave-${portfolioId}-${dpmCommandCenterDefaults.asOfDate}`,
+          rationale: "Canonical Workbench live validation created an RFC-0041 rebalance wave.",
+          as_of_date: dpmCommandCenterDefaults.asOfDate,
+          actor_id: "workbench-system",
+          portfolios: [{ portfolio_id: portfolioId }],
+        },
+      }
+    );
+    dpmWaveId = extractDpmWaveId(dpmWaveCreate);
+  }
+  if (!dpmWaveId) {
+    throw new Error("DPM rebalance-wave create returned no manage-owned wave id.");
+  }
+  const dpmWaveReportInput = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/dpm/command-center/waves/${encodeURIComponent(dpmWaveId)}/report-input`,
+    "DPM rebalance-wave report input",
+    timeoutMs
+  );
+  const dpmWaveReportInputPayload = dpmWaveReportInput?.data ?? dpmWaveReportInput;
+  const dpmWaveReportInputRef =
+    readString(dpmWaveReportInputPayload?.report_input_ref) ||
+    readString(dpmWaveReportInputPayload?.evidence_ref?.ref_id);
+  if (!dpmWaveReportInputRef) {
+    throw new Error("DPM rebalance-wave report input returned no report input evidence ref.");
+  }
+  const dpmWaveAiPmMemo = await postJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/dpm/command-center/waves/${encodeURIComponent(dpmWaveId)}/ai-pm-memo`,
+    "DPM rebalance-wave AI PM memo",
+    timeoutMs,
+    {
+      requested_outputs: ["wave_pm_memo", "approval_checklist", "evidence_gaps"],
+      audience: ["portfolio_manager", "investment_control", "operations"],
+    }
+  );
+  const dpmWaveAiPmMemoPayload = dpmWaveAiPmMemo?.data ?? dpmWaveAiPmMemo;
+  const dpmWaveAiPmMemoSourceService =
+    readString(dpmWaveAiPmMemo?.source_service) ?? readString(dpmWaveAiPmMemo?.sourceService);
+  if (dpmWaveAiPmMemoSourceService !== "lotus-ai") {
+    throw new Error("DPM rebalance-wave AI PM memo did not return lotus-ai source authority.");
+  }
+  const dpmWaveAiPmMemoRunId = extractWorkflowPackRunId(dpmWaveAiPmMemoPayload);
+  if (!dpmWaveAiPmMemoRunId) {
+    throw new Error("DPM rebalance-wave AI PM memo returned no workflow-pack run reference.");
+  }
+  summary.workflowPackChecks.push({
+    description: "DPM rebalance-wave AI PM memo",
+    sourceService: dpmWaveAiPmMemoSourceService,
+    waveId: dpmWaveId,
+    sourceRunId: dpmWaveAiPmMemoRunId,
+    resultReviewState:
+      dpmWaveAiPmMemoPayload?.workflow_pack_run?.review_state ??
+      dpmWaveAiPmMemoPayload?.execution?.review_state ??
+      dpmWaveAiPmMemoPayload?.status ??
+      "UNKNOWN",
+  });
 
   const reportCapabilities = await fetchJson(
     summary,
@@ -623,6 +709,9 @@ async function run() {
   panelGovernance.recordPanelClassification("dpm.wave_command_center", "ready", "lotus-manage", {
     route: `/workbench/${portfolioId}`,
     source: "Gateway DPM rebalance-wave composition",
+    waveId: dpmWaveId,
+    reportInputRef: dpmWaveReportInputPayload.report_input_ref,
+    aiMemoRunId: dpmWaveAiPmMemoRunId,
   });
   panelGovernance.assertNoUnsupportedBlankPanels();
   panelGovernance.assertPanelSupportabilityAlignment();

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -480,6 +480,8 @@ export async function validateDpmWaveCommandCenterPanel(
     "Handoff",
     "Proof posture",
     "Supportability",
+    "Report input",
+    "AI memo",
   ]) {
     await expect(wavePanel.getByRole("button", { name: actionName })).toBeVisible({
       timeout: timeoutMs,
@@ -489,6 +491,24 @@ export async function validateDpmWaveCommandCenterPanel(
     timeout: timeoutMs,
   });
   await expect(wavePanel.getByText("Preview wave completed through Gateway.")).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await wavePanel.getByRole("button", { name: "Create wave" }).click({
+    timeout: timeoutMs,
+  });
+  await expect(wavePanel.getByText("Create wave completed through Gateway.")).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await wavePanel.getByRole("button", { name: "Report input" }).click({
+    timeout: timeoutMs,
+  });
+  await expect(wavePanel.getByText("Load report input completed through Gateway.")).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await wavePanel.getByRole("button", { name: "AI memo" }).click({
+    timeout: timeoutMs,
+  });
+  await expect(wavePanel.getByText("Request AI memo completed through Gateway.")).toBeVisible({
     timeout: timeoutMs,
   });
   await screenshotRegisteredPanel(page, "dpm.wave_command_center");

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -300,6 +300,16 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     operation: "dpm.waves.supportability",
   },
   {
+    route: "workbench.dpm-command-center",
+    panel: "wave-report-input",
+    operation: "dpm.waves.report-input",
+  },
+  {
+    route: "workbench.dpm-command-center",
+    panel: "wave-ai-pm-memo",
+    operation: "dpm.waves.ai-pm-memo",
+  },
+  {
     route: "workbench.legacy-advisor",
     panel: "advisor-overview",
     operation: "workbench.overview",

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -22,6 +22,7 @@ import {
   DpmProofPackAiPmMemoResponse,
   DpmProofPackGatewayResponse,
   DpmProofPackMarkdownResponse,
+  DpmWaveAiPmMemoResponse,
   DpmWaveGatewayResponse,
   ReportJobHandleResponse,
   ReportBatchHandleResponse,
@@ -1184,6 +1185,47 @@ export async function getDpmWaveSupportability(
         "client",
         `/dpm/command-center/waves/${encodeURIComponent(waveId)}/supportability`,
         "DPM rebalance wave supportability"
+      )
+  );
+}
+
+export async function getDpmWaveReportInput(waveId: string): Promise<DpmWaveGatewayResponse> {
+  return await observeWorkbenchResource(
+    "dpm.waves.report-input",
+    async () =>
+      await fetchWorkbenchResource<DpmWaveGatewayResponse>(
+        "client",
+        `/dpm/command-center/waves/${encodeURIComponent(waveId)}/report-input`,
+        "DPM rebalance wave report input"
+      )
+  );
+}
+
+export async function requestDpmWaveAiPmMemo(waveId: string): Promise<DpmWaveAiPmMemoResponse> {
+  return await observeWorkbenchMutation(
+    "dpm.waves.ai-pm-memo",
+    async () =>
+      await fetchWorkbenchMutation<DpmWaveAiPmMemoResponse>(
+        buildWorkbenchUrl(
+          "client",
+          `/dpm/command-center/waves/${encodeURIComponent(waveId)}/ai-pm-memo`
+        ),
+        "request DPM rebalance wave AI PM memo",
+        {
+          method: "POST",
+          headers: buildDpmWaveCallerHeaders(),
+          body: JSON.stringify({
+            requested_outputs: [
+              "wave_pm_memo",
+              "wave_rationale_summary",
+              "approval_checklist",
+              "risk_caveats",
+              "operations_handoff",
+              "evidence_gaps",
+            ],
+            audience: ["portfolio_manager", "investment_control", "operations"],
+          }),
+        }
       )
   );
 }

--- a/src/features/workbench/components/dpm-wave-command-center-panel.tsx
+++ b/src/features/workbench/components/dpm-wave-command-center-panel.tsx
@@ -16,14 +16,16 @@ import {
   getDpmWave,
   getDpmWaveItems,
   getDpmWaveProofPackPosture,
+  getDpmWaveReportInput,
   getDpmWaveSupportability,
   handoffDpmWave,
   previewDpmWave,
+  requestDpmWaveAiPmMemo,
   simulateDpmWave,
   sourceCheckDpmWave,
   stageDpmWave,
 } from "@/features/workbench/api";
-import type { DpmWaveGatewayResponse } from "@/features/workbench/types";
+import type { DpmWaveAiPmMemoResponse, DpmWaveGatewayResponse } from "@/features/workbench/types";
 import {
   buildDpmWaveCommandCenterModel,
   type DpmWaveCommandCenterPanelState,
@@ -86,6 +88,9 @@ export default function DpmWaveCommandCenterPanel({
   const [detailResponse, setDetailResponse] = useState<DpmWaveGatewayResponse | null>(null);
   const [itemsResponse, setItemsResponse] = useState<DpmWaveGatewayResponse | null>(null);
   const [actionResponse, setActionResponse] = useState<DpmWaveGatewayResponse | null>(null);
+  const [reportInputResponse, setReportInputResponse] =
+    useState<DpmWaveGatewayResponse | null>(null);
+  const [aiMemoResponse, setAiMemoResponse] = useState<DpmWaveAiPmMemoResponse | null>(null);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
@@ -94,6 +99,8 @@ export default function DpmWaveCommandCenterPanel({
     waveDetail: detailResponse,
     waveItems: itemsResponse,
     actionResponse,
+    waveReportInput: reportInputResponse,
+    waveAiMemo: aiMemoResponse,
   });
   const selectedWaveId = model.selectedWaveId;
   const stateCopy = statePanelCopy(model.state, portfolioId);
@@ -115,6 +122,24 @@ export default function DpmWaveCommandCenterPanel({
     try {
       const response = await action();
       setActionResponse(response);
+      setActionMessage(`${label} completed through Gateway.`);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : `${label} failed`);
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function runMemoAction(label: string, action: () => Promise<DpmWaveAiPmMemoResponse>) {
+    if (pendingAction) {
+      return;
+    }
+    setPendingAction(label);
+    setActionError(null);
+    setActionMessage(null);
+    try {
+      const response = await action();
+      setAiMemoResponse(response);
       setActionMessage(`${label} completed through Gateway.`);
     } catch (error) {
       setActionError(error instanceof Error ? error.message : `${label} failed`);
@@ -202,6 +227,24 @@ export default function DpmWaveCommandCenterPanel({
     void runAction("Load supportability", () => getDpmWaveSupportability(selectedWaveId));
   }
 
+  function loadReportInput() {
+    if (!selectedWaveId) {
+      return;
+    }
+    void runAction("Load report input", async () => {
+      const response = await getDpmWaveReportInput(selectedWaveId);
+      setReportInputResponse(response);
+      return response;
+    });
+  }
+
+  function requestAiMemo() {
+    if (!selectedWaveId) {
+      return;
+    }
+    void runMemoAction("Request AI memo", () => requestDpmWaveAiPmMemo(selectedWaveId));
+  }
+
   return (
     <SectionBlock
       title="Rebalance Wave Command Center"
@@ -268,6 +311,12 @@ export default function DpmWaveCommandCenterPanel({
         </ActionButton>
         <ActionButton priority="secondary" onClick={loadSupportability} disabled={!selectedWaveId || Boolean(pendingAction)}>
           Supportability
+        </ActionButton>
+        <ActionButton priority="secondary" onClick={loadReportInput} disabled={!selectedWaveId || Boolean(pendingAction)}>
+          Report input
+        </ActionButton>
+        <ActionButton priority="secondary" onClick={requestAiMemo} disabled={!selectedWaveId || Boolean(pendingAction)}>
+          AI memo
         </ActionButton>
       </div>
 
@@ -361,6 +410,10 @@ export default function DpmWaveCommandCenterPanel({
             <MetricRow label="Handoff Refs" value={model.handoffRows.length.toString()} />
             <MetricRow label="External Execution" value={model.externalExecutionClaimed} />
             <MetricRow label="Remediation Owner" value={model.remediationOwner} />
+            <MetricRow label="Report Input" value={model.reportInputStatus} />
+            <MetricRow label="Report Input Ref" value={model.reportInputRef} />
+            <MetricRow label="AI Memo" value={model.aiMemoStatus} />
+            <MetricRow label="AI Memo Run" value={model.aiMemoRunId} />
           </div>
         </div>
       </div>

--- a/src/features/workbench/dpm-wave-command-center-view-model.ts
+++ b/src/features/workbench/dpm-wave-command-center-view-model.ts
@@ -1,4 +1,4 @@
-import type { DpmWaveGatewayResponse } from "./types";
+import type { DpmWaveAiPmMemoResponse, DpmWaveGatewayResponse } from "./types";
 
 export type DpmWaveCommandCenterPanelState =
   | "ready"
@@ -51,6 +51,10 @@ export type DpmWaveCommandCenterPanelModel = {
   selectedWaveItemCount: string;
   selectedWaveIssueCount: string;
   selectedWaveSupportabilityReason: string;
+  reportInputRef: string;
+  reportInputStatus: string;
+  aiMemoStatus: string;
+  aiMemoRunId: string;
   summaryRows: DpmWaveSummaryRow[];
   metricRows: DpmWaveMetricRow[];
   itemRows: DpmWaveItemRow[];
@@ -64,9 +68,15 @@ export function buildDpmWaveCommandCenterModel(params: {
   waveDetail?: DpmWaveGatewayResponse | null;
   waveItems?: DpmWaveGatewayResponse | null;
   actionResponse?: DpmWaveGatewayResponse | null;
+  waveReportInput?: DpmWaveGatewayResponse | null;
+  waveAiMemo?: DpmWaveAiPmMemoResponse | null;
 }): DpmWaveCommandCenterPanelModel {
   const primary =
-    params.actionResponse ?? params.waveDetail ?? params.waveList ?? params.waveItems;
+    params.actionResponse ??
+    params.waveDetail ??
+    params.waveReportInput ??
+    params.waveList ??
+    params.waveItems;
   const listRows = buildSummaryRows(params.waveList?.data);
   const waveRecord = readWaveRecord(params.actionResponse?.data) || readWaveRecord(params.waveDetail?.data);
   const itemData = params.waveItems?.data ?? params.actionResponse?.data ?? params.waveDetail?.data;
@@ -115,6 +125,12 @@ export function buildDpmWaveCommandCenterModel(params: {
       listRows.find((row) => row.waveId === selectedWaveId)?.supportabilityReason ||
       firstNonEmpty(supportability?.reason_codes) ||
       "N/A",
+    reportInputRef: readReportInputRef(params.waveReportInput?.data, params.waveAiMemo),
+    reportInputStatus: params.waveReportInput
+      ? normalizeState(params.waveReportInput.supportability.state)
+      : "NOT_REQUESTED",
+    aiMemoStatus: readAiMemoStatus(params.waveAiMemo),
+    aiMemoRunId: readAiMemoRunId(params.waveAiMemo),
     summaryRows: listRows,
     metricRows: buildMetricRows(metricSource),
     itemRows,
@@ -124,6 +140,38 @@ export function buildDpmWaveCommandCenterModel(params: {
       readValue(proofPackPosture, "external_execution_claimed")
     ),
   };
+}
+
+function readReportInputRef(
+  reportInput: Record<string, unknown> | undefined,
+  memo: DpmWaveAiPmMemoResponse | null | undefined
+): string {
+  const evidenceRef = readRecord(reportInput?.evidence_ref);
+  return (
+    readString(reportInput ?? {}, "report_input_ref") ||
+    readString(evidenceRef, "ref_id") ||
+    readString(memo?.wave_report_input ?? {}, "report_input_ref") ||
+    "N/A"
+  );
+}
+
+function readAiMemoStatus(memo: DpmWaveAiPmMemoResponse | null | undefined): string {
+  if (!memo) {
+    return "NOT_REQUESTED";
+  }
+  return normalizeState(
+    readString(memo.data, "status") ||
+      readString(memo.data, "review_state") ||
+      readString(readRecord(memo.data.output), "review_state") ||
+      "REVIEW_REQUIRED"
+  );
+}
+
+function readAiMemoRunId(memo: DpmWaveAiPmMemoResponse | null | undefined): string {
+  if (!memo) {
+    return "N/A";
+  }
+  return readString(memo.data, "run_id") || readString(memo.data, "workflow_run_id") || "N/A";
 }
 
 function resolvePanelState(

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1281,6 +1281,19 @@ export type DpmWaveGatewayResponse = {
   data: Record<string, unknown>;
 };
 
+export type DpmWaveAiPmMemoResponse = {
+  correlation_id: string;
+  contract_version: string;
+  source_service: string;
+  evidence_source_service: string;
+  manage_upstream_status: number;
+  ai_upstream_status: number;
+  supportability: DpmWaveSupportability;
+  wave_report_input: Record<string, unknown>;
+  memo_request: Record<string, unknown>;
+  data: Record<string, unknown>;
+};
+
 export type DpmOutcomeReviewNarrativeResponse = {
   correlation_id: string;
   contract_version: string;

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -409,6 +409,16 @@ describe("analytics UI observability metrics", () => {
         "wave-supportability",
         "dpm.waves.supportability",
       ],
+      [
+        "workbench.dpm-command-center",
+        "wave-report-input",
+        "dpm.waves.report-input",
+      ],
+      [
+        "workbench.dpm-command-center",
+        "wave-ai-pm-memo",
+        "dpm.waves.ai-pm-memo",
+      ],
       ["workbench.legacy-advisor", "advisor-overview", "workbench.overview"],
       ["workbench.legacy-advisor", "portfolio-360", "workbench.portfolio-360"],
       ["workbench.legacy-advisor", "portfolio-analytics", "workbench.analytics"],

--- a/tests/unit/dpm-wave-command-center-panel.test.tsx
+++ b/tests/unit/dpm-wave-command-center-panel.test.tsx
@@ -8,9 +8,11 @@ import {
   getDpmWave,
   getDpmWaveItems,
   getDpmWaveProofPackPosture,
+  getDpmWaveReportInput,
   getDpmWaveSupportability,
   handoffDpmWave,
   previewDpmWave,
+  requestDpmWaveAiPmMemo,
   simulateDpmWave,
   sourceCheckDpmWave,
   stageDpmWave,
@@ -23,9 +25,11 @@ vi.mock("../../src/features/workbench/api", () => ({
   getDpmWave: vi.fn(),
   getDpmWaveItems: vi.fn(),
   getDpmWaveProofPackPosture: vi.fn(),
+  getDpmWaveReportInput: vi.fn(),
   getDpmWaveSupportability: vi.fn(),
   handoffDpmWave: vi.fn(),
   previewDpmWave: vi.fn(),
+  requestDpmWaveAiPmMemo: vi.fn(),
   simulateDpmWave: vi.fn(),
   sourceCheckDpmWave: vi.fn(),
   stageDpmWave: vi.fn(),
@@ -88,6 +92,9 @@ describe("DpmWaveCommandCenterPanel", () => {
     expect(screen.getByRole("button", { name: "Handoff" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Proof posture" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Supportability" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Report input" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "AI memo" })).toBeEnabled();
+    expect(screen.getAllByText("NOT_REQUESTED").length).toBeGreaterThanOrEqual(2);
   });
 
   it("requests review, workflow, proof, and supportability actions through Gateway helpers", async () => {
@@ -122,6 +129,32 @@ describe("DpmWaveCommandCenterPanel", () => {
     vi.mocked(handoffDpmWave).mockResolvedValue(waveResponse);
     vi.mocked(getDpmWaveProofPackPosture).mockResolvedValue(waveResponse);
     vi.mocked(getDpmWaveSupportability).mockResolvedValue(waveResponse);
+    vi.mocked(getDpmWaveReportInput).mockResolvedValue({
+      ...waveResponse,
+      data: {
+        wave_id: "dwv_001",
+        report_input_ref: "report-input:dwv_001",
+        source_refs: ["lotus-manage:wave:dwv_001"],
+      },
+    });
+    vi.mocked(requestDpmWaveAiPmMemo).mockResolvedValue({
+      correlation_id: "corr-wave-ai-memo",
+      contract_version: "v1",
+      source_service: "lotus-ai",
+      evidence_source_service: "lotus-manage",
+      manage_upstream_status: 200,
+      ai_upstream_status: 200,
+      supportability: waveResponse.supportability,
+      wave_report_input: {
+        wave_id: "dwv_001",
+        report_input_ref: "report-input:dwv_001",
+      },
+      memo_request: {
+        requested_outputs: ["wave_pm_memo", "approval_checklist"],
+        audience: ["portfolio_manager", "investment_control"],
+      },
+      data: { run_id: "wf_run_wave_memo_001", status: "REVIEW_REQUIRED" },
+    });
 
     render(
       <DpmWaveCommandCenterPanel
@@ -161,6 +194,14 @@ describe("DpmWaveCommandCenterPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Supportability" }));
     await waitFor(() => expect(getDpmWaveSupportability).toHaveBeenCalledWith("dwv_001"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Report input" }));
+    await waitFor(() => expect(getDpmWaveReportInput).toHaveBeenCalledWith("dwv_001"));
+    expect(await screen.findByText("report-input:dwv_001")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "AI memo" }));
+    await waitFor(() => expect(requestDpmWaveAiPmMemo).toHaveBeenCalledWith("dwv_001"));
+    expect(await screen.findByText("wf_run_wave_memo_001")).toBeInTheDocument();
   });
 
   it("creates a wave without direct manage calls", async () => {

--- a/tests/unit/dpm-wave-command-center-view-model.test.ts
+++ b/tests/unit/dpm-wave-command-center-view-model.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { buildDpmWaveCommandCenterModel } from "../../src/features/workbench/dpm-wave-command-center-view-model";
-import type { DpmWaveGatewayResponse } from "../../src/features/workbench/types";
+import type {
+  DpmWaveAiPmMemoResponse,
+  DpmWaveGatewayResponse,
+} from "../../src/features/workbench/types";
 
 const waveListResponse: DpmWaveGatewayResponse = {
   correlation_id: "corr-wave-list",
@@ -104,6 +107,50 @@ describe("DPM wave command-center view model", () => {
     expect(model.proofPackRows[0].value).toContain("sha256:proof");
     expect(model.handoffRows[0].label).toBe("dwh_1");
     expect(model.externalExecutionClaimed).toBe("No");
+  });
+
+  it("surfaces report-input and AI PM memo posture without deriving execution truth", () => {
+    const aiMemoResponse: DpmWaveAiPmMemoResponse = {
+      correlation_id: "corr-wave-ai-memo",
+      contract_version: "v1",
+      source_service: "lotus-ai",
+      evidence_source_service: "lotus-manage",
+      manage_upstream_status: 200,
+      ai_upstream_status: 200,
+      supportability: waveListResponse.supportability,
+      wave_report_input: {
+        wave_id: "dwv_001",
+        report_input_ref: "report-input:dwv_001",
+      },
+      memo_request: {
+        requested_outputs: ["wave_pm_memo", "approval_checklist"],
+        audience: ["portfolio_manager", "investment_control"],
+      },
+      data: {
+        run_id: "wf_run_wave_memo_001",
+        status: "REVIEW_REQUIRED",
+      },
+    };
+
+    const model = buildDpmWaveCommandCenterModel({
+      waveList: waveListResponse,
+      waveReportInput: {
+        ...waveListResponse,
+        data: {
+          wave_id: "dwv_001",
+          evidence_ref: {
+            ref_id: "dwv_001:dpm_wave_report_input",
+          },
+        },
+      },
+      waveAiMemo: aiMemoResponse,
+    });
+
+    expect(model.reportInputStatus).toBe("READY");
+    expect(model.reportInputRef).toBe("dwv_001:dpm_wave_report_input");
+    expect(model.aiMemoStatus).toBe("REVIEW_REQUIRED");
+    expect(model.aiMemoRunId).toBe("wf_run_wave_memo_001");
+    expect(model.externalExecutionClaimed).toBe("N/A");
   });
 
   it("does not infer readiness from a present wave when manage supportability is blocked", () => {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -73,6 +73,7 @@ describe("canonical live validation script", () => {
     );
     expect(browserValidator).toContain("DPM rebalance-wave preview did not return ready manage supportability");
     expect(browserValidator).toContain("supportedPortfolioMemoryStates");
+    expect(browserValidator).toContain('"degraded"');
     expect(browserValidator).toContain("DPM portfolio memory did not return populated manage supportability");
     expect(browserValidator).toContain("gatewayModuleHealth.lotus_manage");
     expect(browserValidator).toContain("/api/v1/dpm/command-center?");
@@ -359,6 +360,13 @@ describe("canonical live validation script", () => {
     expect(script).toContain("/ai-pm-memo");
     expect(script).toContain("DPM proof-pack AI PM memo did not return lotus-ai source authority.");
     expect(script).toContain("DPM proof-pack AI PM memo returned no workflow-pack run reference.");
+    expect(script).toContain("DPM rebalance-wave report input");
+    expect(script).toContain("DPM rebalance-wave report input returned no report input evidence ref.");
+    expect(script).toContain("DPM rebalance-wave AI PM memo");
+    expect(script).toContain("DPM rebalance-wave create");
+    expect(script).toContain("DPM rebalance-wave create returned no manage-owned wave id.");
+    expect(script).toContain("DPM rebalance-wave AI PM memo did not return lotus-ai source authority.");
+    expect(script).toContain("DPM rebalance-wave AI PM memo returned no workflow-pack run reference.");
     expect(script).toContain("Gateway workbench overview returned no manage rebalance-run reference");
     expect(script).toContain("source_type: \"REBALANCE_RUN\"");
     expect(browserWorkflowModule).toContain("screenshotRegisteredPanel");

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -41,6 +41,8 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     assert "first RFC-0041 rebalance-wave command-center" in rfc
     assert "`/api/v1/dpm/command-center/waves*`" in rfc
     assert "approval, staging, handoff" in rfc
+    assert "`GET /api/v1/dpm/command-center/waves/{wave_id}/report-input`" in rfc
+    assert "`POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo`" in rfc
     assert "`GET /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}`" in rfc
     assert "Dimension Matrix" in rfc
     assert "AI Evidence Panel" in rfc
@@ -53,8 +55,9 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     assert "AI-evidence ready but AI memo unavailable" in rfc
     assert "outcome-review search, detail, supportability" in integrations
     assert "create, detail, item, source-check, simulation, approval, staging, handoff" in integrations
+    assert "supportability, report-input, and AI PM memo contracts" in integrations
     assert "must not calculate expected-versus-realized values" in integrations
-    assert "calculate wave readiness" in integrations
+    assert "calculate wave\n    readiness" in integrations
     assert "proof-pack truth" in integrations
     assert "proof-pack panel consumes the Gateway proof-pack" in integrations
     assert "proof-pack sections" in integrations
@@ -63,4 +66,5 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     assert "RFC-0040 proof-pack evidence" in roadmap
     assert "DPM rebalance-wave command center" in supported_features
     assert "approval, staging, handoff" in supported_features
+    assert "governed AI PM memo request" in supported_features
     assert "external OMS/execution integration" in supported_features

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -24,12 +24,14 @@ import {
   getDpmWave,
   getDpmWaveItems,
   getDpmWaveProofPackPosture,
+  getDpmWaveReportInput,
   getDpmWaveSupportability,
   handoffDpmWave,
   listDpmWaves,
   previewDpmWave,
   requestDpmOutcomeReviewAiNarrative,
   requestDpmProofPackAiPmMemo,
+  requestDpmWaveAiPmMemo,
   getArchivedDocumentMetadata,
   getPortfolio360,
   getReportBatchStatus,
@@ -2036,6 +2038,8 @@ describe("workbench api", () => {
     await handoffDpmWave("dwv_001");
     await getDpmWaveProofPackPosture("dwv_001");
     await getDpmWaveSupportability("dwv_001");
+    await getDpmWaveReportInput("dwv_001");
+    await requestDpmWaveAiPmMemo("dwv_001");
 
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
     expect(fetchMock.mock.calls[0][0]).toBe(`${expectedBaseUrl}/dpm/command-center/waves/preview`);
@@ -2049,6 +2053,8 @@ describe("workbench api", () => {
     expect(fetchMock.mock.calls[8][0]).toBe(`${expectedBaseUrl}/dpm/command-center/waves/dwv_001/handoff`);
     expect(fetchMock.mock.calls[9][0]).toBe(`${expectedBaseUrl}/dpm/command-center/waves/dwv_001/proof-pack`);
     expect(fetchMock.mock.calls[10][0]).toBe(`${expectedBaseUrl}/dpm/command-center/waves/dwv_001/supportability`);
+    expect(fetchMock.mock.calls[11][0]).toBe(`${expectedBaseUrl}/dpm/command-center/waves/dwv_001/report-input`);
+    expect(fetchMock.mock.calls[12][0]).toBe(`${expectedBaseUrl}/dpm/command-center/waves/dwv_001/ai-pm-memo`);
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
       body: {
         trigger_type: "EXPLICIT_PORTFOLIO_LIST",
@@ -2081,6 +2087,17 @@ describe("workbench api", () => {
       actor_id: "workbench-system",
       reason_code: "INTERNAL_HANDOFF_READY",
     });
+    expect(JSON.parse(fetchMock.mock.calls[12][1].body)).toMatchObject({
+      requested_outputs: [
+        "wave_pm_memo",
+        "wave_rationale_summary",
+        "approval_checklist",
+        "risk_caveats",
+        "operations_handoff",
+        "evidence_gaps",
+      ],
+      audience: ["portfolio_manager", "investment_control", "operations"],
+    });
     const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
     expect(metricEventsJson).toContain("wave-preview");
     expect(metricEventsJson).toContain("wave-create");
@@ -2093,6 +2110,8 @@ describe("workbench api", () => {
     expect(metricEventsJson).toContain("wave-handoff");
     expect(metricEventsJson).toContain("wave-proof-pack");
     expect(metricEventsJson).toContain("wave-supportability");
+    expect(metricEventsJson).toContain("wave-report-input");
+    expect(metricEventsJson).toContain("wave-ai-pm-memo");
     expect(metricEventsJson).not.toContain("PB_SG_GLOBAL_BAL_001");
     expect(metricEventsJson).not.toContain("dwv_001");
   });

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -49,10 +49,12 @@ promote dormant labels into product ownership just because historical route file
   `/workbench/{portfolioId}` through Gateway `/api/v1/dpm/command-center/waves*`. Workbench loads
   the explicit portfolio-list wave queue, previews and creates canonical portfolio waves, opens
   wave detail and item posture, and sends source-check, simulation, approval, staging, handoff,
-  proof-posture, and supportability actions through Gateway. It renders manage-owned wave
-  lifecycle, item state, source-readiness state, supportability, proof-pack refs, handoff refs, and
-  `external_execution_claimed` posture without direct `lotus-manage` calls or local readiness
-  calculation. Item-selection drawers, dedicated `/dpm/waves` routes, PM-book discovery, CIO
+  proof-posture, supportability, report-input, and governed AI PM memo actions through Gateway. It
+  renders manage-owned wave lifecycle, item state, source-readiness state, supportability,
+  report-input refs, proof-pack refs, handoff refs, lotus-ai workflow-pack run posture, and
+  `external_execution_claimed` posture without direct `lotus-manage` or `lotus-ai` calls, local
+  readiness calculation, local report-input construction, prompt construction, or memo narrative
+  generation. Item-selection drawers, dedicated `/dpm/waves` routes, PM-book discovery, CIO
   workflow, and external OMS execution remain future scope until separately implemented and proven.
 - RFC-0098/RFC-0038 mandate command-center cockpit rendering is implemented on
   `/workbench/{portfolioId}` through Gateway `/api/v1/dpm/command-center`,

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -83,9 +83,10 @@ must travel through Gateway-shaped contracts.
     performance, core, report, archive, or AI. RFC-0040 proof-pack JSON, hashes, Markdown,
     report-input payloads, and AI-evidence payloads remain manage-owned, while proof-pack PM memo
     execution remains `lotus-ai` owned; both must reach Workbench through Gateway composition.
-    RFC-0041 rebalance-wave preview, create, source-check,
-    simulation, selection, approval, staging, handoff, and supportability also remain
-    manage-owned and must reach Workbench through Gateway wave composition only. RFC-0039
+    RFC-0041 rebalance-wave preview, create, source-check, simulation, selection, approval,
+    staging, handoff, supportability, and report-input also remain manage-owned, while wave PM
+    memo execution remains `lotus-ai` owned; both must reach Workbench through Gateway wave
+    composition only. RFC-0039
     construction alternative generation, retrieval, supportability, and selection are manage-owned
     and must reach Workbench through Gateway construction composition only. RFC-0042
     outcome-review search, detail, supportability, report-input, AI-evidence, preview, create, and
@@ -96,16 +97,17 @@ must travel through Gateway-shaped contracts.
     reach Workbench through Gateway portfolio-memory composition only.
     The implemented Workbench construction panel consumes the Gateway construction alternative-set
     contracts, the implemented wave command-center panel consumes Gateway wave list, preview,
-    create, detail, item, source-check, simulation, approval, staging, handoff, proof-posture, and
-    supportability contracts, the implemented proof-pack panel consumes the Gateway proof-pack
+    create, detail, item, source-check, simulation, approval, staging, handoff, proof-posture,
+    supportability, report-input, and AI PM memo contracts, the implemented proof-pack panel consumes the Gateway proof-pack
     generation, detail, Markdown, report-input, AI-evidence, and AI PM memo contracts, and the
     implemented outcome panel consumes the Gateway outcome-review list and AI-narrative contracts.
     The implemented portfolio-memory panel consumes the Gateway portfolio-memory contract and
     preserves manage event order without reconstructing timeline nodes.
     Workbench must not calculate expected-versus-realized values. It must not rebuild proof-pack
-    sections, compute proof-pack hashes, construct prompts, infer PM quality, calculate wave readiness,
-    reconstruct portfolio-memory events, claim external execution, or optimize construction
-    alternatives; proof-pack sections remain manage-owned evidence.
+    sections, compute proof-pack hashes, construct prompts, infer PM quality, calculate wave
+    readiness, construct report input, generate memo narrative locally, reconstruct
+    portfolio-memory events, claim external execution, or optimize construction alternatives;
+    proof-pack sections and wave report input remain manage-owned evidence.
 16. The implemented RFC-0038 mandate command-center cockpit consumes Gateway
     `/api/v1/dpm/command-center`, `/monitoring/run-once`, `/exceptions`, and `/mandates*`
     contracts. Workbench renders manage-owned health distribution, source readiness,

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -11,10 +11,10 @@ It is intended for developers, business users, operations, sales/pre-sales, and 
 | Performance and risk review | `/performance` route modes | Gateway performance/risk APIs | Supported with bounded observability and canonical proof. |
 | Data-product discovery | `/data-products` | Gateway domain-product APIs | Supported for catalog, dependencies, and live trust posture. |
 | DPM mandate command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit and monitoring action. |
-| DPM rebalance-wave command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/waves*` | Implemented for wave queue, preview, create, detail, items, source-check, simulation, approval, staging, handoff, proof posture, and supportability through Gateway only; canonical live wave proof pending. |
+| DPM rebalance-wave command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/waves*` | Implemented for wave queue, preview, create, detail, items, source-check, simulation, approval, staging, handoff, proof posture, supportability, report-input, and governed AI PM memo request through Gateway only. |
 | DPM construction alternatives | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/construction/alternative-sets*` | Implemented for generation, comparison, and PM selection through Gateway only. |
 | DPM proof-pack evidence | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/proof-packs*` | Implemented for generation from Gateway rebalance-run reference, proof-pack identity, sections, hashes, Markdown/report/AI posture, and governed PM memo request posture. |
-| DPM portfolio memory | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory` | Implemented for manage-owned timeline event order, event mix, source systems, source refs, artifact refs, reason codes, supportability, and content hash; canonical live memory proof pending. |
+| DPM portfolio memory | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory` | Implemented for manage-owned timeline event order, event mix, source systems, source refs, artifact refs, reason codes, supportability, and content hash; canonical live proof accepts populated ready, partial, degraded, and blocked source truth while still failing empty or unsupported memory. |
 | DPM outcome review | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/outcome-reviews*` | Implemented for review list, dimensions, source lineage, report input, AI evidence, report job, and AI narrative request. |
 
 ## DPM Portfolio Memory
@@ -28,7 +28,7 @@ Implemented:
 2. renders manage-owned supportability, event count, event type counts, source systems, reason
    codes, and content hash,
 3. preserves event order, event type, event time, source refs, artifact refs, and reason codes,
-4. handles empty, partial, unsupported, unavailable, and endpoint error states without implying
+4. handles empty, partial, degraded, unsupported, unavailable, and endpoint error states without implying
    local reconstruction,
 5. emits bounded observability for `dpm.portfolio-memory.get` without portfolio ids, event ids,
    source refs, content hashes, request bodies, response bodies, or screen content as labels.
@@ -52,10 +52,12 @@ Implemented:
 3. opens wave detail and item posture,
 4. source-checks, simulates, approves, stages, and hands off selected waves through Gateway,
 5. renders manage-owned lifecycle state, item state, source-readiness state, supportability,
-   aggregate metrics, proof-pack refs, handoff refs, reason codes, blocked actions, remediation
-   owner, and `external_execution_claimed` posture,
-6. emits bounded Workbench observability labels without portfolio ids, wave ids, request bodies, or
-   response bodies as metric labels.
+   aggregate metrics, report-input refs, proof-pack refs, handoff refs, reason codes, blocked
+   actions, remediation owner, and `external_execution_claimed` posture,
+6. requests a governed `lotus-ai` wave PM memo workflow-pack run through Gateway only and displays
+   review-required workflow-pack posture without constructing prompts or memo text locally,
+7. emits bounded Workbench observability labels without portfolio ids, wave ids, report-input refs,
+   workflow-pack run ids, request bodies, or response bodies as metric labels.
 
 Not yet supported:
 
@@ -65,7 +67,8 @@ Not yet supported:
 4. richer workflow drawers and eligibility explanations beyond manage reason-code rendering,
 5. CIO approval workflow,
 6. external OMS/execution integration,
-7. client-side source-readiness, proof-pack, or handoff calculation.
+7. client-side source-readiness, report-input, proof-pack, AI prompt, memo narrative, or handoff
+   calculation.
 
 ## DPM Flow Diagram
 


### PR DESCRIPTION
## Summary\n- add Workbench Gateway helpers, UI actions, view-model state, and observability for DPM wave report-input and AI PM memo handoff\n- harden live validation to create a canonical wave when needed, accept populated degraded portfolio-memory truth, and prove report-input plus AI memo through Gateway\n- update README, RFC-0098, repository context, and repo-local wiki source for the current implementation-backed feature posture\n\n## Validation\n- npm run typecheck\n- npm test -- --run tests/unit/dpm-wave-command-center-view-model.test.ts tests/unit/live-canonical-validation-script.test.ts tests/unit/live-validation-browser-workflows.test.ts\n- python -m pytest tests/unit/test_rfc0098_documentation.py -q\n- npm run live:validate:ui\n- make check\n- git diff --check\n- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench (expected drift: API-Surface.md, Integrations.md, Supported-Features.md until post-merge publish)