### PR TITLE
feat: use PM-book command-center monitoring

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -52,8 +52,11 @@ Current repository posture:
    Gateway `/api/v1/dpm/command-center`, `/monitoring/run-once`, `/exceptions`, and
    `/mandates*`. Workbench shows manage-owned book health distribution, source readiness,
    attention queue, recommended actions, latest monitoring-run lineage, active exceptions, and
-   mandate health dimensions without calculating mandate health, inferring PM-book membership,
-   reconstructing source readiness, merging exceptions, or calling `lotus-manage` directly.
+   mandate health dimensions without calculating mandate health, reconstructing source readiness,
+   merging exceptions, or calling `lotus-manage` directly. The command-center run-monitoring
+   action sends the governed PM/book/as-of context through Gateway and lets Manage resolve
+   source-owned PM-book membership from lotus-core rather than sending a browser-selected mandate
+   fallback.
 8. `/workbench/{portfolioId}` renders the RFC-0042 DPM outcome-review panel from Gateway
    `/api/v1/dpm/command-center/outcome-reviews*`, preserving manage-owned expected-versus-realized
    dimensions, source lineage, supportability, report-input posture, AI-evidence posture, and

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -590,6 +590,13 @@ RFC-0038 command-center cockpit support is now implemented as an embedded
 | `GET /api/v1/dpm/command-center/mandates/by-portfolio/{portfolio_id}` | `/workbench/{portfolioId}` mandate binding |
 | `GET /api/v1/dpm/command-center/mandates/{mandate_id}/health` | `/workbench/{portfolioId}` mandate health dimensions |
 
+The embedded run-monitoring action uses the governed DPM context for tenant `default`,
+PM `PM_SG_DPM_001`, book `BOOK_SG_BALANCED_DPM`, and as-of date `2026-05-03`. Workbench sends that
+context through the Gateway BFF with an empty `mandate_ids` list so `lotus-manage` can resolve the
+source-owned PM-book cohort from lotus-core `PortfolioManagerBookMembership:v1`. Workbench must not
+derive PM-book membership, fabricate a cohort from the current page portfolio, or send a hidden
+single-mandate fallback as if it were book-level monitoring.
+
 The Workbench view model must preserve:
 
 1. contract name and version,

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -833,9 +833,7 @@ export async function runDpmCommandCenterMonitoring(params?: {
 }): Promise<DpmCommandCenterGatewayResponse> {
   const dpmContext = resolveDefaultDpmContext();
   const callerContext = resolveDefaultCallerContext();
-  const mandateIds = params?.mandateIds?.length
-    ? params.mandateIds
-    : [dpmContext.mandateId];
+  const mandateIds = params?.mandateIds ?? [];
   const asOfDate = params?.asOfDate ?? dpmContext.commandCenterAsOfDate;
   return await observeWorkbenchMutation(
     "dpm.command-center.monitoring.run-once",

--- a/src/features/workbench/components/dpm-command-center-panel.tsx
+++ b/src/features/workbench/components/dpm-command-center-panel.tsx
@@ -126,9 +126,7 @@ export default function DpmCommandCenterPanel({
     setRunError(null);
     setRunMessage(null);
     try {
-      const response = await runDpmCommandCenterMonitoring({
-        mandateIds: model.mandateId !== "N/A" ? [model.mandateId] : undefined,
-      });
+      const response = await runDpmCommandCenterMonitoring();
       setRunResponse(response);
       setRunMessage(
         `Monitoring ${response.data.monitoring_run_id ?? "run"} returned ${

--- a/tests/unit/dpm-command-center-panel.test.tsx
+++ b/tests/unit/dpm-command-center-panel.test.tsx
@@ -136,9 +136,7 @@ describe("DpmCommandCenterPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Run monitoring" }));
 
     await waitFor(() => {
-      expect(runDpmCommandCenterMonitoring).toHaveBeenCalledWith({
-        mandateIds: ["MANDATE_PB_SG_GLOBAL_BAL_001"],
-      });
+      expect(runDpmCommandCenterMonitoring).toHaveBeenCalledWith();
     });
     expect(
       screen.getByText("Monitoring dmr_2 returned SUCCEEDED"),

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -38,6 +38,9 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     assert "must not reconstruct timeline nodes" in rfc
     assert "DPM portfolio memory" in supported_features
     assert "source refs, artifact refs, reason codes" in supported_features
+    assert "source-owned PM-book cohort" in rfc
+    assert "PortfolioManagerBookMembership:v1" in rfc
+    assert "PM-book-backed monitoring action" in supported_features
     assert "first RFC-0041 rebalance-wave command-center" in rfc
     assert "`/api/v1/dpm/command-center/waves*`" in rfc
     assert "approval, staging, handoff" in rfc

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -1804,7 +1804,7 @@ describe("workbench api", () => {
     expect(metricEventsJson).not.toContain("dmr_1");
   });
 
-  it("runs DPM command-center monitoring through Gateway without reconstructing health", async () => {
+  it("runs DPM command-center monitoring through Gateway PM-book discovery by default", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
@@ -1828,7 +1828,6 @@ describe("workbench api", () => {
     );
 
     await runDpmCommandCenterMonitoring({
-      mandateIds: ["MANDATE_PB_SG_GLOBAL_BAL_001"],
       tenantId: "default",
       portfolioManagerId: "PM_SG_DPM_001",
       bookId: "BOOK_SG_BALANCED_DPM",
@@ -1845,7 +1844,7 @@ describe("workbench api", () => {
     );
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
       body: {
-        mandate_ids: ["MANDATE_PB_SG_GLOBAL_BAL_001"],
+        mandate_ids: [],
         as_of_date: "2026-05-03",
         tenant_id: "default",
         portfolio_manager_id: "PM_SG_DPM_001",

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -10,7 +10,7 @@ It is intended for developers, business users, operations, sales/pre-sales, and 
 | Portfolio summary and detail | `/portfolio`, `/portfolio?tab=detailed` | Gateway Workbench portfolio APIs | Supported with canonical live proof. |
 | Performance and risk review | `/performance` route modes | Gateway performance/risk APIs | Supported with bounded observability and canonical proof. |
 | Data-product discovery | `/data-products` | Gateway domain-product APIs | Supported for catalog, dependencies, and live trust posture. |
-| DPM mandate command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit and monitoring action. |
+| DPM mandate command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit and PM-book-backed monitoring action through Gateway/Manage. |
 | DPM rebalance-wave command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/waves*` | Implemented for wave queue, preview, create, detail, items, source-check, simulation, approval, staging, handoff, proof posture, supportability, report-input, and governed AI PM memo request through Gateway only. |
 | DPM construction alternatives | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/construction/alternative-sets*` | Implemented for generation, comparison, and PM selection through Gateway only. |
 | DPM proof-pack evidence | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/proof-packs*` | Implemented for generation from Gateway rebalance-run reference, proof-pack identity, sections, hashes, Markdown/report/AI posture, and governed PM memo request posture. |
@@ -90,6 +90,7 @@ flowchart LR
 ## Demo Guidance
 
 Use `PB_SG_GLOBAL_BAL_001` and the canonical local runtime. Demo claims should say that Workbench
-is Gateway-backed and manage-owned for DPM operating truth. Do not claim external execution,
-automatic PM-book discovery, or autonomous CIO approval until those owning services and Workbench
-proof promote them.
+is Gateway-backed and manage-owned for DPM operating truth. You may claim source-owned PM-book
+resolution for the embedded command-center run-monitoring action after canonical validation passes.
+Do not claim external execution, Workbench-local PM-book inference, dedicated PM-book wave discovery
+screens, or autonomous CIO approval until those owning services and Workbench proof promote them.


### PR DESCRIPTION
## Summary
- updates Workbench command-center monitoring so the embedded action sends governed PM/book/as-of context through Gateway with no single-mandate fallback
- documents that Manage resolves PM-book membership from lotus-core `PortfolioManagerBookMembership:v1`; Workbench does not infer membership locally
- updates RFC0098, repo context, supported-features wiki source, and focused documentation guard coverage

## Validation
- `npm test -- --run tests/unit/workbench-api.test.ts tests/unit/dpm-command-center-panel.test.tsx` (49 passed)
- `python -m pytest tests/unit/test_rfc0098_documentation.py -q` (1 passed)
- `npm run typecheck`
- `git diff --check` (only normal LF-to-CRLF warnings)
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` reports expected pre-merge drift limited to `Supported-Features.md`

## Boundaries
- Workbench still consumes Gateway/BFF only
- generated `output/` evidence remains untracked
- dedicated PM-book wave screens and external execution remain unsupported