### PR TITLE
Validate DPM command center support states

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -56,7 +56,10 @@ Current repository posture:
    merging exceptions, or calling `lotus-manage` directly. The command-center run-monitoring
    action sends the governed PM/book/as-of context through Gateway and lets Manage resolve
    source-owned PM-book membership from lotus-core rather than sending a browser-selected mandate
-   fallback.
+   fallback. Workbench maps manage command-center supportability states into explicit panel
+   posture: populated canonical `READY` remains demo-ready, `PARTIAL` plus source-readiness
+   `DEGRADED` or `BLOCKED` are visible partial states, and `EMPTY` remains an explicit empty state instead of
+   being treated as a successful populated cockpit.
 8. `/workbench/{portfolioId}` renders the RFC-0042 DPM outcome-review panel from Gateway
    `/api/v1/dpm/command-center/outcome-reviews*`, preserving manage-owned expected-versus-realized
    dimensions, source lineage, supportability, report-input posture, AI-evidence posture, and

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -339,7 +339,10 @@ script. Browser validation failures must fail the PowerShell command. The Manage
 supportability summary is recorded as source-supportability evidence, including stale state and
 reason when present; DPM panel proof is gated by the command-center, wave, outcome-review, proof-pack,
 and portfolio-memory contracts instead of failing on unrelated historical action-register freshness.
-Do not treat partial screenshot output as successful evidence.
+The DPM mandate command-center panel is screenshot-ready only when Gateway returns a canonical
+populated `READY` supportability posture. Partial, degraded, blocked, and empty command-center
+supportability must not collapse into a false ready panel. Do not treat partial screenshot output
+as successful evidence.
 
 The summary includes `calculationChecks` for canonical performance and risk sanity. These checks
 assert numeric ranges, contribution reconciliation, governed attribution fallback posture, risk

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -20,11 +20,11 @@ UI tables, and recorded the canonical `mandates/by-portfolio/PB_SG_GLOBAL_BAL_00
 
 WTBD-003 populated seed automation was then completed locally on 2026-05-07 through
 `lotus-platform` canonical front-office QA. The governed runtime now refreshes
-`MANDATE_PB_SG_GLOBAL_BAL_001` from core through manage, verifies Gateway mandate lookup, health,
-and command-center summary, classifies `dpm.command_center` as `ready`, and captures the registered
-DPM command-center screenshot under `output/playwright/live-canonical/`. Workbench still preserves
-`seed_gap` for non-populated environments, but the governed canonical portfolio path is no longer
-gap-coded.
+`MANDATE_PB_SG_GLOBAL_BAL_001` from core through manage, runs a Manage monitoring pass, verifies
+Gateway mandate lookup, health, and command-center summary, and classifies `dpm.command_center`
+truthfully from Manage supportability. The current canonical source products now produce a populated
+`READY` command center for the canonical PM/book/as-of filter. Workbench still preserves `seed_gap` for
+non-populated environments, but the governed canonical portfolio path is no longer gap-coded.
 
 RFC41-WTBD-006 implementation is now in progress on the
 `wtbd-rfc41-workbench-wave-command-center` branch. The first Workbench wave command-center panel is

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -89,6 +89,31 @@ function readSupportabilityState(supportability) {
   return readString(supportability?.state) || readString(supportability?.supportability_state);
 }
 
+function classifyCommandCenterPanelState(commandCenterPayload) {
+  const supportability = commandCenterPayload?.supportability;
+  const explicitState = readSupportabilityState(supportability)?.toLowerCase();
+  if (explicitState === "ready") {
+    return "ready";
+  }
+  if (explicitState === "partial" || explicitState === "degraded" || explicitState === "blocked") {
+    return "partial";
+  }
+  if (explicitState === "empty") {
+    return "empty";
+  }
+  const completenessState = readString(supportability?.data_completeness_state)?.toLowerCase();
+  if (completenessState === "complete") {
+    return "ready";
+  }
+  if (completenessState === "partial") {
+    return "partial";
+  }
+  if (completenessState === "empty") {
+    return "empty";
+  }
+  return "partial";
+}
+
 function extractGeneratedProofPackId(response) {
   return (
     readString(response?.data?.proof_pack?.proof_pack_id) ||
@@ -455,6 +480,12 @@ async function run() {
   if (!dpmCommandCenterPayload?.supportability) {
     throw new Error("DPM command-center summary returned no manage supportability envelope.");
   }
+  const dpmCommandCenterPanelState = classifyCommandCenterPanelState(dpmCommandCenterPayload);
+  if (!["ready", "partial"].includes(dpmCommandCenterPanelState)) {
+    throw new Error(
+      `DPM command-center summary did not return canonical populated posture; observed ${dpmCommandCenterPanelState}.`
+    );
+  }
 
   const portfolioMemory = await fetchJson(
     summary,
@@ -697,9 +728,12 @@ async function run() {
     sectionCount: proofPackSectionCount,
     sourceHashCount: proofPackSourceHashCount,
   });
-  panelGovernance.recordPanelClassification("dpm.command_center", "ready", "lotus-manage", {
+  panelGovernance.recordPanelClassification("dpm.command_center", dpmCommandCenterPanelState, "lotus-manage", {
     route: `/workbench/${portfolioId}`,
     source: "Gateway DPM command-center summary",
+    supportabilityState: readSupportabilityState(dpmCommandCenterPayload.supportability),
+    dataCompletenessState: dpmCommandCenterPayload.supportability.data_completeness_state,
+    reason: readString(dpmCommandCenterPayload.supportability.reason),
   });
   panelGovernance.recordPanelClassification("dpm.portfolio_memory", "ready", "lotus-manage", {
     route: `/workbench/${portfolioId}`,

--- a/src/features/workbench/dpm-command-center-view-model.ts
+++ b/src/features/workbench/dpm-command-center-view-model.ts
@@ -188,6 +188,9 @@ function resolvePanelState(
   if (supportabilityState === "PARTIAL" || supportabilityState === "UNKNOWN") {
     return "partial";
   }
+  if (supportabilityState === "DEGRADED") {
+    return "partial";
+  }
   if (
     supportabilityState === "UNSUPPORTED" ||
     supportabilityState === "BLOCKED"
@@ -354,6 +357,8 @@ function formatLabel(value: string): string {
     .replace(/\b\w/g, (match) => match.toUpperCase());
 }
 
-function normalizeState(state: string): string {
-  return state.trim().toUpperCase() || "UNKNOWN";
+function normalizeState(state: string | null | undefined): string {
+  return typeof state === "string" && state.trim().length > 0
+    ? state.trim().toUpperCase()
+    : "UNKNOWN";
 }

--- a/tests/unit/dpm-command-center-view-model.test.ts
+++ b/tests/unit/dpm-command-center-view-model.test.ts
@@ -133,4 +133,24 @@ describe("DPM command-center view model", () => {
     expect(model.supportabilityState).toBe("UNKNOWN");
     expect(model.latestMonitoringRunStatus).toBe("SUCCEEDED");
   });
+
+  it("treats degraded supportability as explicit partial command-center posture", () => {
+    const model = buildDpmCommandCenterPanelModel({
+      commandCenter: {
+        ...commandCenterResponse,
+        supportability: {
+          ...commandCenterResponse.supportability,
+          state: "DEGRADED",
+          data_completeness_state: "COMPLETE",
+          partial_readiness_reasons: ["COMMAND_CENTER_SOURCE_READINESS_DEGRADED"],
+        },
+      },
+    });
+
+    expect(model.state).toBe("partial");
+    expect(model.supportabilityState).toBe("DEGRADED");
+    expect(model.partialReadinessReasons).toEqual([
+      "COMMAND_CENTER_SOURCE_READINESS_DEGRADED",
+    ]);
+  });
 });

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -342,6 +342,9 @@ describe("canonical live validation script", () => {
     expect(script).toContain("DPM portfolio memory returned no manage-owned timeline events.");
     expect(script).toContain('recordPanelClassification("dpm.portfolio_memory"');
     expect(browserWorkflowModule).toContain("DPM Command Center");
+    expect(script).toContain("classifyCommandCenterPanelState");
+    expect(script).toContain("DPM command-center summary did not return canonical populated posture");
+    expect(script).toContain("supportabilityState: readSupportabilityState");
     expect(browserWorkflowModule).toContain("DPM attention queue");
     expect(browserWorkflowModule).toContain("DPM mandate health dimensions");
     expect(script).toContain("Generate DPM proof-pack evidence");

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -10,7 +10,7 @@ It is intended for developers, business users, operations, sales/pre-sales, and 
 | Portfolio summary and detail | `/portfolio`, `/portfolio?tab=detailed` | Gateway Workbench portfolio APIs | Supported with canonical live proof. |
 | Performance and risk review | `/performance` route modes | Gateway performance/risk APIs | Supported with bounded observability and canonical proof. |
 | Data-product discovery | `/data-products` | Gateway domain-product APIs | Supported for catalog, dependencies, and live trust posture. |
-| DPM mandate command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit and PM-book-backed monitoring action through Gateway/Manage. |
+| DPM mandate command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit and PM-book-backed monitoring action through Gateway/Manage. Workbench preserves Manage supportability posture: populated canonical `READY` is demo-ready, `PARTIAL`/`DEGRADED`/`BLOCKED` render as explicit partial states, and `EMPTY` stays an empty state rather than a false ready cockpit. |
 | DPM rebalance-wave command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/waves*` | Implemented for wave queue, preview, create, detail, items, source-check, simulation, approval, staging, handoff, proof posture, supportability, report-input, and governed AI PM memo request through Gateway only. |
 | DPM construction alternatives | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/construction/alternative-sets*` | Implemented for generation, comparison, and PM selection through Gateway only. |
 | DPM proof-pack evidence | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/proof-packs*` | Implemented for generation from Gateway rebalance-run reference, proof-pack identity, sections, hashes, Markdown/report/AI posture, and governed PM memo request posture. |
@@ -92,5 +92,8 @@ flowchart LR
 Use `PB_SG_GLOBAL_BAL_001` and the canonical local runtime. Demo claims should say that Workbench
 is Gateway-backed and manage-owned for DPM operating truth. You may claim source-owned PM-book
 resolution for the embedded command-center run-monitoring action after canonical validation passes.
+Canonical screenshots require a populated `READY` command-center summary. The Workbench view model
+and live validator preserve partial, degraded, blocked, and empty posture for
+diagnostics and regression evidence.
 Do not claim external execution, Workbench-local PM-book inference, dedicated PM-book wave discovery
 screens, or autonomous CIO approval until those owning services and Workbench proof promote them.


### PR DESCRIPTION
## Summary
- maps DPM command-center supportability into Workbench panel states with explicit ready, partial, and empty behavior
- updates canonical live validation so dpm.command_center is classified and screenshot-backed
- updates RFC-0098, runtime docs, context, tests, and repo-local wiki truth

## Evidence
- Unit/live validator: npm test -- --run tests/unit/dpm-command-center-view-model.test.ts tests/unit/live-canonical-validation-script.test.ts tests/unit/live-validation-browser-workflows.test.ts
- Typecheck: npm run typecheck
- Diff: git diff --check
- Live proof source: lotus-platform Invoke-Canonical-FrontOffice-QA passed with dpm.command_center ready
- Live artifacts: output/playwright/live-canonical/live-validation-summary.json; output/playwright/live-canonical/dpm-command-center-live.png

## Governance
- Stranded truth scan: git fetch origin --prune; git branch -r --no-merged origin/main returned no unmerged remote branches requiring classification across the active repos at close-out.
- Wiki check-only: expected pre-merge drift in wiki/Supported-Features.md; publish after merge.
- Coordinates with lotus-platform and lotus-manage PRs for RFC38-WTBD-003 closure.