### PR TITLE
Fix construction generation retry identity

### DIFF
--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -109,6 +109,26 @@ function buildPerformanceWorkspaceQuery(params: {
   return query.toString();
 }
 
+function buildUniqueMutationToken(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function buildConstructionGenerationIdempotencyKey(params: {
+  portfolioId: string;
+  constructionAsOf: string;
+  mutationToken: string;
+}): string {
+  return [
+    "workbench-construction",
+    params.portfolioId,
+    params.constructionAsOf,
+    params.mutationToken,
+  ].join("-");
+}
+
 async function fetchWorkbenchJson<T>(
   url: string,
   errorLabel: string,
@@ -1232,6 +1252,7 @@ export async function generateDpmConstructionAlternatives(params: {
   portfolio: WorkbenchPortfolio360;
   methods?: string[];
   actorId?: string;
+  idempotencyKey?: string;
 }): Promise<DpmConstructionGatewayResponse> {
   const portfolioId = params.portfolio.portfolio.portfolio_id;
   const actorId = params.actorId ?? "workbench-construction-operator";
@@ -1251,6 +1272,20 @@ export async function generateDpmConstructionAlternatives(params: {
     typeof statefulInput?.as_of === "string"
       ? statefulInput.as_of
       : params.portfolio.as_of_date;
+  const mutationToken = buildUniqueMutationToken();
+  const idempotencyKey =
+    params.idempotencyKey ??
+    buildConstructionGenerationIdempotencyKey({
+      portfolioId,
+      constructionAsOf,
+      mutationToken,
+    });
+  const correlationId = [
+    "corr-workbench-construction",
+    portfolioId,
+    constructionAsOf,
+    mutationToken,
+  ].join("-");
   return await observeWorkbenchMutation(
     "dpm.construction.alternatives.generate",
     async () =>
@@ -1261,10 +1296,10 @@ export async function generateDpmConstructionAlternatives(params: {
           method: "POST",
           headers: buildDpmConstructionCallerHeaders({
             actorId,
-            correlationId: `corr-workbench-construction-${portfolioId}-${constructionAsOf}`,
+            correlationId,
           }),
           body: JSON.stringify({
-            idempotency_key: `workbench-construction-${portfolioId}-${constructionAsOf}`,
+            idempotency_key: idempotencyKey,
             body: requestBody,
           }),
         }

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -2222,6 +2222,7 @@ describe("workbench api", () => {
     await generateDpmConstructionAlternatives({
       portfolio: constructionPortfolio(),
       methods: ["DO_NOTHING_BASELINE", "MIN_TURNOVER"],
+      idempotencyKey: "workbench-construction-test-idem-1",
     });
 
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
@@ -2232,9 +2233,7 @@ describe("workbench api", () => {
     expect(options.headers["X-Caller-Application"]).toBe("lotus-workbench");
     expect(options.headers["X-Actor-Id"]).toBe("workbench-construction-operator");
     const body = JSON.parse(options.body);
-    expect(body.idempotency_key).toBe(
-      "workbench-construction-PB_SG_GLOBAL_BAL_001-2026-04-10"
-    );
+    expect(body.idempotency_key).toBe("workbench-construction-test-idem-1");
     expect(body.body.input_mode).toBe("stateful");
     expect(body.body.methods).toEqual([
       "DO_NOTHING_BASELINE",
@@ -2258,6 +2257,59 @@ describe("workbench api", () => {
     expect(metricEventsJson).toContain("construction-alternatives");
     expect(metricEventsJson).not.toContain("PB_SG_GLOBAL_BAL_001");
     expect(metricEventsJson).not.toContain("cas_1");
+  });
+
+  it("uses a fresh DPM construction generation idempotency key for each default request", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr-rfc39",
+            contract_version: "v1",
+            source_service: "lotus-manage",
+            upstream_status: 200,
+            supportability: {
+              source_service: "lotus-manage",
+              authority: "lotus-manage:RFC-0039",
+              state: "READY",
+              reason_codes: [],
+            },
+            data: { alternative_set_id: "cas_1", alternatives: [] },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await generateDpmConstructionAlternatives({
+      portfolio: constructionPortfolio(),
+    });
+    await generateDpmConstructionAlternatives({
+      portfolio: constructionPortfolio(),
+    });
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const firstBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const secondBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    const firstHeaders = fetchMock.mock.calls[0][1].headers;
+    const secondHeaders = fetchMock.mock.calls[1][1].headers;
+    expect(firstBody.idempotency_key).toMatch(
+      /^workbench-construction-PB_SG_GLOBAL_BAL_001-2026-04-10-/
+    );
+    expect(secondBody.idempotency_key).toMatch(
+      /^workbench-construction-PB_SG_GLOBAL_BAL_001-2026-04-10-/
+    );
+    expect(firstBody.idempotency_key).not.toBe(secondBody.idempotency_key);
+    expect(firstHeaders["X-Correlation-Id"]).toMatch(
+      /^corr-workbench-construction-PB_SG_GLOBAL_BAL_001-2026-04-10-/
+    );
+    expect(secondHeaders["X-Correlation-Id"]).toMatch(
+      /^corr-workbench-construction-PB_SG_GLOBAL_BAL_001-2026-04-10-/
+    );
+    expect(firstHeaders["X-Correlation-Id"]).not.toBe(
+      secondHeaders["X-Correlation-Id"]
+    );
   });
 
   it("loads and selects DPM construction alternatives through Gateway endpoints", async () => {


### PR DESCRIPTION
## Summary
- give each Workbench-triggered DPM construction generation a fresh idempotency key
- give the paired manage call a fresh correlation id so repeated generations do not collide with persisted run records
- keep deterministic idempotency injection available for unit tests

## Evidence
- `npm run test -- tests/unit/workbench-api.test.ts` (46 passed)
- `npm run typecheck`
- `docker compose up -d --build` (Workbench image rebuilt; existing ag-grid autoprefixer warning only)
- `LOTUS_LIVE_EVIDENCE_DIR=output/rfc39-wtbd-audit-20260509-construction-live-fixed2 npm run live:validate:construction` (1 passed)

## Notes
- No repo-local wiki change: this is a product-surface reliability fix, not a user-facing contract or operator workflow change.
- This was found during the RFC39 WTBD gold-pass audit before claiming the slice complete.