### PR TITLE
Pass core query URL to manage canonical runtime

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -151,7 +151,8 @@ posture required by the validator:
 
 - `DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED=true`
 - `DPM_STATEFUL_CORE_SOURCING_ENABLED=true`
-- `DPM_CORE_BASE_URL=http://host.docker.internal:8202` for Docker-backed manage
+- `DPM_CORE_BASE_URL=http://host.docker.internal:8202` and
+  `DPM_CORE_QUERY_BASE_URL=http://host.docker.internal:8201` for Docker-backed manage
 
 Local manage overrides use the canonical host URL `http://core-control.dev.lotus` for the same
 source-data authority. This keeps capability truth aligned with the proof target: stateful mode

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -247,9 +247,11 @@ function Start-CanonicalManage {
     DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED = "true"
     DPM_STATEFUL_CORE_SOURCING_ENABLED = "true"
     DPM_CORE_BASE_URL = "http://core-control.dev.lotus"
+    DPM_CORE_QUERY_BASE_URL = "http://core-query.dev.lotus"
   }
   $dockerManageEnvironment = $localManageEnvironment.Clone()
   $dockerManageEnvironment["DPM_CORE_BASE_URL"] = "http://host.docker.internal:8202"
+  $dockerManageEnvironment["DPM_CORE_QUERY_BASE_URL"] = "http://host.docker.internal:8201"
 
   if (Test-LocalApp "manage") {
     Invoke-RepoCommand $manageRepo "docker compose down --remove-orphans"

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -126,7 +126,9 @@ describe("canonical live validation script", () => {
     expect(script).toContain('DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED = "true"');
     expect(script).toContain('DPM_STATEFUL_CORE_SOURCING_ENABLED = "true"');
     expect(script).toContain('DPM_CORE_BASE_URL = "http://core-control.dev.lotus"');
+    expect(script).toContain('DPM_CORE_QUERY_BASE_URL = "http://core-query.dev.lotus"');
     expect(script).toContain('$dockerManageEnvironment["DPM_CORE_BASE_URL"] = "http://host.docker.internal:8202"');
+    expect(script).toContain('$dockerManageEnvironment["DPM_CORE_QUERY_BASE_URL"] = "http://host.docker.internal:8201"');
     expect(script).toContain("Invoke-WithProcessEnvironment -Environment $localManageEnvironment");
     expect(script).toContain("Invoke-ComposeUp $manageRepo $dockerManageEnvironment");
     expect(script).toContain('Invoke-ComposeUp $workbenchRepo @{ BFF_BASE_URL = "http://host.docker.internal:8100" }');


### PR DESCRIPTION
## Summary

- passes `DPM_CORE_QUERY_BASE_URL` into local and Docker-backed canonical manage runtime
- documents the manage control-plane/query-plane split in the canonical front-office runbook
- extends the runtime script unit test to guard both manage core URLs

## Evidence

- `npm test -- --run tests/unit/live-canonical-validation-script.test.ts` -> 11 passed

## Notes

This enables `lotus-manage` to consume query-plane source products such as `PortfolioCashflowProjection:v1` during canonical core/manage proof mode.