### PR TITLE
Expose MWR reason-code drilldowns

### DIFF
--- a/docs/architecture/workbench-ui-gateway-capability-contract.md
+++ b/docs/architecture/workbench-ui-gateway-capability-contract.md
@@ -131,6 +131,10 @@ expanding the API surface:
 - Performance money-weighted return
   - `money_weighted_return`
   - shown only when the contract actually provides it
+  - supportability fields `status`, `reason_codes`, `warnings`, `fallback_from`,
+    `fallback_reason`, `is_approximation`, and `holding_period_return_pct` are exposed through
+    the Performance return-path MWR drill-down when Gateway publishes a non-ordinary MWR posture
+    such as XIRR fallback, no-root, multiple-root, or approximation behavior
 - Portfolio reporting freshness
   - `readiness.reporting.generated_at_utc`
   - `readiness.reporting.row_count`

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11456,6 +11456,100 @@ a:hover {
   color: #617185;
 }
 
+.performance-mwr-drilldown {
+  border: 1px solid rgba(112, 132, 158, 0.24);
+  border-radius: 8px;
+  background: rgba(248, 251, 253, 0.88);
+  padding: 0;
+}
+
+.performance-mwr-drilldown summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  list-style: none;
+  min-height: 2.75rem;
+  padding: 0.62rem 0.88rem;
+}
+
+.performance-mwr-drilldown summary::-webkit-details-marker {
+  display: none;
+}
+
+.performance-mwr-drilldown summary span {
+  color: rgba(53, 68, 88, 0.78);
+  font-size: 0.73rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.performance-mwr-drilldown summary strong {
+  color: #21344f;
+  font-size: 0.82rem;
+  font-weight: 800;
+  text-align: right;
+}
+
+.performance-mwr-drilldown-body {
+  border-top: 1px solid rgba(112, 132, 158, 0.2);
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem 0.88rem 0.88rem;
+}
+
+.performance-mwr-drilldown-facts {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(126px, 1fr));
+  margin: 0;
+}
+
+.performance-mwr-drilldown-facts div {
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(112, 132, 158, 0.18);
+  border-radius: 8px;
+  padding: 0.5rem 0.62rem;
+}
+
+.performance-mwr-drilldown-facts dt,
+.performance-mwr-reason-group h4 {
+  color: rgba(53, 68, 88, 0.72);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  margin: 0 0 0.25rem;
+  text-transform: uppercase;
+}
+
+.performance-mwr-drilldown-facts dd {
+  color: #18263a;
+  font-size: 0.82rem;
+  font-weight: 750;
+  margin: 0;
+}
+
+.performance-mwr-reason-group ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.performance-mwr-reason-group li {
+  background: rgba(34, 76, 120, 0.08);
+  border: 1px solid rgba(34, 76, 120, 0.16);
+  border-radius: 999px;
+  color: #21344f;
+  font-size: 0.74rem;
+  font-weight: 800;
+  padding: 0.31rem 0.56rem;
+}
+
 .performance-chart-legend {
   display: flex;
   flex-wrap: wrap;

--- a/src/apps/performance/components/performance-chart-panel.tsx
+++ b/src/apps/performance/components/performance-chart-panel.tsx
@@ -20,6 +20,9 @@ import PerformanceObservationTrail from "./performance-observation-trail";
 import PerformanceReturnPathChartStage from "./performance-return-path-chart-stage";
 import PerformanceReturnPathNotices from "./performance-return-path-notices";
 import PerformanceReturnPathSummary from "./performance-return-path-summary";
+import PerformanceMwrDrilldown, {
+  buildPerformanceMwrDrilldown,
+} from "./performance-mwr-drilldown";
 import {
   buildReturnPathChartOption,
   resolveReportDates,
@@ -125,6 +128,10 @@ export default function PerformanceChartPanel({
     capabilities,
     reportingCurrency,
   });
+  const mwrDrilldown = useMemo(
+    () => buildPerformanceMwrDrilldown(moneyWeightedReturn),
+    [moneyWeightedReturn]
+  );
   const chartTableModel = useMemo(
     () =>
       buildPerformanceReturnPathTableModel({
@@ -298,6 +305,7 @@ export default function PerformanceChartPanel({
               items={outcomeStripItems}
             />
           ) : null}
+          {mwrDrilldown ? <PerformanceMwrDrilldown model={mwrDrilldown} /> : null}
           <PerformanceObservationTrail tableModel={chartTableModel} />
         </>
       ) : null}

--- a/src/apps/performance/components/performance-mwr-drilldown.tsx
+++ b/src/apps/performance/components/performance-mwr-drilldown.tsx
@@ -1,0 +1,178 @@
+import type { MoneyWeightedReturnSummary } from "@/features/workbench/types";
+
+import { formatPct } from "../formatters";
+
+export type PerformanceMwrDrilldownModel = {
+  summaryLabel: string;
+  statusLabel: string | null;
+  methodLabel: string | null;
+  inputModeLabel: string | null;
+  annualizedLabel: string | null;
+  holdingPeriodLabel: string | null;
+  approximationLabel: string | null;
+  fallbackLabel: string | null;
+  reasonCodes: string[];
+  warnings: string[];
+  notes: string[];
+};
+
+export function buildPerformanceMwrDrilldown(
+  moneyWeightedReturn?: MoneyWeightedReturnSummary | null
+): PerformanceMwrDrilldownModel | null {
+  if (!moneyWeightedReturn) {
+    return null;
+  }
+
+  const reasonCodes = normalizeTextArray(moneyWeightedReturn.reason_codes);
+  const warnings = normalizeTextArray(moneyWeightedReturn.warnings);
+  const notes = normalizeTextArray(moneyWeightedReturn.notes);
+  const fallbackLabel = buildFallbackLabel(moneyWeightedReturn);
+  const status = normalizeText(moneyWeightedReturn.status);
+  const isApproximation = moneyWeightedReturn.is_approximation === true;
+  const hasSupportSignal =
+    reasonCodes.length > 0 ||
+    warnings.length > 0 ||
+    Boolean(fallbackLabel) ||
+    isApproximation ||
+    (status !== null && status !== "CALCULATED");
+
+  if (!hasSupportSignal) {
+    return null;
+  }
+
+  const summaryParts = [
+    status ? formatMwrContractLabel(status) : null,
+    moneyWeightedReturn.method ? formatMwrMethodLabel(moneyWeightedReturn.method) : null,
+    isApproximation ? "Approximation" : null,
+  ].filter(Boolean);
+
+  return {
+    summaryLabel: summaryParts.join(" • ") || "MWR supportability",
+    statusLabel: status ? formatMwrContractLabel(status) : null,
+    methodLabel: moneyWeightedReturn.method
+      ? formatMwrMethodLabel(moneyWeightedReturn.method)
+      : null,
+    inputModeLabel: moneyWeightedReturn.input_mode
+      ? formatMwrContractLabel(moneyWeightedReturn.input_mode)
+      : null,
+    annualizedLabel:
+      moneyWeightedReturn.annualized_return_pct != null
+        ? formatPct(moneyWeightedReturn.annualized_return_pct)
+        : null,
+    holdingPeriodLabel:
+      moneyWeightedReturn.holding_period_return_pct != null
+        ? formatPct(moneyWeightedReturn.holding_period_return_pct)
+        : null,
+    approximationLabel:
+      moneyWeightedReturn.is_approximation == null
+        ? null
+        : moneyWeightedReturn.is_approximation
+          ? "Approximation"
+          : "Exact method result",
+    fallbackLabel,
+    reasonCodes,
+    warnings,
+    notes,
+  };
+}
+
+export default function PerformanceMwrDrilldown({
+  model,
+}: {
+  model: PerformanceMwrDrilldownModel;
+}) {
+  const facts = [
+    { label: "Status", value: model.statusLabel },
+    { label: "Method", value: model.methodLabel },
+    { label: "Input mode", value: model.inputModeLabel },
+    { label: "Annualized", value: model.annualizedLabel },
+    { label: "Holding period", value: model.holdingPeriodLabel },
+    { label: "Approximation", value: model.approximationLabel },
+    { label: "Fallback", value: model.fallbackLabel },
+  ].filter((item): item is { label: string; value: string } => Boolean(item.value));
+
+  return (
+    <details className="performance-mwr-drilldown" aria-label="MWR reason-code drill-down">
+      <summary>
+        <span>MWR supportability</span>
+        <strong>{model.summaryLabel}</strong>
+      </summary>
+      <div className="performance-mwr-drilldown-body">
+        {facts.length > 0 ? (
+          <dl className="performance-mwr-drilldown-facts">
+            {facts.map((item) => (
+              <div key={item.label}>
+                <dt>{item.label}</dt>
+                <dd>{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+        ) : null}
+        <ReasonCodeList title="Reason codes" values={model.reasonCodes} />
+        <ReasonCodeList title="Warnings" values={model.warnings} />
+        <ReasonCodeList title="Notes" values={model.notes} />
+      </div>
+    </details>
+  );
+}
+
+function ReasonCodeList({ title, values }: { title: string; values: string[] }) {
+  if (values.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="performance-mwr-reason-group" aria-label={`MWR ${title.toLowerCase()}`}>
+      <h4>{title}</h4>
+      <ul>
+        {values.map((value) => (
+          <li key={value}>{value}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function normalizeTextArray(values?: string[] | null): string[] {
+  return Array.from(
+    new Set((values ?? []).map((value) => value.trim()).filter((value) => value.length > 0))
+  );
+}
+
+function normalizeText(value?: string | null): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function buildFallbackLabel(moneyWeightedReturn: MoneyWeightedReturnSummary): string | null {
+  const from = normalizeText(moneyWeightedReturn.fallback_from);
+  const reason = normalizeText(moneyWeightedReturn.fallback_reason);
+
+  if (!from && !reason) {
+    return null;
+  }
+
+  if (from && reason) {
+    return `${formatMwrMethodLabel(from)}: ${reason}`;
+  }
+
+  return from ? formatMwrMethodLabel(from) : reason;
+}
+
+function formatMwrMethodLabel(value: string): string {
+  return value === value.toUpperCase() && !value.includes("_") ? value : formatMwrContractLabel(value);
+}
+
+function formatMwrContractLabel(value: string): string {
+  return value
+    .split(/[_\s-]+/)
+    .filter((part) => part.length > 0)
+    .map((part) => {
+      if (part === "XIRR" || part === "MWR") {
+        return part;
+      }
+      const lowered = part.toLowerCase();
+      return lowered.charAt(0).toUpperCase() + lowered.slice(1);
+    })
+    .join(" ");
+}

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -174,8 +174,16 @@ export type PerformanceChartPoint = {
 export type MoneyWeightedReturnSummary = {
   money_weighted_return_pct: number | null;
   annualized_return_pct: number | null;
+  holding_period_return_pct?: number | null;
   input_mode?: string | null;
   method: string | null;
+  status?: string | null;
+  reason_codes?: string[];
+  warnings?: string[];
+  is_annualized_primary?: boolean | null;
+  fallback_from?: string | null;
+  fallback_reason?: string | null;
+  is_approximation?: boolean | null;
   start_date: string | null;
   end_date: string | null;
   begin_market_value?: number | null;

--- a/tests/unit/performance-chart-panel.test.tsx
+++ b/tests/unit/performance-chart-panel.test.tsx
@@ -508,6 +508,42 @@ describe("PerformanceChartPanel", () => {
     expect(screen.getByLabelText("Return decision readout")).not.toHaveTextContent("XIRR");
   });
 
+  it("renders MWR reason-code drill-down from gateway supportability fields", () => {
+    const props = buildChartProps();
+
+    render(
+      <PerformanceChartPanel
+        {...props}
+        moneyWeightedReturn={{
+          ...props.moneyWeightedReturn!,
+          status: "FALLBACK_USED",
+          method: "MODIFIED_DIETZ",
+          reason_codes: ["NO_ROOT_FOUND", "DIETZ_FALLBACK_USED"],
+          warnings: ["XIRR solver did not find one root."],
+          fallback_from: "XIRR",
+          fallback_reason: "No unique XIRR root was found.",
+          is_approximation: true,
+          holding_period_return_pct: 3.05,
+          notes: ["Modified Dietz fallback used."],
+        }}
+      />
+    );
+
+    const drilldown = screen.getByLabelText("MWR reason-code drill-down");
+    expect(drilldown).toHaveTextContent("MWR supportability");
+    expect(drilldown).toHaveTextContent("Fallback Used • Modified Dietz • Approximation");
+
+    fireEvent.click(within(drilldown).getByText("MWR supportability"));
+
+    expect(within(drilldown).getByText("Reason codes")).toBeInTheDocument();
+    expect(within(drilldown).getByText("NO_ROOT_FOUND")).toBeInTheDocument();
+    expect(within(drilldown).getByText("DIETZ_FALLBACK_USED")).toBeInTheDocument();
+    expect(within(drilldown).getByText("Warnings")).toBeInTheDocument();
+    expect(within(drilldown).getByText("XIRR solver did not find one root.")).toBeInTheDocument();
+    expect(within(drilldown).getByText("Fallback")).toBeInTheDocument();
+    expect(within(drilldown).getByText("XIRR: No unique XIRR root was found.")).toBeInTheDocument();
+  });
+
   it("renders a compact unavailable panel instead of the large chart canvas when no series is available", () => {
     const scenario = buildBenchmarkUnassignedPerformanceScenario();
     const returnPath = buildPerformanceReturnPathScenarioData(scenario);

--- a/tests/unit/performance-summary-context-helpers.test.ts
+++ b/tests/unit/performance-summary-context-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   getPerformanceBenchmarkOptionLabel,
   getPerformanceReturnPathPresentation,
 } from "../../src/apps/performance/components/performance-summary-context-helpers";
+import { buildPerformanceMwrDrilldown as buildMwrDrilldown } from "../../src/apps/performance/components/performance-mwr-drilldown";
 import {
   buildBenchmarkUnassignedPerformanceScenario,
   buildPartialBenchmarkPerformanceScenario,
@@ -270,6 +271,39 @@ describe("performance summary context helpers", () => {
         is_assigned: true,
       })
     ).toBe("Global Balanced 60/40 • USD • Composite");
+  });
+
+  it("builds MWR reason-code drill-down only when supportability signals exist", () => {
+    const scenario = buildSupportedPerformanceScenario();
+
+    expect(buildMwrDrilldown(scenario.workspace.money_weighted_return)).toBeNull();
+
+    const model = buildMwrDrilldown({
+      ...scenario.workspace.money_weighted_return!,
+      status: "FALLBACK_USED",
+      method: "MODIFIED_DIETZ",
+      reason_codes: ["NO_ROOT_FOUND", "DIETZ_FALLBACK_USED", "NO_ROOT_FOUND"],
+      warnings: ["XIRR solver did not find a unique root."],
+      fallback_from: "XIRR",
+      fallback_reason: "No unique XIRR root was found.",
+      is_approximation: true,
+      holding_period_return_pct: 3.05,
+      notes: ["Modified Dietz fallback used."],
+    });
+
+    expect(model).toMatchObject({
+      summaryLabel: "Fallback Used • Modified Dietz • Approximation",
+      statusLabel: "Fallback Used",
+      methodLabel: "Modified Dietz",
+      inputModeLabel: "Stateful",
+      annualizedLabel: "5.12%",
+      holdingPeriodLabel: "3.05%",
+      approximationLabel: "Approximation",
+      fallbackLabel: "XIRR: No unique XIRR root was found.",
+      reasonCodes: ["NO_ROOT_FOUND", "DIETZ_FALLBACK_USED"],
+      warnings: ["XIRR solver did not find a unique root."],
+      notes: ["Modified Dietz fallback used."],
+    });
   });
 
   it("keeps benchmark context focused on benchmark identity and market metadata", () => {

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -129,6 +129,11 @@ Performance:
 http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001
 ```
 
+The Performance return-path panel consumes Gateway-published MWR supportability fields and exposes
+reason-code drill-downs for non-ordinary MWR posture, including XIRR fallback, approximation, no-root
+and multiple-root solver states. Workbench displays the emitted Gateway contract and does not
+recalculate MWR or infer reason codes client-side.
+
 Performance risk mode:
 
 ```txt


### PR DESCRIPTION
## Summary
- adds a Workbench Performance MWR supportability drill-down that renders Gateway-published status, reason codes, warnings, fallback, approximation, and holding-period fields for non-ordinary MWR posture
- extends the Workbench MWR summary type to match the Gateway contract without client-side recalculation or inference
- updates implementation-backed docs and wiki source for the Performance API surface and UI/Gateway capability contract

## Validation
- `npm test -- --run tests/unit/performance-summary-context-helpers.test.ts tests/unit/performance-chart-panel.test.tsx` - passed, 23 tests
- `npm run typecheck` - passed
- `npm run lint` - passed
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench -AllowUnpublishedSourceChanges` - passed with expected unpublished source warning for branch-local wiki edits
- `make check` - passed: lint, typecheck, coverage-backed Vitest, build
- `npm run test:e2e -- tests/e2e/performance-workbench.smoke.spec.ts` - exited 0; all five tests skipped because the local BFF could not reach Gateway at `127.0.0.1:80`

## Governance
- Pre-slice stranded-truth reconciliation completed.
- `lotus-gateway`: no unmerged governance branches found; Gateway already preserved the required MWR supportability contract.
- `lotus-workbench`: unmerged remote branches were inspected for durable governance paths; no required durable truth was found for this slice.
- Wiki source changed in this PR and must be published after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-workbench`.