### PR TITLE
RFC-046: harden Workbench workflow-pack live proof

### DIFF
--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -266,6 +266,16 @@ export async function validateAdvisorBriefPanel(
   if (performAcceptReviewActionProof) {
     const reviewRegion = page.getByLabel("Advisor brief review actions");
     const supportabilityRegion = page.getByLabel("Advisor brief supportability");
+    if ((await reviewRegion.count()) === 0) {
+      await expect(supportabilityRegion).toBeVisible({ timeout: timeoutMs });
+      summary.uiChecks.push({
+        description: "Advisor brief ACCEPT review action",
+        kind: "workflow-pack-review-action",
+        actionType: "ACCEPT",
+        state: "not-currently-allowed",
+      });
+      return;
+    }
     await expect(reviewRegion).toBeVisible({ timeout: timeoutMs });
     await reviewRegion.getByLabel("Reviewed by").fill("live.validator.ui");
     await reviewRegion

--- a/scripts/live/validation/workflow-pack-proof.mjs
+++ b/scripts/live/validation/workflow-pack-proof.mjs
@@ -160,6 +160,40 @@ function assertAcceptedRunPosture(payload) {
   return run;
 }
 
+function isReviewActionAllowed(payload, actionType) {
+  const run = assertWorkflowPackRunPresence(payload, `Advisor brief ${actionType} source run`);
+  const allowedActions = Array.isArray(run.allowed_review_actions)
+    ? run.allowed_review_actions
+    : [];
+  return allowedActions.includes(actionType);
+}
+
+function recordSkippedReviewAction(summary, payload, actionType, route) {
+  const run = assertWorkflowPackRunPresence(payload, `Advisor brief ${actionType} source run`);
+  const taskFlow = assertInitialTaskFlowPosture(
+    payload,
+    run.run_id,
+    `Advisor brief ${actionType} source run`
+  );
+  recordWorkflowPackCheck(summary, {
+    actionType,
+    route,
+    sourceRunId: run.run_id,
+    taskFlowId: taskFlow.task_flow_id,
+    taskFlowStatus: taskFlow.flow_status,
+    taskFlowSupportabilityStatus: taskFlow.supportability_status,
+    resultReviewState: run.review_state,
+    resultSupportabilityStatus: run.supportability_status,
+    skipped: true,
+    skipReason: `Review action ${actionType} is not currently allowed by workflow-pack run posture.`,
+    runtimeState: run.runtime_state,
+    allowedReviewActions: Array.isArray(run.allowed_review_actions)
+      ? run.allowed_review_actions
+      : [],
+  });
+  return { run, taskFlow };
+}
+
 function assertReplacementLineagePosture(payload, expectedReviewState, replacementRunId) {
   const run = assertWorkflowPackRunPresence(
     payload,
@@ -209,9 +243,21 @@ export async function validateAdvisorBriefWorkflowPackReviewChain({
     detailBasis: "NET",
     benchmarkCode,
   });
+  const acceptRoute = `/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${acceptQuery}`;
+  const acceptSourceRoute = `/api/v1/workbench/${portfolioId}/performance/advisor-brief?${acceptQuery}`;
+  const acceptSource = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}${acceptSourceRoute}`,
+    "Advisor brief ACCEPT source run",
+    timeoutMs
+  );
+  if (!isReviewActionAllowed(acceptSource, "ACCEPT")) {
+    recordSkippedReviewAction(summary, acceptSource, "ACCEPT", acceptRoute);
+    return;
+  }
   const acceptedBrief = await postJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${acceptQuery}`,
+    `${gatewayBaseUrl}${acceptRoute}`,
     "Advisor brief ACCEPT review action",
     timeoutMs,
     {
@@ -224,7 +270,7 @@ export async function validateAdvisorBriefWorkflowPackReviewChain({
   const acceptedTaskFlow = assertAcceptedTaskFlowPosture(acceptedBrief, acceptedRun.run_id);
   recordWorkflowPackCheck(summary, {
     actionType: "ACCEPT",
-    route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${acceptQuery}`,
+    route: acceptRoute,
     sourceRunId: acceptedRun.run_id,
     taskFlowId: acceptedTaskFlow.task_flow_id,
     taskFlowStatus: acceptedTaskFlow.flow_status,

--- a/tests/unit/live-validation-workflow-pack-proof.test.ts
+++ b/tests/unit/live-validation-workflow-pack-proof.test.ts
@@ -69,6 +69,8 @@ function createAdvisorBriefPayload({
   runId,
   reviewState = "AWAITING_REVIEW",
   supportabilityStatus,
+  runtimeState = "COMPLETED",
+  allowedReviewActions = ["ACCEPT", "REJECT", "REVISE", "SUPERSEDE", "ABANDON"],
   superseded,
   replacementRunId,
   taskFlowId,
@@ -79,6 +81,8 @@ function createAdvisorBriefPayload({
   runId: string;
   reviewState?: string;
   supportabilityStatus?: string;
+  runtimeState?: string;
+  allowedReviewActions?: string[];
   superseded?: boolean;
   replacementRunId?: unknown;
   taskFlowId: string;
@@ -89,7 +93,9 @@ function createAdvisorBriefPayload({
   return {
     workflow_pack_run: {
       run_id: runId,
+      runtime_state: runtimeState,
       review_state: reviewState,
+      allowed_review_actions: allowedReviewActions,
       ...(supportabilityStatus === undefined
         ? {}
         : { supportability_status: supportabilityStatus }),
@@ -203,7 +209,7 @@ describe("live validation workflow-pack proof", () => {
       },
     });
 
-    expect(getCalls).toHaveLength(4);
+    expect(getCalls).toHaveLength(5);
     expect(postCalls).toEqual([
       expect.objectContaining({
         url: expect.stringContaining("/performance/advisor-brief/review-actions?period=YTD"),
@@ -326,5 +332,60 @@ describe("live validation workflow-pack proof", () => {
         }),
       ])
     );
+  });
+
+  it("records degraded advisor-brief review posture without posting an invalid action", async () => {
+    const summary = createSummary();
+    const getCalls: string[] = [];
+    const postCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+
+    await validateAdvisorBriefWorkflowPackReviewChain({
+      summary,
+      gatewayBaseUrl: "http://gateway.dev.lotus",
+      portfolioId: "PB_SG_GLOBAL_BAL_001",
+      benchmarkCode: "BMK_PB_GLOBAL_BALANCED_60_40",
+      canonicalAsOfDate: "2026-04-10",
+      timeoutMs: 1000,
+      fetchJson: async (_summary: unknown, url: string) => {
+        getCalls.push(url);
+        return createAdvisorBriefPayload({
+          runId: "packrun-ytd-net-failed",
+          runtimeState: "FAILED",
+          reviewState: "AWAITING_REVIEW",
+          allowedReviewActions: [],
+          supportabilityStatus: "ACTION_REQUIRED",
+          taskFlowId: "taskflow-ytd-net-failed",
+          taskFlowStatus: "FAILED",
+          taskFlowSupportabilityStatus: "ACTION_REQUIRED",
+        });
+      },
+      postJson: async (
+        _summary: unknown,
+        url: string,
+        _description: string,
+        _timeoutMs: number,
+        body: Record<string, unknown>
+      ) => {
+        postCalls.push({ url, body });
+        throw new Error("postJson should not be called for a non-reviewable run.");
+      },
+    });
+
+    expect(getCalls).toHaveLength(1);
+    expect(postCalls).toEqual([]);
+    expect(summary.workflowPackChecks).toEqual([
+      expect.objectContaining({
+        actionType: "ACCEPT",
+        sourceRunId: "packrun-ytd-net-failed",
+        taskFlowId: "taskflow-ytd-net-failed",
+        taskFlowStatus: "FAILED",
+        taskFlowSupportabilityStatus: "ACTION_REQUIRED",
+        resultReviewState: "AWAITING_REVIEW",
+        resultSupportabilityStatus: "ACTION_REQUIRED",
+        skipped: true,
+        runtimeState: "FAILED",
+        allowedReviewActions: [],
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- make canonical validator handle non-reviewable advisor brief workflow-pack posture truthfully
- avoid posting invalid ACCEPT actions when workflow-pack allowed actions are empty
- record skipped review proof with runtime state and allowed action evidence
- support UI proof when review actions are not currently available

## Evidence
- Remote Feature Lane passed on head f37159744f4279abcdc37a71188588e0b4b3d8f5
- Live validation workflow-pack proof tests passed locally
- Canonical Workbench validation passed with generated screenshot evidence

## Notes
- Live stack was left running.