### PR TITLE
Fix performance evidence panel ready mapping

### DIFF
--- a/scripts/live/validation/calculation-sanity.mjs
+++ b/scripts/live/validation/calculation-sanity.mjs
@@ -205,8 +205,10 @@ export function assertPerformanceCalculationSanity({
       fallbackAvailable: attributionCapability.fallback_available === true,
     }
   );
-  const evidenceState = performanceSummary?.capabilities?.evidence?.state ?? "unavailable";
+  const evidenceCapabilityState = performanceSummary?.capabilities?.evidence?.state ?? "unavailable";
+  const evidenceState = evidenceCapabilityState === "supported" ? "ready" : evidenceCapabilityState;
   recordPanelClassification("performance.evidence", evidenceState, "lotus-gateway", {
+    capabilityState: evidenceCapabilityState,
     reason: performanceSummary?.capabilities?.evidence?.reason ?? null,
   });
 }

--- a/tests/unit/live-validation-calculation-sanity.test.ts
+++ b/tests/unit/live-validation-calculation-sanity.test.ts
@@ -115,6 +115,67 @@ describe("live validation calculation sanity helpers", () => {
     ]);
   });
 
+  it("maps supported performance evidence capability into the panel-ready vocabulary", () => {
+    const summary = createSummary();
+
+    assertPerformanceCalculationSanity({
+      summary,
+      recordPanelClassification: createClassifier(summary),
+      performanceSummary: {
+        net_performance: {
+          portfolio_return_pct: 9.33,
+          benchmark_return_pct: 6.52,
+          active_return_pct: 2.81,
+        },
+        overview: {
+          market_value_base: 1_500_000,
+          cash_weight_pct: 12.4,
+          position_count: 18,
+        },
+        capabilities: {
+          evidence: {
+            state: "supported",
+            reason: "lineage evidence is complete",
+          },
+        },
+      },
+      performanceDetails: {
+        net_chart: [{}, {}, {}, {}],
+        contribution: {
+          levels: [
+            {
+              rows: [{}, {}, {}, {}],
+              total_contribution_pct: 9.33,
+            },
+          ],
+        },
+        capabilities: {
+          attribution_detail: {
+            state: "supported",
+            fallback_available: false,
+          },
+        },
+        attribution: {
+          levels: [
+            {
+              rows: [{}, {}],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(summary.panelClassifications).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          panel: "performance.evidence",
+          state: "ready",
+          capabilityState: "supported",
+        }),
+      ])
+    );
+  });
+
   it("fails performance attribution when governed fallback is missing", () => {
     const summary = createSummary();
 


### PR DESCRIPTION
## Summary
- map supported Gateway evidence capability into the Workbench panel-ready vocabulary
- preserve the upstream capability state in live validation evidence
- add a regression for supported evidence classification

## Validation
- npm test -- --run tests/unit/live-validation-calculation-sanity.test.ts tests/unit/live-validation-panel-governance.test.ts
- npm run typecheck
- git diff --check
- npm run live:validate passed for PB_SG_GLOBAL_BAL_001 with 31 API checks, 12 screenshots, 0 console errors, and performance.evidence ready