### PR TITLE
RFC 047 contribution evidence in Workbench

### DIFF
--- a/src/apps/performance/components/performance-contribution-context-note.tsx
+++ b/src/apps/performance/components/performance-contribution-context-note.tsx
@@ -18,6 +18,11 @@ function formatContributionWeightingScheme(weightingScheme?: string | null) {
   }
 }
 
+function formatContributionStatus(label: string, status?: string | null) {
+  const normalized = status?.trim();
+  return normalized ? `${label}: ${normalized}` : null;
+}
+
 export default function PerformanceContributionContextNote({
   contribution,
   className = "performance-contribution-context-note",
@@ -33,10 +38,21 @@ export default function PerformanceContributionContextNote({
   ]
     .filter(Boolean)
     .join(" • ");
+  const evidenceText = [
+    formatContributionStatus("Source economics", contribution.source_economics_evidence?.status),
+    formatContributionStatus("Smoothing", contribution.smoothing_evidence?.status),
+  ]
+    .filter(Boolean)
+    .join(" • ");
+  const sourceReasonText = contribution.source_economics_evidence?.reason_codes.length
+    ? `Source reasons: ${contribution.source_economics_evidence.reason_codes.join(", ")}`
+    : null;
 
   return (
     <div className={className} role="note">
       <strong>{coverageText}</strong>
+      {evidenceText ? <span>{evidenceText}</span> : null}
+      {sourceReasonText ? <span>{sourceReasonText}</span> : null}
       {showReconciliation ? (
         <span>
           {getContributionReconciliationAssessment(contribution) ??

--- a/src/apps/performance/components/performance-summary-contributors-section.tsx
+++ b/src/apps/performance/components/performance-summary-contributors-section.tsx
@@ -86,6 +86,9 @@ export default function PerformanceSummaryContributorsSection({
         <div className="performance-contributors-asymmetric-side">
           {renderRankedContributorCard(secondaryGroup)}
         </div>
+        {workspace.contribution ? (
+          <PerformanceContributionContextNote contribution={workspace.contribution} />
+        ) : null}
         {instrumentDetailDisclosure}
       </div>
     ) : (
@@ -93,6 +96,9 @@ export default function PerformanceSummaryContributorsSection({
         <div className="performance-contributors-compare-grid">
           {rankedContributorGroups.map((group) => renderRankedContributorCard(group))}
         </div>
+        {workspace.contribution ? (
+          <PerformanceContributionContextNote contribution={workspace.contribution} />
+        ) : null}
         {instrumentDetailDisclosure}
       </div>
     );

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -228,6 +228,25 @@ export type ContributionLevelView = {
   total_portfolio_return_pct?: number | null;
 };
 
+export type ContributionSmoothingEvidenceView = {
+  status: string | null;
+  reason_codes: string[];
+  raw_contribution_pct: number | null;
+  final_contribution_pct: number | null;
+  linked_return_pct: number | null;
+  smoothing_residual_pct: number | null;
+};
+
+export type ContributionSourceEconomicsEvidenceView = {
+  status: string | null;
+  reason_codes: string[];
+  source_contracts: string[];
+  available_economics: string[];
+  unsupported_economics: string[];
+  degraded_economics: string[];
+  source_snapshot_count: number | null;
+};
+
 export type ContributionSummaryView = {
   metric_basis: string;
   weighting_scheme: string | null;
@@ -238,6 +257,8 @@ export type ContributionSummaryView = {
   portfolio_fx_contribution_pct: number | null;
   position_rows: ContributionPositionView[];
   levels: ContributionLevelView[];
+  smoothing_evidence?: ContributionSmoothingEvidenceView | null;
+  source_economics_evidence?: ContributionSourceEconomicsEvidenceView | null;
 };
 
 export type AttributionRowView = {

--- a/tests/fixtures/performance-workspace-fixtures.ts
+++ b/tests/fixtures/performance-workspace-fixtures.ts
@@ -456,6 +456,23 @@ export function buildPerformanceWorkspaceDetails(
       coverage_mv_pct: 98.7,
       portfolio_local_contribution_pct: 4.8,
       portfolio_fx_contribution_pct: 0.62,
+      smoothing_evidence: {
+        status: "APPLIED",
+        reason_codes: ["CARINO_FACTOR_APPLIED"],
+        raw_contribution_pct: 5.31,
+        final_contribution_pct: 5.42,
+        linked_return_pct: 5.42,
+        smoothing_residual_pct: 0,
+      },
+      source_economics_evidence: {
+        status: "SOURCE_LIMITED",
+        reason_codes: ["LOTUS_CORE_ANALYTICS_INPUTS_USED", "COMPONENT_PNL_NOT_SOURCE_AUTHORED"],
+        source_contracts: ["PortfolioTimeseriesInput:v1", "PositionTimeseriesInput:v1"],
+        available_economics: ["portfolio_market_values", "position_market_values"],
+        unsupported_economics: ["income_pnl", "tax_pnl"],
+        degraded_economics: ["unsupported_cash_flow_types"],
+        source_snapshot_count: 2,
+      },
       position_rows: options?.aggregateContributionOnly
         ? []
         : [

--- a/tests/integration/performance-analytics-page.test.tsx
+++ b/tests/integration/performance-analytics-page.test.tsx
@@ -473,6 +473,12 @@ describe("PerformanceAnalyticsPage", () => {
     ).toBeTruthy();
     expect(within(contributorsModule as HTMLElement).getByLabelText("Top Contributors impact bars")).toBeInTheDocument();
     expect(within(contributorsModule as HTMLElement).getByLabelText("Top Detractors impact bars")).toBeInTheDocument();
+    expect(within(contributorsModule as HTMLElement).getByText("Source economics: SOURCE_LIMITED • Smoothing: APPLIED")).toBeInTheDocument();
+    expect(
+      within(contributorsModule as HTMLElement).getByText(
+        "Source reasons: LOTUS_CORE_ANALYTICS_INPUTS_USED, COMPONENT_PNL_NOT_SOURCE_AUTHORED"
+      )
+    ).toBeInTheDocument();
     expect(within(contributorsModule as HTMLElement).getByText("Instrument detail")).toBeInTheDocument();
     expect(within(contributorsModule as HTMLElement).queryByLabelText("Contributor summary")).not.toBeInTheDocument();
     expect(within(contributorsModule as HTMLElement).queryByLabelText("Contributor driver strip")).not.toBeInTheDocument();

--- a/tests/unit/performance-summary-contributors-section.test.tsx
+++ b/tests/unit/performance-summary-contributors-section.test.tsx
@@ -84,7 +84,12 @@ describe("PerformanceSummaryContributorsSection", () => {
       screen.queryByText("Open the full instrument-level contribution breakdown in one ranked table.")
     ).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Contributor driver strip")).not.toBeInTheDocument();
-    expect(screen.queryByRole("note")).not.toBeInTheDocument();
+    const contributionEvidenceNote = screen.getByRole("note");
+    expect(contributionEvidenceNote).toHaveTextContent("Source economics: SOURCE_LIMITED");
+    expect(contributionEvidenceNote).toHaveTextContent("Smoothing: APPLIED");
+    expect(contributionEvidenceNote).toHaveTextContent(
+      "Source reasons: LOTUS_CORE_ANALYTICS_INPUTS_USED, COMPONENT_PNL_NOT_SOURCE_AUTHORED"
+    );
     expect(screen.queryByText("Avg. Weight 24.00%")).not.toBeInTheDocument();
     expect(screen.queryByText("Avg. Weight 8.00%")).not.toBeInTheDocument();
 


### PR DESCRIPTION
Consumes lotus-gateway RFC 047 contribution evidence in Workbench. Adds typed source-economics and smoothing evidence, surfaces exact source-owned statuses in the performance drivers module, and strengthens fixture-backed assertions.\n\nValidation:\n- npm run typecheck\n- npm run lint\n- npm test