### PR TITLE
test: harden RFC 047 live evidence validation

### DIFF
--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -356,6 +356,7 @@ export async function validateEvidencePanel(
     timeout: timeoutMs,
   });
   const evidenceStatusStrip = page.getByLabel("Evidence support status");
+  let screenshotState = "truthfully_degraded";
   if (await evidenceStatusStrip.count()) {
     await expect(evidenceStatusStrip).toBeVisible({ timeout: timeoutMs });
     summary.uiChecks.push({
@@ -363,6 +364,7 @@ export async function validateEvidencePanel(
       kind: "status-strip",
       state: "supported",
     });
+    screenshotState = "demo_ready";
   } else {
     await expect(page.getByText(/Evidence (partially available|unavailable)/)).toBeVisible({
       timeout: timeoutMs,
@@ -374,7 +376,7 @@ export async function validateEvidencePanel(
     });
   }
   await screenshotRegisteredPanel(page, "performance.evidence", {
-    state: "truthfully_degraded",
+    state: screenshotState,
   });
 }
 

--- a/scripts/live/validation/calculation-sanity.mjs
+++ b/scripts/live/validation/calculation-sanity.mjs
@@ -31,17 +31,59 @@ function recordCalculationCheck(summary, description, evidence) {
 }
 
 function readSourceSupportabilityItems(...payloads) {
-  return payloads.flatMap((payload) =>
-    Array.isArray(payload?.source_supportability) ? payload.source_supportability : []
-  );
+  return payloads.flatMap((payload) => [
+    ...(Array.isArray(payload?.source_supportability) ? payload.source_supportability : []),
+    ...readContributionSourceEconomicsItems(payload),
+  ]);
+}
+
+function readContributionSourceEconomicsItems(payload) {
+  const sourceEconomicsEvidence = payload?.contribution?.source_economics_evidence;
+  if (!sourceEconomicsEvidence || typeof sourceEconomicsEvidence !== "object") {
+    return [];
+  }
+
+  return [
+    {
+      source_service: deriveContributionSourceEconomicsOwner(sourceEconomicsEvidence),
+      operation: "performance.contribution.source_economics",
+      state: sourceEconomicsEvidence.status,
+      freshness_bucket:
+        typeof sourceEconomicsEvidence.source_snapshot_count === "number" &&
+        sourceEconomicsEvidence.source_snapshot_count > 0
+          ? "fresh"
+          : "unknown",
+    },
+  ];
+}
+
+function deriveContributionSourceEconomicsOwner(sourceEconomicsEvidence) {
+  if (typeof sourceEconomicsEvidence.source_owner === "string" && sourceEconomicsEvidence.source_owner) {
+    return sourceEconomicsEvidence.source_owner;
+  }
+
+  const sourceContracts = Array.isArray(sourceEconomicsEvidence.source_contracts)
+    ? sourceEconomicsEvidence.source_contracts
+    : [];
+  if (
+    sourceContracts.some(
+      (contract) =>
+        typeof contract === "string" &&
+        (contract.includes("PortfolioTimeseriesInput") || contract.includes("PositionTimeseriesInput"))
+    )
+  ) {
+    return "lotus-core";
+  }
+
+  return "lotus-performance";
 }
 
 function normalizeSupportabilityState(value) {
   const normalized = typeof value === "string" ? value.toLowerCase() : "";
-  if (["ready", "supported", "ok", "complete"].includes(normalized)) {
+  if (["ready", "supported", "ok", "complete", "source_backed", "caller_supplied"].includes(normalized)) {
     return "ready";
   }
-  if (["partial", "stale"].includes(normalized)) {
+  if (["partial", "stale", "source_limited"].includes(normalized)) {
     return "partial";
   }
   if (["blocked", "degraded", "unavailable", "unsupported", "action_required"].includes(normalized)) {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -401,7 +401,8 @@ describe("canonical live validation script", () => {
     expect(contractModule).toContain('panelId: "performance.risk.snapshot"');
     expect(contractModule).toContain('screenshotName: "performance-risk-live.png"');
     expect(browserWorkflowModule).toContain("panel: panelId");
-    expect(browserWorkflowModule).toContain('state: "truthfully_degraded"');
+    expect(browserWorkflowModule).toContain('screenshotState = "demo_ready"');
+    expect(browserWorkflowModule).toContain("state: screenshotState");
     expect(browserWorkflowModule).toContain("path: target");
     expect(evidenceWriter).toContain("SHOT-INDEX.md");
     expect(script).toContain("writeShotIndex");

--- a/tests/unit/live-validation-calculation-sanity.test.ts
+++ b/tests/unit/live-validation-calculation-sanity.test.ts
@@ -59,6 +59,11 @@ describe("live validation calculation sanity helpers", () => {
       performanceDetails: {
         net_chart: [{}, {}, {}, {}],
         contribution: {
+          source_economics_evidence: {
+            status: "SOURCE_LIMITED",
+            source_contracts: ["PortfolioTimeseriesInput:v1", "PositionTimeseriesInput:v1"],
+            source_snapshot_count: 4,
+          },
           levels: [
             {
               rows: [{}, {}, {}, {}],
@@ -107,10 +112,10 @@ describe("live validation calculation sanity helpers", () => {
         owner: "lotus-gateway",
         source: "gateway.source_supportability",
         state: "partial",
-        itemCount: 2,
+        itemCount: 3,
         staleCount: 1,
-        partialCount: 1,
-        services: ["lotus-performance"],
+        partialCount: 2,
+        services: ["lotus-core", "lotus-performance"],
       }),
     ]);
   });


### PR DESCRIPTION
## Summary
- derive contribution source-economics supportability in canonical live validation
- mark the performance evidence screenshot as demo-ready only when the evidence support strip is present
- keep degraded screenshot state for partial/unavailable evidence panels

## Validation
- npm test -- --run tests/unit/live-validation-calculation-sanity.test.ts tests/unit/live-canonical-validation-script.test.ts
- npm run typecheck
- npm run lint
- powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1 -ScreenshotDirectory output/rfc047-slice11-validation-harness-proof-2

Live stack was left running by operator request.