### PR TITLE
feat: surface attribution supportability posture

### DIFF
--- a/src/apps/performance/components/performance-analysis-attribution-breakdown.tsx
+++ b/src/apps/performance/components/performance-analysis-attribution-breakdown.tsx
@@ -2,10 +2,14 @@ import { AnalyticsTable } from "@/design-system";
 import type { AttributionSummaryView } from "@/features/workbench/types";
 
 import { formatLabel, formatPct } from "../formatters";
+import {
+  getAttributionSupportabilityLine,
+} from "./performance-attribution-presentations";
+import PerformanceAttributionReconciliationNote from "./performance-attribution-reconciliation-note";
 import { getAttributionTotals, NOT_ADDITIVE_CELL } from "./performance-workspace-view-helpers";
 
 type PerformanceAnalysisAttributionBreakdownProps = {
-  levels: AttributionSummaryView["levels"];
+  attribution: AttributionSummaryView;
 };
 
 function getDifference(
@@ -127,11 +131,17 @@ function PerformanceAttributionLevelTable({
 }
 
 export default function PerformanceAnalysisAttributionBreakdown({
-  levels,
+  attribution,
 }: PerformanceAnalysisAttributionBreakdownProps) {
+  const supportabilityLine = getAttributionSupportabilityLine(attribution);
+
   return (
     <div className="performance-analysis-detail-stack performance-attribution-breakdown-stack">
-      {levels.map((level) =>
+      <PerformanceAttributionReconciliationNote attribution={attribution} />
+      {supportabilityLine ? (
+        <p className="performance-analysis-summary-fallback-copy">{supportabilityLine}</p>
+      ) : null}
+      {attribution.levels.map((level) =>
         level.rows.length > 0 ? (
           <PerformanceAttributionLevelTable key={level.dimension} level={level} />
         ) : (

--- a/src/apps/performance/components/performance-analysis-attribution-section.tsx
+++ b/src/apps/performance/components/performance-analysis-attribution-section.tsx
@@ -7,7 +7,10 @@ import PerformanceAnalysisAttributionBreakdown from "./performance-analysis-attr
 import PerformanceAnalysisModuleState from "./performance-analysis-module-state";
 import PerformanceAnalysisSegmentToolbar from "./performance-analysis-segment-toolbar";
 import PerformancePanelInfoDrawer from "./performance-panel-info-drawer";
-import { getAttributionDetailClassificationGapBody } from "./performance-attribution-presentations";
+import {
+  getAttributionDetailClassificationGapBody,
+  getAttributionSourcePosture,
+} from "./performance-attribution-presentations";
 import type { PerformanceAnalysisAttributionSectionProps } from "./performance-workspace-types";
 import { isCapabilityOptionSupported } from "./performance-capability-options";
 import { getAttributionMethodologyRows } from "./performance-analysis-methodology-rows";
@@ -32,6 +35,7 @@ export default function PerformanceAnalysisAttributionSection({
     partialFailures: workspace.partial_failures,
     attributionDimension,
   });
+  const attributionSourcePosture = getAttributionSourcePosture(workspace.attribution);
   const missingAttributionLevelsBody =
     capabilities.attributionDetail.state !== "unavailable" &&
     (!workspace.attribution || !hasAttributionSummaryLevels)
@@ -48,6 +52,22 @@ export default function PerformanceAnalysisAttributionSection({
         ...capabilities.attributionDetail,
         state: "partial" as const,
         reason: missingAttributionLevelsBody,
+      }
+    : attributionSourcePosture?.state === "partial"
+    ? {
+        ...capabilities.attributionDetail,
+        state: "partial" as const,
+        reason:
+          attributionSourcePosture.reason ??
+          "lotus-performance returned attribution with source supportability qualifications.",
+      }
+    : attributionSourcePosture?.state === "unavailable"
+    ? {
+        ...capabilities.attributionDetail,
+        state: "unavailable" as const,
+        reason:
+          attributionSourcePosture.reason ??
+          "lotus-performance marked attribution unavailable for this selection.",
       }
     : capabilities.attributionDetail;
   const attributionMethodologyRows = getAttributionMethodologyRows(
@@ -92,6 +112,7 @@ export default function PerformanceAnalysisAttributionSection({
         body={
           attributionClassificationGapBody ??
           missingAttributionLevelsBody ??
+          attributionSourcePosture?.reason ??
           effectiveAttributionCapability.reason ??
           "Attribution detail is not available for the current selection."
         }
@@ -100,6 +121,8 @@ export default function PerformanceAnalysisAttributionSection({
             ? "Select a supported segment or use a benchmark with complete classification coverage for this dimension."
             : missingAttributionLevelsBody
             ? "Use the attribution trend and supportability posture while the selected segment detail is incomplete."
+            : attributionSourcePosture?.state === "partial"
+            ? "Review source reason codes, residual materiality, and supportability evidence before using attribution in client-facing commentary."
             : hasAttributionSummaryLevels
             ? "Summary-level attribution remains available even when segment rows are absent."
             : "Benchmark-relative attribution requires a comparable benchmark and source-backed attribution levels."
@@ -107,7 +130,7 @@ export default function PerformanceAnalysisAttributionSection({
         allowPartialContent={hasAttributionSummaryLevels && !attributionClassificationGapBody}
       >
         {workspace.attribution ? (
-          <PerformanceAnalysisAttributionBreakdown levels={workspace.attribution.levels} />
+          <PerformanceAnalysisAttributionBreakdown attribution={workspace.attribution} />
         ) : null}
       </PerformanceAnalysisModuleState>
     </WorkbenchChartShell>

--- a/src/apps/performance/components/performance-analysis-decision-summary.tsx
+++ b/src/apps/performance/components/performance-analysis-decision-summary.tsx
@@ -16,6 +16,7 @@ import {
   getTopPositionContributionRows,
   hasPositionContributionRanking,
 } from "../view-model";
+import { getAttributionSourcePosture } from "./performance-attribution-presentations";
 
 function getTopDriverLabel(workspace: WorkbenchPerformanceWorkspace): string | null {
   if (hasPositionContributionRanking(workspace)) {
@@ -43,6 +44,7 @@ export default function PerformanceAnalysisDecisionSummary({
   const selectedPerformance =
     detailBasis === "GROSS" ? workspace.gross_performance : workspace.net_performance;
   const attribution = workspace.attribution;
+  const attributionPosture = getAttributionSourcePosture(attribution);
   const topDriverLabel = getTopDriverLabel(workspace);
   const contributionCoverage = workspace.contribution?.coverage_mv_pct;
   const headline =
@@ -81,11 +83,23 @@ export default function PerformanceAnalysisDecisionSummary({
       ? {
           label: "Residual",
           value: formatPct(attribution.residual_pct),
-          support: attribution.linking
-            ? `${attribution.linking} linking`
-            : "Attribution reconciliation",
+          support:
+            attribution.residual_materiality?.classification != null
+              ? `${attribution.residual_materiality.classification} residual`
+              : attribution.linking
+                ? `${attribution.linking} linking`
+                : "Attribution reconciliation",
           definition:
             "Difference between attributed effects and total active return after applying the selected linking method.",
+        }
+      : null,
+    attributionPosture?.state !== "supported"
+      ? {
+          label: "Attribution Posture",
+          value: attributionPosture?.state === "partial" ? "Partial" : "Unavailable",
+          support: attributionPosture?.reason ?? "Source supportability qualification",
+          definition:
+            "Source-owned attribution status returned by lotus-performance for this selection.",
         }
       : null,
     contributionCoverage != null

--- a/src/apps/performance/components/performance-attribution-presentations.ts
+++ b/src/apps/performance/components/performance-attribution-presentations.ts
@@ -11,8 +11,26 @@ import {
 } from "./performance-summary-context-helpers";
 
 function getAttributionResidualAssessment(
-  residualPct: number | null | undefined
+  attribution:
+    | AttributionSummaryView
+    | {
+        residual_pct: number | null | undefined;
+        residual_materiality?: AttributionSummaryView["residual_materiality"];
+      }
 ): string | null {
+  const materiality = attribution.residual_materiality;
+  if (materiality?.classification) {
+    if (materiality.classification === "immaterial") {
+      return "Residual immaterial";
+    }
+    if (materiality.classification === "watch") {
+      return "Residual under review";
+    }
+    if (materiality.classification === "material") {
+      return "Material residual";
+    }
+  }
+  const residualPct = attribution.residual_pct;
   if (residualPct == null) {
     return null;
   }
@@ -30,6 +48,7 @@ export function getAttributionReconciliationText(
         sum_of_effects_pct?: number | null | undefined;
         total_effect_pct?: number | null | undefined;
         residual_pct: number | null | undefined;
+        residual_materiality?: AttributionSummaryView["residual_materiality"];
       }
 ) {
   const effectsPct =
@@ -39,7 +58,7 @@ export function getAttributionReconciliationText(
 
   return {
     headline:
-      getAttributionResidualAssessment(attribution.residual_pct) ??
+      getAttributionResidualAssessment(attribution) ??
       "Attribution reconciliation unavailable",
     detail: [
       attribution.active_return_pct != null
@@ -47,10 +66,64 @@ export function getAttributionReconciliationText(
         : null,
       effectsPct != null ? `effects sum ${formatPct(effectsPct)}` : null,
       attribution.residual_pct != null ? `residual ${formatPct(attribution.residual_pct)}` : null,
+      attribution.residual_materiality?.treatment
+        ? `treatment ${formatLabel(attribution.residual_materiality.treatment)}`
+        : null,
     ]
       .filter(Boolean)
       .join(" • "),
   };
+}
+
+export function getAttributionSourcePosture(
+  attribution: AttributionSummaryView | null | undefined
+): { state: "supported" | "partial" | "unavailable"; reason: string | null } | null {
+  if (!attribution) {
+    return null;
+  }
+  const status = attribution.status?.toLowerCase();
+  const firstReason = attribution.reasons?.[0]?.message;
+  const reasonCode = attribution.reason_codes?.[0];
+  const reason = firstReason ?? (reasonCode ? formatLabel(reasonCode) : null);
+
+  if (status === "partial" || status === "warning") {
+    return { state: "partial", reason };
+  }
+  if (status === "unavailable" || status === "invalid") {
+    return { state: "unavailable", reason };
+  }
+  return { state: "supported", reason };
+}
+
+export function getAttributionSupportabilityLine(
+  attribution: AttributionSummaryView | null | undefined
+): string | null {
+  if (!attribution?.supportability_evidence) {
+    return null;
+  }
+  const evidence = attribution.supportability_evidence;
+  const counts = [
+    evidence.portfolio_only_group_count
+      ? `${evidence.portfolio_only_group_count} portfolio-only group`
+      : null,
+    evidence.benchmark_only_group_count
+      ? `${evidence.benchmark_only_group_count} benchmark-only group`
+      : null,
+    evidence.unclassified_group_count
+      ? `${evidence.unclassified_group_count} unclassified group`
+      : null,
+    evidence.missing_benchmark_return_count
+      ? `${evidence.missing_benchmark_return_count} missing benchmark return`
+      : null,
+    evidence.negative_weight_count ? `${evidence.negative_weight_count} negative weight` : null,
+  ].filter(Boolean);
+
+  if (counts.length) {
+    return counts.join(" • ");
+  }
+  return `Linking ${formatLabel(evidence.linking_status)} • currency ${formatLabel(
+    evidence.currency_attribution_status
+  )}`;
 }
 
 export function getAttributionDetailContextItems(

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -282,6 +282,32 @@ export type AttributionLevelView = {
   rows: AttributionRowView[];
 };
 
+export type AttributionReasonView = {
+  code: string;
+  severity: string;
+  message: string;
+  affected_group_count: number;
+};
+
+export type AttributionResidualMaterialityView = {
+  classification: string;
+  treatment: string;
+  absolute_residual_pct: number;
+  warning_threshold_pct: number;
+  material_threshold_pct: number;
+};
+
+export type AttributionSupportabilityEvidenceView = {
+  portfolio_only_group_count: number;
+  benchmark_only_group_count: number;
+  unclassified_group_count: number;
+  missing_benchmark_return_count: number;
+  negative_weight_count: number;
+  zero_portfolio_exposure_count: number;
+  currency_attribution_status: string;
+  linking_status: string;
+};
+
 export type PerformanceBenchmarkOptionView = {
   benchmark_code: string;
   benchmark_name: string;
@@ -423,6 +449,10 @@ export type PerformanceAttributionTrendRow = {
   cumulative_total_effect_pct: number | null;
   active_return_pct: number | null;
   residual_pct: number | null;
+  status?: string;
+  reason_codes?: string[];
+  residual_materiality?: AttributionResidualMaterialityView | null;
+  supportability_evidence?: AttributionSupportabilityEvidenceView | null;
 };
 
 export type WorkbenchPerformanceAttributionTrend = {
@@ -445,6 +475,9 @@ export type WorkbenchPerformanceAttributionTrend = {
 };
 
 export type AttributionSummaryView = {
+  status?: string;
+  reason_codes?: string[];
+  reasons?: AttributionReasonView[];
   metric_basis: string;
   model: string | null;
   linking: string | null;
@@ -453,6 +486,8 @@ export type AttributionSummaryView = {
   active_return_pct: number | null;
   sum_of_effects_pct: number | null;
   residual_pct: number | null;
+  residual_materiality?: AttributionResidualMaterialityView | null;
+  supportability_evidence?: AttributionSupportabilityEvidenceView | null;
   levels: AttributionLevelView[];
 };
 

--- a/tests/fixtures/performance-workspace-fixtures.ts
+++ b/tests/fixtures/performance-workspace-fixtures.ts
@@ -509,6 +509,18 @@ export function buildPerformanceWorkspaceDetails(
     attribution: options?.unavailableAttribution
       ? null
       : {
+          status: options?.summaryOnlyAttribution ? "partial" : "valid",
+          reason_codes: options?.summaryOnlyAttribution ? ["off_benchmark_exposure"] : [],
+          reasons: options?.summaryOnlyAttribution
+            ? [
+                {
+                  code: "off_benchmark_exposure",
+                  severity: "warning",
+                  message: "Portfolio-only exposure was found in the attribution set.",
+                  affected_group_count: 1,
+                },
+              ]
+            : [],
           metric_basis: "NET",
           model: "BF",
           linking: "carino",
@@ -517,6 +529,23 @@ export function buildPerformanceWorkspaceDetails(
           active_return_pct: 0.52,
           sum_of_effects_pct: 0.5,
           residual_pct: 0.02,
+          residual_materiality: {
+            classification: options?.summaryOnlyAttribution ? "watch" : "immaterial",
+            treatment: options?.summaryOnlyAttribution ? "review" : "no_action",
+            absolute_residual_pct: 0.02,
+            warning_threshold_pct: 0.001,
+            material_threshold_pct: 0.01,
+          },
+          supportability_evidence: {
+            portfolio_only_group_count: options?.summaryOnlyAttribution ? 1 : 0,
+            benchmark_only_group_count: 0,
+            unclassified_group_count: 0,
+            missing_benchmark_return_count: 0,
+            negative_weight_count: 0,
+            zero_portfolio_exposure_count: 0,
+            currency_attribution_status: "not_requested",
+            linking_status: "linked",
+          },
           levels: [
             {
               dimension: "asset_class",
@@ -1048,6 +1077,25 @@ export function buildPerformanceAttributionTrend(
         cumulative_total_effect_pct: 0.22,
         active_return_pct: 0.22,
         residual_pct: 0,
+        status: "valid",
+        reason_codes: [],
+        residual_materiality: {
+          classification: "immaterial",
+          treatment: "no_action",
+          absolute_residual_pct: 0,
+          warning_threshold_pct: 0.001,
+          material_threshold_pct: 0.01,
+        },
+        supportability_evidence: {
+          portfolio_only_group_count: 0,
+          benchmark_only_group_count: 0,
+          unclassified_group_count: 0,
+          missing_benchmark_return_count: 0,
+          negative_weight_count: 0,
+          zero_portfolio_exposure_count: 0,
+          currency_attribution_status: "not_requested",
+          linking_status: "linked",
+        },
       },
     ],
     warnings: [],

--- a/tests/unit/performance-analysis-attribution-section.test.tsx
+++ b/tests/unit/performance-analysis-attribution-section.test.tsx
@@ -41,7 +41,7 @@ describe("PerformanceAnalysisAttributionSection", () => {
     expect(screen.queryByRole("group", { name: "Attribution detail context" })).not.toBeInTheDocument();
     expect(screen.getByText("View Details")).toBeInTheDocument();
     expect(screen.queryByLabelText("Attribution summary strip")).not.toBeInTheDocument();
-    expect(screen.queryByRole("note")).not.toBeInTheDocument();
+    expect(screen.getByRole("note")).toHaveTextContent("Residual immaterial");
     expect(document.querySelector(".performance-analysis-drilldown-workspace")).toBeFalsy();
     expect(document.querySelectorAll(".performance-analysis-drilldown-pane")).toHaveLength(0);
     expect(screen.queryByLabelText("Top Effects panel")).not.toBeInTheDocument();
@@ -103,14 +103,15 @@ describe("PerformanceAnalysisAttributionSection", () => {
 
     expect(screen.getByText("Attribution detail is partial")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Benchmark-relative attribution is available only at summary level for the current selection."
-      )
+      screen.getByText("Portfolio-only exposure was found in the attribution set.")
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Summary-level attribution remains available even when segment rows are absent.")
+      screen.getByText(
+        "Review source reason codes, residual materiality, and supportability evidence before using attribution in client-facing commentary."
+      )
     ).toBeInTheDocument();
-    expect(screen.queryByRole("note")).not.toBeInTheDocument();
+    expect(screen.getByRole("note")).toHaveTextContent("Residual under review");
+    expect(screen.getByText("1 portfolio-only group")).toBeInTheDocument();
     expect(screen.queryByRole("group", { name: "Attribution detail context" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Attribution summary strip")).not.toBeInTheDocument();
     expect(screen.queryByRole("tab")).not.toBeInTheDocument();

--- a/tests/unit/performance-attribution-presentations.test.ts
+++ b/tests/unit/performance-attribution-presentations.test.ts
@@ -4,6 +4,8 @@ import {
   getAttributionDetailClassificationGapBody,
   getAttributionDetailContextItems,
   getAttributionReconciliationText,
+  getAttributionSourcePosture,
+  getAttributionSupportabilityLine,
   getAttributionTrendUnavailableBody,
   getAttributionTrendSummaryItems,
 } from "../../src/apps/performance/components/performance-attribution-presentations";
@@ -56,9 +58,22 @@ describe("performance attribution presentations", () => {
     const scenario = buildSupportedPerformanceScenario();
 
     expect(getAttributionReconciliationText(scenario.workspace.attribution!)).toEqual({
-      headline: "Residual remains after effects",
-      detail: "Active return 0.52% • effects sum 0.50% • residual 0.02%",
+      headline: "Residual immaterial",
+      detail:
+        "Active return 0.52% • effects sum 0.50% • residual 0.02% • treatment No Action",
     });
+  });
+
+  it("preserves source-owned attribution posture and supportability evidence", () => {
+    const scenario = buildPartialAttributionPerformanceScenario();
+
+    expect(getAttributionSourcePosture(scenario.workspace.attribution)).toEqual({
+      state: "partial",
+      reason: "Portfolio-only exposure was found in the attribution set.",
+    });
+    expect(getAttributionSupportabilityLine(scenario.workspace.attribution)).toBe(
+      "1 portfolio-only group"
+    );
   });
 
   it("explains missing benchmark classification when attribution trend is unavailable", () => {


### PR DESCRIPTION
## Summary
- consume Gateway attribution status, reason codes, residual materiality, and supportability evidence in Workbench types
- surface source-owned attribution posture in the performance analysis panel and decision summary
- keep UI gateway-first and avoid local recomputation of attribution status

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build