### PR TITLE
RFC 048: bind canonical live validation to governed as-of

### DIFF
--- a/scripts/live/Capture-LotusFrontOfficeEvidence.ps1
+++ b/scripts/live/Capture-LotusFrontOfficeEvidence.ps1
@@ -1,6 +1,7 @@
 param(
   [string]$PortfolioId = "PB_SG_GLOBAL_BAL_001",
   [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40",
+  [string]$AsOfDate = "2026-04-10",
   [string]$OutputDirectory = "",
   [int]$LogTail = 200,
   [string[]]$ForbiddenEvidencePatterns = @("DEMO_ADV_USD_001"),
@@ -195,9 +196,9 @@ $apiChecks += Write-HttpArtifact "archive-ready" "http://archive.dev.lotus/healt
 $apiChecks += Write-HttpArtifact "render-ready" "http://render.dev.lotus/health/ready" "api\render-ready.json"
 $apiChecks += Write-HttpArtifact "gateway-platform-capabilities" "http://gateway.dev.lotus/api/v1/platform/capabilities" "api\gateway-platform-capabilities.json" -Headers $canonicalCallerContextHeaders
 $apiChecks += Write-HttpArtifact "gateway-workbench-overview" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/overview" "api\gateway-workbench-overview.json" -Headers $canonicalCallerContextHeaders
-$apiChecks += Write-HttpArtifact "gateway-performance-summary" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "api\gateway-performance-summary.json" -Headers $canonicalCallerContextHeaders
-$apiChecks += Write-HttpArtifact "gateway-risk-summary" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/risk/summary?period=YTD&detail_basis=NET&benchmark_code=$BenchmarkCode" "api\gateway-risk-summary.json" -Headers $canonicalCallerContextHeaders
-$apiChecks += Write-HttpArtifact "gateway-advisor-brief" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "api\gateway-advisor-brief.json" -Headers $canonicalCallerContextHeaders
+$apiChecks += Write-HttpArtifact "gateway-performance-summary" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode&report_end_date=$AsOfDate" "api\gateway-performance-summary.json" -Headers $canonicalCallerContextHeaders
+$apiChecks += Write-HttpArtifact "gateway-risk-summary" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/risk/summary?period=YTD&detail_basis=NET&benchmark_code=$BenchmarkCode&as_of_date=$AsOfDate" "api\gateway-risk-summary.json" -Headers $canonicalCallerContextHeaders
+$apiChecks += Write-HttpArtifact "gateway-advisor-brief" "http://gateway.dev.lotus/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode&report_end_date=$AsOfDate" "api\gateway-advisor-brief.json" -Headers $canonicalCallerContextHeaders
 $apiChecks += Write-HttpArtifact "manage-supportability-summary" "http://manage.dev.lotus/api/v1/rebalance/supportability/summary" "api\manage-supportability-summary.json"
 $apiChecks += Write-HttpArtifact "report-integration-capabilities" "http://report.dev.lotus/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default" "api\report-integration-capabilities.json"
 

--- a/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
@@ -1,6 +1,7 @@
 param(
   [string]$PortfolioId = "PB_SG_GLOBAL_BAL_001",
   [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40",
+  [string]$AsOfDate = "2026-04-10",
   [string]$WorkbenchBaseUrl = "http://workbench.dev.lotus",
   [string]$GatewayBaseUrl = "http://gateway.dev.lotus",
   [string]$ScreenshotDirectory = ""
@@ -97,9 +98,9 @@ Test-Endpoint "http://report.dev.lotus/integration/capabilities?consumerSystem=l
 Test-Endpoint "$GatewayBaseUrl/api/v1/foundation/portfolios/$PortfolioId/workspace" "Gateway foundation workspace" -Headers $canonicalCallerContextHeaders
 Test-Endpoint "$GatewayBaseUrl/api/v1/platform/capabilities" "Gateway platform capabilities" -Headers $canonicalCallerContextHeaders
 Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/overview" "Gateway workbench overview" -Headers $canonicalCallerContextHeaders
-Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "Gateway performance summary" -Headers $canonicalCallerContextHeaders
-Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/risk/summary?period=YTD&detail_basis=NET&benchmark_code=$BenchmarkCode" "Gateway risk summary" -Headers $canonicalCallerContextHeaders
-Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode" "Gateway advisor brief" -Headers $canonicalCallerContextHeaders
+Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode&report_end_date=$AsOfDate" "Gateway performance summary" -Headers $canonicalCallerContextHeaders
+Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/risk/summary?period=YTD&detail_basis=NET&benchmark_code=$BenchmarkCode&as_of_date=$AsOfDate" "Gateway risk summary" -Headers $canonicalCallerContextHeaders
+Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode&report_end_date=$AsOfDate" "Gateway advisor brief" -Headers $canonicalCallerContextHeaders
 
 Push-Location $repoRoot
 try {
@@ -109,6 +110,8 @@ try {
     $PortfolioId,
     "--benchmark-code",
     $BenchmarkCode,
+    "--as-of-date",
+    $AsOfDate,
     "--workbench-base-url",
     $WorkbenchBaseUrl,
     "--gateway-base-url",

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -224,7 +224,7 @@ async function run() {
 
   const performanceSummary = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}&report_end_date=${canonicalAsOfDate}`,
     "Performance summary",
     timeoutMs
   );
@@ -234,7 +234,7 @@ async function run() {
 
   const performanceDetails = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/details?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/details?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}&report_end_date=${canonicalAsOfDate}`,
     "Performance details",
     timeoutMs
   );
@@ -244,7 +244,7 @@ async function run() {
 
   const riskSummary = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/summary?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/summary?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&as_of_date=${canonicalAsOfDate}`,
     "Risk summary",
     timeoutMs
   );
@@ -254,25 +254,25 @@ async function run() {
 
   const riskConcentration = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/concentration?period=YTD&benchmark_code=${benchmarkCode}`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/concentration?period=YTD&benchmark_code=${benchmarkCode}&as_of_date=${canonicalAsOfDate}`,
     "Risk concentration",
     timeoutMs
   );
   const riskDrawdown = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/drawdown?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&include_underwater_series=true`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/drawdown?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&as_of_date=${canonicalAsOfDate}&include_underwater_series=true`,
     "Risk drawdown",
     timeoutMs
   );
   const riskRolling = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/rolling?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&include_time_series=true`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/rolling?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&as_of_date=${canonicalAsOfDate}&include_time_series=true`,
     "Risk rolling",
     timeoutMs
   );
   const riskAttribution = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/attribution?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&attribution_type=total_risk&grouping_dimension=sector`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/attribution?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&as_of_date=${canonicalAsOfDate}&attribution_type=total_risk&grouping_dimension=sector`,
     "Risk attribution",
     timeoutMs
   );
@@ -304,7 +304,7 @@ async function run() {
 
   const advisorBrief = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}&report_end_date=${canonicalAsOfDate}`,
     "Advisor brief",
     timeoutMs
   );
@@ -316,7 +316,7 @@ async function run() {
   }
   summary.workflowPackChecks.push({
     actionType: "INITIAL_VISIBLE",
-    route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}`,
+    route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}&report_end_date=${canonicalAsOfDate}`,
     sourceRunId: advisorBrief.workflow_pack_run.run_id,
     resultReviewState: advisorBrief.workflow_pack_run.review_state,
     resultSupportabilityStatus: advisorBrief.workflow_pack_run.supportability_status,
@@ -793,6 +793,8 @@ async function run() {
     await validatePerformanceSummaryPanel(page, {
       workbenchBaseUrl,
       portfolioId,
+      benchmarkCode,
+      canonicalAsOfDate,
       timeoutMs,
       assertTableHasRows: browserHelpers.assertTableHasRows,
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
@@ -801,6 +803,7 @@ async function run() {
       workbenchBaseUrl,
       portfolioId,
       benchmarkCode,
+      canonicalAsOfDate,
       timeoutMs,
       assertTableHasRows: browserHelpers.assertTableHasRows,
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
@@ -810,6 +813,7 @@ async function run() {
       workbenchBaseUrl,
       portfolioId,
       benchmarkCode,
+      canonicalAsOfDate,
       timeoutMs,
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
       performAcceptReviewActionProof: true,
@@ -818,6 +822,7 @@ async function run() {
       workbenchBaseUrl,
       portfolioId,
       benchmarkCode,
+      canonicalAsOfDate,
       timeoutMs,
       assertTableHasRows: browserHelpers.assertTableHasRows,
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
@@ -827,6 +832,7 @@ async function run() {
       workbenchBaseUrl,
       portfolioId,
       benchmarkCode,
+      canonicalAsOfDate,
       timeoutMs,
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -153,12 +153,14 @@ export async function validatePerformanceSummaryPanel(
   {
     workbenchBaseUrl,
     portfolioId,
+    benchmarkCode,
+    canonicalAsOfDate,
     timeoutMs,
     assertTableHasRows,
     screenshotRegisteredPanel,
   }
 ) {
-  await page.goto(`${workbenchBaseUrl}/performance?portfolioId=${portfolioId}`, {
+  await page.goto(`${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}&reportEndDate=${canonicalAsOfDate}`, {
     waitUntil: "networkidle",
     timeout: timeoutMs,
   });
@@ -172,7 +174,7 @@ export async function validatePerformanceSummaryPanel(
   await expect(page.getByRole("heading", { name: "Performance Drivers" })).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(page.getByText("Observation Trail")).toBeVisible({ timeout: timeoutMs });
+  await expect(page.getByText(/Observation trail/i)).toBeVisible({ timeout: timeoutMs });
   await expect(page.getByText(/\d+\s+periods?/i)).toBeVisible({ timeout: timeoutMs });
   await assertTableHasRows(
     tableByExactLabel(page, "Return path observation table"),
@@ -189,13 +191,14 @@ export async function validatePerformanceAnalysisPanel(
     workbenchBaseUrl,
     portfolioId,
     benchmarkCode,
+    canonicalAsOfDate,
     timeoutMs,
     assertTableHasRows,
     screenshotRegisteredPanel,
   }
 ) {
   await page.goto(
-    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=analysis&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=analysis&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}&reportEndDate=${canonicalAsOfDate}`,
     { waitUntil: "networkidle", timeout: timeoutMs }
   );
   await assertRailModeActive(page, /^Performance Analysis/, timeoutMs);
@@ -228,13 +231,14 @@ export async function validateAdvisorBriefPanel(
     workbenchBaseUrl,
     portfolioId,
     benchmarkCode,
+    canonicalAsOfDate,
     timeoutMs,
     screenshotRegisteredPanel,
     performAcceptReviewActionProof = false,
   }
 ) {
   await page.goto(
-    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=advisor&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=advisor&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}&reportEndDate=${canonicalAsOfDate}`,
     { waitUntil: "networkidle", timeout: timeoutMs }
   );
   await assertRailModeActive(page, /^Advisor Brief/, timeoutMs);
@@ -303,13 +307,14 @@ export async function validateRiskPanel(
     workbenchBaseUrl,
     portfolioId,
     benchmarkCode,
+    canonicalAsOfDate,
     timeoutMs,
     assertTableHasRows,
     screenshotRegisteredPanel,
   }
 ) {
   await page.goto(
-    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}&reportEndDate=${canonicalAsOfDate}`,
     { waitUntil: "networkidle", timeout: timeoutMs }
   );
   await assertRailModeActive(page, /^Risk Review/, timeoutMs);
@@ -343,12 +348,13 @@ export async function validateEvidencePanel(
     workbenchBaseUrl,
     portfolioId,
     benchmarkCode,
+    canonicalAsOfDate,
     timeoutMs,
     screenshotRegisteredPanel,
   }
 ) {
   await page.goto(
-    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=evidence&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}`,
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=evidence&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}&reportEndDate=${canonicalAsOfDate}`,
     { waitUntil: "networkidle", timeout: timeoutMs }
   );
   await assertRailModeActive(page, /^Evidence/, timeoutMs);

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -385,7 +385,7 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain('workbenchPanelByClass(page, "outcome-review-panel")');
     expect(browserWorkflowModule).toContain('workbenchPanelByClass(page, "proof-pack-panel")');
     expect(browserWorkflowModule).toContain("requireVisible");
-    expect(browserWorkflowModule).toContain("Observation Trail");
+    expect(browserWorkflowModule).toContain("Observation trail");
     expect(browserWorkflowModule).toContain('outcomeReviewPanel.getByText("Report Input", { exact: true })');
     expect(browserWorkflowModule).toContain("performAcceptReviewActionProof");
     expect(browserWorkflowModule).toContain("Accept Brief");


### PR DESCRIPTION
## Summary
- bind front-office live validation probes to the canonical RFC-0076 as-of date
- pass the canonical report end date through Workbench performance browser proof routes
- update validation assertions for current Workbench observation-trail copy

## Validation
- npm test -- --runTestsByPath tests/unit/live-canonical-validation-script.test.ts tests/unit/live-validation-browser-workflows.test.ts tests/unit/live-validation-contract-modules.test.ts
- powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1 -AsOfDate 2026-04-10 -ScreenshotDirectory output/playwright/rfc-048-live-canonical