### PR TITLE
Fix live performance evidence readiness validation

### DIFF
--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -12,7 +12,7 @@ import {
   writeShotIndex,
   writeValidationSummary,
 } from "./validation/evidence-summary-writer.mjs";
-import { checkDns, fetchJson, fetchText, postJson } from "./validation/probes.mjs";
+import { checkDns, fetchJson, fetchJsonUntil, fetchText, postJson } from "./validation/probes.mjs";
 import {
   assertPerformanceCalculationSanity,
   assertRiskCalculationSanity,
@@ -222,11 +222,16 @@ async function run() {
     throw new Error(`Foundation workspace did not resolve ${portfolioId}.`);
   }
 
-  const performanceSummary = await fetchJson(
+  const performanceSummaryUrl = `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}&report_end_date=${canonicalAsOfDate}`;
+  const performanceSummary = await fetchJsonUntil(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}&report_end_date=${canonicalAsOfDate}`,
-    "Performance summary",
-    timeoutMs
+    performanceSummaryUrl,
+    "Performance summary evidence readiness",
+    timeoutMs,
+    (payload) =>
+      payload?.capabilities?.evidence?.state === "supported"
+        ? true
+        : `evidence state is ${payload?.capabilities?.evidence?.state ?? "missing"}`
   );
   if (!performanceSummary?.portfolio_id) {
     throw new Error("Performance summary returned no portfolio payload.");

--- a/scripts/live/validation/probes.mjs
+++ b/scripts/live/validation/probes.mjs
@@ -43,6 +43,43 @@ export async function fetchJson(
   });
 }
 
+export async function fetchJsonUntil(
+  summary,
+  url,
+  description,
+  timeoutMs,
+  predicate,
+  {
+    attempts = 12,
+    delayMs = 5000,
+    fetchImpl = globalThis.fetch,
+    sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  } = {}
+) {
+  let lastPayload;
+  let lastReason = "predicate returned false";
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    lastPayload = await fetchJson(summary, url, `${description} attempt ${attempt}`, timeoutMs, fetchImpl);
+    const result = predicate(lastPayload);
+    if (result === true) {
+      summary.apiChecks.push({
+        description,
+        url,
+        status: "ready",
+        kind: "json-readiness",
+        method: "GET",
+        attempts: attempt,
+      });
+      return lastPayload;
+    }
+    lastReason = typeof result === "string" && result.trim() ? result : lastReason;
+    if (attempt < attempts) {
+      await sleep(delayMs);
+    }
+  }
+  throw new Error(`${description} did not reach ready state after ${attempts} attempts at ${url}: ${lastReason}`);
+}
+
 export async function postJson(
   summary,
   url,

--- a/tests/unit/live-validation-probes.test.ts
+++ b/tests/unit/live-validation-probes.test.ts
@@ -1,6 +1,6 @@
 import * as probeHelpers from "../../scripts/live/validation/probes.mjs";
 
-const { checkDns, fetchJson, fetchText, postJson } = probeHelpers as {
+const { checkDns, fetchJson, fetchJsonUntil, fetchText, postJson } = probeHelpers as {
   checkDns: (
     summary: { dns: unknown[]; apiChecks: unknown[] },
     hostname: string,
@@ -15,6 +15,19 @@ const { checkDns, fetchJson, fetchText, postJson } = probeHelpers as {
     description: string,
     timeoutMs: number,
     fetchImpl?: typeof fetch
+  ) => Promise<T>;
+  fetchJsonUntil: <T = unknown>(
+    summary: { dns: unknown[]; apiChecks: unknown[] },
+    url: string,
+    description: string,
+    timeoutMs: number,
+    predicate: (payload: T) => true | string | false,
+    options?: {
+      attempts?: number;
+      delayMs?: number;
+      fetchImpl?: typeof fetch;
+      sleep?: (milliseconds: number) => Promise<void>;
+    }
   ) => Promise<T>;
   fetchText: (
     summary: { dns: unknown[]; apiChecks: unknown[] },
@@ -39,6 +52,14 @@ function createSummary() {
     apiChecks: [],
   };
 }
+
+type EvidenceReadinessPayload = {
+  capabilities: {
+    evidence: {
+      state: string;
+    };
+  };
+};
 
 describe("live validation probe helpers", () => {
   it("records optional DNS failures without aborting validation", async () => {
@@ -159,6 +180,81 @@ describe("live validation probe helpers", () => {
         method: "POST",
       },
     ]);
+  });
+
+  it("polls JSON probes until live readiness evidence is available", async () => {
+    const summary = createSummary();
+    const responses = [
+      { capabilities: { evidence: { state: "partial" } } },
+      { capabilities: { evidence: { state: "supported" } } },
+    ];
+
+    const payload = await fetchJsonUntil<EvidenceReadinessPayload>(
+      summary,
+      "http://gateway.dev.lotus/api/v1/workbench/PB_1/performance/summary",
+      "Performance summary evidence readiness",
+      1000,
+      (candidate) =>
+        candidate.capabilities.evidence.state === "supported"
+          ? true
+          : `evidence state is ${candidate.capabilities.evidence.state}`,
+      {
+        attempts: 3,
+        delayMs: 1,
+        sleep: async () => undefined,
+        fetchImpl: async () =>
+          new Response(JSON.stringify(responses.shift()), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      }
+    );
+
+    expect(payload.capabilities.evidence.state).toBe("supported");
+    expect(summary.apiChecks).toEqual([
+      expect.objectContaining({
+        description: "Performance summary evidence readiness attempt 1",
+        kind: "json",
+      }),
+      expect.objectContaining({
+        description: "Performance summary evidence readiness attempt 2",
+        kind: "json",
+      }),
+      {
+        description: "Performance summary evidence readiness",
+        url: "http://gateway.dev.lotus/api/v1/workbench/PB_1/performance/summary",
+        status: "ready",
+        kind: "json-readiness",
+        method: "GET",
+        attempts: 2,
+      },
+    ]);
+  });
+
+  it("fails JSON readiness probes with the last observed reason", async () => {
+    const summary = createSummary();
+
+    await expect(
+      fetchJsonUntil<EvidenceReadinessPayload>(
+        summary,
+        "http://gateway.dev.lotus/api/v1/workbench/PB_1/performance/summary",
+        "Performance summary evidence readiness",
+        1000,
+        (candidate) => `evidence state is ${candidate.capabilities.evidence.state}`,
+        {
+          attempts: 2,
+          delayMs: 1,
+          sleep: async () => undefined,
+          fetchImpl: async () =>
+            new Response(JSON.stringify({ capabilities: { evidence: { state: "partial" } } }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+        }
+      )
+    ).rejects.toThrow(
+      "Performance summary evidence readiness did not reach ready state after 2 attempts"
+    );
   });
 
   it("fails non-JSON gateway responses with a high-signal error", async () => {


### PR DESCRIPTION
## Summary
- add a reusable JSON readiness probe for canonical live validation
- poll the performance summary until evidence reaches supported before panel governance classification
- cover readiness success/failure behavior with unit tests

## Validation
- npm test -- --runTestsByPath tests/unit/live-validation-probes.test.ts tests/unit/live-canonical-validation-script.test.ts
- npm run lint
- powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1 -AsOfDate 2026-04-10 -ScreenshotDirectory output/playwright/rfc-048-post-merge-canonical