### PR TITLE
Add DPM copilot summary actions to Workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,25 +66,30 @@ Boundary rules that matter:
    posture.
 6. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0041 rebalance-wave command
    center for wave queue, preview, create, detail, items, source-check, simulation, approval,
-   staging, handoff, report-input, and governed AI PM memo request posture. Workbench renders
-   Gateway/manage/lotus-ai workflow-pack truth and does not calculate wave readiness, build report
-   input, construct AI prompts, generate memo narrative locally, claim external execution, or call
-   `lotus-manage` or `lotus-ai` directly.
+   staging, handoff, report-input, governed AI PM memo, and operations-handoff summary request
+   posture. Workbench renders Gateway/manage/lotus-ai workflow-pack truth and does not calculate
+   wave readiness, build report input, construct AI prompts, generate memo or handoff-summary
+   narrative locally, claim external execution, or call `lotus-manage` or `lotus-ai` directly.
 7. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0042 post-trade outcome-review
    panel for manage-owned expected-versus-realized dimensions, source lineage, supportability,
    and report/AI handoff posture. Workbench renders the Gateway contract and does not calculate
    outcome variance, freshness, supportability, or handoff eligibility locally.
-7. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0039 construction alternatives
+8. `/workbench/{portfolioId}` now includes a governed RFC-0043 exception-summary action on the
+   DPM command-center active-exception queue. The action calls Gateway
+   `/api/v1/dpm/command-center/exceptions/{exception_id}/ai-summary`, displays review-required
+   lotus-ai workflow-pack posture, and does not generate exception narrative, client messages,
+   routing instructions, approvals, PM scoring, or execution claims in browser code.
+8. `/workbench/{portfolioId}` now includes a Gateway-backed RFC-0039 construction alternatives
    lab. Workbench sends stateful construction requests through Gateway
    `/api/v1/dpm/command-center/construction/alternative-sets*`, renders manage-owned
    alternatives, objective/constraint trace counts, supportability, and selected-alternative
    state, and does not create optimizer logic, source data, prices, or selection truth locally.
-8. Recommendations and proposals routes still exist as compatibility paths, but they are no longer
+9. Recommendations and proposals routes still exist as compatibility paths, but they are no longer
    the primary supported front-office app surfaces.
-9. Top-level shell navigation is capability-gated: `Portfolio`, `Performance`, and `Risk` are
+10. Top-level shell navigation is capability-gated: `Portfolio`, `Performance`, and `Risk` are
    active, while `Proposal` and `Advisory` remain disabled in the current normalized shell
    bootstrap contract.
-10. Canonical review-ready browser evidence comes from `npm run live:validate` artifacts under
+11. Canonical review-ready browser evidence comes from `npm run live:validate` artifacts under
    `output/playwright/live-canonical/`, not from ad hoc localhost screenshots.
 
 ## Architecture At A Glance
@@ -291,7 +296,8 @@ Important current product and route truths:
    construct PM memo prompts, or call `lotus-manage`, `lotus-report`, or `lotus-ai` directly.
 11. RFC-0041 rebalance-wave rendering on `/workbench/{portfolioId}` is backed by Gateway
    `/api/v1/dpm/command-center/waves*`; Workbench may render Gateway/manage wave state,
-   report-input readiness, and lotus-ai wave PM memo workflow-pack posture through Gateway, but
+   report-input readiness, lotus-ai wave PM memo workflow-pack posture, and lotus-ai
+   operations-handoff summary posture through Gateway, but
    must not build report input, construct AI prompts, generate memo text locally, score PMs,
    approve trades independently, contact clients, place orders, or call upstream services directly.
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -51,9 +51,11 @@ Current repository posture:
 7. `/workbench/{portfolioId}` renders the RFC-0038 DPM mandate command-center cockpit from
    Gateway `/api/v1/dpm/command-center`, `/monitoring/run-once`, `/exceptions`, and
    `/mandates*`. Workbench shows manage-owned book health distribution, source readiness,
-   attention queue, recommended actions, latest monitoring-run lineage, active exceptions, and
-   mandate health dimensions without calculating mandate health, reconstructing source readiness,
-   merging exceptions, or calling `lotus-manage` directly. The command-center run-monitoring
+   attention queue, recommended actions, latest monitoring-run lineage, active exceptions,
+   governed exception-summary workflow-pack posture, and mandate health dimensions without
+   calculating mandate health, reconstructing source readiness, merging exceptions, generating
+   exception-summary narrative locally, or calling `lotus-manage`/`lotus-ai` directly. The
+   command-center run-monitoring
    action sends the governed PM/book/as-of context through Gateway and lets Manage resolve
    source-owned PM-book membership from lotus-core rather than sending a browser-selected mandate
    fallback. Workbench maps manage command-center supportability states into explicit panel
@@ -91,13 +93,13 @@ Current repository posture:
 12. `/workbench/{portfolioId}` renders the RFC-0041 DPM rebalance-wave command-center panel
    through Gateway `/api/v1/dpm/command-center/waves*`. Workbench lists explicit portfolio-list
    waves, previews and creates canonical portfolio waves, opens wave detail and item posture, and
-   sends source-check, simulation, approval, staging, handoff, report-input, and governed AI PM
-   memo requests through Gateway only. It preserves manage-owned wave state, item state,
+   sends source-check, simulation, approval, staging, handoff, report-input, governed AI PM memo,
+   and governed operations-handoff summary requests through Gateway only. It preserves manage-owned wave state, item state,
    source-readiness state, supportability, aggregate metrics, report-input refs, proof-pack refs,
    handoff refs, blocked actions, lotus-ai workflow-pack run posture, and
    `external_execution_claimed` posture without calling `lotus-manage` or `lotus-ai` directly,
-   calculating readiness, constructing report input, constructing AI prompts, generating memo
-   narrative locally, claiming external execution, or inferring PM-book discovery.
+   calculating readiness, constructing report input, constructing AI prompts, generating memo or
+   handoff-summary narrative locally, claiming external execution, or inferring PM-book discovery.
 13. `/workbench/{portfolioId}` also renders Gateway-provided rebalance action-register
    supportability and portfolio-level DPM operations posture from the portfolio overview
    `rebalance_snapshot`, including source state, freshness, run count, operation count, workflow

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -456,19 +456,21 @@ Workbench must consume these Gateway wave routes when implemented:
 | `POST /api/v1/dpm/command-center/waves/{wave_id}/handoff` | internal operations handoff action |
 | `GET /api/v1/dpm/command-center/waves/{wave_id}/report-input` | report-input evidence drawer |
 | `POST /api/v1/dpm/command-center/waves/{wave_id}/ai-pm-memo` | governed AI PM memo request |
+| `POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary` | governed operations handoff summary request |
 
 Implementation note as of 2026-05-08: the first RFC-0041 rebalance-wave command-center
 realization is embedded in `/workbench/{portfolioId}` through Gateway
 `/api/v1/dpm/command-center/waves*`. Workbench loads the explicit portfolio-list wave queue,
 previews and creates canonical portfolio waves, opens wave detail and item posture, and calls
 source-check, simulation, approval, staging, handoff, proof-posture, supportability, report-input,
-and governed AI PM memo requests through the Workbench BFF/Gateway boundary. The panel renders
+governed AI PM memo, and governed operations-handoff summary requests through the Workbench
+BFF/Gateway boundary. The panel renders
 manage-owned wave id, lifecycle state, item count, issue count, supportability reason codes,
 blocked actions, aggregate metrics, item states, source-readiness state, alternative refs,
 report-input refs, proof-pack refs, handoff refs, lotus-ai workflow-pack run posture, and
 `external_execution_claimed` posture without direct `lotus-manage` or `lotus-ai` calls,
-client-side readiness calculation, report-input construction, prompt construction, or local memo
-narrative generation. Item-selection drawers, richer supportability drawers, dedicated
+client-side readiness calculation, report-input construction, prompt construction, local memo
+narrative generation, or local operations handoff-summary generation. Item-selection drawers, richer supportability drawers, dedicated
 `/dpm/waves` routes, PM-book discovery, CIO approval workflow, and external OMS execution remain
 future scope until Gateway/Manage and Workbench proof promote them.
 
@@ -587,6 +589,7 @@ RFC-0038 command-center cockpit support is now implemented as an embedded
 | `GET /api/v1/dpm/command-center` | `/workbench/{portfolioId}` DPM command-center cockpit |
 | `POST /api/v1/dpm/command-center/monitoring/run-once` | `/workbench/{portfolioId}` run-monitoring action |
 | `GET /api/v1/dpm/command-center/exceptions` | `/workbench/{portfolioId}` active exception queue |
+| `POST /api/v1/dpm/command-center/exceptions/{exception_id}/ai-summary` | `/workbench/{portfolioId}` governed exception-summary action |
 | `GET /api/v1/dpm/command-center/mandates/by-portfolio/{portfolio_id}` | `/workbench/{portfolioId}` mandate binding |
 | `GET /api/v1/dpm/command-center/mandates/{mandate_id}/health` | `/workbench/{portfolioId}` mandate health dimensions |
 
@@ -596,6 +599,12 @@ context through the Gateway BFF with an empty `mandate_ids` list so `lotus-manag
 source-owned PM-book cohort from lotus-core `PortfolioManagerBookMembership:v1`. Workbench must not
 derive PM-book membership, fabricate a cohort from the current page portfolio, or send a hidden
 single-mandate fallback as if it were book-level monitoring.
+
+The embedded exception-summary action is support-only. Workbench sends the selected manage
+exception id to Gateway, optionally preserves the mandate/state filters already visible in the
+panel, and displays the returned lotus-ai workflow-pack run posture. Browser code must not produce
+exception narrative, client messages, PM scoring, routing instructions, approvals, or execution
+claims.
 
 The Workbench view model must preserve:
 

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -156,6 +156,11 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
   },
   {
     route: "workbench.dpm-command-center",
+    panel: "mandate-command-center-exception-ai-summary",
+    operation: "dpm.command-center.exceptions.ai-summary",
+  },
+  {
+    route: "workbench.dpm-command-center",
     panel: "mandate-command-center-mandate",
     operation: "dpm.command-center.mandate.by-portfolio",
   },
@@ -308,6 +313,11 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     route: "workbench.dpm-command-center",
     panel: "wave-ai-pm-memo",
     operation: "dpm.waves.ai-pm-memo",
+  },
+  {
+    route: "workbench.dpm-command-center",
+    panel: "wave-operations-handoff-summary",
+    operation: "dpm.waves.operations-handoff-summary",
   },
   {
     route: "workbench.legacy-advisor",

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -15,9 +15,11 @@ import {
   WorkbenchPortfolio360,
   DpmCommandCenterGatewayResponse,
   DpmConstructionGatewayResponse,
+  DpmExceptionSummaryResponse,
   DpmOutcomeReviewGatewayResponse,
   DpmOutcomeReviewHandoffResponse,
   DpmOutcomeReviewNarrativeResponse,
+  DpmOperationsHandoffSummaryResponse,
   DpmPortfolioMemoryGatewayResponse,
   DpmProofPackAiPmMemoResponse,
   DpmProofPackGatewayResponse,
@@ -921,6 +923,50 @@ export async function getDpmCommandCenterExceptions(params?: {
   );
 }
 
+export async function requestDpmExceptionSummary(params: {
+  exceptionId: string;
+  portfolioId?: string;
+  mandateId?: string;
+  state?: string;
+}): Promise<DpmExceptionSummaryResponse> {
+  const body: Record<string, unknown> = {
+    requested_outputs: [
+      "exception_summary",
+      "severity_summary",
+      "recommended_triage",
+      "support_references",
+      "evidence_gaps",
+    ],
+    audience: ["portfolio_manager", "investment_control", "operations"],
+  };
+  if (params.portfolioId) {
+    body.portfolio_id = params.portfolioId;
+  }
+  if (params.mandateId) {
+    body.mandate_id = params.mandateId;
+  }
+  if (params.state) {
+    body.state = params.state;
+  }
+
+  return await observeWorkbenchMutation(
+    "dpm.command-center.exceptions.ai-summary",
+    async () =>
+      await fetchWorkbenchMutation<DpmExceptionSummaryResponse>(
+        buildWorkbenchUrl(
+          "client",
+          `/dpm/command-center/exceptions/${encodeURIComponent(params.exceptionId)}/ai-summary`
+        ),
+        "request DPM exception AI summary",
+        {
+          method: "POST",
+          headers: buildDpmWaveCallerHeaders(),
+          body: JSON.stringify(body),
+        }
+      )
+  );
+}
+
 export async function getDpmMandateByPortfolio(
   portfolioId: string
 ): Promise<DpmCommandCenterGatewayResponse> {
@@ -1242,6 +1288,36 @@ export async function requestDpmWaveAiPmMemo(waveId: string): Promise<DpmWaveAiP
               "evidence_gaps",
             ],
             audience: ["portfolio_manager", "investment_control", "operations"],
+          }),
+        }
+      )
+  );
+}
+
+export async function requestDpmOperationsHandoffSummary(
+  waveId: string
+): Promise<DpmOperationsHandoffSummaryResponse> {
+  return await observeWorkbenchMutation(
+    "dpm.waves.operations-handoff-summary",
+    async () =>
+      await fetchWorkbenchMutation<DpmOperationsHandoffSummaryResponse>(
+        buildWorkbenchUrl(
+          "client",
+          `/dpm/command-center/waves/${encodeURIComponent(waveId)}/operations-handoff-summary`
+        ),
+        "request DPM operations handoff AI summary",
+        {
+          method: "POST",
+          headers: buildDpmWaveCallerHeaders(),
+          body: JSON.stringify({
+            requested_outputs: [
+              "operations_summary",
+              "execution_prerequisites",
+              "blocking_conditions",
+              "support_references",
+              "evidence_gaps",
+            ],
+            audience: ["operations", "portfolio_manager", "investment_control"],
           }),
         }
       )

--- a/src/features/workbench/components/dpm-command-center-panel.tsx
+++ b/src/features/workbench/components/dpm-command-center-panel.tsx
@@ -10,8 +10,14 @@ import {
   SemanticBadge,
   Text,
 } from "@/design-system";
-import { runDpmCommandCenterMonitoring } from "@/features/workbench/api";
-import type { DpmCommandCenterGatewayResponse } from "@/features/workbench/types";
+import {
+  requestDpmExceptionSummary,
+  runDpmCommandCenterMonitoring,
+} from "@/features/workbench/api";
+import type {
+  DpmCommandCenterGatewayResponse,
+  DpmExceptionSummaryResponse,
+} from "@/features/workbench/types";
 import {
   buildDpmCommandCenterPanelModel,
   type DpmCommandCenterPanelState,
@@ -89,9 +95,13 @@ export default function DpmCommandCenterPanel({
 }: Props) {
   const [runResponse, setRunResponse] =
     useState<DpmCommandCenterGatewayResponse | null>(null);
-  const [runPending, setRunPending] = useState(false);
+  const [pendingAction, setPendingAction] = useState<
+    "monitoring" | "exception-summary" | null
+  >(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [runMessage, setRunMessage] = useState<string | null>(null);
+  const [exceptionSummary, setExceptionSummary] =
+    useState<DpmExceptionSummaryResponse | null>(null);
   const model = buildDpmCommandCenterPanelModel({
     commandCenter,
     exceptions,
@@ -117,12 +127,15 @@ export default function DpmCommandCenterPanel({
     model.state === "unsupported" ||
     model.state === "unavailable";
   const stateCopy = statePanelCopy(model.state);
+  const exceptionSummaryStatus = readWorkflowPackStatus(exceptionSummary?.data);
+  const exceptionSummaryRunId = readWorkflowPackRunId(exceptionSummary?.data);
+  const runPending = pendingAction !== null;
 
   async function runMonitoring() {
     if (runPending) {
       return;
     }
-    setRunPending(true);
+    setPendingAction("exception-summary");
     setRunError(null);
     setRunMessage(null);
     try {
@@ -140,7 +153,37 @@ export default function DpmCommandCenterPanel({
           : "DPM command-center monitoring failed",
       );
     } finally {
-      setRunPending(false);
+      setPendingAction(null);
+    }
+  }
+
+  async function requestExceptionSummary() {
+    if (runPending || !model.selectedExceptionId) {
+      return;
+    }
+    setPendingAction("monitoring");
+    setRunError(null);
+    setRunMessage(null);
+    try {
+      const response = await requestDpmExceptionSummary({
+        exceptionId: model.selectedExceptionId,
+        mandateId: model.mandateId !== "N/A" ? model.mandateId : undefined,
+        state: "ACTIVE",
+      });
+      setExceptionSummary(response);
+      setRunMessage(
+        `Exception summary ${readWorkflowPackStatus(response.data)} (${readWorkflowPackRunId(
+          response.data,
+        )})`,
+      );
+    } catch (error) {
+      setRunError(
+        error instanceof Error
+          ? error.message
+          : "DPM exception summary request failed",
+      );
+    } finally {
+      setPendingAction(null);
     }
   }
 
@@ -187,7 +230,14 @@ export default function DpmCommandCenterPanel({
           onClick={runMonitoring}
           disabled={runPending}
         >
-          {runPending ? "Running monitoring" : "Run monitoring"}
+          {pendingAction === "monitoring" ? "Running monitoring" : "Run monitoring"}
+        </ActionButton>
+        <ActionButton
+          priority="secondary"
+          onClick={requestExceptionSummary}
+          disabled={runPending || !model.selectedExceptionId}
+        >
+          {pendingAction === "exception-summary" ? "Requesting summary" : "Exception summary"}
         </ActionButton>
         <div>
           {runMessage ? (
@@ -277,6 +327,8 @@ export default function DpmCommandCenterPanel({
         />
         <MetricRow label="Mandate" value={model.mandateId} />
         <MetricRow label="Mandate Health" value={model.mandateHealthState} />
+        <MetricRow label="Exception Summary" value={exceptionSummaryStatus} />
+        <MetricRow label="Exception Summary Run" value={exceptionSummaryRunId} />
       </div>
 
       <AnalyticsTable
@@ -407,4 +459,45 @@ export default function DpmCommandCenterPanel({
       </Text>
     </SectionBlock>
   );
+}
+
+function readWorkflowPackStatus(data: Record<string, unknown> | undefined): string {
+  if (!data) {
+    return "NOT_REQUESTED";
+  }
+  const workflowPackRun = readRecord(data.workflow_pack_run);
+  const output = readRecord(data.output);
+  return (
+    readString(data.status) ??
+    readString(data.review_state) ??
+    readString(workflowPackRun.review_state) ??
+    readString(output.review_state) ??
+    "REVIEW_REQUIRED"
+  );
+}
+
+function readWorkflowPackRunId(data: Record<string, unknown> | undefined): string {
+  if (!data) {
+    return "N/A";
+  }
+  const workflowPackRun = readRecord(data.workflow_pack_run);
+  const execution = readRecord(data.execution);
+  const audit = readRecord(execution.audit);
+  return (
+    readString(data.run_id) ??
+    readString(data.workflow_run_id) ??
+    readString(workflowPackRun.run_id) ??
+    readString(audit.workflow_pack_run_id) ??
+    "N/A"
+  );
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
 }

--- a/src/features/workbench/components/dpm-wave-command-center-panel.tsx
+++ b/src/features/workbench/components/dpm-wave-command-center-panel.tsx
@@ -20,12 +20,17 @@ import {
   getDpmWaveSupportability,
   handoffDpmWave,
   previewDpmWave,
+  requestDpmOperationsHandoffSummary,
   requestDpmWaveAiPmMemo,
   simulateDpmWave,
   sourceCheckDpmWave,
   stageDpmWave,
 } from "@/features/workbench/api";
-import type { DpmWaveAiPmMemoResponse, DpmWaveGatewayResponse } from "@/features/workbench/types";
+import type {
+  DpmOperationsHandoffSummaryResponse,
+  DpmWaveAiPmMemoResponse,
+  DpmWaveGatewayResponse,
+} from "@/features/workbench/types";
 import {
   buildDpmWaveCommandCenterModel,
   type DpmWaveCommandCenterPanelState,
@@ -91,6 +96,8 @@ export default function DpmWaveCommandCenterPanel({
   const [reportInputResponse, setReportInputResponse] =
     useState<DpmWaveGatewayResponse | null>(null);
   const [aiMemoResponse, setAiMemoResponse] = useState<DpmWaveAiPmMemoResponse | null>(null);
+  const [operationsHandoffSummaryResponse, setOperationsHandoffSummaryResponse] =
+    useState<DpmOperationsHandoffSummaryResponse | null>(null);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
@@ -101,6 +108,7 @@ export default function DpmWaveCommandCenterPanel({
     actionResponse,
     waveReportInput: reportInputResponse,
     waveAiMemo: aiMemoResponse,
+    operationsHandoffSummary: operationsHandoffSummaryResponse,
   });
   const selectedWaveId = model.selectedWaveId;
   const stateCopy = statePanelCopy(model.state, portfolioId);
@@ -140,6 +148,27 @@ export default function DpmWaveCommandCenterPanel({
     try {
       const response = await action();
       setAiMemoResponse(response);
+      setActionMessage(`${label} completed through Gateway.`);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : `${label} failed`);
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function runOperationsSummaryAction(
+    label: string,
+    action: () => Promise<DpmOperationsHandoffSummaryResponse>
+  ) {
+    if (pendingAction) {
+      return;
+    }
+    setPendingAction(label);
+    setActionError(null);
+    setActionMessage(null);
+    try {
+      const response = await action();
+      setOperationsHandoffSummaryResponse(response);
       setActionMessage(`${label} completed through Gateway.`);
     } catch (error) {
       setActionError(error instanceof Error ? error.message : `${label} failed`);
@@ -245,6 +274,15 @@ export default function DpmWaveCommandCenterPanel({
     void runMemoAction("Request AI memo", () => requestDpmWaveAiPmMemo(selectedWaveId));
   }
 
+  function requestOperationsHandoffSummary() {
+    if (!selectedWaveId) {
+      return;
+    }
+    void runOperationsSummaryAction("Request operations summary", () =>
+      requestDpmOperationsHandoffSummary(selectedWaveId)
+    );
+  }
+
   return (
     <SectionBlock
       title="Rebalance Wave Command Center"
@@ -317,6 +355,13 @@ export default function DpmWaveCommandCenterPanel({
         </ActionButton>
         <ActionButton priority="secondary" onClick={requestAiMemo} disabled={!selectedWaveId || Boolean(pendingAction)}>
           AI memo
+        </ActionButton>
+        <ActionButton
+          priority="secondary"
+          onClick={requestOperationsHandoffSummary}
+          disabled={!selectedWaveId || Boolean(pendingAction)}
+        >
+          {pendingAction === "Request operations summary" ? "Requesting summary" : "Ops summary"}
         </ActionButton>
       </div>
 
@@ -414,6 +459,8 @@ export default function DpmWaveCommandCenterPanel({
             <MetricRow label="Report Input Ref" value={model.reportInputRef} />
             <MetricRow label="AI Memo" value={model.aiMemoStatus} />
             <MetricRow label="AI Memo Run" value={model.aiMemoRunId} />
+            <MetricRow label="Ops Summary" value={model.operationsHandoffSummaryStatus} />
+            <MetricRow label="Ops Summary Run" value={model.operationsHandoffSummaryRunId} />
           </div>
         </div>
       </div>

--- a/src/features/workbench/dpm-command-center-view-model.ts
+++ b/src/features/workbench/dpm-command-center-view-model.ts
@@ -66,6 +66,7 @@ export type DpmCommandCenterPanelModel = {
   attentionRows: DpmCommandCenterAttentionRow[];
   recommendedActions: DpmCommandCenterActionRow[];
   exceptionRows: DpmCommandCenterExceptionRow[];
+  selectedExceptionId: string | null;
   mandateId: string;
   mandateHealthScore: string;
   mandateHealthState: string;
@@ -100,6 +101,7 @@ export function buildDpmCommandCenterPanelModel(params: {
       attentionRows: [],
       recommendedActions: [],
       exceptionRows: [],
+      selectedExceptionId: null,
       mandateId: "N/A",
       mandateHealthScore: "N/A",
       mandateHealthState: "N/A",
@@ -121,6 +123,8 @@ export function buildDpmCommandCenterPanelModel(params: {
   const latestMonitoringRun = readRecord(
     commandData.latest_monitoring_run || commandData.monitoring_run,
   );
+
+  const exceptionRows = buildExceptionRows(params.exceptions?.data);
 
   return {
     state: resolvePanelState(supportabilityState),
@@ -160,7 +164,9 @@ export function buildDpmCommandCenterPanelModel(params: {
     recommendedActions: buildRecommendedActionRows(
       commandData.recommended_actions,
     ),
-    exceptionRows: buildExceptionRows(params.exceptions?.data),
+    exceptionRows,
+    selectedExceptionId:
+      exceptionRows.find((row) => row.exceptionId !== "N/A")?.exceptionId ?? null,
     mandateId,
     mandateHealthScore: formatValue(
       readValue(mandateHealthData, "health_score"),

--- a/src/features/workbench/dpm-wave-command-center-view-model.ts
+++ b/src/features/workbench/dpm-wave-command-center-view-model.ts
@@ -1,4 +1,8 @@
-import type { DpmWaveAiPmMemoResponse, DpmWaveGatewayResponse } from "./types";
+import type {
+  DpmOperationsHandoffSummaryResponse,
+  DpmWaveAiPmMemoResponse,
+  DpmWaveGatewayResponse,
+} from "./types";
 
 export type DpmWaveCommandCenterPanelState =
   | "ready"
@@ -55,6 +59,8 @@ export type DpmWaveCommandCenterPanelModel = {
   reportInputStatus: string;
   aiMemoStatus: string;
   aiMemoRunId: string;
+  operationsHandoffSummaryStatus: string;
+  operationsHandoffSummaryRunId: string;
   summaryRows: DpmWaveSummaryRow[];
   metricRows: DpmWaveMetricRow[];
   itemRows: DpmWaveItemRow[];
@@ -70,6 +76,7 @@ export function buildDpmWaveCommandCenterModel(params: {
   actionResponse?: DpmWaveGatewayResponse | null;
   waveReportInput?: DpmWaveGatewayResponse | null;
   waveAiMemo?: DpmWaveAiPmMemoResponse | null;
+  operationsHandoffSummary?: DpmOperationsHandoffSummaryResponse | null;
 }): DpmWaveCommandCenterPanelModel {
   const primary =
     params.actionResponse ??
@@ -131,6 +138,8 @@ export function buildDpmWaveCommandCenterModel(params: {
       : "NOT_REQUESTED",
     aiMemoStatus: readAiMemoStatus(params.waveAiMemo),
     aiMemoRunId: readAiMemoRunId(params.waveAiMemo),
+    operationsHandoffSummaryStatus: readWorkflowPackStatus(params.operationsHandoffSummary),
+    operationsHandoffSummaryRunId: readWorkflowPackRunId(params.operationsHandoffSummary),
     summaryRows: listRows,
     metricRows: buildMetricRows(metricSource),
     itemRows,
@@ -140,6 +149,45 @@ export function buildDpmWaveCommandCenterModel(params: {
       readValue(proofPackPosture, "external_execution_claimed")
     ),
   };
+}
+
+function readWorkflowPackStatus(
+  response:
+    | { data: Record<string, unknown> }
+    | null
+    | undefined
+): string {
+  if (!response) {
+    return "NOT_REQUESTED";
+  }
+  return normalizeState(
+    readString(response.data, "status") ||
+      readString(response.data, "review_state") ||
+      readString(readRecord(response.data.workflow_pack_run), "review_state") ||
+      readString(readRecord(response.data.output), "review_state") ||
+      "REVIEW_REQUIRED"
+  );
+}
+
+function readWorkflowPackRunId(
+  response:
+    | { data: Record<string, unknown> }
+    | null
+    | undefined
+): string {
+  if (!response) {
+    return "N/A";
+  }
+  const workflowPackRun = readRecord(response.data.workflow_pack_run);
+  const execution = readRecord(response.data.execution);
+  const audit = readRecord(execution.audit);
+  return (
+    readString(response.data, "run_id") ||
+    readString(response.data, "workflow_run_id") ||
+    readString(workflowPackRun, "run_id") ||
+    readString(audit, "workflow_pack_run_id") ||
+    "N/A"
+  );
 }
 
 function readReportInputRef(

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1362,6 +1362,32 @@ export type DpmWaveAiPmMemoResponse = {
   data: Record<string, unknown>;
 };
 
+export type DpmOperationsHandoffSummaryResponse = {
+  correlation_id: string;
+  contract_version: string;
+  source_service: string;
+  evidence_source_service: string;
+  manage_upstream_status: number;
+  ai_upstream_status: number;
+  supportability: DpmWaveSupportability;
+  wave_report_input: Record<string, unknown>;
+  handoff_summary_request: Record<string, unknown>;
+  data: Record<string, unknown>;
+};
+
+export type DpmExceptionSummaryResponse = {
+  correlation_id: string;
+  contract_version: string;
+  source_service: string;
+  evidence_source_service: string;
+  manage_upstream_status: number;
+  ai_upstream_status: number;
+  supportability: DpmCommandCenterSupportability;
+  exception_summary_input: Record<string, unknown>;
+  exception_summary_request: Record<string, unknown>;
+  data: Record<string, unknown>;
+};
+
 export type DpmOutcomeReviewNarrativeResponse = {
   correlation_id: string;
   contract_version: string;

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -306,6 +306,11 @@ describe("analytics UI observability metrics", () => {
       ],
       [
         "workbench.dpm-command-center",
+        "mandate-command-center-exception-ai-summary",
+        "dpm.command-center.exceptions.ai-summary",
+      ],
+      [
+        "workbench.dpm-command-center",
         "mandate-command-center-mandate",
         "dpm.command-center.mandate.by-portfolio",
       ],
@@ -418,6 +423,11 @@ describe("analytics UI observability metrics", () => {
         "workbench.dpm-command-center",
         "wave-ai-pm-memo",
         "dpm.waves.ai-pm-memo",
+      ],
+      [
+        "workbench.dpm-command-center",
+        "wave-operations-handoff-summary",
+        "dpm.waves.operations-handoff-summary",
       ],
       ["workbench.legacy-advisor", "advisor-overview", "workbench.overview"],
       ["workbench.legacy-advisor", "portfolio-360", "workbench.portfolio-360"],

--- a/tests/unit/dpm-command-center-panel.test.tsx
+++ b/tests/unit/dpm-command-center-panel.test.tsx
@@ -2,10 +2,14 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import DpmCommandCenterPanel from "../../src/features/workbench/components/dpm-command-center-panel";
-import { runDpmCommandCenterMonitoring } from "../../src/features/workbench/api";
+import {
+  requestDpmExceptionSummary,
+  runDpmCommandCenterMonitoring,
+} from "../../src/features/workbench/api";
 import type { DpmCommandCenterGatewayResponse } from "../../src/features/workbench/types";
 
 vi.mock("../../src/features/workbench/api", () => ({
+  requestDpmExceptionSummary: vi.fn(),
   runDpmCommandCenterMonitoring: vi.fn(),
 }));
 
@@ -112,6 +116,10 @@ describe("DpmCommandCenterPanel", () => {
     expect(
       screen.getByRole("button", { name: "Run monitoring" }),
     ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Exception summary" }),
+    ).toBeEnabled();
+    expect(screen.getAllByText("NOT_REQUESTED").length).toBeGreaterThan(0);
   });
 
   it("requests monitoring through Gateway only", async () => {
@@ -141,6 +149,68 @@ describe("DpmCommandCenterPanel", () => {
     expect(
       screen.getByText("Monitoring dmr_2 returned SUCCEEDED"),
     ).toBeInTheDocument();
+  });
+
+  it("requests exception summary through Gateway only and preserves workflow-pack posture", async () => {
+    vi.mocked(requestDpmExceptionSummary).mockResolvedValue({
+      correlation_id: "corr-exception-summary",
+      contract_version: "v1",
+      source_service: "lotus-ai",
+      evidence_source_service: "lotus-manage",
+      manage_upstream_status: 200,
+      ai_upstream_status: 200,
+      supportability: readyResponse.supportability,
+      exception_summary_input: {
+        exception_id: "me_1",
+        source_refs: ["lotus-manage:monitoring-exception:me_1"],
+      },
+      exception_summary_request: {
+        requested_outputs: ["exception_summary", "recommended_triage"],
+        audience: ["portfolio_manager", "operations"],
+      },
+      data: {
+        workflow_pack_run: {
+          run_id: "wf_run_exception_summary_001",
+          review_state: "REVIEW_REQUIRED",
+        },
+      },
+    });
+
+    render(
+      <DpmCommandCenterPanel
+        commandCenter={readyResponse}
+        exceptions={{
+          ...readyResponse,
+          data: {
+            items: [
+              {
+                exception_id: "me_1",
+                mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001",
+                severity: "HIGH",
+                reason_code: "TAX_LOT_SOURCE_PARTIAL",
+                recommended_action: "REPAIR_SOURCE_DATA",
+                state: "ACTIVE",
+              },
+            ],
+          },
+        }}
+        mandate={{
+          ...readyResponse,
+          data: { mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001" },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Exception summary" }));
+
+    await waitFor(() => {
+      expect(requestDpmExceptionSummary).toHaveBeenCalledWith({
+        exceptionId: "me_1",
+        mandateId: "MANDATE_PB_SG_GLOBAL_BAL_001",
+        state: "ACTIVE",
+      });
+    });
+    expect(await screen.findByText("wf_run_exception_summary_001")).toBeInTheDocument();
   });
 
   it("renders empty command-center state without claiming failure", () => {

--- a/tests/unit/dpm-command-center-view-model.test.ts
+++ b/tests/unit/dpm-command-center-view-model.test.ts
@@ -104,6 +104,7 @@ describe("DPM command-center view model", () => {
       recommendedAction: "REPAIR_SOURCE_DATA",
     });
     expect(model.exceptionRows[0].exceptionId).toBe("me_1");
+    expect(model.selectedExceptionId).toBe("me_1");
     expect(model.mandateHealthScore).toBe("97");
     expect(model.mandateHealthDimensions[0].reasons).toBe(
       "TAX_LOT_SOURCE_PARTIAL",

--- a/tests/unit/dpm-wave-command-center-panel.test.tsx
+++ b/tests/unit/dpm-wave-command-center-panel.test.tsx
@@ -12,6 +12,7 @@ import {
   getDpmWaveSupportability,
   handoffDpmWave,
   previewDpmWave,
+  requestDpmOperationsHandoffSummary,
   requestDpmWaveAiPmMemo,
   simulateDpmWave,
   sourceCheckDpmWave,
@@ -29,6 +30,7 @@ vi.mock("../../src/features/workbench/api", () => ({
   getDpmWaveSupportability: vi.fn(),
   handoffDpmWave: vi.fn(),
   previewDpmWave: vi.fn(),
+  requestDpmOperationsHandoffSummary: vi.fn(),
   requestDpmWaveAiPmMemo: vi.fn(),
   simulateDpmWave: vi.fn(),
   sourceCheckDpmWave: vi.fn(),
@@ -94,7 +96,8 @@ describe("DpmWaveCommandCenterPanel", () => {
     expect(screen.getByRole("button", { name: "Supportability" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Report input" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "AI memo" })).toBeEnabled();
-    expect(screen.getAllByText("NOT_REQUESTED").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByRole("button", { name: "Ops summary" })).toBeEnabled();
+    expect(screen.getAllByText("NOT_REQUESTED").length).toBeGreaterThanOrEqual(3);
   });
 
   it("requests review, workflow, proof, and supportability actions through Gateway helpers", async () => {
@@ -155,6 +158,29 @@ describe("DpmWaveCommandCenterPanel", () => {
       },
       data: { run_id: "wf_run_wave_memo_001", status: "REVIEW_REQUIRED" },
     });
+    vi.mocked(requestDpmOperationsHandoffSummary).mockResolvedValue({
+      correlation_id: "corr-ops-summary",
+      contract_version: "v1",
+      source_service: "lotus-ai",
+      evidence_source_service: "lotus-manage",
+      manage_upstream_status: 200,
+      ai_upstream_status: 200,
+      supportability: waveResponse.supportability,
+      wave_report_input: {
+        wave_id: "dwv_001",
+        report_input_ref: "report-input:dwv_001",
+      },
+      handoff_summary_request: {
+        requested_outputs: ["operations_summary", "blocking_conditions"],
+        audience: ["operations", "portfolio_manager"],
+      },
+      data: {
+        workflow_pack_run: {
+          run_id: "wf_run_ops_summary_001",
+          review_state: "REVIEW_REQUIRED",
+        },
+      },
+    });
 
     render(
       <DpmWaveCommandCenterPanel
@@ -202,6 +228,12 @@ describe("DpmWaveCommandCenterPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "AI memo" }));
     await waitFor(() => expect(requestDpmWaveAiPmMemo).toHaveBeenCalledWith("dwv_001"));
     expect(await screen.findByText("wf_run_wave_memo_001")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Ops summary" }));
+    await waitFor(() =>
+      expect(requestDpmOperationsHandoffSummary).toHaveBeenCalledWith("dwv_001"),
+    );
+    expect(await screen.findByText("wf_run_ops_summary_001")).toBeInTheDocument();
   });
 
   it("creates a wave without direct manage calls", async () => {

--- a/tests/unit/dpm-wave-command-center-view-model.test.ts
+++ b/tests/unit/dpm-wave-command-center-view-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { buildDpmWaveCommandCenterModel } from "../../src/features/workbench/dpm-wave-command-center-view-model";
 import type {
+  DpmOperationsHandoffSummaryResponse,
   DpmWaveAiPmMemoResponse,
   DpmWaveGatewayResponse,
 } from "../../src/features/workbench/types";
@@ -151,6 +152,41 @@ describe("DPM wave command-center view model", () => {
     expect(model.aiMemoStatus).toBe("REVIEW_REQUIRED");
     expect(model.aiMemoRunId).toBe("wf_run_wave_memo_001");
     expect(model.externalExecutionClaimed).toBe("N/A");
+  });
+
+  it("surfaces operations handoff summary posture as support-only workflow-pack truth", () => {
+    const operationsSummary: DpmOperationsHandoffSummaryResponse = {
+      correlation_id: "corr-ops-summary",
+      contract_version: "v1",
+      source_service: "lotus-ai",
+      evidence_source_service: "lotus-manage",
+      manage_upstream_status: 200,
+      ai_upstream_status: 200,
+      supportability: waveListResponse.supportability,
+      wave_report_input: {
+        wave_id: "dwv_001",
+        report_input_ref: "report-input:dwv_001",
+      },
+      handoff_summary_request: {
+        requested_outputs: ["operations_summary", "blocking_conditions"],
+        audience: ["operations", "portfolio_manager"],
+      },
+      data: {
+        workflow_pack_run: {
+          run_id: "wf_run_ops_summary_001",
+          review_state: "REVIEW_REQUIRED",
+        },
+      },
+    };
+
+    const model = buildDpmWaveCommandCenterModel({
+      waveList: waveListResponse,
+      operationsHandoffSummary: operationsSummary,
+    });
+
+    expect(model.operationsHandoffSummaryStatus).toBe("REVIEW_REQUIRED");
+    expect(model.operationsHandoffSummaryRunId).toBe("wf_run_ops_summary_001");
+    expect(model.aiMemoStatus).toBe("NOT_REQUESTED");
   });
 
   it("does not infer readiness from a present wave when manage supportability is blocked", () => {

--- a/tests/unit/test_rfc0098_documentation.py
+++ b/tests/unit/test_rfc0098_documentation.py
@@ -58,7 +58,10 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     assert "AI-evidence ready but AI memo unavailable" in rfc
     assert "outcome-review search, detail, supportability" in integrations
     assert "create, detail, item, source-check, simulation, approval, staging, handoff" in integrations
-    assert "supportability, report-input, and AI PM memo contracts" in integrations
+    assert "supportability, report-input, AI PM memo, and operations-handoff summary contracts" in integrations
+    assert "Gateway exception-summary contract" in integrations
+    assert "`POST /api/v1/dpm/command-center/waves/{wave_id}/operations-handoff-summary`" in rfc
+    assert "`POST /api/v1/dpm/command-center/exceptions/{exception_id}/ai-summary`" in rfc
     assert "must not calculate expected-versus-realized values" in integrations
     assert "calculate wave\n    readiness" in integrations
     assert "proof-pack truth" in integrations
@@ -69,5 +72,6 @@ def test_rfc0098_experience_uses_gateway_and_manage_truth() -> None:
     assert "RFC-0040 proof-pack evidence" in roadmap
     assert "DPM rebalance-wave command center" in supported_features
     assert "approval, staging, handoff" in supported_features
-    assert "governed AI PM memo request" in supported_features
+    assert "governed AI PM memo, and governed operations-handoff summary requests" in supported_features
+    assert "governed exception-summary request" in supported_features
     assert "external OMS/execution integration" in supported_features

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -29,6 +29,8 @@ import {
   handoffDpmWave,
   listDpmWaves,
   previewDpmWave,
+  requestDpmExceptionSummary,
+  requestDpmOperationsHandoffSummary,
   requestDpmOutcomeReviewAiNarrative,
   requestDpmProofPackAiPmMemo,
   requestDpmWaveAiPmMemo,
@@ -2039,6 +2041,12 @@ describe("workbench api", () => {
     await getDpmWaveSupportability("dwv_001");
     await getDpmWaveReportInput("dwv_001");
     await requestDpmWaveAiPmMemo("dwv_001");
+    await requestDpmOperationsHandoffSummary("dwv_001");
+    await requestDpmExceptionSummary({
+      exceptionId: "me_1",
+      mandateId: "MANDATE_PB_SG_GLOBAL_BAL_001",
+      state: "ACTIVE",
+    });
 
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
     expect(fetchMock.mock.calls[0][0]).toBe(`${expectedBaseUrl}/dpm/command-center/waves/preview`);
@@ -2054,6 +2062,12 @@ describe("workbench api", () => {
     expect(fetchMock.mock.calls[10][0]).toBe(`${expectedBaseUrl}/dpm/command-center/waves/dwv_001/supportability`);
     expect(fetchMock.mock.calls[11][0]).toBe(`${expectedBaseUrl}/dpm/command-center/waves/dwv_001/report-input`);
     expect(fetchMock.mock.calls[12][0]).toBe(`${expectedBaseUrl}/dpm/command-center/waves/dwv_001/ai-pm-memo`);
+    expect(fetchMock.mock.calls[13][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/waves/dwv_001/operations-handoff-summary`
+    );
+    expect(fetchMock.mock.calls[14][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/exceptions/me_1/ai-summary`
+    );
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
       body: {
         trigger_type: "EXPLICIT_PORTFOLIO_LIST",
@@ -2097,6 +2111,28 @@ describe("workbench api", () => {
       ],
       audience: ["portfolio_manager", "investment_control", "operations"],
     });
+    expect(JSON.parse(fetchMock.mock.calls[13][1].body)).toMatchObject({
+      requested_outputs: [
+        "operations_summary",
+        "execution_prerequisites",
+        "blocking_conditions",
+        "support_references",
+        "evidence_gaps",
+      ],
+      audience: ["operations", "portfolio_manager", "investment_control"],
+    });
+    expect(JSON.parse(fetchMock.mock.calls[14][1].body)).toMatchObject({
+      mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001",
+      state: "ACTIVE",
+      requested_outputs: [
+        "exception_summary",
+        "severity_summary",
+        "recommended_triage",
+        "support_references",
+        "evidence_gaps",
+      ],
+      audience: ["portfolio_manager", "investment_control", "operations"],
+    });
     const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
     expect(metricEventsJson).toContain("wave-preview");
     expect(metricEventsJson).toContain("wave-create");
@@ -2111,6 +2147,8 @@ describe("workbench api", () => {
     expect(metricEventsJson).toContain("wave-supportability");
     expect(metricEventsJson).toContain("wave-report-input");
     expect(metricEventsJson).toContain("wave-ai-pm-memo");
+    expect(metricEventsJson).toContain("wave-operations-handoff-summary");
+    expect(metricEventsJson).toContain("mandate-command-center-exception-ai-summary");
     expect(metricEventsJson).not.toContain("PB_SG_GLOBAL_BAL_001");
     expect(metricEventsJson).not.toContain("dwv_001");
   });

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -49,12 +49,14 @@ promote dormant labels into product ownership just because historical route file
   `/workbench/{portfolioId}` through Gateway `/api/v1/dpm/command-center/waves*`. Workbench loads
   the explicit portfolio-list wave queue, previews and creates canonical portfolio waves, opens
   wave detail and item posture, and sends source-check, simulation, approval, staging, handoff,
-  proof-posture, supportability, report-input, and governed AI PM memo actions through Gateway. It
+  proof-posture, supportability, report-input, governed AI PM memo, and governed operations
+  handoff summary actions through Gateway. It
   renders manage-owned wave lifecycle, item state, source-readiness state, supportability,
   report-input refs, proof-pack refs, handoff refs, lotus-ai workflow-pack run posture, and
   `external_execution_claimed` posture without direct `lotus-manage` or `lotus-ai` calls, local
-  readiness calculation, local report-input construction, prompt construction, or memo narrative
-  generation. Item-selection drawers, dedicated `/dpm/waves` routes, PM-book discovery, CIO
+  readiness calculation, local report-input construction, prompt construction, memo narrative
+  generation, or operations handoff-summary generation. Item-selection drawers, dedicated
+  `/dpm/waves` routes, PM-book discovery, CIO
   workflow, and external OMS execution remain future scope until separately implemented and proven.
 - RFC-0098/RFC-0038 mandate command-center cockpit rendering is implemented on
   `/workbench/{portfolioId}` through Gateway `/api/v1/dpm/command-center`,
@@ -62,9 +64,10 @@ promote dormant labels into product ownership just because historical route file
   `/api/v1/dpm/command-center/exceptions`, and
   `/api/v1/dpm/command-center/mandates*`. Workbench renders manage-owned book health
   distribution, source readiness, attention queue, recommended actions, latest monitoring-run
-  lineage, active exceptions, and mandate health dimensions. It does not calculate mandate health,
-  infer PM-book membership, reconstruct source readiness, merge exceptions, resolve exceptions
-  locally, or call `lotus-manage` directly. Demo promotion still requires the canonical
+  lineage, active exceptions, governed exception-summary workflow-pack posture, and mandate health
+  dimensions. It does not calculate mandate health, infer PM-book membership, reconstruct source
+  readiness, merge exceptions, resolve exceptions locally, generate exception-summary narrative,
+  or call `lotus-manage` or `lotus-ai` directly. Demo promotion still requires the canonical
   `PB_SG_GLOBAL_BAL_001` live evidence pack and screenshot review.
 - RFC-0098/RFC-0039 construction alternatives rendering is implemented on
   `/workbench/{portfolioId}` through Gateway

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -85,8 +85,8 @@ must travel through Gateway-shaped contracts.
     execution remains `lotus-ai` owned; both must reach Workbench through Gateway composition.
     RFC-0041 rebalance-wave preview, create, source-check, simulation, selection, approval,
     staging, handoff, supportability, and report-input also remain manage-owned, while wave PM
-    memo execution remains `lotus-ai` owned; both must reach Workbench through Gateway wave
-    composition only. RFC-0039
+    memo and operations-handoff summary execution remain `lotus-ai` owned; both must reach
+    Workbench through Gateway wave composition only. RFC-0039
     construction alternative generation, retrieval, supportability, and selection are manage-owned
     and must reach Workbench through Gateway construction composition only. RFC-0042
     outcome-review search, detail, supportability, report-input, AI-evidence, preview, create, and
@@ -95,17 +95,21 @@ must travel through Gateway-shaped contracts.
     RFC40-WTBD-010 portfolio-memory timeline events, source refs, artifact refs, event counts,
     source systems, reason codes, supportability, and content hashes remain manage-owned and must
     reach Workbench through Gateway portfolio-memory composition only.
+    RFC-0043 monitoring-exception summary execution remains `lotus-ai` owned and must reach
+    Workbench through Gateway exception-summary composition only.
     The implemented Workbench construction panel consumes the Gateway construction alternative-set
     contracts, the implemented wave command-center panel consumes Gateway wave list, preview,
     create, detail, item, source-check, simulation, approval, staging, handoff, proof-posture,
-    supportability, report-input, and AI PM memo contracts, the implemented proof-pack panel consumes the Gateway proof-pack
+    supportability, report-input, AI PM memo, and operations-handoff summary contracts, the
+    implemented proof-pack panel consumes the Gateway proof-pack
     generation, detail, Markdown, report-input, AI-evidence, and AI PM memo contracts, and the
     implemented outcome panel consumes the Gateway outcome-review list and AI-narrative contracts.
+    The implemented command-center exception queue consumes the Gateway exception-summary contract.
     The implemented portfolio-memory panel consumes the Gateway portfolio-memory contract and
     preserves manage event order without reconstructing timeline nodes.
     Workbench must not calculate expected-versus-realized values. It must not rebuild proof-pack
     sections, compute proof-pack hashes, construct prompts, infer PM quality, calculate wave
-    readiness, construct report input, generate memo narrative locally, reconstruct
+    readiness, construct report input, generate memo or exception-summary narrative locally, reconstruct
     portfolio-memory events, claim external execution, or optimize construction alternatives;
     proof-pack sections and wave report input remain manage-owned evidence.
 16. The implemented RFC-0038 mandate command-center cockpit consumes Gateway

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -10,8 +10,8 @@ It is intended for developers, business users, operations, sales/pre-sales, and 
 | Portfolio summary and detail | `/portfolio`, `/portfolio?tab=detailed` | Gateway Workbench portfolio APIs | Supported with canonical live proof. |
 | Performance and risk review | `/performance` route modes | Gateway performance/risk APIs | Supported with bounded observability and canonical proof. |
 | Data-product discovery | `/data-products` | Gateway domain-product APIs | Supported for catalog, dependencies, and live trust posture. |
-| DPM mandate command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit and PM-book-backed monitoring action through Gateway/Manage. Workbench preserves Manage supportability posture: populated canonical `READY` is demo-ready, `PARTIAL`/`DEGRADED`/`BLOCKED` render as explicit partial states, and `EMPTY` stays an empty state rather than a false ready cockpit. |
-| DPM rebalance-wave command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/waves*` | Implemented for wave queue, preview, create, detail, items, source-check, simulation, approval, staging, handoff, proof posture, supportability, report-input, and governed AI PM memo request through Gateway only. |
+| DPM mandate command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit, PM-book-backed monitoring action, active exception queue, and governed exception-summary request through Gateway/Manage/lotus-ai. Workbench preserves Manage supportability posture: populated canonical `READY` is demo-ready, `PARTIAL`/`DEGRADED`/`BLOCKED` render as explicit partial states, and `EMPTY` stays an empty state rather than a false ready cockpit. |
+| DPM rebalance-wave command center | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/waves*` | Implemented for wave queue, preview, create, detail, items, source-check, simulation, approval, staging, handoff, proof posture, supportability, report-input, governed AI PM memo, and governed operations-handoff summary requests through Gateway only. |
 | DPM construction alternatives | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/construction/alternative-sets*` | Implemented for generation, comparison, and PM selection through Gateway only. |
 | DPM proof-pack evidence | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/proof-packs*` | Implemented for generation from Gateway rebalance-run reference, proof-pack identity, sections, hashes, Markdown/report/AI posture, and governed PM memo request posture. |
 | DPM portfolio memory | `/workbench/{portfolioId}` | Gateway `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory` | Implemented for manage-owned timeline event order, event mix, source systems, source refs, artifact refs, reason codes, supportability, and content hash; canonical live proof accepts populated ready, partial, degraded, and blocked source truth while still failing empty or unsupported memory. |
@@ -54,8 +54,9 @@ Implemented:
 5. renders manage-owned lifecycle state, item state, source-readiness state, supportability,
    aggregate metrics, report-input refs, proof-pack refs, handoff refs, reason codes, blocked
    actions, remediation owner, and `external_execution_claimed` posture,
-6. requests a governed `lotus-ai` wave PM memo workflow-pack run through Gateway only and displays
-   review-required workflow-pack posture without constructing prompts or memo text locally,
+6. requests governed `lotus-ai` wave PM memo and operations-handoff summary workflow-pack runs
+   through Gateway only and displays review-required workflow-pack posture without constructing
+   prompts, memo text, handoff summaries, execution instructions, or client messages locally,
 7. emits bounded Workbench observability labels without portfolio ids, wave ids, report-input refs,
    workflow-pack run ids, request bodies, or response bodies as metric labels.
 
@@ -67,8 +68,8 @@ Not yet supported:
 4. richer workflow drawers and eligibility explanations beyond manage reason-code rendering,
 5. CIO approval workflow,
 6. external OMS/execution integration,
-7. client-side source-readiness, report-input, proof-pack, AI prompt, memo narrative, or handoff
-   calculation.
+7. client-side source-readiness, report-input, proof-pack, AI prompt, memo narrative,
+   operations-handoff summary, exception-summary narrative, or handoff calculation.
 
 ## DPM Flow Diagram
 


### PR DESCRIPTION
## Summary
- add Gateway-only Workbench actions for DPM operations handoff summary and active exception summary workflow-pack requests
- surface lotus-ai workflow-pack run/review posture in the wave and command-center panels without generating prompts, summaries, approvals, routing, PM scoring, client messages, or execution claims in browser code
- update RFC-0098, README, repository context, and wiki source to reflect the implemented support boundaries and non-claims

## Validation
- `python -m pytest tests/unit/test_rfc0098_documentation.py -q` -> 1 passed
- `npm test -- --run tests/unit/analytics-observability-metrics.test.ts tests/unit/dpm-wave-command-center-view-model.test.ts tests/unit/dpm-wave-command-center-panel.test.tsx tests/unit/dpm-command-center-view-model.test.ts tests/unit/dpm-command-center-panel.test.tsx tests/unit/workbench-api.test.ts` -> 77 passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `git diff --check` -> passed
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` -> passed
- `make check` -> lint, typecheck, 751 coverage tests at 90.97% statements, and production build passed

## Governance
- Stranded-truth scan before this slice found `origin/feat/rfc047-contribution-contract-alignment` as active performance/contribution work owned outside this DPM slice; this branch avoids those files.
- Final pre-commit stranded-truth scan returned no additional unmerged governance branches.
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` currently reports expected drift for `API-Surface.md`, `Integrations.md`, and `Supported-Features.md` because this PR updates repo-local wiki source. Publish wiki after merge.