### PR TITLE
RFC 049 composite performance workbench clients

### DIFF
--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -95,6 +95,16 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     operation: "performance.workspace.advisor-brief.review-action",
   },
   {
+    route: "workbench.performance",
+    panel: "performance-composite-twr",
+    operation: "performance.composites.twr",
+  },
+  {
+    route: "workbench.performance",
+    panel: "performance-composite-inspection",
+    operation: "performance.composites.inspect",
+  },
+  {
     route: "workbench.risk",
     panel: "risk-summary",
     operation: "risk.summary",

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -1,4 +1,7 @@
 import {
+  CompositePerformanceGatewayResponse,
+  CompositePerformanceInspectionRequest,
+  CompositePerformanceTwrRequest,
   WorkbenchAnalytics,
   WorkbenchAdvisorBriefWorkflowPackRunReviewActionRequest,
   WorkbenchPerformanceAdvisorBrief,
@@ -542,6 +545,42 @@ export async function getWorkbenchPerformanceAttributionTrendClient(
         `/workbench/${portfolioId}/performance/attribution-trend`,
         "performance attribution trend",
         query
+      )
+  );
+}
+
+export async function calculateCompositePerformanceTwrClient(
+  payload: CompositePerformanceTwrRequest
+): Promise<CompositePerformanceGatewayResponse> {
+  return await observeWorkbenchMutation(
+    "performance.composites.twr",
+    async () =>
+      await fetchWorkbenchMutation<CompositePerformanceGatewayResponse>(
+        `${BFF_PROXY_BASE}/performance/composites/twr`,
+        "composite performance TWR",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        }
+      )
+  );
+}
+
+export async function inspectCompositePerformanceClient(
+  payload: CompositePerformanceInspectionRequest
+): Promise<CompositePerformanceGatewayResponse> {
+  return await observeWorkbenchMutation(
+    "performance.composites.inspect",
+    async () =>
+      await fetchWorkbenchMutation<CompositePerformanceGatewayResponse>(
+        `${BFF_PROXY_BASE}/performance/composites/inspect`,
+        "composite performance inspection",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        }
       )
   );
 }

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -140,6 +140,28 @@ export type WorkbenchAnalytics = {
   partial_failures: WorkbenchOverview["partial_failures"];
 };
 
+export type CompositePerformanceTwrRequest = {
+  calculation_id?: string;
+  composite_id: string;
+  period_start: string;
+  period_end: string;
+};
+
+export type CompositePerformanceInspectionRequest = {
+  inspection_id?: string;
+  composite_id: string;
+  period_start: string;
+  period_end: string;
+};
+
+export type CompositePerformanceGatewayResponse = {
+  correlation_id: string;
+  contract_version: string;
+  source_service: "lotus-performance";
+  upstream_status: number;
+  data: Record<string, unknown>;
+};
+
 export type PerformanceComparativeSummary = {
   metric_basis: string;
   portfolio_return_pct: number | null;

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -272,6 +272,16 @@ describe("analytics UI observability metrics", () => {
         "performance-advisor-brief-review-action",
         "performance.workspace.advisor-brief.review-action",
       ],
+      [
+        "workbench.performance",
+        "performance-composite-twr",
+        "performance.composites.twr",
+      ],
+      [
+        "workbench.performance",
+        "performance-composite-inspection",
+        "performance.composites.inspect",
+      ],
       ["workbench.risk", "risk-summary", "risk.summary"],
       ["workbench.risk", "risk-concentration", "risk.concentration"],
       ["workbench.risk", "risk-drawdown", "risk.drawdown"],

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -4,6 +4,7 @@ import {
   approveDpmWave,
   applySandboxChanges,
   buildArchivedDocumentDownloadUrl,
+  calculateCompositePerformanceTwrClient,
   createPortfolioReportBatch,
   createSandboxSession,
   generateDpmConstructionAlternatives,
@@ -52,6 +53,7 @@ import {
   getWorkbenchPerformanceWorkspaceDetails,
   getWorkbenchPerformanceWorkspaceSummaryClient,
   getWorkbenchPerformanceWorkspaceSummary,
+  inspectCompositePerformanceClient,
   postWorkbenchPerformanceAdvisorBriefReviewActionClient,
   runReportBatchOnce,
   runDpmCommandCenterMonitoring,
@@ -75,6 +77,134 @@ describe("workbench api", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     resetAnalyticsUiMetricEvents();
+  });
+
+  it("calls gateway composite performance endpoints through the Workbench BFF", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          correlation_id: "corr-composite",
+          contract_version: "composite-performance-gateway.v1",
+          source_service: "lotus-performance",
+          upstream_status: 200,
+          data: {
+            composite_id: "PB_GLOBAL_BALANCED_USD",
+            status: "READY",
+            methodology: "persisted_member_return_asset_weighted_twr_v1",
+            periods: [],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await calculateCompositePerformanceTwrClient({
+      calculation_id: "calc-1",
+      composite_id: "PB_GLOBAL_BALANCED_USD",
+      period_start: "2026-01-01",
+      period_end: "2026-03-31",
+    });
+
+    expect(response.source_service).toBe("lotus-performance");
+    const [requestedUrl, requestInit] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    const requestHeaders = requestInit.headers as Record<string, string>;
+    expect(requestedUrl).toBe(`${expectedBaseUrl}/performance/composites/twr`);
+    expect(JSON.parse(requestInit.body as string)).toEqual({
+      calculation_id: "calc-1",
+      composite_id: "PB_GLOBAL_BALANCED_USD",
+      period_start: "2026-01-01",
+      period_end: "2026-03-31",
+    });
+    expect(requestHeaders["Content-Type"]).toBe("application/json");
+    expect(getAnalyticsUiMetricEvents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          metric_name: "lotus_workbench_api_request_duration_seconds",
+          labels: expect.objectContaining({
+            route: "workbench.performance",
+            panel: "performance-composite-twr",
+            operation: "performance.composites.twr",
+            status_class: "2xx",
+          }),
+        }),
+        expect.objectContaining({
+          metric_name: "lotus_workbench_panel_state_total",
+          labels: expect.objectContaining({
+            route: "workbench.performance",
+            panel: "performance-composite-twr",
+            operation: "performance.composites.twr",
+            state: "ready",
+          }),
+        }),
+      ])
+    );
+    expect(getAnalyticsUiMetricEvents()).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          metric_name: "lotus_workbench_panel_hydration_duration_seconds",
+          labels: expect.objectContaining({
+            operation: "performance.composites.twr",
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("calls gateway composite inspection endpoint through the Workbench BFF", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          correlation_id: "corr-composite",
+          contract_version: "composite-performance-gateway.v1",
+          source_service: "lotus-performance",
+          upstream_status: 200,
+          data: {
+            composite_id: "PB_GLOBAL_BALANCED_USD",
+            verdict: "supportable_with_warnings",
+            artifacts: [{ artifact_name: "member_inputs.csv" }],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await inspectCompositePerformanceClient({
+      inspection_id: "insp-1",
+      composite_id: "PB_GLOBAL_BALANCED_USD",
+      period_start: "2026-01-01",
+      period_end: "2026-03-31",
+    });
+
+    expect(response.data.verdict).toBe("supportable_with_warnings");
+    const [requestedUrl, requestInit] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(requestedUrl).toBe(
+      `${expectedBaseUrl}/performance/composites/inspect`
+    );
+    expect(JSON.parse(requestInit.body as string)).toEqual({
+      inspection_id: "insp-1",
+      composite_id: "PB_GLOBAL_BALANCED_USD",
+      period_start: "2026-01-01",
+      period_end: "2026-03-31",
+    });
+    expect(getAnalyticsUiMetricEvents()[0]).toEqual(
+      expect.objectContaining({
+        metric_name: "lotus_workbench_api_request_duration_seconds",
+        labels: expect.objectContaining({
+          route: "workbench.performance",
+          panel: "performance-composite-inspection",
+          operation: "performance.composites.inspect",
+          status_class: "2xx",
+        }),
+      })
+    );
   });
 
   it("calls sandbox session create endpoint", async () => {


### PR DESCRIPTION
Implements the lotus-workbench downstream consumer seam for lotus-performance RFC 049 composite performance.\n\n- Adds typed Workbench API helpers for composite TWR and inspection through Gateway/BFF.\n- Adds bounded analytics observability registry entries.\n- Adds focused unit tests proving Gateway/BFF usage and bounded telemetry.\n\nValidation run locally:\n- npm test -- --run tests/unit/workbench-api.test.ts tests/unit/analytics-observability-metrics.test.ts\n- npm run typecheck\n- git diff --check