### PR TITLE
feat(workbench): add PM quality fairness preview surface

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -51,7 +51,7 @@ Current repository posture:
 7. `/workbench/{portfolioId}` is the Manage workspace. It uses the same Workbench left rail as
    Portfolio, Positions, Transactions, Cashflow, Performance, and Risk, and it exposes focused
    Manage sub-surfaces through the `mode` query: overview, mandate, waves, construction, memory,
-   reviews, and proof. The route file remains orchestration-only; Manage workspace composition,
+   reviews, proof, and quality. The route file remains orchestration-only; Manage workspace composition,
    mode navigation, and data fan-out live under `src/features/workbench/manage-workspace.tsx`.
 8. Manage overview summarizes the Manage operating posture, while `mode=mandate` renders a focused
    Mandate Health surface from the RFC-0038 DPM command-center contracts exposed through Gateway
@@ -89,7 +89,15 @@ Current repository posture:
     prompt construction. Manage surfaces also preserve Gateway-provided action-register
     supportability from the portfolio overview `rebalance_snapshot`; missing supportability is
     shown as unknown/N/A rather than as verified zero activity.
-14. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
+14. Manage `mode=quality` renders the PM operating quality governance surface from Gateway
+    `/api/v1/dpm/command-center/pm-operating-quality/policies*`,
+    `/score-runs*`, and `/fairness-analyses/preview`. Workbench renders Manage-owned policy,
+    score-run, source-defined segment, fairness-analysis preview, source refs, reason-code,
+    supportability, and forbidden-use posture without calculating PM scores, discovering segments,
+    calculating segment averages or governed spreads, inferring protected classes, ranking PMs,
+    creating HR/compensation/conduct decisions, approving trades, contacting clients, routing
+    orders, or claiming OMS/execution truth.
+15. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
 
 ## Architecture And Module Map
 
@@ -215,6 +223,12 @@ Important validation expectations:
     remain bounded to route, panel, operation, freshness, supportability, status class, and error
     category; portfolio ids, event ids, source refs, artifact refs, content hashes, request bodies,
     response bodies, and screen content must never be emitted as metric labels.
+16. DPM PM operating quality policy, score-run, score-run preview, create, and fairness-analysis
+    preview operations are Workbench gateway-only operations. Observability labels must remain
+    bounded to route, panel, operation, freshness, supportability, status class, and error category;
+    policy ids, policy versions, score-run ids, fairness-analysis ids, segment ids, PM ids, book ids,
+    source refs, content hashes, request bodies, response bodies, score values, and screen content
+    must never be emitted as metric labels.
 
 ### Visual Review Gate
 

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -335,6 +335,41 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     operation: "dpm.waves.operations-handoff-summary",
   },
   {
+    route: "workbench.manage",
+    panel: "pm-operating-quality-policy-list",
+    operation: "dpm.pm-operating-quality.policies.list",
+  },
+  {
+    route: "workbench.manage",
+    panel: "pm-operating-quality-policy-detail",
+    operation: "dpm.pm-operating-quality.policies.get",
+  },
+  {
+    route: "workbench.manage",
+    panel: "pm-operating-quality-policy-upsert",
+    operation: "dpm.pm-operating-quality.policies.put",
+  },
+  {
+    route: "workbench.manage",
+    panel: "pm-operating-quality-score-run-list",
+    operation: "dpm.pm-operating-quality.score-runs.list",
+  },
+  {
+    route: "workbench.manage",
+    panel: "pm-operating-quality-score-run-detail",
+    operation: "dpm.pm-operating-quality.score-runs.get",
+  },
+  {
+    route: "workbench.manage",
+    panel: "pm-operating-quality-score-run-preview",
+    operation: "dpm.pm-operating-quality.score-runs.preview",
+  },
+  {
+    route: "workbench.manage",
+    panel: "pm-operating-quality-score-run-create",
+    operation: "dpm.pm-operating-quality.score-runs.create",
+  },
+  {
     route: "workbench.legacy-advisor",
     panel: "advisor-overview",
     operation: "workbench.overview",

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -370,6 +370,11 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
     operation: "dpm.pm-operating-quality.score-runs.create",
   },
   {
+    route: "workbench.manage",
+    panel: "pm-operating-quality-fairness-preview",
+    operation: "dpm.pm-operating-quality.fairness-analyses.preview",
+  },
+  {
     route: "workbench.legacy-advisor",
     panel: "advisor-overview",
     operation: "workbench.overview",

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -25,6 +25,7 @@ import {
   DpmOutcomeReviewNarrativeResponse,
   DpmOperationsHandoffSummaryResponse,
   DpmPortfolioMemoryGatewayResponse,
+  DpmPmOperatingQualityGatewayResponse,
   DpmProofPackAiPmMemoResponse,
   DpmProofPackGatewayResponse,
   DpmProofPackMarkdownResponse,
@@ -1417,6 +1418,179 @@ export async function requestDpmOperationsHandoffSummary(
   );
 }
 
+export async function listDpmPmOperatingQualityPolicies(params?: {
+  policyId?: string;
+  enabled?: boolean;
+  asOfDate?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<DpmPmOperatingQualityGatewayResponse> {
+  const dpmContext = resolveDefaultDpmContext();
+  const query = new URLSearchParams();
+  query.set("limit", String(params?.limit ?? 10));
+  query.set("offset", String(params?.offset ?? 0));
+  if (params?.policyId) {
+    query.set("policy_id", params.policyId);
+  }
+  if (params?.enabled !== undefined) {
+    query.set("enabled", String(params.enabled));
+  }
+  query.set("as_of_date", params?.asOfDate ?? dpmContext.commandCenterAsOfDate);
+  return await observeWorkbenchResource(
+    "dpm.pm-operating-quality.policies.list",
+    async () =>
+      await fetchWorkbenchResource<DpmPmOperatingQualityGatewayResponse>(
+        "server",
+        "/dpm/command-center/pm-operating-quality/policies",
+        "DPM PM operating quality policies",
+        query
+      )
+  );
+}
+
+export async function getDpmPmOperatingQualityPolicy(params: {
+  policyId: string;
+  policyVersion: string;
+}): Promise<DpmPmOperatingQualityGatewayResponse> {
+  return await observeWorkbenchResource(
+    "dpm.pm-operating-quality.policies.get",
+    async () =>
+      await fetchWorkbenchResource<DpmPmOperatingQualityGatewayResponse>(
+        "client",
+        `/dpm/command-center/pm-operating-quality/policies/${encodeURIComponent(
+          params.policyId
+        )}/versions/${encodeURIComponent(params.policyVersion)}`,
+        "DPM PM operating quality policy"
+      )
+  );
+}
+
+export async function putDpmPmOperatingQualityPolicy(params: {
+  policyId: string;
+  policyVersion: string;
+  body: Record<string, unknown>;
+  actorId?: string;
+}): Promise<DpmPmOperatingQualityGatewayResponse> {
+  return await observeWorkbenchMutation(
+    "dpm.pm-operating-quality.policies.put",
+    async () =>
+      await fetchWorkbenchMutation<DpmPmOperatingQualityGatewayResponse>(
+        buildWorkbenchUrl(
+          "client",
+          `/dpm/command-center/pm-operating-quality/policies/${encodeURIComponent(
+            params.policyId
+          )}/versions/${encodeURIComponent(params.policyVersion)}`
+        ),
+        "persist DPM PM operating quality policy",
+        {
+          method: "PUT",
+          headers: buildDpmPmOperatingQualityCallerHeaders(params.actorId),
+          body: JSON.stringify({ body: params.body }),
+        }
+      )
+  );
+}
+
+export async function listDpmPmOperatingQualityScoreRuns(params?: {
+  pmId?: string;
+  bookId?: string;
+  policyId?: string;
+  asOfDate?: string;
+  state?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<DpmPmOperatingQualityGatewayResponse> {
+  const dpmContext = resolveDefaultDpmContext();
+  const query = new URLSearchParams();
+  query.set("book_id", params?.bookId ?? dpmContext.commandCenterBookId);
+  query.set("as_of_date", params?.asOfDate ?? dpmContext.commandCenterAsOfDate);
+  query.set("limit", String(params?.limit ?? 10));
+  query.set("offset", String(params?.offset ?? 0));
+  if (params?.pmId) {
+    query.set("pm_id", params.pmId);
+  }
+  if (params?.policyId) {
+    query.set("policy_id", params.policyId);
+  }
+  if (params?.state) {
+    query.set("state", params.state);
+  }
+  return await observeWorkbenchResource(
+    "dpm.pm-operating-quality.score-runs.list",
+    async () =>
+      await fetchWorkbenchResource<DpmPmOperatingQualityGatewayResponse>(
+        "server",
+        "/dpm/command-center/pm-operating-quality/score-runs",
+        "DPM PM operating quality score runs",
+        query
+      )
+  );
+}
+
+export async function getDpmPmOperatingQualityScoreRun(
+  scoreRunId: string
+): Promise<DpmPmOperatingQualityGatewayResponse> {
+  return await observeWorkbenchResource(
+    "dpm.pm-operating-quality.score-runs.get",
+    async () =>
+      await fetchWorkbenchResource<DpmPmOperatingQualityGatewayResponse>(
+        "client",
+        `/dpm/command-center/pm-operating-quality/score-runs/${encodeURIComponent(scoreRunId)}`,
+        "DPM PM operating quality score run"
+      )
+  );
+}
+
+export async function previewDpmPmOperatingQualityScoreRun(params: {
+  pmId?: string;
+  bookId?: string;
+  policyId?: string;
+  policyVersion?: string;
+  asOfDate?: string;
+  actorId?: string;
+  outcomeReviewIds?: string[];
+}): Promise<DpmPmOperatingQualityGatewayResponse> {
+  const body = buildPmOperatingQualityScoreRunBody(params);
+  return await observeWorkbenchMutation(
+    "dpm.pm-operating-quality.score-runs.preview",
+    async () =>
+      await fetchWorkbenchMutation<DpmPmOperatingQualityGatewayResponse>(
+        buildWorkbenchUrl("client", "/dpm/command-center/pm-operating-quality/score-runs/preview"),
+        "preview DPM PM operating quality score run",
+        {
+          method: "POST",
+          headers: buildDpmPmOperatingQualityCallerHeaders(params.actorId),
+          body: JSON.stringify({ body }),
+        }
+      )
+  );
+}
+
+export async function createDpmPmOperatingQualityScoreRun(params: {
+  pmId?: string;
+  bookId?: string;
+  policyId?: string;
+  policyVersion?: string;
+  asOfDate?: string;
+  actorId?: string;
+  outcomeReviewIds?: string[];
+}): Promise<DpmPmOperatingQualityGatewayResponse> {
+  const body = buildPmOperatingQualityScoreRunBody(params);
+  return await observeWorkbenchMutation(
+    "dpm.pm-operating-quality.score-runs.create",
+    async () =>
+      await fetchWorkbenchMutation<DpmPmOperatingQualityGatewayResponse>(
+        buildWorkbenchUrl("client", "/dpm/command-center/pm-operating-quality/score-runs"),
+        "create DPM PM operating quality score run",
+        {
+          method: "POST",
+          headers: buildDpmPmOperatingQualityCallerHeaders(params.actorId),
+          body: JSON.stringify({ body }),
+        }
+      )
+  );
+}
+
 export async function generateDpmConstructionAlternatives(params: {
   portfolio: WorkbenchPortfolio360;
   methods?: string[];
@@ -1838,6 +2012,38 @@ function buildDpmWaveCallerHeaders(actorId?: string): Record<string, string> {
     "X-Actor-Id": actorId ?? callerContext.actorId,
     "X-Caller-Application": "lotus-workbench",
     "X-Correlation-Id": "corr-workbench-dpm-wave",
+  };
+}
+
+function buildDpmPmOperatingQualityCallerHeaders(actorId?: string): Record<string, string> {
+  const callerContext = resolveDefaultCallerContext();
+  return {
+    "Content-Type": "application/json",
+    "X-Actor-Id": actorId ?? callerContext.actorId,
+    "X-Caller-Application": "lotus-workbench",
+    "X-Correlation-Id": "corr-workbench-pm-operating-quality",
+  };
+}
+
+function buildPmOperatingQualityScoreRunBody(params: {
+  pmId?: string;
+  bookId?: string;
+  policyId?: string;
+  policyVersion?: string;
+  asOfDate?: string;
+  actorId?: string;
+  outcomeReviewIds?: string[];
+}): Record<string, unknown> {
+  const dpmContext = resolveDefaultDpmContext();
+  const callerContext = resolveDefaultCallerContext();
+  return {
+    pm_id: params.pmId ?? dpmContext.commandCenterPortfolioManagerId,
+    book_id: params.bookId ?? dpmContext.commandCenterBookId,
+    policy_id: params.policyId ?? "pmq_sg_dpm",
+    policy_version: params.policyVersion ?? "2026.05",
+    as_of_date: params.asOfDate ?? dpmContext.commandCenterAsOfDate,
+    actor_id: params.actorId ?? callerContext.actorId,
+    outcome_review_ids: params.outcomeReviewIds ?? [],
   };
 }
 

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -1591,6 +1591,55 @@ export async function createDpmPmOperatingQualityScoreRun(params: {
   );
 }
 
+export type DpmPmOperatingQualityFairnessSegmentRequest = {
+  segment_id: string;
+  segment_type: string;
+  display_name: string;
+  score_run_ids: string[];
+  source_refs?: Array<Record<string, unknown>>;
+};
+
+export async function previewDpmPmOperatingQualityFairnessAnalysis(params: {
+  policyId: string;
+  policyVersion: string;
+  asOfDate?: string;
+  actorId?: string;
+  segments: DpmPmOperatingQualityFairnessSegmentRequest[];
+  minimumSegmentScoreRunCount?: number;
+  maximumAverageScoreSpread?: string;
+}): Promise<DpmPmOperatingQualityGatewayResponse> {
+  const dpmContext = resolveDefaultDpmContext();
+  const body: Record<string, unknown> = {
+    policy_id: params.policyId,
+    policy_version: params.policyVersion,
+    as_of_date: params.asOfDate ?? dpmContext.commandCenterAsOfDate,
+    actor_id: params.actorId ?? "workbench-pm-operating-quality-operator",
+    segments: params.segments,
+  };
+  if (typeof params.minimumSegmentScoreRunCount === "number") {
+    body.minimum_segment_score_run_count = params.minimumSegmentScoreRunCount;
+  }
+  if (params.maximumAverageScoreSpread) {
+    body.maximum_average_score_spread = params.maximumAverageScoreSpread;
+  }
+  return await observeWorkbenchMutation(
+    "dpm.pm-operating-quality.fairness-analyses.preview",
+    async () =>
+      await fetchWorkbenchMutation<DpmPmOperatingQualityGatewayResponse>(
+        buildWorkbenchUrl(
+          "client",
+          "/dpm/command-center/pm-operating-quality/fairness-analyses/preview"
+        ),
+        "preview DPM PM operating quality fairness analysis",
+        {
+          method: "POST",
+          headers: buildDpmPmOperatingQualityCallerHeaders(params.actorId),
+          body: JSON.stringify({ body }),
+        }
+      )
+  );
+}
+
 export async function generateDpmConstructionAlternatives(params: {
   portfolio: WorkbenchPortfolio360;
   methods?: string[];

--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -11,7 +11,10 @@ import {
   SemanticBadge,
   Text,
 } from "@/design-system";
-import { previewDpmPmOperatingQualityScoreRun } from "@/features/workbench/api";
+import {
+  previewDpmPmOperatingQualityFairnessAnalysis,
+  previewDpmPmOperatingQualityScoreRun,
+} from "@/features/workbench/api";
 import {
   buildPmOperatingQualityPanelModel,
   type PmOperatingQualityPanelState,
@@ -67,13 +70,17 @@ export default function PmOperatingQualityPanel({
 }: Props) {
   const [previewResponse, setPreviewResponse] =
     useState<DpmPmOperatingQualityGatewayResponse | null>(null);
+  const [fairnessPreviewResponse, setFairnessPreviewResponse] =
+    useState<DpmPmOperatingQualityGatewayResponse | null>(null);
   const [pendingAction, setPendingAction] = useState(false);
+  const [pendingFairnessAction, setPendingFairnessAction] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const model = buildPmOperatingQualityPanelModel({
     policies,
     scoreRuns,
     preview: previewResponse,
+    fairnessPreview: fairnessPreviewResponse,
   });
   const stateCopy = statePanelCopy(model.state);
   const loadError = policiesError || scoreRunsError;
@@ -106,6 +113,35 @@ export default function PmOperatingQualityPanel({
     }
   }
 
+  async function previewFairnessAnalysis() {
+    if (pendingFairnessAction || model.fairnessSegmentRequests.length < 2) {
+      return;
+    }
+    if (model.policyId === "N/A" || model.policyVersion === "N/A") {
+      setActionError("PM operating quality policy id/version is required for fairness preview.");
+      return;
+    }
+    setPendingFairnessAction(true);
+    setActionError(null);
+    setActionMessage(null);
+    try {
+      const response = await previewDpmPmOperatingQualityFairnessAnalysis({
+        policyId: model.policyId,
+        policyVersion: model.policyVersion,
+        asOfDate: model.fairnessAsOfDate !== "N/A" ? model.fairnessAsOfDate : undefined,
+        segments: model.fairnessSegmentRequests,
+      });
+      setFairnessPreviewResponse(response);
+      setActionMessage("Fairness preview returned Manage segment evidence.");
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : "PM operating quality fairness preview failed"
+      );
+    } finally {
+      setPendingFairnessAction(false);
+    }
+  }
+
   return (
     <SectionBlock
       title="PM Operating Quality"
@@ -117,6 +153,11 @@ export default function PmOperatingQualityPanel({
             {businessStateLabel(model.supportabilityState)}
           </SemanticBadge>
           <SemanticBadge>Manage authority</SemanticBadge>
+          {model.fairnessAnalysisId !== "N/A" ? (
+            <SemanticBadge tone={toneForState(model.fairnessState)}>
+              Fairness {businessStateLabel(model.fairnessState)}
+            </SemanticBadge>
+          ) : null}
         </div>
       }
     >
@@ -132,6 +173,7 @@ export default function PmOperatingQualityPanel({
       <div className="portfolio-memory-status-strip">
         <MetricRow label="Policy" value={`${model.policyId} / ${model.policyVersion}`} />
         <MetricRow label="Latest Score Run" value={model.scoreRunId} />
+        <MetricRow label="Fairness Preview" value={model.fairnessAnalysisId} />
         <MetricRow label="Returned Rows" value={model.count} />
         <MetricRow label="Authority" value={model.authority} />
       </div>
@@ -161,6 +203,17 @@ export default function PmOperatingQualityPanel({
             >
               {pendingAction ? "Previewing" : "Preview"}
             </ActionButton>
+            <ActionButton
+              priority="secondary"
+              onClick={previewFairnessAnalysis}
+              disabled={
+                pendingFairnessAction ||
+                model.blockedActions.includes("PREVIEW_FAIRNESS_ANALYSIS") ||
+                model.fairnessSegmentRequests.length < 2
+              }
+            >
+              {pendingFairnessAction ? "Checking" : "Preview Fairness"}
+            </ActionButton>
           </div>
           {actionMessage ? <Text variant="secondary">{actionMessage}</Text> : null}
           <AnalyticsTable
@@ -173,7 +226,7 @@ export default function PmOperatingQualityPanel({
               { key: "policy", label: "Policy" },
               { key: "state", label: "State" },
               { key: "score", label: "Score" },
-              { key: "evidence", label: "Evidence" },
+              { key: "reason", label: "Reason" },
             ]}
             rows={model.scoreRunRows.map((row) => ({
               key: row.key,
@@ -185,7 +238,7 @@ export default function PmOperatingQualityPanel({
                   {businessStateLabel(row.state)}
                 </SemanticBadge>,
                 row.score,
-                row.contentHash,
+                row.reasonCodes,
               ],
             }))}
             emptyState={{
@@ -201,6 +254,8 @@ export default function PmOperatingQualityPanel({
           </Text>
           <div className="portfolio-memory-action-stack">
             <MetricRow label="Forbidden Uses" value={model.forbiddenUsePosture} />
+            <MetricRow label="Source Segments" value={String(model.fairnessSegmentRequests.length)} />
+            <MetricRow label="Fairness Spread" value={model.fairnessSpread} />
             <MetricRow
               label="Blocked Actions"
               value={model.blockedActions.length ? model.blockedActions.join(", ") : "None"}
@@ -213,6 +268,40 @@ export default function PmOperatingQualityPanel({
           </div>
         </aside>
       </div>
+
+      <AnalyticsTable
+        ariaLabel="PM operating quality fairness segments"
+        variant="analysis"
+        density="compact"
+        columns={[
+          { key: "segment", label: "Segment" },
+          { key: "type", label: "Type" },
+          { key: "state", label: "State" },
+          { key: "count", label: "Score Runs" },
+          { key: "average", label: "Average Score" },
+          { key: "reason", label: "Reason" },
+        ]}
+        rows={model.fairnessSegmentRows.map((row) => ({
+          key: row.key,
+          cells: [
+            <strong key={`${row.key}-segment`}>{row.segment}</strong>,
+            row.segmentType,
+            <SemanticBadge key={`${row.key}-state`} tone={toneForState(row.state)}>
+              {businessStateLabel(row.state)}
+            </SemanticBadge>,
+            row.scoreRunCount,
+            row.averageScore,
+            row.reasonCodes,
+          ],
+        }))}
+        emptyState={{
+          title: "No fairness segment preview returned",
+          body:
+            model.fairnessSegmentRequests.length >= 2
+              ? "Run a Manage fairness preview to inspect source-defined segment posture."
+              : "Manage has not returned source-defined segment assignments for a fairness preview.",
+        }}
+      />
 
       <AnalyticsTable
         ariaLabel="PM operating quality policies"

--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  ActionButton,
+  AnalyticsTable,
+  MetricRow,
+  ScreenStatePanel,
+  SectionBlock,
+  SemanticBadge,
+  Text,
+} from "@/design-system";
+import { previewDpmPmOperatingQualityScoreRun } from "@/features/workbench/api";
+import {
+  buildPmOperatingQualityPanelModel,
+  type PmOperatingQualityPanelState,
+} from "@/features/workbench/pm-operating-quality-view-model";
+import type { DpmPmOperatingQualityGatewayResponse } from "@/features/workbench/types";
+import {
+  businessStateLabel,
+  formatBusinessReason,
+  toneForState,
+} from "@/features/workbench/manage-workspace-view-model";
+
+type Props = {
+  policies: DpmPmOperatingQualityGatewayResponse | null;
+  scoreRuns: DpmPmOperatingQualityGatewayResponse | null;
+  policiesError?: string | null;
+  scoreRunsError?: string | null;
+};
+
+function statePanelCopy(state: PmOperatingQualityPanelState) {
+  if (state === "empty") {
+    return {
+      kind: "empty" as const,
+      title: "No PM operating quality evidence returned",
+      body: "No policy or score-run evidence is currently available for this PM book.",
+    };
+  }
+  if (state === "partial") {
+    return {
+      kind: "partial" as const,
+      title: "PM operating quality evidence is partial",
+      body: "Some policy or score-run inputs require review before a persisted score run is used.",
+    };
+  }
+  if (state === "blocked") {
+    return {
+      kind: "permission_blocked" as const,
+      title: "PM operating quality action is blocked",
+      body: "Manage has published blocked actions for this PM operating quality posture.",
+    };
+  }
+  return {
+    kind: "unavailable" as const,
+    title: "PM operating quality is unavailable",
+    body: "PM operating quality evidence could not be loaded from Gateway.",
+  };
+}
+
+export default function PmOperatingQualityPanel({
+  policies,
+  scoreRuns,
+  policiesError = null,
+  scoreRunsError = null,
+}: Props) {
+  const [previewResponse, setPreviewResponse] =
+    useState<DpmPmOperatingQualityGatewayResponse | null>(null);
+  const [pendingAction, setPendingAction] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const model = buildPmOperatingQualityPanelModel({
+    policies,
+    scoreRuns,
+    preview: previewResponse,
+  });
+  const stateCopy = statePanelCopy(model.state);
+  const loadError = policiesError || scoreRunsError;
+  const shouldShowStatePanel =
+    Boolean(loadError) ||
+    Boolean(actionError) ||
+    model.state === "empty" ||
+    model.state === "partial" ||
+    model.state === "blocked" ||
+    model.state === "unavailable";
+
+  async function previewScoreRun() {
+    if (pendingAction) {
+      return;
+    }
+    setPendingAction(true);
+    setActionError(null);
+    setActionMessage(null);
+    try {
+      const response = await previewDpmPmOperatingQualityScoreRun({
+        policyId: model.policyId !== "N/A" ? model.policyId : undefined,
+        policyVersion: model.policyVersion !== "N/A" ? model.policyVersion : undefined,
+      });
+      setPreviewResponse(response);
+      setActionMessage("Preview returned Manage operating-quality evidence.");
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "PM operating quality preview failed");
+    } finally {
+      setPendingAction(false);
+    }
+  }
+
+  return (
+    <SectionBlock
+      title="PM Operating Quality"
+      subtitle="Gateway-backed supervisory evidence for Manage-owned PM policy and score-run posture."
+      className="pm-operating-quality-panel"
+      actions={
+        <div className="portfolio-memory-badge-row">
+          <SemanticBadge tone={toneForState(model.supportabilityState)}>
+            {businessStateLabel(model.supportabilityState)}
+          </SemanticBadge>
+          <SemanticBadge>Manage authority</SemanticBadge>
+        </div>
+      }
+    >
+      {shouldShowStatePanel ? (
+        <ScreenStatePanel
+          kind={loadError || actionError ? "partial" : stateCopy.kind}
+          surface="portfolio"
+          title={loadError || actionError ? "PM operating quality needs attention" : stateCopy.title}
+          body={loadError || actionError || stateCopy.body}
+        />
+      ) : null}
+
+      <div className="portfolio-memory-status-strip">
+        <MetricRow label="Policy" value={`${model.policyId} / ${model.policyVersion}`} />
+        <MetricRow label="Latest Score Run" value={model.scoreRunId} />
+        <MetricRow label="Returned Rows" value={model.count} />
+        <MetricRow label="Authority" value={model.authority} />
+      </div>
+
+      <div className="portfolio-memory-reason-row">
+        {model.reasonCodes.length > 0 ? (
+          model.reasonCodes.map((reason) => (
+            <SemanticBadge key={reason} tone={toneForState(reason)}>
+              {formatBusinessReason(reason)}
+            </SemanticBadge>
+          ))
+        ) : (
+          <SemanticBadge>No reason codes returned</SemanticBadge>
+        )}
+      </div>
+
+      <div className="portfolio-memory-workspace">
+        <div className="portfolio-memory-timeline-card">
+          <div className="portfolio-memory-card-header">
+            <Text as="h3" variant="subsectionTitle">
+              Score-Run Evidence
+            </Text>
+            <ActionButton
+              priority="secondary"
+              onClick={previewScoreRun}
+              disabled={pendingAction || model.blockedActions.includes("PREVIEW_SCORE_RUN")}
+            >
+              {pendingAction ? "Previewing" : "Preview"}
+            </ActionButton>
+          </div>
+          {actionMessage ? <Text variant="secondary">{actionMessage}</Text> : null}
+          <AnalyticsTable
+            ariaLabel="PM operating quality score runs"
+            variant="analysis"
+            density="compact"
+            columns={[
+              { key: "scoreRun", label: "Score Run" },
+              { key: "pm", label: "PM / Book" },
+              { key: "policy", label: "Policy" },
+              { key: "state", label: "State" },
+              { key: "score", label: "Score" },
+              { key: "evidence", label: "Evidence" },
+            ]}
+            rows={model.scoreRunRows.map((row) => ({
+              key: row.key,
+              cells: [
+                <strong key={`${row.key}-id`}>{row.scoreRunId}</strong>,
+                `${row.pmId} / ${row.bookId}`,
+                row.policy,
+                <SemanticBadge key={`${row.key}-state`} tone={toneForState(row.state)}>
+                  {businessStateLabel(row.state)}
+                </SemanticBadge>,
+                row.score,
+                row.contentHash,
+              ],
+            }))}
+            emptyState={{
+              title: "No score runs returned",
+              body: "Preview or create a Manage score run before using score-run evidence.",
+            }}
+          />
+        </div>
+
+        <aside className="portfolio-memory-actions-card">
+          <Text as="h3" variant="subsectionTitle">
+            Governance Posture
+          </Text>
+          <div className="portfolio-memory-action-stack">
+            <MetricRow label="Forbidden Uses" value={model.forbiddenUsePosture} />
+            <MetricRow
+              label="Blocked Actions"
+              value={model.blockedActions.length ? model.blockedActions.join(", ") : "None"}
+            />
+            <MetricRow label="Policy Versions" value={String(model.policyRows.length)} />
+            <Text variant="secondary">
+              Workbench preserves Gateway and Manage evidence only. It does not rank PMs, calculate
+              PM quality, approve trades, create HR or compensation decisions, or contact clients.
+            </Text>
+          </div>
+        </aside>
+      </div>
+
+      <AnalyticsTable
+        ariaLabel="PM operating quality policies"
+        variant="analysis"
+        density="compact"
+        columns={[
+          { key: "policy", label: "Policy" },
+          { key: "enabled", label: "Enabled" },
+          { key: "state", label: "State" },
+          { key: "asOf", label: "As Of" },
+          { key: "reason", label: "Reason" },
+        ]}
+        rows={model.policyRows.map((row) => ({
+          key: row.key,
+          cells: [
+            <strong key={`${row.key}-policy`}>{`${row.policyId} / ${row.policyVersion}`}</strong>,
+            row.enabled,
+            <SemanticBadge key={`${row.key}-state`} tone={toneForState(row.state)}>
+              {businessStateLabel(row.state)}
+            </SemanticBadge>,
+            row.asOfDate,
+            row.reasonCodes,
+          ],
+        }))}
+        emptyState={{
+          title: "No PM operating quality policy returned",
+          body: "A Manage-owned policy is required before score-run evidence can be used.",
+        }}
+      />
+    </SectionBlock>
+  );
+}

--- a/src/features/workbench/manage-workspace.tsx
+++ b/src/features/workbench/manage-workspace.tsx
@@ -22,6 +22,7 @@ import ManageMandateHealth from "@/features/workbench/components/manage-mandate-
 import DpmWaveCommandCenterPanel from "@/features/workbench/components/dpm-wave-command-center-panel";
 import OutcomeReviewPanel from "@/features/workbench/components/outcome-review-panel";
 import PortfolioMemoryPanel from "@/features/workbench/components/portfolio-memory-panel";
+import PmOperatingQualityPanel from "@/features/workbench/components/pm-operating-quality-panel";
 import ProofPackPanel from "@/features/workbench/components/proof-pack-panel";
 import { buildDpmCommandCenterPanelModel } from "@/features/workbench/dpm-command-center-view-model";
 import { buildDpmWaveCommandCenterModel } from "@/features/workbench/dpm-wave-command-center-view-model";
@@ -49,6 +50,8 @@ import {
   getDpmPortfolioMemory,
   getDpmProofPack,
   getPortfolio360,
+  listDpmPmOperatingQualityPolicies,
+  listDpmPmOperatingQualityScoreRuns,
   listDpmCampaignDefinitions,
   listDpmWaves,
 } from "@/features/workbench/api";
@@ -60,6 +63,7 @@ export type ManageMode =
   | "waves"
   | "construction"
   | "memory"
+  | "quality"
   | "reviews"
   | "proof";
 
@@ -72,6 +76,10 @@ export type ManageWorkspaceData = {
   commandCenterError: string | null;
   portfolioMemory: Awaited<ReturnType<typeof getDpmPortfolioMemory>> | null;
   portfolioMemoryError: string | null;
+  pmOperatingQualityPolicies: Awaited<ReturnType<typeof listDpmPmOperatingQualityPolicies>> | null;
+  pmOperatingQualityPoliciesError: string | null;
+  pmOperatingQualityScoreRuns: Awaited<ReturnType<typeof listDpmPmOperatingQualityScoreRuns>> | null;
+  pmOperatingQualityScoreRunsError: string | null;
   waves: Awaited<ReturnType<typeof listDpmWaves>> | null;
   wavesError: string | null;
   campaignDefinitions: Awaited<ReturnType<typeof listDpmCampaignDefinitions>> | null;
@@ -125,6 +133,13 @@ export const MANAGE_MODE_DEFINITIONS: Array<{
     description: "Portfolio decision memory and operating history.",
   },
   {
+    key: "quality",
+    label: "PM Quality",
+    detail: "Operating quality",
+    title: "PM Operating Quality",
+    description: "Governance review of Manage-owned PM quality policy and evidence.",
+  },
+  {
     key: "reviews",
     label: "Reviews",
     detail: "Outcome review",
@@ -151,6 +166,8 @@ export async function loadManageWorkspaceData(
     memoryResult,
     wavesResult,
     campaignDefinitionsResult,
+    pmQualityPoliciesResult,
+    pmQualityScoreRunsResult,
     reviewsResult,
   ] = await Promise.allSettled([
     getDpmCommandCenter({ limit: 25 }),
@@ -159,6 +176,8 @@ export async function loadManageWorkspaceData(
     getDpmPortfolioMemory({ portfolioId, limit: 100 }),
     listDpmWaves({ triggerType: "EXPLICIT_PORTFOLIO_LIST", limit: 10 }),
     listDpmCampaignDefinitions({ campaignStatus: "ACTIVE", limit: 10 }),
+    listDpmPmOperatingQualityPolicies({ limit: 10 }),
+    listDpmPmOperatingQualityScoreRuns({ limit: 10 }),
     getDpmOutcomeReviews({ portfolioId, limit: 10 }),
   ]);
 
@@ -198,6 +217,16 @@ export async function loadManageWorkspaceData(
     portfolioMemoryError: readSettledError(
       memoryResult,
       "Portfolio-memory endpoint unavailable."
+    ),
+    pmOperatingQualityPolicies: readSettledValue(pmQualityPoliciesResult),
+    pmOperatingQualityPoliciesError: readSettledError(
+      pmQualityPoliciesResult,
+      "PM operating quality policy endpoint unavailable."
+    ),
+    pmOperatingQualityScoreRuns: readSettledValue(pmQualityScoreRunsResult),
+    pmOperatingQualityScoreRunsError: readSettledError(
+      pmQualityScoreRunsResult,
+      "PM operating quality score-run endpoint unavailable."
     ),
     waves: readSettledValue(wavesResult),
     wavesError: readSettledError(wavesResult, "DPM wave endpoint unavailable."),
@@ -341,6 +370,15 @@ function renderManageMode(
           errorMessage={data.portfolioMemoryError}
         />
       );
+    case "quality":
+      return (
+        <PmOperatingQualityPanel
+          policies={data.pmOperatingQualityPolicies}
+          scoreRuns={data.pmOperatingQualityScoreRuns}
+          policiesError={data.pmOperatingQualityPoliciesError}
+          scoreRunsError={data.pmOperatingQualityScoreRunsError}
+        />
+      );
     case "reviews":
       return (
         <OutcomeReviewPanel
@@ -377,6 +415,8 @@ function ManageOverview({ data }: { data: ManageWorkspaceData }) {
   });
   const waveModel = buildDpmWaveCommandCenterModel({ waveList: data.waves });
   const memoryModel = buildPortfolioMemoryPanelModel(data.portfolioMemory);
+  const pmQualityPolicyCount = data.pmOperatingQualityPolicies?.supportability.count ?? 0;
+  const pmQualityScoreRunCount = data.pmOperatingQualityScoreRuns?.supportability.count ?? 0;
   const reviewModel = buildOutcomeReviewPanelModel(data.outcomeReviews);
   const exceptionRows = buildManageExceptionRows(data.commandCenterExceptions);
   const activeExceptionCount = parseCount(commandModel.activeExceptionCount);
@@ -390,6 +430,7 @@ function ManageOverview({ data }: { data: ManageWorkspaceData }) {
     data.commandCenterError ? "Mandate readiness" : null,
     data.wavesError ? "Rebalance waves" : null,
     data.portfolioMemoryError ? "Portfolio memory" : null,
+    data.pmOperatingQualityPoliciesError || data.pmOperatingQualityScoreRunsError ? "PM operating quality" : null,
     data.outcomeReviewError ? "Outcome reviews" : null,
   ].filter((surface): surface is string => Boolean(surface));
   const mandateReadiness =
@@ -493,6 +534,17 @@ function ManageOverview({ data }: { data: ManageWorkspaceData }) {
       detail: "Recent decisions and operating events are captured.",
       href: buildManageModeHref(portfolioId, "memory"),
       action: "Open Portfolio Memory",
+    },
+    {
+      key: "quality",
+      title: "PM Operating Quality",
+      icon: "manage_accounts",
+      state: data.pmOperatingQualityPoliciesError || data.pmOperatingQualityScoreRunsError ? "Needs attention" : "Available",
+      tone: data.pmOperatingQualityPoliciesError || data.pmOperatingQualityScoreRunsError ? ("warn" as const) : ("success" as const),
+      metric: `${pmQualityScoreRunCount || pmQualityPolicyCount} evidence rows`,
+      detail: "Review Manage-owned PM quality policy, score-run, and fairness preview posture.",
+      href: buildManageModeHref(portfolioId, "quality"),
+      action: "Open PM Quality",
     },
     {
       key: "reviews",
@@ -715,6 +767,7 @@ function ManageContextRail({
           ["Open Rebalance", buildManageModeHref(portfolio.portfolio_id, "waves")],
           ["Open Construction", buildManageModeHref(portfolio.portfolio_id, "construction")],
           ["Open Portfolio Memory", buildManageModeHref(portfolio.portfolio_id, "memory")],
+          ["Open PM Quality", buildManageModeHref(portfolio.portfolio_id, "quality")],
           ["Open Outcome Reviews", buildManageModeHref(portfolio.portfolio_id, "reviews")],
           ["Open Evidence Pack", buildManageModeHref(portfolio.portfolio_id, "proof")],
         ];

--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -1,0 +1,272 @@
+import type { DpmPmOperatingQualityGatewayResponse } from "./types";
+
+export type PmOperatingQualityPanelState =
+  | "ready"
+  | "partial"
+  | "blocked"
+  | "empty"
+  | "unavailable";
+
+export type PmOperatingQualityPolicyRow = {
+  key: string;
+  policyId: string;
+  policyVersion: string;
+  enabled: string;
+  state: string;
+  asOfDate: string;
+  reasonCodes: string;
+};
+
+export type PmOperatingQualityScoreRunRow = {
+  key: string;
+  scoreRunId: string;
+  pmId: string;
+  bookId: string;
+  policy: string;
+  state: string;
+  score: string;
+  asOfDate: string;
+  forbiddenUses: string;
+  reasonCodes: string;
+  contentHash: string;
+};
+
+export type PmOperatingQualityPanelModel = {
+  state: PmOperatingQualityPanelState;
+  supportabilityState: string;
+  authority: string;
+  policyId: string;
+  policyVersion: string;
+  scoreRunId: string;
+  count: string;
+  reasonCodes: string[];
+  blockedActions: string[];
+  policyRows: PmOperatingQualityPolicyRow[];
+  scoreRunRows: PmOperatingQualityScoreRunRow[];
+  selectedScoreRun: PmOperatingQualityScoreRunRow | null;
+  forbiddenUsePosture: string;
+};
+
+export function buildPmOperatingQualityPanelModel(params: {
+  policies: DpmPmOperatingQualityGatewayResponse | null;
+  scoreRuns: DpmPmOperatingQualityGatewayResponse | null;
+  preview?: DpmPmOperatingQualityGatewayResponse | null;
+}): PmOperatingQualityPanelModel {
+  const primary = params.preview ?? params.scoreRuns ?? params.policies;
+  const supportability = primary?.supportability;
+  const supportabilityState = normalizeState(supportability?.state);
+  const policyRows = buildPolicyRows(params.policies);
+  const scoreRunRows = [
+    ...buildScoreRunRows(params.preview),
+    ...buildScoreRunRows(params.scoreRuns),
+  ].filter(uniqueByScoreRunId);
+  const selectedScoreRun = scoreRunRows[0] ?? null;
+  const reasonCodes = [
+    ...(supportability?.reason_codes ?? []),
+    ...scoreRunRows.flatMap((row) => splitList(row.reasonCodes)),
+  ].filter(uniqueString);
+  const blockedActions = supportability?.blocked_actions ?? [];
+
+  return {
+    state: resolvePanelState(supportabilityState, policyRows.length, scoreRunRows.length, Boolean(primary)),
+    supportabilityState,
+    authority: supportability?.authority ?? "lotus-manage:RFC-0042/PM_OPERATING_QUALITY",
+    policyId: firstNonEmpty(
+      supportability?.policy_id,
+      selectedScoreRun?.policy.split(" / ")[0],
+      policyRows[0]?.policyId,
+    ),
+    policyVersion: firstNonEmpty(
+      supportability?.policy_version,
+      selectedScoreRun?.policy.split(" / ")[1],
+      policyRows[0]?.policyVersion,
+    ),
+    scoreRunId: firstNonEmpty(supportability?.score_run_id, selectedScoreRun?.scoreRunId),
+    count: formatCount(supportability?.count, scoreRunRows.length),
+    reasonCodes,
+    blockedActions,
+    policyRows,
+    scoreRunRows,
+    selectedScoreRun,
+    forbiddenUsePosture: summarizeForbiddenUses(scoreRunRows),
+  };
+}
+
+function buildPolicyRows(
+  response: DpmPmOperatingQualityGatewayResponse | null
+): PmOperatingQualityPolicyRow[] {
+  if (!response) {
+    return [];
+  }
+  const data = asRecord(response.data);
+  const records = extractRecords(data.policies).length
+    ? extractRecords(data.policies)
+    : [data].filter(hasAnyPolicyIdentity);
+  return records.map((record, index) => {
+    const policyId = readString(record, "policy_id") || response.supportability.policy_id || "N/A";
+    const policyVersion =
+      readString(record, "policy_version") || response.supportability.policy_version || "N/A";
+    return {
+      key: `${policyId}-${policyVersion}-${index}`,
+      policyId,
+      policyVersion,
+      enabled: formatBoolean(record.enabled),
+      state:
+        readString(record, "state") ||
+        readString(record, "supportability_state") ||
+        response.supportability.state ||
+        "UNKNOWN",
+      asOfDate: readString(record, "as_of_date") || "N/A",
+      reasonCodes: formatList(record.reason_codes),
+    };
+  });
+}
+
+function buildScoreRunRows(
+  response: DpmPmOperatingQualityGatewayResponse | null | undefined
+): PmOperatingQualityScoreRunRow[] {
+  if (!response) {
+    return [];
+  }
+  const data = asRecord(response.data);
+  const records = extractRecords(data.score_runs).length
+    ? extractRecords(data.score_runs)
+    : [asRecord(data.score_run)].filter(hasAnyScoreRunIdentity);
+  return records.map((record, index) => {
+    const scoreRunId =
+      readString(record, "score_run_id") ||
+      response.supportability.score_run_id ||
+      `score-run-${index + 1}`;
+    const policyId = readString(record, "policy_id") || response.supportability.policy_id || "N/A";
+    const policyVersion =
+      readString(record, "policy_version") || response.supportability.policy_version || "N/A";
+    return {
+      key: `${scoreRunId}-${index}`,
+      scoreRunId,
+      pmId: readString(record, "pm_id") || "N/A",
+      bookId: readString(record, "book_id") || "N/A",
+      policy: `${policyId} / ${policyVersion}`,
+      state:
+        readString(record, "state") ||
+        readString(record, "supportability_state") ||
+        response.supportability.state ||
+        "UNKNOWN",
+      score: readString(record, "score") || readString(record, "overall_score") || "N/A",
+      asOfDate: readString(record, "as_of_date") || readString(record, "created_at") || "N/A",
+      forbiddenUses: formatList(record.forbidden_uses),
+      reasonCodes: formatList(record.reason_codes),
+      contentHash:
+        readString(record, "content_hash") ||
+        readString(record, "score_run_hash") ||
+        readString(record, "payload_hash") ||
+        "N/A",
+    };
+  });
+}
+
+function resolvePanelState(
+  supportabilityState: string,
+  policyCount: number,
+  scoreRunCount: number,
+  hasResponse: boolean,
+): PmOperatingQualityPanelState {
+  const normalized = supportabilityState.toUpperCase();
+  if (!hasResponse) {
+    return "unavailable";
+  }
+  if (normalized.includes("BLOCKED") || normalized.includes("UNSUPPORTED")) {
+    return "blocked";
+  }
+  if (normalized.includes("PARTIAL") || normalized.includes("DEGRADED") || normalized.includes("WATCH")) {
+    return "partial";
+  }
+  if (normalized.includes("EMPTY") || (policyCount === 0 && scoreRunCount === 0)) {
+    return "empty";
+  }
+  return "ready";
+}
+
+function summarizeForbiddenUses(rows: PmOperatingQualityScoreRunRow[]): string {
+  const forbiddenUses = rows.flatMap((row) => splitList(row.forbiddenUses)).filter(uniqueString);
+  return forbiddenUses.length > 0
+    ? forbiddenUses.map((value) => value.replaceAll("_", " ")).join(", ")
+    : "No forbidden-use list returned";
+}
+
+function uniqueByScoreRunId(row: PmOperatingQualityScoreRunRow, index: number, rows: PmOperatingQualityScoreRunRow[]) {
+  return rows.findIndex((candidate) => candidate.scoreRunId === row.scoreRunId) === index;
+}
+
+function uniqueString(value: string, index: number, values: string[]) {
+  return value.length > 0 && values.indexOf(value) === index;
+}
+
+function hasAnyPolicyIdentity(record: Record<string, unknown>) {
+  return Boolean(readString(record, "policy_id") || readString(record, "policy_version"));
+}
+
+function hasAnyScoreRunIdentity(record: Record<string, unknown>) {
+  return Boolean(readString(record, "score_run_id"));
+}
+
+function formatCount(count: number | null | undefined, fallback: number) {
+  if (typeof count === "number" && Number.isFinite(count)) {
+    return String(count);
+  }
+  return String(fallback);
+}
+
+function firstNonEmpty(...values: Array<string | null | undefined>): string {
+  return values.find((value) => value && value.trim().length > 0 && value !== "N/A") ?? "N/A";
+}
+
+function normalizeState(value: string | null | undefined): string {
+  return value?.trim().toUpperCase() || "UNKNOWN";
+}
+
+function formatBoolean(value: unknown): string {
+  if (typeof value === "boolean") {
+    return value ? "Enabled" : "Disabled";
+  }
+  return "N/A";
+}
+
+function formatList(value: unknown): string {
+  const items = extractStringArray(value);
+  return items.length > 0 ? items.join(", ") : "N/A";
+}
+
+function splitList(value: string): string[] {
+  return value === "N/A" ? [] : value.split(",").map((item) => item.trim()).filter(Boolean);
+}
+
+function extractRecords(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => isRecord(item))
+    : [];
+}
+
+function extractStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    : [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return "";
+}

--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -31,6 +31,24 @@ export type PmOperatingQualityScoreRunRow = {
   contentHash: string;
 };
 
+export type PmOperatingQualityFairnessSegmentRequest = {
+  segment_id: string;
+  segment_type: string;
+  display_name: string;
+  score_run_ids: string[];
+  source_refs?: Array<Record<string, unknown>>;
+};
+
+export type PmOperatingQualityFairnessSegmentRow = {
+  key: string;
+  segment: string;
+  segmentType: string;
+  state: string;
+  scoreRunCount: string;
+  averageScore: string;
+  reasonCodes: string;
+};
+
 export type PmOperatingQualityPanelModel = {
   state: PmOperatingQualityPanelState;
   supportabilityState: string;
@@ -38,21 +56,28 @@ export type PmOperatingQualityPanelModel = {
   policyId: string;
   policyVersion: string;
   scoreRunId: string;
+  fairnessAnalysisId: string;
   count: string;
   reasonCodes: string[];
   blockedActions: string[];
   policyRows: PmOperatingQualityPolicyRow[];
   scoreRunRows: PmOperatingQualityScoreRunRow[];
+  fairnessSegmentRequests: PmOperatingQualityFairnessSegmentRequest[];
+  fairnessSegmentRows: PmOperatingQualityFairnessSegmentRow[];
   selectedScoreRun: PmOperatingQualityScoreRunRow | null;
+  fairnessAsOfDate: string;
   forbiddenUsePosture: string;
+  fairnessState: string;
+  fairnessSpread: string;
 };
 
 export function buildPmOperatingQualityPanelModel(params: {
   policies: DpmPmOperatingQualityGatewayResponse | null;
   scoreRuns: DpmPmOperatingQualityGatewayResponse | null;
   preview?: DpmPmOperatingQualityGatewayResponse | null;
+  fairnessPreview?: DpmPmOperatingQualityGatewayResponse | null;
 }): PmOperatingQualityPanelModel {
-  const primary = params.preview ?? params.scoreRuns ?? params.policies;
+  const primary = params.fairnessPreview ?? params.preview ?? params.scoreRuns ?? params.policies;
   const supportability = primary?.supportability;
   const supportabilityState = normalizeState(supportability?.state);
   const policyRows = buildPolicyRows(params.policies);
@@ -60,10 +85,13 @@ export function buildPmOperatingQualityPanelModel(params: {
     ...buildScoreRunRows(params.preview),
     ...buildScoreRunRows(params.scoreRuns),
   ].filter(uniqueByScoreRunId);
+  const fairnessAnalysis = readFairnessAnalysis(params.fairnessPreview);
+  const fairnessSegmentRows = buildFairnessSegmentRows(fairnessAnalysis);
   const selectedScoreRun = scoreRunRows[0] ?? null;
   const reasonCodes = [
     ...(supportability?.reason_codes ?? []),
     ...scoreRunRows.flatMap((row) => splitList(row.reasonCodes)),
+    ...fairnessSegmentRows.flatMap((row) => splitList(row.reasonCodes)),
   ].filter(uniqueString);
   const blockedActions = supportability?.blocked_actions ?? [];
 
@@ -82,13 +110,22 @@ export function buildPmOperatingQualityPanelModel(params: {
       policyRows[0]?.policyVersion,
     ),
     scoreRunId: firstNonEmpty(supportability?.score_run_id, selectedScoreRun?.scoreRunId),
+    fairnessAnalysisId: firstNonEmpty(
+      supportability?.fairness_analysis_id,
+      readString(fairnessAnalysis, "fairness_analysis_id"),
+    ),
     count: formatCount(supportability?.count, scoreRunRows.length),
     reasonCodes,
     blockedActions,
     policyRows,
     scoreRunRows,
+    fairnessSegmentRequests: extractFairnessSegmentRequests(params.scoreRuns),
+    fairnessSegmentRows,
     selectedScoreRun,
+    fairnessAsOfDate: firstNonEmpty(selectedScoreRun?.asOfDate),
     forbiddenUsePosture: summarizeForbiddenUses(scoreRunRows),
+    fairnessState: normalizeState(readString(fairnessAnalysis, "state")),
+    fairnessSpread: readString(fairnessAnalysis, "observed_average_score_spread") || "N/A",
   };
 }
 
@@ -164,6 +201,58 @@ function buildScoreRunRows(
   });
 }
 
+function extractFairnessSegmentRequests(
+  response: DpmPmOperatingQualityGatewayResponse | null
+): PmOperatingQualityFairnessSegmentRequest[] {
+  if (!response) {
+    return [];
+  }
+  const data = asRecord(response.data);
+  const records = [
+    ...extractRecords(data.fairness_segments),
+    ...extractRecords(data.segments),
+    ...extractRecords(asRecord(data.score_run).fairness_segments),
+  ];
+  return records.map((record) => {
+    const sourceRefs = extractRecords(record.source_refs);
+    return {
+      segment_id: readString(record, "segment_id"),
+      segment_type: readString(record, "segment_type"),
+      display_name: readString(record, "display_name"),
+      score_run_ids: extractStringArray(record.score_run_ids),
+      ...(sourceRefs.length > 0 ? { source_refs: sourceRefs } : {}),
+    };
+  }).filter((segment) =>
+    segment.segment_id &&
+    segment.segment_type &&
+    segment.display_name &&
+    segment.score_run_ids.length > 0
+  );
+}
+
+function readFairnessAnalysis(
+  response: DpmPmOperatingQualityGatewayResponse | null | undefined
+): Record<string, unknown> {
+  return asRecord(asRecord(response?.data).fairness_analysis);
+}
+
+function buildFairnessSegmentRows(
+  fairnessAnalysis: Record<string, unknown>
+): PmOperatingQualityFairnessSegmentRow[] {
+  return extractRecords(fairnessAnalysis.segment_results).map((record, index) => {
+    const segmentId = readString(record, "segment_id") || `segment-${index + 1}`;
+    return {
+      key: `${segmentId}-${index}`,
+      segment: readString(record, "display_name") || segmentId,
+      segmentType: readString(record, "segment_type") || "N/A",
+      state: readString(record, "state") || "UNKNOWN",
+      scoreRunCount: readString(record, "score_run_count") || "0",
+      averageScore: readString(record, "average_score") || "N/A",
+      reasonCodes: formatList(record.reason_codes),
+    };
+  });
+}
+
 function resolvePanelState(
   supportabilityState: string,
   policyCount: number,
@@ -177,7 +266,14 @@ function resolvePanelState(
   if (normalized.includes("BLOCKED") || normalized.includes("UNSUPPORTED")) {
     return "blocked";
   }
-  if (normalized.includes("PARTIAL") || normalized.includes("DEGRADED") || normalized.includes("WATCH")) {
+  if (
+    normalized.includes("PARTIAL") ||
+    normalized.includes("DEGRADED") ||
+    normalized.includes("WATCH") ||
+    normalized.includes("PENDING") ||
+    normalized.includes("REVIEW") ||
+    normalized.includes("BREACH")
+  ) {
     return "partial";
   }
   if (normalized.includes("EMPTY") || (policyCount === 0 && scoreRunCount === 0)) {

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1379,6 +1379,27 @@ export type DpmCampaignDefinitionGatewayResponse = {
   data: Record<string, unknown>;
 };
 
+export type DpmPmOperatingQualitySupportability = {
+  source_service: string;
+  authority: string;
+  state: string;
+  reason_codes: string[];
+  blocked_actions: string[];
+  policy_id?: string | null;
+  policy_version?: string | null;
+  score_run_id?: string | null;
+  count?: number | null;
+};
+
+export type DpmPmOperatingQualityGatewayResponse = {
+  correlation_id: string;
+  contract_version: string;
+  source_service: string;
+  upstream_status: number;
+  supportability: DpmPmOperatingQualitySupportability;
+  data: Record<string, unknown>;
+};
+
 export type DpmWaveAiPmMemoResponse = {
   correlation_id: string;
   contract_version: string;

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1388,6 +1388,7 @@ export type DpmPmOperatingQualitySupportability = {
   policy_id?: string | null;
   policy_version?: string | null;
   score_run_id?: string | null;
+  fairness_analysis_id?: string | null;
   count?: number | null;
 };
 

--- a/tests/integration/workbench-page.test.tsx
+++ b/tests/integration/workbench-page.test.tsx
@@ -130,6 +130,35 @@ describe("WorkbenchPage", () => {
     expect(screen.queryByRole("heading", { name: "Post-Trade Outcome Review" })).not.toBeInTheDocument();
   });
 
+  it("renders PM operating quality as a Gateway-backed manage surface", async () => {
+    const fetchMock = vi.fn(createManageFetch({ portfolioId: "PF_2501" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      await WorkbenchPage({
+        params: Promise.resolve({ portfolioId: "PF_2501" }),
+        searchParams: Promise.resolve({ mode: "quality" }),
+      })
+    );
+
+    expect(screen.getAllByRole("heading", { name: "PM Operating Quality" }).length).toBeGreaterThan(0);
+    expect(screen.getByText("Score-Run Evidence")).toBeInTheDocument();
+    expect(screen.getByText("Governance Posture")).toBeInTheDocument();
+    expect(screen.getByLabelText("PM operating quality fairness segments")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeEnabled();
+    expect(screen.queryByText("sha256:pm-quality")).not.toBeInTheDocument();
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        input.toString().includes("/api/v1/dpm/command-center/pm-operating-quality/policies?")
+      )
+    ).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        input.toString().includes("/api/v1/dpm/command-center/pm-operating-quality/score-runs?")
+      )
+    ).toBe(true);
+  });
+
   it("renders wave lifecycle and proof-pack evidence as a dedicated manage surface", async () => {
     const fetchMock = vi.fn(createManageFetch({ portfolioId: "PF_3001" }));
     vi.stubGlobal("fetch", fetchMock);
@@ -446,6 +475,102 @@ function createManageFetch({ portfolioId }: { portfolioId: string }) {
           blocked_actions: [],
         },
         data: { events: [] },
+      });
+    }
+
+    if (url.includes("/api/v1/dpm/command-center/pm-operating-quality/policies?")) {
+      return jsonResponse({
+        correlation_id: "corr_pmq_policy",
+        contract_version: "v1",
+        source_service: "lotus-manage",
+        upstream_status: 200,
+        supportability: {
+          source_service: "lotus-manage",
+          authority: "lotus-manage:RFC-0042/PM_OPERATING_QUALITY",
+          state: "READY",
+          reason_codes: ["PM_QUALITY_POLICY_APPROVED"],
+          blocked_actions: [],
+          policy_id: "pmq_sg_dpm",
+          policy_version: "2026.05",
+          count: 1,
+        },
+        data: {
+          policies: [
+            {
+              policy_id: "pmq_sg_dpm",
+              policy_version: "2026.05",
+              enabled: true,
+              as_of_date: "2026-05-13",
+              state: "READY",
+              reason_codes: ["PM_QUALITY_POLICY_APPROVED"],
+            },
+          ],
+          count: 1,
+        },
+      });
+    }
+
+    if (url.includes("/api/v1/dpm/command-center/pm-operating-quality/score-runs?")) {
+      return jsonResponse({
+        correlation_id: "corr_pmq_scores",
+        contract_version: "v1",
+        source_service: "lotus-manage",
+        upstream_status: 200,
+        supportability: {
+          source_service: "lotus-manage",
+          authority: "lotus-manage:RFC-0042/PM_OPERATING_QUALITY",
+          state: "READY",
+          reason_codes: ["PM_QUALITY_READY"],
+          blocked_actions: [],
+          policy_id: "pmq_sg_dpm",
+          policy_version: "2026.05",
+          count: 2,
+        },
+        data: {
+          score_runs: [
+            {
+              score_run_id: "pmq_run_001",
+              pm_id: "PM_SG_001",
+              book_id: "PM_BOOK_SG_BALANCED",
+              policy_id: "pmq_sg_dpm",
+              policy_version: "2026.05",
+              state: "READY",
+              score: "90.00",
+              content_hash: "sha256:pm-quality",
+              forbidden_uses: ["protected_class_inference", "autonomous_pm_ranking"],
+              reason_codes: ["PM_QUALITY_READY"],
+            },
+            {
+              score_run_id: "pmq_run_002",
+              pm_id: "PM_SG_002",
+              book_id: "PM_BOOK_SG_BALANCED",
+              policy_id: "pmq_sg_dpm",
+              policy_version: "2026.05",
+              state: "READY",
+              score: "59.00",
+              content_hash: "sha256:pm-quality-2",
+              forbidden_uses: ["protected_class_inference", "autonomous_pm_ranking"],
+              reason_codes: ["PM_QUALITY_READY"],
+            },
+          ],
+          fairness_segments: [
+            {
+              segment_id: "mandate_balanced",
+              segment_type: "MANDATE_TYPE",
+              display_name: "Balanced DPM Mandates",
+              score_run_ids: ["pmq_run_001"],
+              source_refs: [{ source_system: "lotus-core", source_type: "MandateTypeSegment", source_id: "balanced" }],
+            },
+            {
+              segment_id: "mandate_income",
+              segment_type: "MANDATE_TYPE",
+              display_name: "Income DPM Mandates",
+              score_run_ids: ["pmq_run_002"],
+              source_refs: [{ source_system: "lotus-core", source_type: "MandateTypeSegment", source_id: "income" }],
+            },
+          ],
+          count: 2,
+        },
       });
     }
 

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -444,6 +444,46 @@ describe("analytics UI observability metrics", () => {
         "wave-operations-handoff-summary",
         "dpm.waves.operations-handoff-summary",
       ],
+      [
+        "workbench.manage",
+        "pm-operating-quality-policy-list",
+        "dpm.pm-operating-quality.policies.list",
+      ],
+      [
+        "workbench.manage",
+        "pm-operating-quality-policy-detail",
+        "dpm.pm-operating-quality.policies.get",
+      ],
+      [
+        "workbench.manage",
+        "pm-operating-quality-policy-upsert",
+        "dpm.pm-operating-quality.policies.put",
+      ],
+      [
+        "workbench.manage",
+        "pm-operating-quality-score-run-list",
+        "dpm.pm-operating-quality.score-runs.list",
+      ],
+      [
+        "workbench.manage",
+        "pm-operating-quality-score-run-detail",
+        "dpm.pm-operating-quality.score-runs.get",
+      ],
+      [
+        "workbench.manage",
+        "pm-operating-quality-score-run-preview",
+        "dpm.pm-operating-quality.score-runs.preview",
+      ],
+      [
+        "workbench.manage",
+        "pm-operating-quality-score-run-create",
+        "dpm.pm-operating-quality.score-runs.create",
+      ],
+      [
+        "workbench.manage",
+        "pm-operating-quality-fairness-preview",
+        "dpm.pm-operating-quality.fairness-analyses.preview",
+      ],
       ["workbench.legacy-advisor", "advisor-overview", "workbench.overview"],
       ["workbench.legacy-advisor", "portfolio-360", "workbench.portfolio-360"],
       ["workbench.legacy-advisor", "portfolio-analytics", "workbench.analytics"],

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import PmOperatingQualityPanel from "../../src/features/workbench/components/pm-operating-quality-panel";
+import {
+  previewDpmPmOperatingQualityFairnessAnalysis,
+  previewDpmPmOperatingQualityScoreRun,
+} from "../../src/features/workbench/api";
+import type { DpmPmOperatingQualityGatewayResponse } from "../../src/features/workbench/types";
+
+vi.mock("../../src/features/workbench/api", () => ({
+  previewDpmPmOperatingQualityFairnessAnalysis: vi.fn(),
+  previewDpmPmOperatingQualityScoreRun: vi.fn(),
+}));
+
+const policies: DpmPmOperatingQualityGatewayResponse = {
+  correlation_id: "corr-policy",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0042/PM_OPERATING_QUALITY",
+    state: "READY",
+    reason_codes: ["PM_QUALITY_POLICY_APPROVED"],
+    blocked_actions: [],
+    policy_id: "pmq_sg_dpm",
+    policy_version: "2026.05",
+    count: 1,
+  },
+  data: {
+    policies: [
+      {
+        policy_id: "pmq_sg_dpm",
+        policy_version: "2026.05",
+        enabled: true,
+        state: "READY",
+        as_of_date: "2026-05-13",
+      },
+    ],
+  },
+};
+
+const scoreRuns: DpmPmOperatingQualityGatewayResponse = {
+  correlation_id: "corr-score",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0042/PM_OPERATING_QUALITY",
+    state: "READY",
+    reason_codes: ["PM_QUALITY_READY"],
+    blocked_actions: [],
+    policy_id: "pmq_sg_dpm",
+    policy_version: "2026.05",
+    count: 2,
+  },
+  data: {
+    score_runs: [
+      {
+        score_run_id: "pmq_run_001",
+        pm_id: "PM_SG_001",
+        book_id: "PM_BOOK_SG_BALANCED",
+        policy_id: "pmq_sg_dpm",
+        policy_version: "2026.05",
+        state: "READY",
+        score: "90.00",
+        as_of_date: "2026-05-13",
+        content_hash: "sha256:pm-quality",
+        reason_codes: ["PM_QUALITY_READY"],
+        forbidden_uses: ["protected_class_inference", "autonomous_pm_ranking"],
+      },
+    ],
+    fairness_segments: [
+      {
+        segment_id: "mandate_balanced",
+        segment_type: "MANDATE_TYPE",
+        display_name: "Balanced DPM Mandates",
+        score_run_ids: ["pmq_run_001"],
+      },
+      {
+        segment_id: "mandate_income",
+        segment_type: "MANDATE_TYPE",
+        display_name: "Income DPM Mandates",
+        score_run_ids: ["pmq_run_002"],
+      },
+    ],
+  },
+};
+
+describe("PmOperatingQualityPanel", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders PM quality evidence without exposing hashes or claiming ranking decisions", () => {
+    render(<PmOperatingQualityPanel policies={policies} scoreRuns={scoreRuns} />);
+
+    expect(screen.getByRole("heading", { name: "PM Operating Quality" })).toBeInTheDocument();
+    expect(screen.getByText("Score-Run Evidence")).toBeInTheDocument();
+    expect(screen.getByText("Governance Posture")).toBeInTheDocument();
+    expect(screen.getByText("Source Segments")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeEnabled();
+    expect(screen.queryByText("sha256:pm-quality")).not.toBeInTheDocument();
+    expect(screen.getByText(/does not rank PMs/i)).toBeInTheDocument();
+  });
+
+  it("previews fairness analysis through Gateway with source-defined segments only", async () => {
+    vi.mocked(previewDpmPmOperatingQualityFairnessAnalysis).mockResolvedValue({
+      ...scoreRuns,
+      supportability: {
+        ...scoreRuns.supportability,
+        state: "PENDING_REVIEW",
+        reason_codes: ["PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED"],
+        fairness_analysis_id: "pmq_fair_001",
+      },
+      data: {
+        fairness_analysis: {
+          fairness_analysis_id: "pmq_fair_001",
+          state: "PENDING_REVIEW",
+          observed_average_score_spread: "31.00",
+          segment_results: [
+            {
+              segment_id: "mandate_balanced",
+              segment_type: "MANDATE_TYPE",
+              display_name: "Balanced DPM Mandates",
+              state: "READY",
+              score_run_count: 1,
+              average_score: "90.00",
+              reason_codes: ["PM_QUALITY_SEGMENT_READY"],
+            },
+          ],
+        },
+      },
+    });
+
+    render(<PmOperatingQualityPanel policies={policies} scoreRuns={scoreRuns} />);
+    fireEvent.click(screen.getByRole("button", { name: "Preview Fairness" }));
+
+    await waitFor(() => {
+      expect(previewDpmPmOperatingQualityFairnessAnalysis).toHaveBeenCalledWith({
+        policyId: "pmq_sg_dpm",
+        policyVersion: "2026.05",
+        asOfDate: "2026-05-13",
+        segments: [
+          {
+            segment_id: "mandate_balanced",
+            segment_type: "MANDATE_TYPE",
+            display_name: "Balanced DPM Mandates",
+            score_run_ids: ["pmq_run_001"],
+          },
+          {
+            segment_id: "mandate_income",
+            segment_type: "MANDATE_TYPE",
+            display_name: "Income DPM Mandates",
+            score_run_ids: ["pmq_run_002"],
+          },
+        ],
+      });
+    });
+    expect(previewDpmPmOperatingQualityScoreRun).not.toHaveBeenCalled();
+    expect(screen.getByText("Fairness preview returned Manage segment evidence.")).toBeInTheDocument();
+    expect(screen.getByText("31.00")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPmOperatingQualityPanelModel } from "../../src/features/workbench/pm-operating-quality-view-model";
+import type { DpmPmOperatingQualityGatewayResponse } from "../../src/features/workbench/types";
+
+const policies: DpmPmOperatingQualityGatewayResponse = {
+  correlation_id: "corr-policy",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0042/PM_OPERATING_QUALITY",
+    state: "READY",
+    reason_codes: ["PM_QUALITY_POLICY_APPROVED"],
+    blocked_actions: [],
+    policy_id: "pmq_sg_dpm",
+    policy_version: "2026.05",
+    count: 1,
+  },
+  data: {
+    policies: [
+      {
+        policy_id: "pmq_sg_dpm",
+        policy_version: "2026.05",
+        enabled: true,
+        state: "READY",
+        as_of_date: "2026-05-13",
+        reason_codes: ["PM_QUALITY_POLICY_APPROVED"],
+      },
+    ],
+  },
+};
+
+const scoreRuns: DpmPmOperatingQualityGatewayResponse = {
+  correlation_id: "corr-score",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0042/PM_OPERATING_QUALITY",
+    state: "READY",
+    reason_codes: ["PM_QUALITY_READY"],
+    blocked_actions: [],
+    policy_id: "pmq_sg_dpm",
+    policy_version: "2026.05",
+    count: 2,
+  },
+  data: {
+    score_runs: [
+      {
+        score_run_id: "pmq_run_001",
+        pm_id: "PM_SG_001",
+        book_id: "PM_BOOK_SG_BALANCED",
+        policy_id: "pmq_sg_dpm",
+        policy_version: "2026.05",
+        state: "READY",
+        score: "90.00",
+        reason_codes: ["PM_QUALITY_READY"],
+        forbidden_uses: ["protected_class_inference", "autonomous_pm_ranking"],
+      },
+    ],
+    fairness_segments: [
+      {
+        segment_id: "mandate_balanced",
+        segment_type: "MANDATE_TYPE",
+        display_name: "Balanced DPM Mandates",
+        score_run_ids: ["pmq_run_001"],
+        source_refs: [{ source_system: "lotus-core", source_type: "MandateTypeSegment" }],
+      },
+      {
+        segment_id: "mandate_income",
+        segment_type: "MANDATE_TYPE",
+        display_name: "Income DPM Mandates",
+        score_run_ids: ["pmq_run_002"],
+      },
+    ],
+  },
+};
+
+const fairnessPreview: DpmPmOperatingQualityGatewayResponse = {
+  correlation_id: "corr-fairness",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0042/PM_OPERATING_QUALITY",
+    state: "PENDING_REVIEW",
+    reason_codes: ["PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED"],
+    blocked_actions: ["CREATE_SCORE_RUN"],
+    policy_id: "pmq_sg_dpm",
+    policy_version: "2026.05",
+    fairness_analysis_id: "pmq_fair_001",
+  },
+  data: {
+    fairness_analysis: {
+      fairness_analysis_id: "pmq_fair_001",
+      state: "PENDING_REVIEW",
+      observed_average_score_spread: "31.00",
+      segment_results: [
+        {
+          segment_id: "mandate_balanced",
+          segment_type: "MANDATE_TYPE",
+          display_name: "Balanced DPM Mandates",
+          state: "READY",
+          score_run_count: 2,
+          average_score: "90.00",
+          reason_codes: ["PM_QUALITY_SEGMENT_READY"],
+        },
+        {
+          segment_id: "mandate_income",
+          segment_type: "MANDATE_TYPE",
+          display_name: "Income DPM Mandates",
+          state: "REVIEW_REQUIRED",
+          score_run_count: 2,
+          average_score: "59.00",
+          reason_codes: ["PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED"],
+        },
+      ],
+    },
+  },
+};
+
+describe("PM operating quality view model", () => {
+  it("preserves Manage PM quality policy, score-run, and source-defined segment posture", () => {
+    const model = buildPmOperatingQualityPanelModel({ policies, scoreRuns });
+
+    expect(model.state).toBe("ready");
+    expect(model.policyId).toBe("pmq_sg_dpm");
+    expect(model.policyRows).toHaveLength(1);
+    expect(model.scoreRunRows).toHaveLength(1);
+    expect(model.scoreRunRows[0].score).toBe("90.00");
+    expect(model.fairnessSegmentRequests.map((segment) => segment.segment_id)).toEqual([
+      "mandate_balanced",
+      "mandate_income",
+    ]);
+    expect(model.forbiddenUsePosture).toContain("protected class inference");
+  });
+
+  it("renders fairness preview as review-required evidence without client-side analysis", () => {
+    const model = buildPmOperatingQualityPanelModel({
+      policies,
+      scoreRuns,
+      fairnessPreview,
+    });
+
+    expect(model.state).toBe("partial");
+    expect(model.supportabilityState).toBe("PENDING_REVIEW");
+    expect(model.fairnessAnalysisId).toBe("pmq_fair_001");
+    expect(model.fairnessState).toBe("PENDING_REVIEW");
+    expect(model.fairnessSpread).toBe("31.00");
+    expect(model.blockedActions).toEqual(["CREATE_SCORE_RUN"]);
+    expect(model.fairnessSegmentRows.map((row) => row.segment)).toEqual([
+      "Balanced DPM Mandates",
+      "Income DPM Mandates",
+    ]);
+    expect(model.reasonCodes).toContain("PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED");
+  });
+});

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -17,6 +17,8 @@ import {
   getDpmOutcomeReviewReportInput,
   getDpmOutcomeReviews,
   getDpmPortfolioMemory,
+  listDpmPmOperatingQualityPolicies,
+  listDpmPmOperatingQualityScoreRuns,
   getDpmConstructionAlternativeSet,
   getDpmProofPack,
   getDpmProofPackAiEvidenceInput,
@@ -31,6 +33,8 @@ import {
   listDpmCampaignDefinitions,
   listDpmWaves,
   previewDpmWave,
+  previewDpmPmOperatingQualityFairnessAnalysis,
+  previewDpmPmOperatingQualityScoreRun,
   requestDpmExceptionSummary,
   requestDpmOperationsHandoffSummary,
   requestDpmOutcomeReviewAiNarrative,
@@ -2626,6 +2630,85 @@ describe("workbench api", () => {
     expect(metricEventsJson).toContain("construction-selection");
     expect(metricEventsJson).not.toContain("cas_1");
     expect(metricEventsJson).not.toContain("alt_1");
+  });
+
+  it("uses Gateway PM operating quality routes including fairness preview", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr-pmq",
+            contract_version: "v1",
+            source_service: "lotus-manage",
+            upstream_status: 200,
+            supportability: {
+              source_service: "lotus-manage",
+              authority: "lotus-manage:RFC-0042/PM_OPERATING_QUALITY",
+              state: "READY",
+              reason_codes: ["PM_QUALITY_READY"],
+              blocked_actions: [],
+              policy_id: "pmq_sg_dpm",
+              policy_version: "2026.05",
+              score_run_id: "pmq_run_001",
+              fairness_analysis_id: "pmq_fair_001",
+            },
+            data: { ok: true },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await listDpmPmOperatingQualityPolicies({ policyId: "pmq_sg_dpm", limit: 3 });
+    await listDpmPmOperatingQualityScoreRuns({ bookId: "BOOK_SG_BALANCED_DPM", limit: 4 });
+    await previewDpmPmOperatingQualityScoreRun({
+      pmId: "PM_SG_DPM_001",
+      policyId: "pmq_sg_dpm",
+      policyVersion: "2026.05",
+    });
+    await previewDpmPmOperatingQualityFairnessAnalysis({
+      policyId: "pmq_sg_dpm",
+      policyVersion: "2026.05",
+      segments: [
+        {
+          segment_id: "mandate_balanced",
+          segment_type: "MANDATE_TYPE",
+          display_name: "Balanced DPM Mandates",
+          score_run_ids: ["pmq_run_001"],
+        },
+        {
+          segment_id: "mandate_income",
+          segment_type: "MANDATE_TYPE",
+          display_name: "Income DPM Mandates",
+          score_run_ids: ["pmq_run_002"],
+        },
+      ],
+    });
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock.mock.calls[0][0].toString()).toContain(
+      "/dpm/command-center/pm-operating-quality/policies?limit=3&offset=0&policy_id=pmq_sg_dpm"
+    );
+    expect(fetchMock.mock.calls[1][0].toString()).toContain(
+      "/dpm/command-center/pm-operating-quality/score-runs?book_id=BOOK_SG_BALANCED_DPM"
+    );
+    expect(fetchMock.mock.calls[2][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/pm-operating-quality/score-runs/preview`
+    );
+    expect(fetchMock.mock.calls[3][0]).toBe(
+      `${expectedBaseUrl}/dpm/command-center/pm-operating-quality/fairness-analyses/preview`
+    );
+    expect(fetchMock.mock.calls[3][1].headers["X-Caller-Application"]).toBe("lotus-workbench");
+    const fairnessBody = JSON.parse(fetchMock.mock.calls[3][1].body);
+    expect(fairnessBody.body.policy_id).toBe("pmq_sg_dpm");
+    expect(fairnessBody.body.segments).toHaveLength(2);
+    expect(fairnessBody.body.minimum_segment_score_run_count).toBeUndefined();
+    expect(fairnessBody.body.maximum_average_score_spread).toBeUndefined();
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("pm-operating-quality-fairness-preview");
+    expect(metricEventsJson).not.toContain("pmq_run_001");
+    expect(metricEventsJson).not.toContain("pmq_fair_001");
   });
 
   it("generates and loads DPM proof packs through Gateway endpoints", async () => {

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -101,6 +101,12 @@ must travel through Gateway-shaped contracts.
     reach Workbench through Gateway portfolio-memory composition only.
     RFC-0043 monitoring-exception summary execution remains `lotus-ai` owned and must reach
     Workbench through Gateway exception-summary composition only.
+    PM operating quality policies, score runs, score-run preview/create, and fairness-analysis
+    preview are manage-owned and must reach Workbench through Gateway
+    `/api/v1/dpm/command-center/pm-operating-quality*` only. Workbench renders source-defined
+    segment and fairness posture but does not discover segments, calculate PM scores, segment
+    averages, or governed spreads, infer protected classes, rank PMs, create HR/compensation/
+    conduct decisions, approve trades, contact clients, route orders, or claim OMS/execution truth.
     The implemented Workbench construction panel consumes the Gateway construction alternative-set
     contracts, the implemented wave command-center panel consumes Gateway wave list, preview,
     create, detail, item, source-check, simulation, approval, staging, handoff, proof-posture,
@@ -111,7 +117,9 @@ must travel through Gateway-shaped contracts.
     implemented outcome panel consumes the Gateway outcome-review list and AI-narrative contracts.
     The implemented command-center exception queue consumes the Gateway exception-summary contract.
     The implemented portfolio-memory panel consumes the Gateway portfolio-memory contract and
-    preserves manage event order without reconstructing timeline nodes.
+    preserves manage event order without reconstructing timeline nodes, and the implemented PM
+    operating quality panel consumes Gateway policy, score-run, and fairness-analysis preview
+    contracts when Manage/Gateway expose source-defined segment assignments.
     Workbench must not calculate expected-versus-realized values. It must not rebuild proof-pack
     sections, compute proof-pack hashes, construct prompts, infer PM quality, calculate wave
     readiness, construct report input, generate memo or exception-summary narrative locally, reconstruct


### PR DESCRIPTION
## Summary
- Adds a Gateway-backed `mode=quality` PM Operating Quality surface in the Manage workspace.
- Consumes Gateway PM quality policy/score-run endpoints and fairness-analysis preview only through the Workbench BFF.
- Renders Manage-owned policy, score-run, source-defined segment, fairness preview, reason-code, blocked-action, and forbidden-use posture without browser-side score calculation, segment discovery, spread calculation, protected-class inference, PM ranking, HR/compensation/conduct decisions, trade approval, client contact, order routing, or execution claims.
- Updates Workbench observability and repo/wiki integration truth.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test -- --run tests/unit/pm-operating-quality-view-model.test.ts tests/unit/pm-operating-quality-panel.test.tsx tests/unit/workbench-api.test.ts tests/integration/workbench-page.test.tsx`

## Dependency / Truth Note
- This PR is draft until the Gateway BFF route and corresponding `lotus-manage` fairness-analysis preview endpoint are merged or available in the target integration environment.
