### PR TITLE
feat(workbench): uplift PM quality review surface

### DIFF
--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -148,7 +148,7 @@ export default function PmOperatingQualityPanel({
       subtitle="Gateway-backed supervisory evidence for Manage-owned PM policy and score-run posture."
       className="pm-operating-quality-panel"
       actions={
-        <div className="portfolio-memory-badge-row">
+        <div className="pm-quality-badge-row">
           <SemanticBadge tone={toneForState(model.supportabilityState)}>
             {businessStateLabel(model.supportabilityState)}
           </SemanticBadge>
@@ -170,7 +170,7 @@ export default function PmOperatingQualityPanel({
         />
       ) : null}
 
-      <div className="portfolio-memory-status-strip">
+      <div className="pm-quality-status-strip">
         <MetricRow label="Policy" value={`${model.policyId} / ${model.policyVersion}`} />
         <MetricRow label="Latest Score Run" value={model.scoreRunId} />
         <MetricRow label="Fairness Preview" value={model.fairnessAnalysisId} />
@@ -178,7 +178,7 @@ export default function PmOperatingQualityPanel({
         <MetricRow label="Authority" value={model.authority} />
       </div>
 
-      <div className="portfolio-memory-reason-row">
+      <div className="pm-quality-reason-row">
         {model.reasonCodes.length > 0 ? (
           model.reasonCodes.map((reason) => (
             <SemanticBadge key={reason} tone={toneForState(reason)}>
@@ -190,30 +190,32 @@ export default function PmOperatingQualityPanel({
         )}
       </div>
 
-      <div className="portfolio-memory-workspace">
-        <div className="portfolio-memory-timeline-card">
-          <div className="portfolio-memory-card-header">
+      <div className="pm-quality-workspace">
+        <div className="pm-quality-primary-card">
+          <div className="pm-quality-card-header">
             <Text as="h3" variant="subsectionTitle">
               Score-Run Evidence
             </Text>
-            <ActionButton
-              priority="secondary"
-              onClick={previewScoreRun}
-              disabled={pendingAction || model.blockedActions.includes("PREVIEW_SCORE_RUN")}
-            >
-              {pendingAction ? "Previewing" : "Preview"}
-            </ActionButton>
-            <ActionButton
-              priority="secondary"
-              onClick={previewFairnessAnalysis}
-              disabled={
-                pendingFairnessAction ||
-                model.blockedActions.includes("PREVIEW_FAIRNESS_ANALYSIS") ||
-                model.fairnessSegmentRequests.length < 2
-              }
-            >
-              {pendingFairnessAction ? "Checking" : "Preview Fairness"}
-            </ActionButton>
+            <div className="pm-quality-action-row">
+              <ActionButton
+                priority="secondary"
+                onClick={previewScoreRun}
+                disabled={pendingAction || model.blockedActions.includes("PREVIEW_SCORE_RUN")}
+              >
+                {pendingAction ? "Previewing" : "Preview Score Run"}
+              </ActionButton>
+              <ActionButton
+                priority="primary"
+                onClick={previewFairnessAnalysis}
+                disabled={
+                  pendingFairnessAction ||
+                  model.blockedActions.includes("PREVIEW_FAIRNESS_ANALYSIS") ||
+                  model.fairnessSegmentRequests.length < 2
+                }
+              >
+                {pendingFairnessAction ? "Checking" : "Preview Fairness"}
+              </ActionButton>
+            </div>
           </div>
           {actionMessage ? <Text variant="secondary">{actionMessage}</Text> : null}
           <AnalyticsTable
@@ -248,11 +250,11 @@ export default function PmOperatingQualityPanel({
           />
         </div>
 
-        <aside className="portfolio-memory-actions-card">
+        <aside className="pm-quality-governance-card">
           <Text as="h3" variant="subsectionTitle">
             Governance Posture
           </Text>
-          <div className="portfolio-memory-action-stack">
+          <div className="pm-quality-governance-stack">
             <MetricRow label="Forbidden Uses" value={model.forbiddenUsePosture} />
             <MetricRow label="Source Segments" value={String(model.fairnessSegmentRequests.length)} />
             <MetricRow label="Fairness Spread" value={model.fairnessSpread} />
@@ -269,6 +271,32 @@ export default function PmOperatingQualityPanel({
         </aside>
       </div>
 
+      <div className="pm-quality-evidence-grid">
+        <AnalyticsTable
+          ariaLabel="PM operating quality source segments"
+          variant="analysis"
+          density="compact"
+          columns={[
+            { key: "segment", label: "Source Segment" },
+            { key: "type", label: "Type" },
+            { key: "count", label: "Score Runs" },
+            { key: "source", label: "Source Refs" },
+          ]}
+          rows={model.sourceSegmentRows.map((row) => ({
+            key: row.key,
+            cells: [
+              <strong key={`${row.key}-segment`}>{row.segment}</strong>,
+              row.segmentType,
+              row.scoreRunCount,
+              row.sourceRefs,
+            ],
+          }))}
+          emptyState={{
+            title: "No source-defined segments returned",
+            body: "Workbench waits for Manage/Gateway segment assignments before enabling fairness review.",
+          }}
+        />
+
       <AnalyticsTable
         ariaLabel="PM operating quality fairness segments"
         variant="analysis"
@@ -279,6 +307,7 @@ export default function PmOperatingQualityPanel({
           { key: "state", label: "State" },
           { key: "count", label: "Score Runs" },
           { key: "average", label: "Average Score" },
+          { key: "source", label: "Source Refs" },
           { key: "reason", label: "Reason" },
         ]}
         rows={model.fairnessSegmentRows.map((row) => ({
@@ -291,6 +320,7 @@ export default function PmOperatingQualityPanel({
             </SemanticBadge>,
             row.scoreRunCount,
             row.averageScore,
+            row.sourceRefs,
             row.reasonCodes,
           ],
         }))}
@@ -302,6 +332,7 @@ export default function PmOperatingQualityPanel({
               : "Manage has not returned source-defined segment assignments for a fairness preview.",
         }}
       />
+      </div>
 
       <AnalyticsTable
         ariaLabel="PM operating quality policies"

--- a/src/features/workbench/manage-workspace.module.css
+++ b/src/features/workbench/manage-workspace.module.css
@@ -1003,6 +1003,7 @@
 .manageScope :global(.dpm-command-center-panel),
 .manageScope :global(.dpm-wave-command-center-panel),
 .manageScope :global(.portfolio-memory-panel),
+.manageScope :global(.pm-operating-quality-panel),
 .manageScope :global(.construction-alternatives-panel),
 .manageScope :global(.outcome-review-panel),
 .manageScope :global(.proof-pack-panel),
@@ -1027,6 +1028,176 @@
   border-bottom: 1px solid #c6c6cd;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(247, 249, 251, 0.92));
+}
+
+.manageScope :global(.pm-operating-quality-panel > .section-block-header) {
+  margin: -18px -18px 0;
+  padding: 18px;
+  border-bottom: 1px solid #c6c6cd;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(247, 249, 251, 0.92));
+}
+
+.manageScope :global(.pm-operating-quality-panel > .section-block-header h2) {
+  font-size: 20px;
+  line-height: 26px;
+  letter-spacing: 0;
+}
+
+.manageScope :global(.pm-quality-badge-row),
+.manageScope :global(.pm-quality-reason-row) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.manageScope :global(.pm-quality-status-strip) {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0;
+  overflow: hidden;
+  margin-top: 12px;
+  border: 1px solid #c6c6cd;
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.manageScope :global(.pm-quality-status-strip .suite-row) {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  min-height: 96px;
+  padding: 14px 16px;
+  border-top: 0;
+  border-right: 1px solid #e0e3e5;
+}
+
+.manageScope :global(.pm-quality-status-strip .suite-row:last-child) {
+  border-right: 0;
+}
+
+.manageScope :global(.pm-quality-status-strip .suite-row span) {
+  color: #45464d;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.pm-quality-status-strip .suite-row strong) {
+  color: #131b2e;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 19px;
+  overflow-wrap: anywhere;
+}
+
+.manageScope :global(.pm-quality-reason-row) {
+  margin-top: 10px;
+}
+
+.manageScope :global(.pm-quality-workspace) {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(270px, 340px);
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.manageScope :global(.pm-quality-primary-card),
+.manageScope :global(.pm-quality-governance-card) {
+  overflow: hidden;
+  border: 1px solid #c6c6cd;
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.manageScope :global(.pm-quality-card-header) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 50px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #c6c6cd;
+  background: #f7f9fb;
+}
+
+.manageScope :global(.pm-quality-card-header span) {
+  color: #725b26;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  line-height: 16px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.pm-quality-action-row) {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.manageScope :global(.pm-quality-primary-card .analytics-table-frame),
+.manageScope :global(.pm-operating-quality-panel .analytics-table-frame) {
+  border-color: #c6c6cd;
+  box-shadow: 0 1px 2px rgba(19, 27, 46, 0.03);
+}
+
+.manageScope :global(.pm-quality-primary-card .analytics-table-frame) {
+  margin-top: 0;
+  border-width: 0;
+  border-radius: 0;
+}
+
+.manageScope :global(.pm-operating-quality-panel .analytics-table-frame table) {
+  min-width: 780px;
+}
+
+.manageScope :global(.pm-quality-governance-card) {
+  display: grid;
+  align-content: start;
+  gap: 12px;
+  padding: 16px;
+}
+
+.manageScope :global(.pm-quality-governance-stack) {
+  display: grid;
+  gap: 10px;
+}
+
+.manageScope :global(.pm-quality-governance-stack .suite-row) {
+  min-height: 58px;
+  padding: 10px 0;
+  border-top: 1px solid #e0e3e5;
+}
+
+.manageScope :global(.pm-quality-governance-stack .suite-row:first-child) {
+  border-top: 0;
+}
+
+.manageScope :global(.pm-quality-governance-stack .suite-row span) {
+  color: #45464d;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.pm-quality-governance-stack .suite-row strong) {
+  color: #131b2e;
+  font-size: 13px;
+  line-height: 18px;
+  overflow-wrap: anywhere;
+}
+
+.manageScope :global(.pm-quality-evidence-grid) {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+  gap: 12px;
+  margin-top: 14px;
 }
 
 .manageScope :global(.portfolio-memory-panel > .section-block-header h2) {
@@ -3058,6 +3229,9 @@
   .manageScope :global(.portfolio-memory-status-strip),
   .manageScope :global(.portfolio-memory-workspace),
   .manageScope :global(.portfolio-memory-detail-grid),
+  .manageScope :global(.pm-quality-status-strip),
+  .manageScope :global(.pm-quality-workspace),
+  .manageScope :global(.pm-quality-evidence-grid),
   .manageScope :global(.construction-alternatives-summary),
   .manageScope :global(.construction-alternatives-grid),
   .manageScope :global(.construction-alternatives-detail-grid) {

--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -39,6 +39,14 @@ export type PmOperatingQualityFairnessSegmentRequest = {
   source_refs?: Array<Record<string, unknown>>;
 };
 
+export type PmOperatingQualitySourceSegmentRow = {
+  key: string;
+  segment: string;
+  segmentType: string;
+  scoreRunCount: string;
+  sourceRefs: string;
+};
+
 export type PmOperatingQualityFairnessSegmentRow = {
   key: string;
   segment: string;
@@ -46,6 +54,7 @@ export type PmOperatingQualityFairnessSegmentRow = {
   state: string;
   scoreRunCount: string;
   averageScore: string;
+  sourceRefs: string;
   reasonCodes: string;
 };
 
@@ -63,6 +72,7 @@ export type PmOperatingQualityPanelModel = {
   policyRows: PmOperatingQualityPolicyRow[];
   scoreRunRows: PmOperatingQualityScoreRunRow[];
   fairnessSegmentRequests: PmOperatingQualityFairnessSegmentRequest[];
+  sourceSegmentRows: PmOperatingQualitySourceSegmentRow[];
   fairnessSegmentRows: PmOperatingQualityFairnessSegmentRow[];
   selectedScoreRun: PmOperatingQualityScoreRunRow | null;
   fairnessAsOfDate: string;
@@ -87,6 +97,7 @@ export function buildPmOperatingQualityPanelModel(params: {
   ].filter(uniqueByScoreRunId);
   const fairnessAnalysis = readFairnessAnalysis(params.fairnessPreview);
   const fairnessSegmentRows = buildFairnessSegmentRows(fairnessAnalysis);
+  const fairnessSegmentRequests = extractFairnessSegmentRequests(params.scoreRuns);
   const selectedScoreRun = scoreRunRows[0] ?? null;
   const reasonCodes = [
     ...(supportability?.reason_codes ?? []),
@@ -119,7 +130,8 @@ export function buildPmOperatingQualityPanelModel(params: {
     blockedActions,
     policyRows,
     scoreRunRows,
-    fairnessSegmentRequests: extractFairnessSegmentRequests(params.scoreRuns),
+    fairnessSegmentRequests,
+    sourceSegmentRows: buildSourceSegmentRows(fairnessSegmentRequests),
     fairnessSegmentRows,
     selectedScoreRun,
     fairnessAsOfDate: firstNonEmpty(selectedScoreRun?.asOfDate),
@@ -201,6 +213,18 @@ function buildScoreRunRows(
   });
 }
 
+function buildSourceSegmentRows(
+  segments: PmOperatingQualityFairnessSegmentRequest[]
+): PmOperatingQualitySourceSegmentRow[] {
+  return segments.map((segment, index) => ({
+    key: `${segment.segment_id}-${index}`,
+    segment: segment.display_name || segment.segment_id,
+    segmentType: segment.segment_type,
+    scoreRunCount: String(segment.score_run_ids.length),
+    sourceRefs: summarizeSourceRefs(segment.source_refs ?? []),
+  }));
+}
+
 function extractFairnessSegmentRequests(
   response: DpmPmOperatingQualityGatewayResponse | null
 ): PmOperatingQualityFairnessSegmentRequest[] {
@@ -248,6 +272,7 @@ function buildFairnessSegmentRows(
       state: readString(record, "state") || "UNKNOWN",
       scoreRunCount: readString(record, "score_run_count") || "0",
       averageScore: readString(record, "average_score") || "N/A",
+      sourceRefs: summarizeSourceRefs(extractRecords(record.source_refs)),
       reasonCodes: formatList(record.reason_codes),
     };
   });
@@ -330,6 +355,28 @@ function formatBoolean(value: unknown): string {
 function formatList(value: unknown): string {
   const items = extractStringArray(value);
   return items.length > 0 ? items.join(", ") : "N/A";
+}
+
+function summarizeSourceRefs(refs: Array<Record<string, unknown>>): string {
+  if (refs.length === 0) {
+    return "N/A";
+  }
+  return refs
+    .map((ref) =>
+      firstNonEmpty(
+        readString(ref, "source_ref"),
+        [
+          readString(ref, "source_system"),
+          readString(ref, "source_product") || readString(ref, "source_type"),
+          readString(ref, "source_id"),
+        ]
+          .filter(Boolean)
+          .join(":"),
+        readString(ref, "source_type")
+      )
+    )
+    .filter((value) => value !== "N/A")
+    .join(", ") || "N/A";
 }
 
 function splitList(value: string): string[] {

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -78,6 +78,13 @@ const scoreRuns: DpmPmOperatingQualityGatewayResponse = {
         segment_type: "MANDATE_TYPE",
         display_name: "Balanced DPM Mandates",
         score_run_ids: ["pmq_run_001"],
+        source_refs: [
+          {
+            source_system: "lotus-core",
+            source_type: "MandateTypeSegment",
+            source_id: "balanced",
+          },
+        ],
       },
       {
         segment_id: "mandate_income",
@@ -101,6 +108,8 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getByText("Score-Run Evidence")).toBeInTheDocument();
     expect(screen.getByText("Governance Posture")).toBeInTheDocument();
     expect(screen.getByText("Source Segments")).toBeInTheDocument();
+    expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();
+    expect(screen.getByText("lotus-core:MandateTypeSegment:balanced")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeEnabled();
     expect(screen.queryByText("sha256:pm-quality")).not.toBeInTheDocument();
     expect(screen.getByText(/does not rank PMs/i)).toBeInTheDocument();
@@ -144,12 +153,19 @@ describe("PmOperatingQualityPanel", () => {
         policyVersion: "2026.05",
         asOfDate: "2026-05-13",
         segments: [
-          {
-            segment_id: "mandate_balanced",
-            segment_type: "MANDATE_TYPE",
-            display_name: "Balanced DPM Mandates",
-            score_run_ids: ["pmq_run_001"],
-          },
+            {
+              segment_id: "mandate_balanced",
+              segment_type: "MANDATE_TYPE",
+              display_name: "Balanced DPM Mandates",
+              score_run_ids: ["pmq_run_001"],
+              source_refs: [
+                {
+                  source_system: "lotus-core",
+                  source_type: "MandateTypeSegment",
+                  source_id: "balanced",
+                },
+              ],
+            },
           {
             segment_id: "mandate_income",
             segment_type: "MANDATE_TYPE",

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -107,6 +107,13 @@ const fairnessPreview: DpmPmOperatingQualityGatewayResponse = {
           state: "READY",
           score_run_count: 2,
           average_score: "90.00",
+          source_refs: [
+            {
+              source_system: "lotus-manage",
+              source_product: "PmOperatingQualityScoreRun",
+              source_id: "pmq_run_001",
+            },
+          ],
           reason_codes: ["PM_QUALITY_SEGMENT_READY"],
         },
         {
@@ -136,6 +143,12 @@ describe("PM operating quality view model", () => {
       "mandate_balanced",
       "mandate_income",
     ]);
+    expect(model.sourceSegmentRows[0]).toEqual(
+      expect.objectContaining({
+        segment: "Balanced DPM Mandates",
+        sourceRefs: "lotus-core:MandateTypeSegment",
+      })
+    );
     expect(model.forbiddenUsePosture).toContain("protected class inference");
   });
 
@@ -156,6 +169,9 @@ describe("PM operating quality view model", () => {
       "Balanced DPM Mandates",
       "Income DPM Mandates",
     ]);
+    expect(model.fairnessSegmentRows[0].sourceRefs).toBe(
+      "lotus-manage:PmOperatingQualityScoreRun:pmq_run_001"
+    );
     expect(model.reasonCodes).toContain("PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED");
   });
 });


### PR DESCRIPTION
## Summary
- Gives the PM Operating Quality Manage mode its own governance/evidence layout instead of reusing portfolio-memory classes.
- Adds a source-defined segment table before fairness preview, preserving Gateway/Manage source refs without browser-side segment discovery.
- Shows fairness-analysis source refs when Manage returns them and keeps forbidden-use/non-ranking boundaries visible.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test -- --run tests/unit/pm-operating-quality-view-model.test.ts tests/unit/pm-operating-quality-panel.test.tsx tests/integration/workbench-page.test.tsx`
- `git diff --check`

## Notes
- No Stitch design was needed for this first uplift; the layout follows the merged Gateway/Manage contract and existing Workbench manage-surface density.
