### PR TITLE
feat(workbench): clarify PM fairness preview readiness

### DIFF
--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -114,7 +114,11 @@ export default function PmOperatingQualityPanel({
   }
 
   async function previewFairnessAnalysis() {
-    if (pendingFairnessAction || model.fairnessSegmentRequests.length < 2) {
+    if (pendingFairnessAction) {
+      return;
+    }
+    if (model.fairnessPreviewReadinessState !== "READY") {
+      setActionError(model.fairnessPreviewReadiness);
       return;
     }
     if (model.policyId === "N/A" || model.policyVersion === "N/A") {
@@ -209,8 +213,7 @@ export default function PmOperatingQualityPanel({
                 onClick={previewFairnessAnalysis}
                 disabled={
                   pendingFairnessAction ||
-                  model.blockedActions.includes("PREVIEW_FAIRNESS_ANALYSIS") ||
-                  model.fairnessSegmentRequests.length < 2
+                  model.fairnessPreviewReadinessState !== "READY"
                 }
               >
                 {pendingFairnessAction ? "Checking" : "Preview Fairness"}
@@ -256,6 +259,7 @@ export default function PmOperatingQualityPanel({
           </Text>
           <div className="pm-quality-governance-stack">
             <MetricRow label="Forbidden Uses" value={model.forbiddenUsePosture} />
+            <MetricRow label="Preview Readiness" value={model.fairnessPreviewReadiness} />
             <MetricRow label="Source Segments" value={String(model.fairnessSegmentRequests.length)} />
             <MetricRow label="Fairness Spread" value={model.fairnessSpread} />
             <MetricRow

--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -96,6 +96,8 @@ export type PmOperatingQualityPanelModel = {
   fairnessState: string;
   fairnessSpread: string;
   fairnessDetail: PmOperatingQualityFairnessDetail;
+  fairnessPreviewReadinessState: string;
+  fairnessPreviewReadiness: string;
 };
 
 export function buildPmOperatingQualityPanelModel(params: {
@@ -122,21 +124,29 @@ export function buildPmOperatingQualityPanelModel(params: {
     ...fairnessSegmentRows.flatMap((row) => splitList(row.reasonCodes)),
   ].filter(uniqueString);
   const blockedActions = supportability?.blocked_actions ?? [];
+  const policyId = firstNonEmpty(
+    supportability?.policy_id,
+    selectedScoreRun?.policy.split(" / ")[0],
+    policyRows[0]?.policyId,
+  );
+  const policyVersion = firstNonEmpty(
+    supportability?.policy_version,
+    selectedScoreRun?.policy.split(" / ")[1],
+    policyRows[0]?.policyVersion,
+  );
+  const fairnessPreviewReadiness = resolveFairnessPreviewReadiness({
+    policyId,
+    policyVersion,
+    segmentCount: fairnessSegmentRequests.length,
+    blockedActions,
+  });
 
   return {
     state: resolvePanelState(supportabilityState, policyRows.length, scoreRunRows.length, Boolean(primary)),
     supportabilityState,
     authority: supportability?.authority ?? "lotus-manage:RFC-0042/PM_OPERATING_QUALITY",
-    policyId: firstNonEmpty(
-      supportability?.policy_id,
-      selectedScoreRun?.policy.split(" / ")[0],
-      policyRows[0]?.policyId,
-    ),
-    policyVersion: firstNonEmpty(
-      supportability?.policy_version,
-      selectedScoreRun?.policy.split(" / ")[1],
-      policyRows[0]?.policyVersion,
-    ),
+    policyId,
+    policyVersion,
     scoreRunId: firstNonEmpty(supportability?.score_run_id, selectedScoreRun?.scoreRunId),
     fairnessAnalysisId: firstNonEmpty(
       supportability?.fairness_analysis_id,
@@ -156,6 +166,8 @@ export function buildPmOperatingQualityPanelModel(params: {
     fairnessState: normalizeState(readString(fairnessAnalysis, "state")),
     fairnessSpread: readString(fairnessAnalysis, "observed_average_score_spread") || "N/A",
     fairnessDetail: buildFairnessDetail(fairnessAnalysis),
+    fairnessPreviewReadinessState: fairnessPreviewReadiness.state,
+    fairnessPreviewReadiness: fairnessPreviewReadiness.detail,
   };
 }
 
@@ -322,6 +334,42 @@ function buildFairnessDetail(
     forbiddenUses: formatForbiddenUses(fairnessAnalysis.forbidden_uses),
     reasonCodes: formatList(fairnessAnalysis.reason_codes),
   };
+}
+
+function resolveFairnessPreviewReadiness(params: {
+  policyId: string;
+  policyVersion: string;
+  segmentCount: number;
+  blockedActions: string[];
+}): { state: string; detail: string } {
+  if (params.blockedActions.includes("PREVIEW_FAIRNESS_ANALYSIS")) {
+    return {
+      state: "BLOCKED",
+      detail: "Blocked by Manage action register",
+    };
+  }
+  if (params.policyId === "N/A" || params.policyVersion === "N/A") {
+    return {
+      state: "BLOCKED",
+      detail: "Blocked until Manage returns policy id and version",
+    };
+  }
+  if (params.segmentCount < 2) {
+    return {
+      state: "BLOCKED",
+      detail: `Blocked: ${params.segmentCount} source-defined ${formatSegmentCountNoun(
+        params.segmentCount
+      )} returned`,
+    };
+  }
+  return {
+    state: "READY",
+    detail: `Ready: ${params.segmentCount} source-defined segments from Manage`,
+  };
+}
+
+function formatSegmentCountNoun(count: number): string {
+  return count === 1 ? "segment" : "segments";
 }
 
 function resolvePanelState(

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -107,12 +107,39 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getByRole("heading", { name: "PM Operating Quality" })).toBeInTheDocument();
     expect(screen.getByText("Score-Run Evidence")).toBeInTheDocument();
     expect(screen.getByText("Governance Posture")).toBeInTheDocument();
+    expect(screen.getByText("Ready: 2 source-defined segments from Manage")).toBeInTheDocument();
     expect(screen.getByText("Source Segments")).toBeInTheDocument();
     expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();
     expect(screen.getByText("lotus-core:MandateTypeSegment:balanced")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeEnabled();
     expect(screen.queryByText("sha256:pm-quality")).not.toBeInTheDocument();
     expect(screen.getByText(/does not rank PMs/i)).toBeInTheDocument();
+  });
+
+  it("explains when fairness preview is blocked by missing source-defined segments", () => {
+    render(
+      <PmOperatingQualityPanel
+        policies={policies}
+        scoreRuns={{
+          ...scoreRuns,
+          data: {
+            ...scoreRuns.data,
+            fairness_segments: [
+              {
+                segment_id: "mandate_balanced",
+                segment_type: "MANDATE_TYPE",
+                display_name: "Balanced DPM Mandates",
+                score_run_ids: ["pmq_run_001"],
+              },
+            ],
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText("Blocked: 1 source-defined segment returned")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeDisabled();
+    expect(previewDpmPmOperatingQualityFairnessAnalysis).not.toHaveBeenCalled();
   });
 
   it("previews fairness analysis through Gateway with source-defined segments only", async () => {

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -174,6 +174,8 @@ describe("PM operating quality view model", () => {
       "mandate_balanced",
       "mandate_income",
     ]);
+    expect(model.fairnessPreviewReadinessState).toBe("READY");
+    expect(model.fairnessPreviewReadiness).toBe("Ready: 2 source-defined segments from Manage");
     expect(model.sourceSegmentRows[0]).toEqual(
       expect.objectContaining({
         segment: "Balanced DPM Mandates",
@@ -221,5 +223,30 @@ describe("PM operating quality view model", () => {
     expect(model.fairnessSegmentRows[0].minimumScore).toBe("89.00");
     expect(model.fairnessSegmentRows[0].maximumScore).toBe("91.00");
     expect(model.reasonCodes).toContain("PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED");
+  });
+
+  it("blocks fairness preview readiness when Manage returns too few source-defined segments", () => {
+    const model = buildPmOperatingQualityPanelModel({
+      policies,
+      scoreRuns: {
+        ...scoreRuns,
+        data: {
+          ...scoreRuns.data,
+          fairness_segments: [
+            {
+              segment_id: "mandate_balanced",
+              segment_type: "MANDATE_TYPE",
+              display_name: "Balanced DPM Mandates",
+              score_run_ids: ["pmq_run_001"],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(model.fairnessPreviewReadinessState).toBe("BLOCKED");
+    expect(model.fairnessPreviewReadiness).toBe(
+      "Blocked: 1 source-defined segment returned"
+    );
   });
 });


### PR DESCRIPTION
## Summary
- surface fairness preview readiness in the PM operating quality governance card
- disable fairness preview from a view-model readiness state instead of an implicit segment-count check
- explain blocked preview when Manage/Gateway returns too few source-defined segments

## Validation
- npm test -- --run tests/unit/pm-operating-quality-view-model.test.ts tests/unit/pm-operating-quality-panel.test.tsx tests/integration/workbench-page.test.tsx
- npm run lint
- npm run typecheck
- git diff --check

## Wiki
- No wiki change: this is a Workbench presentation clarity update for the existing PM operating quality capability.