### PR TITLE
feat(workbench): clarify PM score preview readiness

### DIFF
--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -96,6 +96,10 @@ export default function PmOperatingQualityPanel({
     if (pendingAction) {
       return;
     }
+    if (model.scoreRunPreviewReadinessState !== "READY") {
+      setActionError(model.scoreRunPreviewReadiness);
+      return;
+    }
     setPendingAction(true);
     setActionError(null);
     setActionMessage(null);
@@ -204,7 +208,7 @@ export default function PmOperatingQualityPanel({
               <ActionButton
                 priority="secondary"
                 onClick={previewScoreRun}
-                disabled={pendingAction || model.blockedActions.includes("PREVIEW_SCORE_RUN")}
+                disabled={pendingAction || model.scoreRunPreviewReadinessState !== "READY"}
               >
                 {pendingAction ? "Previewing" : "Preview Score Run"}
               </ActionButton>
@@ -259,6 +263,7 @@ export default function PmOperatingQualityPanel({
           </Text>
           <div className="pm-quality-governance-stack">
             <MetricRow label="Forbidden Uses" value={model.forbiddenUsePosture} />
+            <MetricRow label="Score Preview Readiness" value={model.scoreRunPreviewReadiness} />
             <MetricRow label="Preview Readiness" value={model.fairnessPreviewReadiness} />
             <MetricRow label="Source Segments" value={String(model.fairnessSegmentRequests.length)} />
             <MetricRow label="Fairness Spread" value={model.fairnessSpread} />

--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -96,6 +96,8 @@ export type PmOperatingQualityPanelModel = {
   fairnessState: string;
   fairnessSpread: string;
   fairnessDetail: PmOperatingQualityFairnessDetail;
+  scoreRunPreviewReadinessState: string;
+  scoreRunPreviewReadiness: string;
   fairnessPreviewReadinessState: string;
   fairnessPreviewReadiness: string;
 };
@@ -140,6 +142,11 @@ export function buildPmOperatingQualityPanelModel(params: {
     segmentCount: fairnessSegmentRequests.length,
     blockedActions,
   });
+  const scoreRunPreviewReadiness = resolveScoreRunPreviewReadiness({
+    policyId,
+    policyVersion,
+    blockedActions,
+  });
 
   return {
     state: resolvePanelState(supportabilityState, policyRows.length, scoreRunRows.length, Boolean(primary)),
@@ -166,6 +173,8 @@ export function buildPmOperatingQualityPanelModel(params: {
     fairnessState: normalizeState(readString(fairnessAnalysis, "state")),
     fairnessSpread: readString(fairnessAnalysis, "observed_average_score_spread") || "N/A",
     fairnessDetail: buildFairnessDetail(fairnessAnalysis),
+    scoreRunPreviewReadinessState: scoreRunPreviewReadiness.state,
+    scoreRunPreviewReadiness: scoreRunPreviewReadiness.detail,
     fairnessPreviewReadinessState: fairnessPreviewReadiness.state,
     fairnessPreviewReadiness: fairnessPreviewReadiness.detail,
   };
@@ -333,6 +342,29 @@ function buildFairnessDetail(
     sourceRefs: summarizeSourceRefs(extractRecords(fairnessAnalysis.source_refs)),
     forbiddenUses: formatForbiddenUses(fairnessAnalysis.forbidden_uses),
     reasonCodes: formatList(fairnessAnalysis.reason_codes),
+  };
+}
+
+function resolveScoreRunPreviewReadiness(params: {
+  policyId: string;
+  policyVersion: string;
+  blockedActions: string[];
+}): { state: string; detail: string } {
+  if (params.blockedActions.includes("PREVIEW_SCORE_RUN")) {
+    return {
+      state: "BLOCKED",
+      detail: "Blocked by Manage action register",
+    };
+  }
+  if (params.policyId === "N/A" || params.policyVersion === "N/A") {
+    return {
+      state: "BLOCKED",
+      detail: "Blocked until Manage returns policy id and version",
+    };
+  }
+  return {
+    state: "READY",
+    detail: `Ready for policy ${params.policyId} / ${params.policyVersion}`,
   };
 }
 

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -107,6 +107,7 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getByRole("heading", { name: "PM Operating Quality" })).toBeInTheDocument();
     expect(screen.getByText("Score-Run Evidence")).toBeInTheDocument();
     expect(screen.getByText("Governance Posture")).toBeInTheDocument();
+    expect(screen.getByText("Ready for policy pmq_sg_dpm / 2026.05")).toBeInTheDocument();
     expect(screen.getByText("Ready: 2 source-defined segments from Manage")).toBeInTheDocument();
     expect(screen.getByText("Source Segments")).toBeInTheDocument();
     expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();
@@ -114,6 +115,37 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeEnabled();
     expect(screen.queryByText("sha256:pm-quality")).not.toBeInTheDocument();
     expect(screen.getByText(/does not rank PMs/i)).toBeInTheDocument();
+  });
+
+  it("explains when score-run preview is blocked by missing policy context", () => {
+    render(
+      <PmOperatingQualityPanel
+        policies={{
+          ...policies,
+          supportability: {
+            ...policies.supportability,
+            policy_id: null,
+            policy_version: null,
+          },
+          data: { policies: [] },
+        }}
+        scoreRuns={{
+          ...scoreRuns,
+          supportability: {
+            ...scoreRuns.supportability,
+            policy_id: null,
+            policy_version: null,
+          },
+          data: { score_runs: [] },
+        }}
+      />
+    );
+
+    expect(
+      screen.getAllByText("Blocked until Manage returns policy id and version").length
+    ).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Preview Score Run" })).toBeDisabled();
+    expect(previewDpmPmOperatingQualityScoreRun).not.toHaveBeenCalled();
   });
 
   it("explains when fairness preview is blocked by missing source-defined segments", () => {

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -170,6 +170,8 @@ describe("PM operating quality view model", () => {
     expect(model.policyRows).toHaveLength(1);
     expect(model.scoreRunRows).toHaveLength(1);
     expect(model.scoreRunRows[0].score).toBe("90.00");
+    expect(model.scoreRunPreviewReadinessState).toBe("READY");
+    expect(model.scoreRunPreviewReadiness).toBe("Ready for policy pmq_sg_dpm / 2026.05");
     expect(model.fairnessSegmentRequests.map((segment) => segment.segment_id)).toEqual([
       "mandate_balanced",
       "mandate_income",
@@ -247,6 +249,34 @@ describe("PM operating quality view model", () => {
     expect(model.fairnessPreviewReadinessState).toBe("BLOCKED");
     expect(model.fairnessPreviewReadiness).toBe(
       "Blocked: 1 source-defined segment returned"
+    );
+  });
+
+  it("blocks score-run preview readiness when Manage does not return policy context", () => {
+    const model = buildPmOperatingQualityPanelModel({
+      policies: {
+        ...policies,
+        supportability: {
+          ...policies.supportability,
+          policy_id: null,
+          policy_version: null,
+        },
+        data: { policies: [] },
+      },
+      scoreRuns: {
+        ...scoreRuns,
+        supportability: {
+          ...scoreRuns.supportability,
+          policy_id: null,
+          policy_version: null,
+        },
+        data: { score_runs: [] },
+      },
+    });
+
+    expect(model.scoreRunPreviewReadinessState).toBe("BLOCKED");
+    expect(model.scoreRunPreviewReadiness).toBe(
+      "Blocked until Manage returns policy id and version"
     );
   });
 });


### PR DESCRIPTION
## Summary
- surface score-run preview readiness in the PM operating quality governance card
- disable score-run preview from a view-model readiness state instead of only checking blocked actions inline
- explain blocked preview when Manage/Gateway has not returned usable policy id/version context

## Validation
- npm test -- --run tests/unit/pm-operating-quality-view-model.test.ts tests/unit/pm-operating-quality-panel.test.tsx tests/integration/workbench-page.test.tsx
- npm run lint
- npm run typecheck
- git diff --check

## Wiki
- No wiki change: this is a Workbench presentation clarity update for the existing PM operating quality capability.