### PR TITLE
feat(workbench): surface PM quality operation evidence

### DIFF
--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -225,6 +225,13 @@ export default function PmOperatingQualityPanel({
             </div>
           </div>
           {actionMessage ? <Text variant="secondary">{actionMessage}</Text> : null}
+          <div className="pm-quality-operation-evidence" aria-label="PM operating quality Gateway operation evidence">
+            <MetricRow label="Operation" value={model.operationEvidence.operation} />
+            <MetricRow label="Correlation" value={model.operationEvidence.correlationId} />
+            <MetricRow label="Contract" value={model.operationEvidence.contractVersion} />
+            <MetricRow label="Source Service" value={model.operationEvidence.sourceService} />
+            <MetricRow label="Upstream Status" value={model.operationEvidence.upstreamStatus} />
+          </div>
           <AnalyticsTable
             ariaLabel="PM operating quality score runs"
             variant="analysis"

--- a/src/features/workbench/manage-workspace.module.css
+++ b/src/features/workbench/manage-workspace.module.css
@@ -1151,6 +1151,43 @@
   border-radius: 0;
 }
 
+.manageScope :global(.pm-quality-operation-evidence) {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-bottom: 1px solid #e0e3e5;
+  background: #ffffff;
+}
+
+.manageScope :global(.pm-quality-operation-evidence .suite-row) {
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  min-height: 68px;
+  padding: 10px 12px;
+  border-top: 0;
+  border-right: 1px solid #e0e3e5;
+}
+
+.manageScope :global(.pm-quality-operation-evidence .suite-row:last-child) {
+  border-right: 0;
+}
+
+.manageScope :global(.pm-quality-operation-evidence .suite-row span) {
+  color: #45464d;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.pm-quality-operation-evidence .suite-row strong) {
+  color: #131b2e;
+  font-size: 12px;
+  line-height: 17px;
+  overflow-wrap: anywhere;
+}
+
 .manageScope :global(.pm-operating-quality-panel .analytics-table-frame table) {
   min-width: 780px;
 }
@@ -3295,6 +3332,7 @@
   .manageScope :global(.portfolio-memory-workspace),
   .manageScope :global(.portfolio-memory-detail-grid),
   .manageScope :global(.pm-quality-status-strip),
+  .manageScope :global(.pm-quality-operation-evidence),
   .manageScope :global(.pm-quality-workspace),
   .manageScope :global(.pm-quality-evidence-grid),
   .manageScope :global(.pm-quality-detail-grid),

--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -74,6 +74,14 @@ export type PmOperatingQualityFairnessDetail = {
   reasonCodes: string;
 };
 
+export type PmOperatingQualityOperationEvidence = {
+  operation: string;
+  correlationId: string;
+  contractVersion: string;
+  sourceService: string;
+  upstreamStatus: string;
+};
+
 export type PmOperatingQualityPanelModel = {
   state: PmOperatingQualityPanelState;
   supportabilityState: string;
@@ -96,6 +104,7 @@ export type PmOperatingQualityPanelModel = {
   fairnessState: string;
   fairnessSpread: string;
   fairnessDetail: PmOperatingQualityFairnessDetail;
+  operationEvidence: PmOperatingQualityOperationEvidence;
   scoreRunPreviewReadinessState: string;
   scoreRunPreviewReadiness: string;
   fairnessPreviewReadinessState: string;
@@ -173,10 +182,43 @@ export function buildPmOperatingQualityPanelModel(params: {
     fairnessState: normalizeState(readString(fairnessAnalysis, "state")),
     fairnessSpread: readString(fairnessAnalysis, "observed_average_score_spread") || "N/A",
     fairnessDetail: buildFairnessDetail(fairnessAnalysis),
+    operationEvidence: buildOperationEvidence({
+      policies: params.policies,
+      scoreRuns: params.scoreRuns,
+      preview: params.preview,
+      fairnessPreview: params.fairnessPreview,
+    }),
     scoreRunPreviewReadinessState: scoreRunPreviewReadiness.state,
     scoreRunPreviewReadiness: scoreRunPreviewReadiness.detail,
     fairnessPreviewReadinessState: fairnessPreviewReadiness.state,
     fairnessPreviewReadiness: fairnessPreviewReadiness.detail,
+  };
+}
+
+function buildOperationEvidence(params: {
+  policies: DpmPmOperatingQualityGatewayResponse | null;
+  scoreRuns: DpmPmOperatingQualityGatewayResponse | null;
+  preview?: DpmPmOperatingQualityGatewayResponse | null;
+  fairnessPreview?: DpmPmOperatingQualityGatewayResponse | null;
+}): PmOperatingQualityOperationEvidence {
+  const operation =
+    params.fairnessPreview
+      ? "Fairness analysis preview"
+      : params.preview
+        ? "Score-run preview"
+        : params.scoreRuns
+          ? "Score-run evidence load"
+          : params.policies
+            ? "Policy evidence load"
+            : "No Gateway operation";
+  const response = params.fairnessPreview ?? params.preview ?? params.scoreRuns ?? params.policies;
+  return {
+    operation,
+    correlationId: response?.correlation_id ?? "N/A",
+    contractVersion: response?.contract_version ?? "N/A",
+    sourceService: response?.source_service ?? "N/A",
+    upstreamStatus:
+      typeof response?.upstream_status === "number" ? String(response.upstream_status) : "N/A",
   };
 }
 

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -107,6 +107,11 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getByRole("heading", { name: "PM Operating Quality" })).toBeInTheDocument();
     expect(screen.getByText("Score-Run Evidence")).toBeInTheDocument();
     expect(screen.getByText("Governance Posture")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("PM operating quality Gateway operation evidence")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Score-run evidence load")).toBeInTheDocument();
+    expect(screen.getByText("corr-score")).toBeInTheDocument();
     expect(screen.getByText("Ready for policy pmq_sg_dpm / 2026.05")).toBeInTheDocument();
     expect(screen.getByText("Ready: 2 source-defined segments from Manage")).toBeInTheDocument();
     expect(screen.getByText("Source Segments")).toBeInTheDocument();
@@ -177,6 +182,7 @@ describe("PmOperatingQualityPanel", () => {
   it("previews fairness analysis through Gateway with source-defined segments only", async () => {
     vi.mocked(previewDpmPmOperatingQualityFairnessAnalysis).mockResolvedValue({
       ...scoreRuns,
+      correlation_id: "corr-pmq-fairness",
       supportability: {
         ...scoreRuns.supportability,
         state: "PENDING_REVIEW",
@@ -268,6 +274,8 @@ describe("PmOperatingQualityPanel", () => {
     });
     expect(previewDpmPmOperatingQualityScoreRun).not.toHaveBeenCalled();
     expect(screen.getByText("Fairness preview returned Manage segment evidence.")).toBeInTheDocument();
+    expect(screen.getByText("Fairness analysis preview")).toBeInTheDocument();
+    expect(screen.getByText("corr-pmq-fairness")).toBeInTheDocument();
     expect(screen.getByText("Fairness Preview Detail")).toBeInTheDocument();
     expect(screen.getByText("PmOperatingQualityFairnessAnalysis / v1")).toBeInTheDocument();
     expect(screen.getByText("15.00")).toBeInTheDocument();

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -172,6 +172,13 @@ describe("PM operating quality view model", () => {
     expect(model.scoreRunRows[0].score).toBe("90.00");
     expect(model.scoreRunPreviewReadinessState).toBe("READY");
     expect(model.scoreRunPreviewReadiness).toBe("Ready for policy pmq_sg_dpm / 2026.05");
+    expect(model.operationEvidence).toEqual({
+      operation: "Score-run evidence load",
+      correlationId: "corr-score",
+      contractVersion: "v1",
+      sourceService: "lotus-manage",
+      upstreamStatus: "200",
+    });
     expect(model.fairnessSegmentRequests.map((segment) => segment.segment_id)).toEqual([
       "mandate_balanced",
       "mandate_income",
@@ -211,6 +218,13 @@ describe("PM operating quality view model", () => {
       })
     );
     expect(model.fairnessDetail.forbiddenUses).toContain("protected class inference");
+    expect(model.operationEvidence).toEqual({
+      operation: "Fairness analysis preview",
+      correlationId: "corr-fairness",
+      contractVersion: "v1",
+      sourceService: "lotus-manage",
+      upstreamStatus: "200",
+    });
     expect(model.blockedActions).toEqual(["CREATE_SCORE_RUN"]);
     expect(model.fairnessSegmentRows.map((row) => row.segment)).toEqual([
       "Balanced DPM Mandates",


### PR DESCRIPTION
## Summary
- render Gateway operation evidence for PM operating quality policy, score-run, and fairness preview responses
- preserve Manage/Gateway metadata including correlation id, contract version, source service, and upstream status
- keep PM score/fairness calculations out of Workbench and add tests for returned metadata

## Validation
- npm test -- --run tests/unit/pm-operating-quality-view-model.test.ts tests/unit/pm-operating-quality-panel.test.tsx
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Wiki
- No wiki change: UI-only metadata rendering for existing Gateway-backed PM operating quality surface.