### PR TITLE
feat(workbench): clarify PM quality action posture

### DIFF
--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -33,6 +33,13 @@ type Props = {
   scoreRunsError?: string | null;
 };
 
+type PmQualityActionError = {
+  body: string;
+  status: string;
+  statusClass: string;
+  source: string;
+};
+
 function statePanelCopy(state: PmOperatingQualityPanelState) {
   if (state === "empty") {
     return {
@@ -62,6 +69,43 @@ function statePanelCopy(state: PmOperatingQualityPanelState) {
   };
 }
 
+function buildActionError(error: unknown, fallback: string): PmQualityActionError {
+  const message = error instanceof Error ? error.message : fallback;
+  const status = resolveErrorStatus(message);
+  return {
+    body: message,
+    status: status ?? "N/A",
+    statusClass: status ? classifyStatus(status) : "unknown",
+    source: "Gateway PM operating quality route",
+  };
+}
+
+function buildBlockedActionError(message: string): PmQualityActionError {
+  return {
+    body: message,
+    status: "N/A",
+    statusClass: "blocked",
+    source: "Manage action register via Gateway supportability",
+  };
+}
+
+function resolveErrorStatus(message: string): string | null {
+  return message.match(/\((\d{3})\)$/)?.[1] ?? null;
+}
+
+function classifyStatus(status: string): string {
+  if (status === "401" || status === "403") {
+    return "permission blocked";
+  }
+  if (status === "404" || status === "409" || status === "422") {
+    return "business blocked";
+  }
+  if (status.startsWith("5")) {
+    return "upstream unavailable";
+  }
+  return "request failed";
+}
+
 export default function PmOperatingQualityPanel({
   policies,
   scoreRuns,
@@ -74,7 +118,7 @@ export default function PmOperatingQualityPanel({
     useState<DpmPmOperatingQualityGatewayResponse | null>(null);
   const [pendingAction, setPendingAction] = useState(false);
   const [pendingFairnessAction, setPendingFairnessAction] = useState(false);
-  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<PmQualityActionError | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const model = buildPmOperatingQualityPanelModel({
     policies,
@@ -97,7 +141,7 @@ export default function PmOperatingQualityPanel({
       return;
     }
     if (model.scoreRunPreviewReadinessState !== "READY") {
-      setActionError(model.scoreRunPreviewReadiness);
+      setActionError(buildBlockedActionError(model.scoreRunPreviewReadiness));
       return;
     }
     setPendingAction(true);
@@ -111,7 +155,7 @@ export default function PmOperatingQualityPanel({
       setPreviewResponse(response);
       setActionMessage("Preview returned Manage operating-quality evidence.");
     } catch (error) {
-      setActionError(error instanceof Error ? error.message : "PM operating quality preview failed");
+      setActionError(buildActionError(error, "PM operating quality preview failed"));
     } finally {
       setPendingAction(false);
     }
@@ -122,11 +166,15 @@ export default function PmOperatingQualityPanel({
       return;
     }
     if (model.fairnessPreviewReadinessState !== "READY") {
-      setActionError(model.fairnessPreviewReadiness);
+      setActionError(buildBlockedActionError(model.fairnessPreviewReadiness));
       return;
     }
     if (model.policyId === "N/A" || model.policyVersion === "N/A") {
-      setActionError("PM operating quality policy id/version is required for fairness preview.");
+      setActionError(
+        buildBlockedActionError(
+          "PM operating quality policy id/version is required for fairness preview."
+        )
+      );
       return;
     }
     setPendingFairnessAction(true);
@@ -143,7 +191,7 @@ export default function PmOperatingQualityPanel({
       setActionMessage("Fairness preview returned Manage segment evidence.");
     } catch (error) {
       setActionError(
-        error instanceof Error ? error.message : "PM operating quality fairness preview failed"
+        buildActionError(error, "PM operating quality fairness preview failed")
       );
     } finally {
       setPendingFairnessAction(false);
@@ -174,7 +222,7 @@ export default function PmOperatingQualityPanel({
           kind={loadError || actionError ? "partial" : stateCopy.kind}
           surface="portfolio"
           title={loadError || actionError ? "PM operating quality needs attention" : stateCopy.title}
-          body={loadError || actionError || stateCopy.body}
+          body={loadError || actionError?.body || stateCopy.body}
         />
       ) : null}
 
@@ -225,6 +273,13 @@ export default function PmOperatingQualityPanel({
             </div>
           </div>
           {actionMessage ? <Text variant="secondary">{actionMessage}</Text> : null}
+          {actionError ? (
+            <div className="pm-quality-action-error" aria-label="PM operating quality action error posture">
+              <MetricRow label="Status Class" value={actionError.statusClass} />
+              <MetricRow label="Gateway Status" value={actionError.status} />
+              <MetricRow label="Error Source" value={actionError.source} />
+            </div>
+          ) : null}
           <div className="pm-quality-operation-evidence" aria-label="PM operating quality Gateway operation evidence">
             <MetricRow label="Operation" value={model.operationEvidence.operation} />
             <MetricRow label="Correlation" value={model.operationEvidence.correlationId} />
@@ -276,7 +331,7 @@ export default function PmOperatingQualityPanel({
             <MetricRow label="Fairness Spread" value={model.fairnessSpread} />
             <MetricRow
               label="Blocked Actions"
-              value={model.blockedActions.length ? model.blockedActions.join(", ") : "None"}
+              value={model.blockedActionPosture}
             />
             <MetricRow label="Policy Versions" value={String(model.policyRows.length)} />
             <Text variant="secondary">

--- a/src/features/workbench/manage-workspace.module.css
+++ b/src/features/workbench/manage-workspace.module.css
@@ -1188,6 +1188,43 @@
   overflow-wrap: anywhere;
 }
 
+.manageScope :global(.pm-quality-action-error) {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-bottom: 1px solid #f3c5c1;
+  background: #fff7f6;
+}
+
+.manageScope :global(.pm-quality-action-error .suite-row) {
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  min-height: 62px;
+  padding: 10px 12px;
+  border-top: 0;
+  border-right: 1px solid #f3c5c1;
+}
+
+.manageScope :global(.pm-quality-action-error .suite-row:last-child) {
+  border-right: 0;
+}
+
+.manageScope :global(.pm-quality-action-error .suite-row span) {
+  color: #93000a;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.pm-quality-action-error .suite-row strong) {
+  color: #191c1e;
+  font-size: 12px;
+  line-height: 17px;
+  overflow-wrap: anywhere;
+}
+
 .manageScope :global(.pm-operating-quality-panel .analytics-table-frame table) {
   min-width: 780px;
 }
@@ -3332,6 +3369,7 @@
   .manageScope :global(.portfolio-memory-workspace),
   .manageScope :global(.portfolio-memory-detail-grid),
   .manageScope :global(.pm-quality-status-strip),
+  .manageScope :global(.pm-quality-action-error),
   .manageScope :global(.pm-quality-operation-evidence),
   .manageScope :global(.pm-quality-workspace),
   .manageScope :global(.pm-quality-evidence-grid),

--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -93,6 +93,7 @@ export type PmOperatingQualityPanelModel = {
   count: string;
   reasonCodes: string[];
   blockedActions: string[];
+  blockedActionPosture: string;
   policyRows: PmOperatingQualityPolicyRow[];
   scoreRunRows: PmOperatingQualityScoreRunRow[];
   fairnessSegmentRequests: PmOperatingQualityFairnessSegmentRequest[];
@@ -171,6 +172,7 @@ export function buildPmOperatingQualityPanelModel(params: {
     count: formatCount(supportability?.count, scoreRunRows.length),
     reasonCodes,
     blockedActions,
+    blockedActionPosture: summarizeBlockedActions(blockedActions, supportability?.source_service),
     policyRows,
     scoreRunRows,
     fairnessSegmentRequests,
@@ -482,6 +484,14 @@ function summarizeForbiddenUses(rows: PmOperatingQualityScoreRunRow[]): string {
     : "No forbidden-use list returned";
 }
 
+function summarizeBlockedActions(actions: string[], sourceService: string | null | undefined): string {
+  if (actions.length === 0) {
+    return "None";
+  }
+  const source = sourceService || "Manage action register";
+  return actions.map((action) => `${action} (${source})`).join(", ");
+}
+
 function uniqueByScoreRunId(row: PmOperatingQualityScoreRunRow, index: number, rows: PmOperatingQualityScoreRunRow[]) {
   return rows.findIndex((candidate) => candidate.scoreRunId === row.scoreRunId) === index;
 }
@@ -539,21 +549,25 @@ function summarizeSourceRefs(refs: Array<Record<string, unknown>>): string {
     return "N/A";
   }
   return refs
-    .map((ref) =>
-      firstNonEmpty(
-        readString(ref, "source_ref"),
-        [
-          readString(ref, "source_system"),
-          readString(ref, "source_product") || readString(ref, "source_type"),
-          readString(ref, "source_id"),
-        ]
-          .filter(Boolean)
-          .join(":"),
-        readString(ref, "source_type")
-      )
-    )
+    .map(formatSourceRef)
     .filter((value) => value !== "N/A")
     .join(", ") || "N/A";
+}
+
+function formatSourceRef(ref: Record<string, unknown>): string {
+  const explicitRef = readString(ref, "source_ref");
+  if (explicitRef) {
+    return `Ref: ${explicitRef}`;
+  }
+  const system = readString(ref, "source_system");
+  const product = readString(ref, "source_product") || readString(ref, "source_type");
+  const id = readString(ref, "source_id");
+  const parts = [
+    system ? `System: ${system}` : "",
+    product ? `Product: ${product}` : "",
+    id ? `Id: ${id}` : "",
+  ].filter(Boolean);
+  return parts.join(" | ") || firstNonEmpty(readString(ref, "source_type"));
 }
 
 function splitList(value: string): string[] {

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -116,7 +116,9 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getByText("Ready: 2 source-defined segments from Manage")).toBeInTheDocument();
     expect(screen.getByText("Source Segments")).toBeInTheDocument();
     expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();
-    expect(screen.getByText("lotus-core:MandateTypeSegment:balanced")).toBeInTheDocument();
+    expect(
+      screen.getByText("System: lotus-core | Product: MandateTypeSegment | Id: balanced")
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeEnabled();
     expect(screen.queryByText("sha256:pm-quality")).not.toBeInTheDocument();
     expect(screen.getByText(/does not rank PMs/i)).toBeInTheDocument();
@@ -151,6 +153,30 @@ describe("PmOperatingQualityPanel", () => {
     ).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Preview Score Run" })).toBeDisabled();
     expect(previewDpmPmOperatingQualityScoreRun).not.toHaveBeenCalled();
+  });
+
+  it("classifies Gateway action failures without calling Manage directly", async () => {
+    vi.mocked(previewDpmPmOperatingQualityScoreRun).mockRejectedValue(
+      new Error("Failed to fetch preview DPM PM operating quality score run (409)")
+    );
+
+    render(<PmOperatingQualityPanel policies={policies} scoreRuns={scoreRuns} />);
+    fireEvent.click(screen.getByRole("button", { name: "Preview Score Run" }));
+
+    await waitFor(() => {
+      expect(previewDpmPmOperatingQualityScoreRun).toHaveBeenCalledWith({
+        policyId: "pmq_sg_dpm",
+        policyVersion: "2026.05",
+      });
+    });
+    expect(
+      screen.getByLabelText("PM operating quality action error posture")
+    ).toBeInTheDocument();
+    expect(screen.getByText("business blocked")).toBeInTheDocument();
+    expect(screen.getByText("409")).toBeInTheDocument();
+    expect(screen.getByText("Gateway PM operating quality route")).toBeInTheDocument();
+    expect(screen.getByText(/Failed to fetch preview DPM PM operating quality score run/)).toBeInTheDocument();
+    expect(previewDpmPmOperatingQualityFairnessAnalysis).not.toHaveBeenCalled();
   });
 
   it("explains when fairness preview is blocked by missing source-defined segments", () => {
@@ -280,7 +306,10 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getByText("PmOperatingQualityFairnessAnalysis / v1")).toBeInTheDocument();
     expect(screen.getByText("15.00")).toBeInTheDocument();
     expect(screen.getAllByText("31.00").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("lotus-manage:PmOperatingQualityScoreRun:pmq_run_001").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001")
+        .length
+    ).toBeGreaterThan(0);
     expect(screen.getAllByText(/protected class inference/i).length).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -188,7 +188,7 @@ describe("PM operating quality view model", () => {
     expect(model.sourceSegmentRows[0]).toEqual(
       expect.objectContaining({
         segment: "Balanced DPM Mandates",
-        sourceRefs: "lotus-core:MandateTypeSegment",
+        sourceRefs: "System: lotus-core | Product: MandateTypeSegment",
       })
     );
     expect(model.forbiddenUsePosture).toContain("protected class inference");
@@ -214,7 +214,7 @@ describe("PM operating quality view model", () => {
         maximumAverageScoreSpread: "15.00",
         observedAverageScoreSpread: "31.00",
         generatedBy: "lotus-manage",
-        sourceRefs: "lotus-manage:PmOperatingQualityScoreRun:pmq_run_001",
+        sourceRefs: "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001",
       })
     );
     expect(model.fairnessDetail.forbiddenUses).toContain("protected class inference");
@@ -226,15 +226,16 @@ describe("PM operating quality view model", () => {
       upstreamStatus: "200",
     });
     expect(model.blockedActions).toEqual(["CREATE_SCORE_RUN"]);
+    expect(model.blockedActionPosture).toBe("CREATE_SCORE_RUN (lotus-manage)");
     expect(model.fairnessSegmentRows.map((row) => row.segment)).toEqual([
       "Balanced DPM Mandates",
       "Income DPM Mandates",
     ]);
     expect(model.fairnessSegmentRows[0].sourceRefs).toBe(
-      "lotus-manage:PmOperatingQualityScoreRun:pmq_run_001"
+      "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001"
     );
     expect(model.fairnessSegmentRows[0].scoreRunRefs).toBe(
-      "lotus-manage:PmOperatingQualityScoreRun:pmq_run_001"
+      "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001"
     );
     expect(model.fairnessSegmentRows[0].minimumScore).toBe("89.00");
     expect(model.fairnessSegmentRows[0].maximumScore).toBe("91.00");


### PR DESCRIPTION
## Summary
- classify PM operating quality preview failures into product-safe status classes from Gateway status codes
- render action error posture separately from load/empty states
- label PM quality source refs as system/product/id instead of compact colon strings
- show blocked actions with Manage/Gateway supportability source context

## Validation
- npm test -- --run tests/unit/pm-operating-quality-view-model.test.ts tests/unit/pm-operating-quality-panel.test.tsx
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Wiki
- No wiki change: existing Gateway-backed PM quality UI rendering semantics only.