### PR TITLE
Clarify PM quality command readiness

### DIFF
--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -273,6 +273,17 @@ export default function PmOperatingQualityPanel({
             </div>
           </div>
           {actionMessage ? <Text variant="secondary">{actionMessage}</Text> : null}
+          <div
+            className="pm-quality-command-readiness"
+            aria-label="PM operating quality command readiness"
+          >
+            <MetricRow label="Score Preview Command" value={model.scoreRunPreviewReadiness} />
+            <MetricRow label="Fairness Preview Command" value={model.fairnessPreviewReadiness} />
+            <MetricRow
+              label="Execution Boundary"
+              value="Gateway and Manage evidence only; no scoring, ranking, trade approval, order routing, or client contact in Workbench"
+            />
+          </div>
           {actionError ? (
             <div className="pm-quality-action-error" aria-label="PM operating quality action error posture">
               <MetricRow label="Status Class" value={actionError.statusClass} />

--- a/src/features/workbench/manage-workspace.module.css
+++ b/src/features/workbench/manage-workspace.module.css
@@ -1151,6 +1151,43 @@
   border-radius: 0;
 }
 
+.manageScope :global(.pm-quality-command-readiness) {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(220px, 1.2fr);
+  border-bottom: 1px solid #e0e3e5;
+  background: #ffffff;
+}
+
+.manageScope :global(.pm-quality-command-readiness .suite-row) {
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  min-height: 72px;
+  padding: 10px 12px;
+  border-top: 0;
+  border-right: 1px solid #e0e3e5;
+}
+
+.manageScope :global(.pm-quality-command-readiness .suite-row:last-child) {
+  border-right: 0;
+}
+
+.manageScope :global(.pm-quality-command-readiness .suite-row span) {
+  color: #45464d;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.pm-quality-command-readiness .suite-row strong) {
+  color: #131b2e;
+  font-size: 12px;
+  line-height: 17px;
+  overflow-wrap: anywhere;
+}
+
 .manageScope :global(.pm-quality-operation-evidence) {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
@@ -3369,6 +3406,7 @@
   .manageScope :global(.portfolio-memory-workspace),
   .manageScope :global(.portfolio-memory-detail-grid),
   .manageScope :global(.pm-quality-status-strip),
+  .manageScope :global(.pm-quality-command-readiness),
   .manageScope :global(.pm-quality-action-error),
   .manageScope :global(.pm-quality-operation-evidence),
   .manageScope :global(.pm-quality-workspace),

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -110,10 +110,20 @@ describe("PmOperatingQualityPanel", () => {
     expect(
       screen.getByLabelText("PM operating quality Gateway operation evidence")
     ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("PM operating quality command readiness")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Score Preview Command")).toBeInTheDocument();
+    expect(screen.getByText("Fairness Preview Command")).toBeInTheDocument();
+    expect(screen.getByText(/no scoring, ranking, trade approval/i)).toBeInTheDocument();
     expect(screen.getByText("Score-run evidence load")).toBeInTheDocument();
     expect(screen.getByText("corr-score")).toBeInTheDocument();
-    expect(screen.getByText("Ready for policy pmq_sg_dpm / 2026.05")).toBeInTheDocument();
-    expect(screen.getByText("Ready: 2 source-defined segments from Manage")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Ready for policy pmq_sg_dpm / 2026.05").length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Ready: 2 source-defined segments from Manage").length
+    ).toBeGreaterThan(0);
     expect(screen.getByText("Source Segments")).toBeInTheDocument();
     expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();
     expect(
@@ -200,8 +210,35 @@ describe("PmOperatingQualityPanel", () => {
       />
     );
 
-    expect(screen.getByText("Blocked: 1 source-defined segment returned")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Blocked: 1 source-defined segment returned").length
+    ).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeDisabled();
+    expect(previewDpmPmOperatingQualityFairnessAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("keeps Manage action-register blocks visible before command execution", () => {
+    render(
+      <PmOperatingQualityPanel
+        policies={policies}
+        scoreRuns={{
+          ...scoreRuns,
+          supportability: {
+            ...scoreRuns.supportability,
+            state: "BLOCKED",
+            blocked_actions: ["PREVIEW_FAIRNESS_ANALYSIS"],
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText("PM operating quality command readiness")).toBeInTheDocument();
+    expect(screen.getAllByText("Blocked by Manage action register").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText("PREVIEW_FAIRNESS_ANALYSIS (lotus-manage)")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Preview Fairness" }));
     expect(previewDpmPmOperatingQualityFairnessAnalysis).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -294,4 +294,24 @@ describe("PM operating quality view model", () => {
       "Blocked until Manage returns policy id and version"
     );
   });
+
+  it("preserves Manage action-register fairness preview blocks", () => {
+    const model = buildPmOperatingQualityPanelModel({
+      policies,
+      scoreRuns: {
+        ...scoreRuns,
+        supportability: {
+          ...scoreRuns.supportability,
+          state: "BLOCKED",
+          blocked_actions: ["PREVIEW_FAIRNESS_ANALYSIS"],
+        },
+      },
+    });
+
+    expect(model.state).toBe("blocked");
+    expect(model.fairnessPreviewReadinessState).toBe("BLOCKED");
+    expect(model.fairnessPreviewReadiness).toBe("Blocked by Manage action register");
+    expect(model.blockedActionPosture).toBe("PREVIEW_FAIRNESS_ANALYSIS (lotus-manage)");
+    expect(model.scoreRunPreviewReadinessState).toBe("READY");
+  });
 });


### PR DESCRIPTION
## Summary
- expose PM operating-quality score and fairness command readiness next to the action controls
- keep the execution boundary explicit: Workbench renders Gateway/Manage evidence only and does not score, rank, approve trades, route orders, or contact clients
- add regression coverage for Manage action-register fairness preview blocks

## Validation
- npm test -- --run tests/unit/pm-operating-quality-view-model.test.ts tests/unit/pm-operating-quality-panel.test.tsx
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Wiki
- No wiki change: this is a UI clarity/test hardening slice for an already documented PM operating-quality surface.