### PR TITLE
Surface PM quality score-run source refs

### DIFF
--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -308,6 +308,7 @@ export default function PmOperatingQualityPanel({
               { key: "policy", label: "Policy" },
               { key: "state", label: "State" },
               { key: "score", label: "Score" },
+              { key: "source", label: "Source Refs" },
               { key: "reason", label: "Reason" },
             ]}
             rows={model.scoreRunRows.map((row) => ({
@@ -320,12 +321,13 @@ export default function PmOperatingQualityPanel({
                   {businessStateLabel(row.state)}
                 </SemanticBadge>,
                 row.score,
+                row.sourceRefs,
                 row.reasonCodes,
               ],
             }))}
             emptyState={{
               title: "No score runs returned",
-              body: "Preview or create a Manage score run before using score-run evidence.",
+              body: "Load or preview Manage score-run evidence before using score-run posture.",
             }}
           />
         </div>

--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -27,6 +27,7 @@ export type PmOperatingQualityScoreRunRow = {
   score: string;
   asOfDate: string;
   forbiddenUses: string;
+  sourceRefs: string;
   reasonCodes: string;
   contentHash: string;
 };
@@ -286,6 +287,7 @@ function buildScoreRunRows(
       score: readString(record, "score") || readString(record, "overall_score") || "N/A",
       asOfDate: readString(record, "as_of_date") || readString(record, "created_at") || "N/A",
       forbiddenUses: formatList(record.forbidden_uses),
+      sourceRefs: summarizeSourceRefs(extractRecords(record.source_refs)),
       reasonCodes: formatList(record.reason_codes),
       contentHash:
         readString(record, "content_hash") ||

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -70,6 +70,13 @@ const scoreRuns: DpmPmOperatingQualityGatewayResponse = {
         content_hash: "sha256:pm-quality",
         reason_codes: ["PM_QUALITY_READY"],
         forbidden_uses: ["protected_class_inference", "autonomous_pm_ranking"],
+        source_refs: [
+          {
+            source_system: "lotus-manage",
+            source_product: "PmOperatingQualityScoreRun",
+            source_id: "pmq_run_001",
+          },
+        ],
       },
     ],
     fairness_segments: [
@@ -125,7 +132,11 @@ describe("PmOperatingQualityPanel", () => {
       screen.getAllByText("Ready: 2 source-defined segments from Manage").length
     ).toBeGreaterThan(0);
     expect(screen.getByText("Source Segments")).toBeInTheDocument();
+    expect(screen.getAllByText("Source Refs").length).toBeGreaterThan(0);
     expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();
+    expect(
+      screen.getByText("System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001")
+    ).toBeInTheDocument();
     expect(
       screen.getByText("System: lotus-core | Product: MandateTypeSegment | Id: balanced")
     ).toBeInTheDocument();

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -59,6 +59,13 @@ const scoreRuns: DpmPmOperatingQualityGatewayResponse = {
         score: "90.00",
         reason_codes: ["PM_QUALITY_READY"],
         forbidden_uses: ["protected_class_inference", "autonomous_pm_ranking"],
+        source_refs: [
+          {
+            source_system: "lotus-manage",
+            source_product: "PmOperatingQualityScoreRun",
+            source_id: "pmq_run_001",
+          },
+        ],
       },
     ],
     fairness_segments: [
@@ -170,6 +177,9 @@ describe("PM operating quality view model", () => {
     expect(model.policyRows).toHaveLength(1);
     expect(model.scoreRunRows).toHaveLength(1);
     expect(model.scoreRunRows[0].score).toBe("90.00");
+    expect(model.scoreRunRows[0].sourceRefs).toBe(
+      "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001"
+    );
     expect(model.scoreRunPreviewReadinessState).toBe("READY");
     expect(model.scoreRunPreviewReadiness).toBe("Ready for policy pmq_sg_dpm / 2026.05");
     expect(model.operationEvidence).toEqual({


### PR DESCRIPTION
## Summary
- preserve Manage/Gateway score-run source refs in the PM operating-quality view model
- render score-run source refs in the score-run evidence table
- remove unsupported-looking empty-state copy that implied a create action from this table

## Validation
- npm test -- --run tests/unit/pm-operating-quality-view-model.test.ts tests/unit/pm-operating-quality-panel.test.tsx
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Wiki
- No wiki change: this is a UI evidence-preservation hardening slice for an already documented PM operating-quality surface.