### PR TITLE
Show PM quality score-run boundaries

### DIFF
--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -306,8 +306,10 @@ export default function PmOperatingQualityPanel({
               { key: "scoreRun", label: "Score Run" },
               { key: "pm", label: "PM / Book" },
               { key: "policy", label: "Policy" },
+              { key: "asOf", label: "As Of" },
               { key: "state", label: "State" },
               { key: "score", label: "Score" },
+              { key: "forbiddenUses", label: "Forbidden Uses" },
               { key: "source", label: "Source Refs" },
               { key: "reason", label: "Reason" },
             ]}
@@ -317,10 +319,12 @@ export default function PmOperatingQualityPanel({
                 <strong key={`${row.key}-id`}>{row.scoreRunId}</strong>,
                 `${row.pmId} / ${row.bookId}`,
                 row.policy,
+                row.asOfDate,
                 <SemanticBadge key={`${row.key}-state`} tone={toneForState(row.state)}>
                   {businessStateLabel(row.state)}
                 </SemanticBadge>,
                 row.score,
+                row.forbiddenUses,
                 row.sourceRefs,
                 row.reasonCodes,
               ],

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -133,6 +133,10 @@ describe("PmOperatingQualityPanel", () => {
     ).toBeGreaterThan(0);
     expect(screen.getByText("Source Segments")).toBeInTheDocument();
     expect(screen.getAllByText("Source Refs").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("As Of").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("2026-05-13").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Forbidden Uses").length).toBeGreaterThan(0);
+    expect(screen.getByText("protected_class_inference, autonomous_pm_ranking")).toBeInTheDocument();
     expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();
     expect(
       screen.getByText("System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001")


### PR DESCRIPTION
## Summary
- render score-run as-of date in PM operating-quality score-run evidence
- render per-score-run forbidden-use boundaries beside returned scores and source refs
- add regression coverage to keep temporal scope and forbidden-use posture visible without exposing hashes

## Validation
- npm test -- --run tests/unit/pm-operating-quality-view-model.test.ts tests/unit/pm-operating-quality-panel.test.tsx
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Wiki
- No wiki change: this is a UI evidence-preservation hardening slice for an already documented PM operating-quality surface.