### PR TITLE
feat(workbench): clarify PM quality boundary labels

### DIFF
--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -286,7 +286,7 @@ function buildScoreRunRows(
         "UNKNOWN",
       score: readString(record, "score") || readString(record, "overall_score") || "N/A",
       asOfDate: readString(record, "as_of_date") || readString(record, "created_at") || "N/A",
-      forbiddenUses: formatList(record.forbidden_uses),
+      forbiddenUses: formatForbiddenUses(record.forbidden_uses),
       sourceRefs: summarizeSourceRefs(extractRecords(record.source_refs)),
       reasonCodes: formatList(record.reason_codes),
       contentHash:

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -136,7 +136,9 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getAllByText("As Of").length).toBeGreaterThan(0);
     expect(screen.getAllByText("2026-05-13").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Forbidden Uses").length).toBeGreaterThan(0);
-    expect(screen.getByText("protected_class_inference, autonomous_pm_ranking")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("protected class inference, autonomous pm ranking").length
+    ).toBeGreaterThan(0);
     expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();
     expect(
       screen.getByText("System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001")

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -180,6 +180,9 @@ describe("PM operating quality view model", () => {
     expect(model.scoreRunRows[0].sourceRefs).toBe(
       "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001"
     );
+    expect(model.scoreRunRows[0].forbiddenUses).toBe(
+      "protected class inference, autonomous pm ranking"
+    );
     expect(model.scoreRunPreviewReadinessState).toBe("READY");
     expect(model.scoreRunPreviewReadiness).toBe("Ready for policy pmq_sg_dpm / 2026.05");
     expect(model.operationEvidence).toEqual({


### PR DESCRIPTION
## Summary
- render PM operating-quality score-run forbidden-use boundaries as advisor-readable labels
- keep the UI backed by Gateway-returned forbidden-use values without browser-side scoring, segment discovery, or PM ranking
- extend view-model and panel tests for the readable boundary posture

## Validation
- npm test -- --run tests/unit/pm-operating-quality-view-model.test.ts tests/unit/pm-operating-quality-panel.test.tsx
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Notes
- Workbench-only change; no Manage direct calls and no Gateway contract changes.
- No wiki update required: no operator-facing documentation truth changed.