### PR TITLE
feat(workbench): clarify PM quality segment labels

### DIFF
--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -304,7 +304,7 @@ function buildSourceSegmentRows(
   return segments.map((segment, index) => ({
     key: `${segment.segment_id}-${index}`,
     segment: segment.display_name || segment.segment_id,
-    segmentType: segment.segment_type,
+    segmentType: formatSegmentType(segment.segment_type),
     scoreRunCount: String(segment.score_run_ids.length),
     sourceRefs: summarizeSourceRefs(segment.source_refs ?? []),
   }));
@@ -353,7 +353,7 @@ function buildFairnessSegmentRows(
     return {
       key: `${segmentId}-${index}`,
       segment: readString(record, "display_name") || segmentId,
-      segmentType: readString(record, "segment_type") || "N/A",
+      segmentType: formatSegmentType(readString(record, "segment_type")),
       state: readString(record, "state") || "UNKNOWN",
       scoreRunCount: readString(record, "score_run_count") || "0",
       averageScore: readString(record, "average_score") || "N/A",
@@ -544,6 +544,22 @@ function formatForbiddenUses(value: unknown): string {
 
 function formatForbiddenUse(value: string): string {
   return value.replaceAll("_", " ");
+}
+
+function formatSegmentType(value: string | null | undefined): string {
+  const normalized = value?.trim().toUpperCase();
+  if (!normalized) {
+    return "N/A";
+  }
+  const labels: Record<string, string> = {
+    MANDATE_TYPE: "Mandate type",
+    REGION: "Region",
+    BOOK_PROFILE: "Book profile",
+    CLIENT_CONSTRAINT_PROFILE: "Client constraint profile",
+    MARKET_REGIME: "Market regime",
+    CUSTOM_SOURCE_SEGMENT: "Custom source segment",
+  };
+  return labels[normalized] ?? normalized.replaceAll("_", " ").toLowerCase();
 }
 
 function summarizeSourceRefs(refs: Array<Record<string, unknown>>): string {

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -146,6 +146,7 @@ describe("PmOperatingQualityPanel", () => {
     expect(
       screen.getByText("System: lotus-core | Product: MandateTypeSegment | Id: balanced")
     ).toBeInTheDocument();
+    expect(screen.getAllByText("Mandate type").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeEnabled();
     expect(screen.queryByText("sha256:pm-quality")).not.toBeInTheDocument();
     expect(screen.getByText(/does not rank PMs/i)).toBeInTheDocument();

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -201,6 +201,7 @@ describe("PM operating quality view model", () => {
     expect(model.sourceSegmentRows[0]).toEqual(
       expect.objectContaining({
         segment: "Balanced DPM Mandates",
+        segmentType: "Mandate type",
         sourceRefs: "System: lotus-core | Product: MandateTypeSegment",
       })
     );
@@ -244,6 +245,7 @@ describe("PM operating quality view model", () => {
       "Balanced DPM Mandates",
       "Income DPM Mandates",
     ]);
+    expect(model.fairnessSegmentRows[0].segmentType).toBe("Mandate type");
     expect(model.fairnessSegmentRows[0].sourceRefs).toBe(
       "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001"
     );


### PR DESCRIPTION
## Summary
- render PM operating-quality source and fairness segment types as advisor-readable labels
- preserve raw Gateway/Manage segment type values for fairness preview requests
- cover source segment and fairness segment label posture in unit/panel tests

## Validation
- npm test -- --run tests/unit/pm-operating-quality-view-model.test.ts tests/unit/pm-operating-quality-panel.test.tsx
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Notes
- Workbench-only presentation change; no Manage direct calls and no browser-side scoring, segment discovery, fairness analytics, or PM ranking.
- No wiki update required: no operator-facing documentation truth changed.