### PR TITLE
feat(workbench): clarify PM quality reason codes

### DIFF
--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -69,6 +69,18 @@ function statePanelCopy(state: PmOperatingQualityPanelState) {
   };
 }
 
+function formatReasonCodeList(value: string): string {
+  if (!value || value === "N/A" || value === "-") {
+    return value || "N/A";
+  }
+  return value
+    .split(",")
+    .map((reason) => reason.trim())
+    .filter(Boolean)
+    .map((reason) => `${formatBusinessReason(reason)} (${reason})`)
+    .join(", ");
+}
+
 function buildActionError(error: unknown, fallback: string): PmQualityActionError {
   const message = error instanceof Error ? error.message : fallback;
   const status = resolveErrorStatus(message);
@@ -326,7 +338,7 @@ export default function PmOperatingQualityPanel({
                 row.score,
                 row.forbiddenUses,
                 row.sourceRefs,
-                row.reasonCodes,
+                formatReasonCodeList(row.reasonCodes),
               ],
             }))}
             emptyState={{
@@ -389,7 +401,10 @@ export default function PmOperatingQualityPanel({
           <div className="pm-quality-detail-stack">
             <MetricRow label="Generated At" value={model.fairnessDetail.generatedAt} />
             <MetricRow label="Analysis Source Refs" value={model.fairnessDetail.sourceRefs} />
-            <MetricRow label="Analysis Reason Codes" value={model.fairnessDetail.reasonCodes} />
+            <MetricRow
+              label="Analysis Reason Codes"
+              value={formatReasonCodeList(model.fairnessDetail.reasonCodes)}
+            />
             <MetricRow label="Forbidden Use Boundary" value={model.fairnessDetail.forbiddenUses} />
           </div>
         </div>
@@ -447,7 +462,7 @@ export default function PmOperatingQualityPanel({
               `${row.minimumScore} / ${row.maximumScore}`,
               row.scoreRunRefs,
               row.sourceRefs,
-              row.reasonCodes,
+              formatReasonCodeList(row.reasonCodes),
             ],
           }))}
           emptyState={{
@@ -480,7 +495,7 @@ export default function PmOperatingQualityPanel({
               {businessStateLabel(row.state)}
             </SemanticBadge>,
             row.asOfDate,
-            row.reasonCodes,
+            formatReasonCodeList(row.reasonCodes),
           ],
         }))}
         emptyState={{

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -139,6 +139,7 @@ describe("PmOperatingQualityPanel", () => {
     expect(
       screen.getAllByText("protected class inference, autonomous pm ranking").length
     ).toBeGreaterThan(0);
+    expect(screen.getAllByText("Pm Quality Ready (PM_QUALITY_READY)").length).toBeGreaterThan(0);
     expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();
     expect(
       screen.getByText("System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001")
@@ -366,5 +367,10 @@ describe("PmOperatingQualityPanel", () => {
         .length
     ).toBeGreaterThan(0);
     expect(screen.getAllByText(/protected class inference/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(
+        "Pm Quality Fairness Spread Review Required (PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED)"
+      ).length
+    ).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- render PM operating-quality reason codes as readable labels with the original Manage/Gateway code preserved in parentheses
- apply the same presentation to score-run rows, fairness detail, fairness segment rows, and policy rows
- keep data model and Gateway-backed values unchanged; no browser-side scoring, segment discovery, fairness analytics, or PM ranking

## Validation
- npm test -- --run tests/unit/pm-operating-quality-panel.test.tsx tests/unit/pm-operating-quality-view-model.test.ts
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Notes
- Workbench-only presentation change; Gateway/Manage remain PM operating-quality authority.
- No wiki update required: no operator-facing documentation truth changed.