### PR TITLE
Clarify PM quality blocked actions

### DIFF
--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -491,7 +491,7 @@ function summarizeBlockedActions(actions: string[], sourceService: string | null
     return "None";
   }
   const source = sourceService || "Manage action register";
-  return actions.map((action) => `${action} (${source})`).join(", ");
+  return actions.map((action) => `${formatActionLabel(action)} (${action}; ${source})`).join(", ");
 }
 
 function uniqueByScoreRunId(row: PmOperatingQualityScoreRunRow, index: number, rows: PmOperatingQualityScoreRunRow[]) {
@@ -544,6 +544,13 @@ function formatForbiddenUses(value: unknown): string {
 
 function formatForbiddenUse(value: string): string {
   return value.replaceAll("_", " ");
+}
+
+function formatActionLabel(value: string): string {
+  return value
+    .replaceAll("_", " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
 }
 
 function formatSegmentType(value: string | null | undefined): string {

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -254,7 +254,7 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getByLabelText("PM operating quality command readiness")).toBeInTheDocument();
     expect(screen.getAllByText("Blocked by Manage action register").length).toBeGreaterThan(0);
     expect(
-      screen.getByText("PREVIEW_FAIRNESS_ANALYSIS (lotus-manage)")
+      screen.getByText("Preview Fairness Analysis (PREVIEW_FAIRNESS_ANALYSIS; lotus-manage)")
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: "Preview Fairness" }));

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -240,7 +240,7 @@ describe("PM operating quality view model", () => {
       upstreamStatus: "200",
     });
     expect(model.blockedActions).toEqual(["CREATE_SCORE_RUN"]);
-    expect(model.blockedActionPosture).toBe("CREATE_SCORE_RUN (lotus-manage)");
+    expect(model.blockedActionPosture).toBe("Create Score Run (CREATE_SCORE_RUN; lotus-manage)");
     expect(model.fairnessSegmentRows.map((row) => row.segment)).toEqual([
       "Balanced DPM Mandates",
       "Income DPM Mandates",
@@ -326,7 +326,9 @@ describe("PM operating quality view model", () => {
     expect(model.state).toBe("blocked");
     expect(model.fairnessPreviewReadinessState).toBe("BLOCKED");
     expect(model.fairnessPreviewReadiness).toBe("Blocked by Manage action register");
-    expect(model.blockedActionPosture).toBe("PREVIEW_FAIRNESS_ANALYSIS (lotus-manage)");
+    expect(model.blockedActionPosture).toBe(
+      "Preview Fairness Analysis (PREVIEW_FAIRNESS_ANALYSIS; lotus-manage)"
+    );
     expect(model.scoreRunPreviewReadinessState).toBe("READY");
   });
 });


### PR DESCRIPTION
## Summary
- Render Manage action-register blocked actions with readable labels while preserving the raw action code and source service.
- Keep PM operating quality command boundaries Gateway-backed and unchanged.
- Update panel and view-model tests for the blocked action presentation contract.

## Validation
- npm test -- --run tests/unit/pm-operating-quality-panel.test.tsx tests/unit/pm-operating-quality-view-model.test.ts
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Wiki
- No wiki change: this is a Workbench display-label refinement for existing Gateway-backed PM quality data.