### PR TITLE
Preserve PM quality forbidden-use codes

### DIFF
--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -543,7 +543,7 @@ function formatForbiddenUses(value: unknown): string {
 }
 
 function formatForbiddenUse(value: string): string {
-  return value.replaceAll("_", " ");
+  return `${formatActionLabel(value)} (${value})`;
 }
 
 function formatActionLabel(value: string): string {

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -137,7 +137,9 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getAllByText("2026-05-13").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Forbidden Uses").length).toBeGreaterThan(0);
     expect(
-      screen.getAllByText("protected class inference, autonomous pm ranking").length
+      screen.getAllByText(
+        "Protected Class Inference (protected_class_inference), Autonomous Pm Ranking (autonomous_pm_ranking)"
+      ).length
     ).toBeGreaterThan(0);
     expect(screen.getAllByText("Pm Quality Ready (PM_QUALITY_READY)").length).toBeGreaterThan(0);
     expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -181,7 +181,7 @@ describe("PM operating quality view model", () => {
       "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001"
     );
     expect(model.scoreRunRows[0].forbiddenUses).toBe(
-      "protected class inference, autonomous pm ranking"
+      "Protected Class Inference (protected_class_inference), Autonomous Pm Ranking (autonomous_pm_ranking)"
     );
     expect(model.scoreRunPreviewReadinessState).toBe("READY");
     expect(model.scoreRunPreviewReadiness).toBe("Ready for policy pmq_sg_dpm / 2026.05");
@@ -205,7 +205,9 @@ describe("PM operating quality view model", () => {
         sourceRefs: "System: lotus-core | Product: MandateTypeSegment",
       })
     );
-    expect(model.forbiddenUsePosture).toContain("protected class inference");
+    expect(model.forbiddenUsePosture).toContain(
+      "Protected Class Inference (protected_class_inference)"
+    );
   });
 
   it("renders fairness preview as review-required evidence without client-side analysis", () => {
@@ -231,7 +233,9 @@ describe("PM operating quality view model", () => {
         sourceRefs: "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001",
       })
     );
-    expect(model.fairnessDetail.forbiddenUses).toContain("protected class inference");
+    expect(model.fairnessDetail.forbiddenUses).toContain(
+      "Protected Class Inference (protected_class_inference)"
+    );
     expect(model.operationEvidence).toEqual({
       operation: "Fairness analysis preview",
       correlationId: "corr-fairness",


### PR DESCRIPTION
## Summary
- Render PM operating quality forbidden-use boundaries with readable labels plus raw Manage codes.
- Preserve the Gateway/Manage values without browser-side policy inference or scoring.
- Update view-model and panel tests for the forbidden-use display contract.

## Validation
- npm test -- --run tests/unit/pm-operating-quality-panel.test.tsx tests/unit/pm-operating-quality-view-model.test.ts
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Wiki
- No wiki change: this is a Workbench display-label refinement for existing Gateway-backed PM quality data.