### PR TITLE
Preserve PM acronym in quality labels

### DIFF
--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -550,7 +550,8 @@ function formatActionLabel(value: string): string {
   return value
     .replaceAll("_", " ")
     .toLowerCase()
-    .replace(/\b\w/g, (match) => match.toUpperCase());
+    .replace(/\b\w/g, (match) => match.toUpperCase())
+    .replace(/\b(Pm|Hr|Oms|Dpm|Ai|Usd)\b/g, (match) => match.toUpperCase());
 }
 
 function formatSegmentType(value: string | null | undefined): string {

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -138,7 +138,7 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getAllByText("Forbidden Uses").length).toBeGreaterThan(0);
     expect(
       screen.getAllByText(
-        "Protected Class Inference (protected_class_inference), Autonomous Pm Ranking (autonomous_pm_ranking)"
+        "Protected Class Inference (protected_class_inference), Autonomous PM Ranking (autonomous_pm_ranking)"
       ).length
     ).toBeGreaterThan(0);
     expect(screen.getAllByText("Pm Quality Ready (PM_QUALITY_READY)").length).toBeGreaterThan(0);

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -181,7 +181,7 @@ describe("PM operating quality view model", () => {
       "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001"
     );
     expect(model.scoreRunRows[0].forbiddenUses).toBe(
-      "Protected Class Inference (protected_class_inference), Autonomous Pm Ranking (autonomous_pm_ranking)"
+      "Protected Class Inference (protected_class_inference), Autonomous PM Ranking (autonomous_pm_ranking)"
     );
     expect(model.scoreRunPreviewReadinessState).toBe("READY");
     expect(model.scoreRunPreviewReadiness).toBe("Ready for policy pmq_sg_dpm / 2026.05");


### PR DESCRIPTION
## Summary
- Preserve governed acronyms such as PM in PM operating quality display labels.
- Keep raw Manage source codes visible next to readable labels.
- Update view-model and panel tests for the label contract.

## Validation
- npm test -- --run tests/unit/pm-operating-quality-panel.test.tsx tests/unit/pm-operating-quality-view-model.test.ts
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Wiki
- No wiki change: this is a label-casing refinement for existing Gateway-backed PM quality data.