### PR TITLE
Preserve PM acronym in reason labels

### DIFF
--- a/src/features/workbench/business-label-formatters.ts
+++ b/src/features/workbench/business-label-formatters.ts
@@ -1,0 +1,3 @@
+export function preserveBusinessAcronyms(value: string): string {
+  return value.replace(/\b(Pm|Hr|Oms|Dpm|Ai|Usd)\b/g, (match) => match.toUpperCase());
+}

--- a/src/features/workbench/manage-workspace-view-model.ts
+++ b/src/features/workbench/manage-workspace-view-model.ts
@@ -337,7 +337,11 @@ export function formatBusinessReason(value: string | null | undefined): string {
   if (normalized.includes("CASH")) {
     return "Cash range";
   }
-  return businessStateLabel(value);
+  return preserveBusinessAcronyms(businessStateLabel(value));
+}
+
+function preserveBusinessAcronyms(value: string): string {
+  return value.replace(/\b(Pm|Hr|Oms|Dpm|Ai|Usd)\b/g, (match) => match.toUpperCase());
 }
 
 export function businessLastReviewed(value: string | null | undefined): string {

--- a/src/features/workbench/manage-workspace-view-model.ts
+++ b/src/features/workbench/manage-workspace-view-model.ts
@@ -1,4 +1,5 @@
 import type { buildDpmCommandCenterPanelModel } from "@/features/workbench/dpm-command-center-view-model";
+import { preserveBusinessAcronyms } from "@/features/workbench/business-label-formatters";
 
 import type { ManageWorkspaceData } from "./manage-workspace";
 
@@ -338,10 +339,6 @@ export function formatBusinessReason(value: string | null | undefined): string {
     return "Cash range";
   }
   return preserveBusinessAcronyms(businessStateLabel(value));
-}
-
-function preserveBusinessAcronyms(value: string): string {
-  return value.replace(/\b(Pm|Hr|Oms|Dpm|Ai|Usd)\b/g, (match) => match.toUpperCase());
 }
 
 export function businessLastReviewed(value: string | null | undefined): string {

--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -1,3 +1,4 @@
+import { preserveBusinessAcronyms } from "./business-label-formatters";
 import type { DpmPmOperatingQualityGatewayResponse } from "./types";
 
 export type PmOperatingQualityPanelState =
@@ -547,11 +548,12 @@ function formatForbiddenUse(value: string): string {
 }
 
 function formatActionLabel(value: string): string {
-  return value
-    .replaceAll("_", " ")
-    .toLowerCase()
-    .replace(/\b\w/g, (match) => match.toUpperCase())
-    .replace(/\b(Pm|Hr|Oms|Dpm|Ai|Usd)\b/g, (match) => match.toUpperCase());
+  return preserveBusinessAcronyms(
+    value
+      .replaceAll("_", " ")
+      .toLowerCase()
+      .replace(/\b\w/g, (match) => match.toUpperCase())
+  );
 }
 
 function formatSegmentType(value: string | null | undefined): string {

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -141,7 +141,7 @@ describe("PmOperatingQualityPanel", () => {
         "Protected Class Inference (protected_class_inference), Autonomous PM Ranking (autonomous_pm_ranking)"
       ).length
     ).toBeGreaterThan(0);
-    expect(screen.getAllByText("Pm Quality Ready (PM_QUALITY_READY)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("PM Quality Ready (PM_QUALITY_READY)").length).toBeGreaterThan(0);
     expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();
     expect(
       screen.getByText("System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001")
@@ -371,7 +371,7 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getAllByText(/protected class inference/i).length).toBeGreaterThan(0);
     expect(
       screen.getAllByText(
-        "Pm Quality Fairness Spread Review Required (PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED)"
+        "PM Quality Fairness Spread Review Required (PM_QUALITY_FAIRNESS_SPREAD_REVIEW_REQUIRED)"
       ).length
     ).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary
- Preserve governed acronyms such as PM in shared Workbench business reason labels.
- Keep raw Gateway/Manage reason codes visible in PM operating quality reason rows.
- Update PM quality panel assertions for the reason-label contract.

## Validation
- npm test -- --run tests/unit/pm-operating-quality-panel.test.tsx tests/unit/pm-operating-quality-view-model.test.ts
- npm test -- --run tests/unit/manage-workspace-view-model.test.ts tests/unit/dpm-command-center-panel.test.tsx
- npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- git diff --check

## Wiki
- No wiki change: this is a shared Workbench label-casing refinement for existing Gateway-backed reason codes.