### PR TITLE
Render source ref ID labels consistently

### DIFF
--- a/src/features/workbench/business-label-formatters.ts
+++ b/src/features/workbench/business-label-formatters.ts
@@ -1,3 +1,3 @@
 export function preserveBusinessAcronyms(value: string): string {
-  return value.replace(/\b(Pm|Hr|Oms|Dpm|Ai|Usd)\b/g, (match) => match.toUpperCase());
+  return value.replace(/\b(Pm|Hr|Oms|Dpm|Ai|Usd|Id)\b/g, (match) => match.toUpperCase());
 }

--- a/src/features/workbench/pm-operating-quality-view-model.ts
+++ b/src/features/workbench/pm-operating-quality-view-model.ts
@@ -593,7 +593,7 @@ function formatSourceRef(ref: Record<string, unknown>): string {
   const parts = [
     system ? `System: ${system}` : "",
     product ? `Product: ${product}` : "",
-    id ? `Id: ${id}` : "",
+    id ? `ID: ${id}` : "",
   ].filter(Boolean);
   return parts.join(" | ") || firstNonEmpty(readString(ref, "source_type"));
 }

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -144,10 +144,10 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getAllByText("PM Quality Ready (PM_QUALITY_READY)").length).toBeGreaterThan(0);
     expect(screen.getByLabelText("PM operating quality source segments")).toBeInTheDocument();
     expect(
-      screen.getByText("System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001")
+      screen.getByText("System: lotus-manage | Product: PmOperatingQualityScoreRun | ID: pmq_run_001")
     ).toBeInTheDocument();
     expect(
-      screen.getByText("System: lotus-core | Product: MandateTypeSegment | Id: balanced")
+      screen.getByText("System: lotus-core | Product: MandateTypeSegment | ID: balanced")
     ).toBeInTheDocument();
     expect(screen.getAllByText("Mandate type").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Preview Fairness" })).toBeEnabled();
@@ -365,7 +365,7 @@ describe("PmOperatingQualityPanel", () => {
     expect(screen.getByText("15.00")).toBeInTheDocument();
     expect(screen.getAllByText("31.00").length).toBeGreaterThan(0);
     expect(
-      screen.getAllByText("System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001")
+      screen.getAllByText("System: lotus-manage | Product: PmOperatingQualityScoreRun | ID: pmq_run_001")
         .length
     ).toBeGreaterThan(0);
     expect(screen.getAllByText(/protected class inference/i).length).toBeGreaterThan(0);

--- a/tests/unit/pm-operating-quality-view-model.test.ts
+++ b/tests/unit/pm-operating-quality-view-model.test.ts
@@ -178,7 +178,7 @@ describe("PM operating quality view model", () => {
     expect(model.scoreRunRows).toHaveLength(1);
     expect(model.scoreRunRows[0].score).toBe("90.00");
     expect(model.scoreRunRows[0].sourceRefs).toBe(
-      "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001"
+      "System: lotus-manage | Product: PmOperatingQualityScoreRun | ID: pmq_run_001"
     );
     expect(model.scoreRunRows[0].forbiddenUses).toBe(
       "Protected Class Inference (protected_class_inference), Autonomous PM Ranking (autonomous_pm_ranking)"
@@ -230,7 +230,7 @@ describe("PM operating quality view model", () => {
         maximumAverageScoreSpread: "15.00",
         observedAverageScoreSpread: "31.00",
         generatedBy: "lotus-manage",
-        sourceRefs: "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001",
+        sourceRefs: "System: lotus-manage | Product: PmOperatingQualityScoreRun | ID: pmq_run_001",
       })
     );
     expect(model.fairnessDetail.forbiddenUses).toContain(
@@ -251,10 +251,10 @@ describe("PM operating quality view model", () => {
     ]);
     expect(model.fairnessSegmentRows[0].segmentType).toBe("Mandate type");
     expect(model.fairnessSegmentRows[0].sourceRefs).toBe(
-      "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001"
+      "System: lotus-manage | Product: PmOperatingQualityScoreRun | ID: pmq_run_001"
     );
     expect(model.fairnessSegmentRows[0].scoreRunRefs).toBe(
-      "System: lotus-manage | Product: PmOperatingQualityScoreRun | Id: pmq_run_001"
+      "System: lotus-manage | Product: PmOperatingQualityScoreRun | ID: pmq_run_001"
     );
     expect(model.fairnessSegmentRows[0].minimumScore).toBe("89.00");
     expect(model.fairnessSegmentRows[0].maximumScore).toBe("91.00");


### PR DESCRIPTION
## Summary
- render PM operating-quality source reference labels as `ID` instead of `Id`
- extend the shared Workbench acronym formatter so source-ref labels stay consistent with PM/DPM/USD casing
- keep Gateway/Manage source reference values unchanged

## Validation
- `npm test -- --run tests/unit/pm-operating-quality-panel.test.tsx tests/unit/pm-operating-quality-view-model.test.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

## Integration posture
- Workbench-only UI/view-model formatting cleanup
- Continues to consume Gateway-backed PM operating-quality responses only
- No browser-side score, segment average, fairness spread, PM ranking, HR/compensation/conduct, trade approval, client contact, order routing, or OMS truth calculation added

## Wiki
- No wiki change: no operator-facing contract, route, or workflow truth changed.