### PR TITLE
Show concentration top-position proof

### DIFF
--- a/docs/operations/risk-workspace-supportability.md
+++ b/docs/operations/risk-workspace-supportability.md
@@ -199,7 +199,8 @@ Current payload blocks:
 1. `portfolio_concentration`
    - portfolio-level HHI current / proposed / delta
 2. `single_position_concentration`
-   - top-position weights
+   - source-owned `TOP_POSITION_WEIGHT` current / proposed / delta fields from
+     `ConcentrationRiskReport:v1`
    - top-`n` cumulative weights
    - named current / proposed top-position drivers
 3. `issuer_concentration`
@@ -219,6 +220,10 @@ This gives the front office three explicit answers on first paint:
 1. how concentrated the live book is,
 2. which position and issuer are driving that concentration,
 3. how trustworthy the issuer concentration view is.
+
+Workbench may format the source-owned top-position weights and driver names for display, but it
+must not recalculate `TOP_POSITION_WEIGHT`, infer the largest position locally, or override the
+current/proposed driver identities returned through Gateway.
 
 ## Cache and refresh posture
 

--- a/src/apps/performance/risk-workspace-view-model.ts
+++ b/src/apps/performance/risk-workspace-view-model.ts
@@ -1750,7 +1750,30 @@ function mapConcentrationContextRows(
   }
   const executionContext = payload.execution_context;
   const valuationContext = payload.valuation_context;
+  const currentTopPosition = payload.single_position_concentration.top_position_current;
+  const proposedTopPosition = payload.single_position_concentration.top_position_proposed;
   return [
+    {
+      key: "top_position_methodology",
+      label: "Top Position Methodology",
+      value: "TOP_POSITION_WEIGHT",
+      definition:
+        "Source-owned concentration methodology from lotus-risk ConcentrationRiskReport:v1.",
+      support:
+        "Gateway and Workbench render returned top-position weights and drivers without recalculating them.",
+    },
+    {
+      key: "top_position_driver",
+      label: "Top Position Driver",
+      value: formatConcentrationPositionDriverLabel(currentTopPosition),
+      definition:
+        "Current largest-position driver returned by the source concentration report.",
+      support: buildTopPositionDriverSupport({
+        currentDriver: currentTopPosition,
+        proposedDriver: proposedTopPosition,
+        delta: payload.single_position_concentration.top_position_weight_delta,
+      }),
+    },
     {
       key: "issuer_coverage",
       label: "Issuer Coverage",
@@ -1789,6 +1812,39 @@ function mapConcentrationContextRows(
       support: valuationContext?.portfolio_currency ? "Portfolio currency" : "Portfolio currency",
     },
   ];
+}
+
+function formatConcentrationPositionDriverLabel(driver: {
+  security_id?: string | null;
+  security_name?: string | null;
+}) {
+  return driver.security_name ?? driver.security_id ?? "N/A";
+}
+
+function buildTopPositionDriverSupport({
+  currentDriver,
+  proposedDriver,
+  delta,
+}: {
+  currentDriver: {
+    security_id?: string | null;
+    security_name?: string | null;
+    weight: number;
+  };
+  proposedDriver: {
+    security_id?: string | null;
+    security_name?: string | null;
+    weight: number;
+  };
+  delta: number;
+}) {
+  const currentLabel = formatConcentrationPositionDriverLabel(currentDriver);
+  const proposedLabel = formatConcentrationPositionDriverLabel(proposedDriver);
+  return `Current ${currentLabel} ${formatRiskPercentValue(
+    currentDriver.weight
+  )}; proposed ${proposedLabel} ${formatRiskPercentValue(
+    proposedDriver.weight
+  )}; source delta ${formatSignedRiskPercentValue(delta)}.`;
 }
 
 function mapDrawdownHeadlineMetrics(
@@ -2168,6 +2224,14 @@ function formatRiskPercentValue(
     minimumFractionDigits,
     maximumFractionDigits,
   });
+}
+
+function formatSignedRiskPercentValue(value: number | null | undefined) {
+  if (typeof value !== "number") {
+    return "N/A";
+  }
+  const formatted = formatRiskPercentValue(value);
+  return value > 0 ? `+${formatted}` : formatted;
 }
 
 function describeDrawdownHeadlineMetric(

--- a/tests/unit/performance-risk-view-model.test.ts
+++ b/tests/unit/performance-risk-view-model.test.ts
@@ -58,9 +58,25 @@ describe("buildPerformanceRiskViewModel", () => {
       label: "Portfolio Concentration Index",
       interpretationBand: "Moderate",
     });
-    expect(viewModel.concentrationContextRows[0]).toMatchObject({
-      label: "Issuer Coverage",
-    });
+    expect(viewModel.concentrationContextRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Top Position Methodology",
+          value: "TOP_POSITION_WEIGHT",
+          support:
+            "Gateway and Workbench render returned top-position weights and drivers without recalculating them.",
+        }),
+        expect.objectContaining({
+          label: "Top Position Driver",
+          value: "PIMCO GIS Income Fund",
+          support:
+            "Current PIMCO GIS Income Fund 18.40%; proposed PIMCO GIS Income Fund 18.40%; source delta 0.00%.",
+        }),
+        expect.objectContaining({
+          label: "Issuer Coverage",
+        }),
+      ])
+    );
     expect(viewModel.supportability.map((item) => item.key)).toEqual([
       "summary:portfolio_returns",
       "summary:benchmark_returns",

--- a/tests/unit/risk-concentration-panel.test.tsx
+++ b/tests/unit/risk-concentration-panel.test.tsx
@@ -69,6 +69,10 @@ describe("RiskConcentrationPanel", () => {
       name: "Concentration methodology and coverage",
     });
 
+    expect(within(dialog).getByText("Top Position Methodology")).toBeInTheDocument();
+    expect(within(dialog).getByText("TOP_POSITION_WEIGHT")).toBeInTheDocument();
+    expect(within(dialog).getByText("Top Position Driver")).toBeInTheDocument();
+    expect(within(dialog).getByText("PIMCO GIS Income Fund")).toBeInTheDocument();
     expect(within(dialog).getByText("Issuer Coverage")).toBeInTheDocument();
     expect(within(dialog).getByText("Grouping Level")).toBeInTheDocument();
     expect(within(dialog).getByText("Reporting Currency")).toBeInTheDocument();

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -115,6 +115,10 @@ must travel through Gateway-shaped contracts.
     implemented proof-pack panel consumes the Gateway proof-pack
     generation, detail, Markdown, report-input, AI-evidence, and AI PM memo contracts, and the
     implemented outcome panel consumes the Gateway outcome-review list and AI-narrative contracts.
+    Performance risk concentration consumes Gateway `ConcentrationRiskReport:v1` output from
+    `lotus-risk`, including source-owned `TOP_POSITION_WEIGHT` current/proposed/delta fields and
+    current/proposed top-position driver identities; Workbench renders these fields but does not
+    recompute top-position weights or infer largest holdings locally.
     The implemented command-center exception queue consumes the Gateway exception-summary contract.
     The implemented portfolio-memory panel consumes the Gateway portfolio-memory contract and
     preserves manage event order without reconstructing timeline nodes, and the implemented PM


### PR DESCRIPTION
## Summary
- render source-owned TOP_POSITION_WEIGHT methodology and current/proposed top-position drivers in the risk concentration methodology drawer
- keep Workbench formatting-only: no browser-side HHI or top-position calculation
- document Gateway-backed concentration supportability and wiki integration truth

## Validation
- npm test -- --run tests/unit/performance-risk-view-model.test.ts tests/unit/risk-concentration-panel.test.tsx
- make typecheck
- make lint
- npm run build
- git diff --check
- targeted Playwright runtime proof through Gateway: output/playwright/diagnostic-concentration-top-position-proof/concentration-top-position-methodology.png

## Wiki
- repo-local wiki/Integrations.md updated; publish after merge