### PR TITLE
Clarify PM quality fairness preview posture

### DIFF
--- a/src/features/workbench/components/pm-operating-quality-panel.tsx
+++ b/src/features/workbench/components/pm-operating-quality-panel.tsx
@@ -140,6 +140,7 @@ export default function PmOperatingQualityPanel({
   });
   const stateCopy = statePanelCopy(model.state);
   const loadError = policiesError || scoreRunsError;
+  const hasFairnessPreview = model.fairnessAnalysisId !== "N/A";
   const shouldShowStatePanel =
     Boolean(loadError) ||
     Boolean(actionError) ||
@@ -377,9 +378,27 @@ export default function PmOperatingQualityPanel({
             <Text as="h3" variant="subsectionTitle">
               Fairness Preview Detail
             </Text>
-            <SemanticBadge tone={toneForState(model.fairnessState)}>
-              {businessStateLabel(model.fairnessState)}
+            <SemanticBadge tone={toneForState(hasFairnessPreview ? model.fairnessState : "PENDING")}>
+              {hasFairnessPreview ? businessStateLabel(model.fairnessState) : "Not previewed"}
             </SemanticBadge>
+          </div>
+          <div
+            className="pm-quality-fairness-preview-posture"
+            aria-label="PM operating quality fairness preview posture"
+          >
+            <MetricRow
+              label="Gateway Preview State"
+              value={
+                hasFairnessPreview
+                  ? "Fairness analysis returned by Gateway"
+                  : "Awaiting Gateway fairness preview"
+              }
+            />
+            <MetricRow label="Preview Readiness" value={model.fairnessPreviewReadiness} />
+            <MetricRow
+              label="Authority Boundary"
+              value="Manage owns segment posture and fairness spread; Workbench does not calculate or rank"
+            />
           </div>
           <div className="pm-quality-detail-grid">
             <MetricRow label="Product" value={model.fairnessDetail.product} />

--- a/src/features/workbench/manage-workspace.module.css
+++ b/src/features/workbench/manage-workspace.module.css
@@ -1325,6 +1325,43 @@
   border-bottom: 1px solid #e0e3e5;
 }
 
+.manageScope :global(.pm-quality-fairness-preview-posture) {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(240px, 1.2fr);
+  border-bottom: 1px solid #e0e3e5;
+  background: #fffdf8;
+}
+
+.manageScope :global(.pm-quality-fairness-preview-posture .suite-row) {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  min-height: 76px;
+  padding: 12px 14px;
+  border-top: 0;
+  border-right: 1px solid #e0e3e5;
+}
+
+.manageScope :global(.pm-quality-fairness-preview-posture .suite-row:last-child) {
+  border-right: 0;
+}
+
+.manageScope :global(.pm-quality-fairness-preview-posture .suite-row span) {
+  color: #725b26;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.pm-quality-fairness-preview-posture .suite-row strong) {
+  color: #131b2e;
+  font-size: 13px;
+  line-height: 18px;
+  overflow-wrap: anywhere;
+}
+
 .manageScope :global(.pm-quality-detail-grid .suite-row) {
   display: grid;
   align-content: start;

--- a/tests/unit/pm-operating-quality-panel.test.tsx
+++ b/tests/unit/pm-operating-quality-panel.test.tsx
@@ -122,6 +122,10 @@ describe("PmOperatingQualityPanel", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Score Preview Command")).toBeInTheDocument();
     expect(screen.getByText("Fairness Preview Command")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("PM operating quality fairness preview posture")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Awaiting Gateway fairness preview")).toBeInTheDocument();
     expect(screen.getByText(/no scoring, ranking, trade approval/i)).toBeInTheDocument();
     expect(screen.getByText("Score-run evidence load")).toBeInTheDocument();
     expect(screen.getByText("corr-score")).toBeInTheDocument();
@@ -359,6 +363,7 @@ describe("PmOperatingQualityPanel", () => {
     expect(previewDpmPmOperatingQualityScoreRun).not.toHaveBeenCalled();
     expect(screen.getByText("Fairness preview returned Manage segment evidence.")).toBeInTheDocument();
     expect(screen.getByText("Fairness analysis preview")).toBeInTheDocument();
+    expect(screen.getByText("Fairness analysis returned by Gateway")).toBeInTheDocument();
     expect(screen.getByText("corr-pmq-fairness")).toBeInTheDocument();
     expect(screen.getByText("Fairness Preview Detail")).toBeInTheDocument();
     expect(screen.getByText("PmOperatingQualityFairnessAnalysis / v1")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add an explicit Gateway fairness-preview posture strip to the PM operating quality surface
- distinguish source segment readiness from a returned Manage-owned PmOperatingQualityFairnessAnalysis preview
- keep the authority boundary visible: Manage owns segment posture/fairness spread and Workbench does not calculate or rank

## Validation
- npm test -- --run tests/unit/pm-operating-quality-panel.test.tsx tests/unit/pm-operating-quality-view-model.test.ts
- git diff --check
- make typecheck
- make lint
- npm run build
- targeted Playwright runtime proof: output/playwright/diagnostic-pm-quality-preview-posture/pm-quality-preview-posture.png

## Wiki
- no wiki change: this is a UI posture clarification over existing Gateway-backed PM quality support