### PR TITLE
Improve cashflow workspace experience

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1834,17 +1834,19 @@ a:hover {
 
 .portfolio-cashflow-summary-strip {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: var(--space-3);
 }
 
 .portfolio-cashflow-summary-stat {
   display: grid;
   gap: var(--space-1);
-  padding: var(--space-3);
+  align-content: start;
+  min-height: 7.75rem;
+  padding: var(--space-4);
   border: 1px solid rgba(217, 224, 231, 0.9);
-  border-radius: var(--radius-md);
-  background: #fbfcfd;
+  border-radius: var(--radius-sm);
+  background: #fff;
 }
 
 .portfolio-cashflow-summary-stat span {
@@ -1856,41 +1858,73 @@ a:hover {
 }
 
 .portfolio-cashflow-summary-stat strong {
-  font-size: 0.9375rem;
+  font-size: 1.35rem;
   font-weight: 700;
-  line-height: 1.3;
+  line-height: 1.15;
   color: var(--text);
   font-variant-numeric: tabular-nums;
 }
 
+.portfolio-cashflow-summary-stat em {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-style: normal;
+  line-height: 1.35;
+}
+
+.portfolio-cashflow-summary-stat-dark {
+  border-color: #131b2e;
+  background: #131b2e;
+}
+
+.portfolio-cashflow-summary-stat-dark span {
+  color: #ffdf9d;
+}
+
+.portfolio-cashflow-summary-stat-dark strong,
+.portfolio-cashflow-summary-stat-dark em {
+  color: #fff;
+}
+
 .portfolio-cashflow-chart {
+  position: relative;
   min-height: 0;
-  max-height: 15.5rem;
+  height: 20rem;
+  max-height: 20rem;
+  padding: var(--space-2) 0;
+  border: 1px solid rgba(217, 224, 231, 0.9);
+  border-radius: var(--radius-sm);
+  background: #fff;
 }
 
 .portfolio-timeseries-chart-svg {
   display: block;
   width: 100%;
   height: 100%;
-  max-height: 15.5rem;
+  max-height: 19rem;
 }
 
 .portfolio-timeseries-chart-area {
-  fill: #dbe7f0;
+  fill: rgba(219, 231, 240, 0.42);
 }
 
 .portfolio-timeseries-chart-line {
   fill: none;
-  stroke: #315d8a;
-  stroke-width: 2.5;
+  stroke: #131b2e;
+  stroke-width: 2.75;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
 
 .portfolio-timeseries-chart-point {
-  fill: #315d8a;
+  fill: #131b2e;
   stroke: #fff;
   stroke-width: 2;
+}
+
+.portfolio-cashflow-grid-line {
+  stroke: rgba(105, 117, 134, 0.16);
+  stroke-width: 1;
 }
 
 .portfolio-cashflow-zero-line {
@@ -1909,6 +1943,46 @@ a:hover {
 
 .portfolio-cashflow-flow-bar-negative {
   fill: rgba(161, 90, 63, 0.74);
+}
+
+.portfolio-cashflow-focus-callout rect {
+  fill: #2d3133;
+  stroke: rgba(255, 223, 157, 0.72);
+  stroke-width: 0.75;
+  filter: drop-shadow(0 8px 12px rgba(15, 23, 42, 0.18));
+}
+
+.portfolio-cashflow-focus-callout circle {
+  fill: #ffdf9d;
+}
+
+.portfolio-cashflow-focus-callout text {
+  fill: #eff1f3;
+  font-size: 5.5px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.portfolio-cashflow-focus-callout text:first-of-type {
+  fill: rgba(239, 241, 243, 0.78);
+  font-size: 4.8px;
+}
+
+.portfolio-cashflow-forecast-mix {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
+.portfolio-cashflow-forecast-mix span {
+  border: 1px solid rgba(217, 224, 231, 0.9);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.5rem;
+  background: #fff;
 }
 
 .portfolio-cashflow-axis-grid {
@@ -2209,15 +2283,16 @@ a:hover {
 }
 
 .portfolio-cashflow-card {
-  gap: 0.625rem;
+  gap: var(--space-3);
 }
 
 .portfolio-cashflow-card-flat .portfolio-cashflow-chart {
-  max-height: 11rem;
+  height: 14rem;
+  max-height: 14rem;
 }
 
 .portfolio-cashflow-card-flat .portfolio-timeseries-chart-svg {
-  max-height: 11rem;
+  max-height: 13rem;
 }
 
 @media (max-width: 960px) {
@@ -2231,6 +2306,10 @@ a:hover {
   .portfolio-chart-module-body,
   .portfolio-allocation-body {
     grid-template-columns: 1fr;
+  }
+
+  .portfolio-cashflow-summary-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .portfolio-allocation-ranked {

--- a/src/apps/portfolio/components/portfolio-chart-panels.tsx
+++ b/src/apps/portfolio/components/portfolio-chart-panels.tsx
@@ -182,14 +182,34 @@ export function PortfolioProjectedCashflowPanel({
   const points = cashflowOutlook.upcoming_points;
   const cumulativeValues = points.map((point) => point.projected_cumulative_cashflow_base);
   const flowValues = points.map((point) => point.net_cashflow_base);
-  const minValue = Math.min(...cumulativeValues, 0);
-  const maxValue = Math.max(...cumulativeValues, 0);
+  const cumulativeMin = cumulativeValues.length ? Math.min(...cumulativeValues) : 0;
+  const cumulativeMax = cumulativeValues.length ? Math.max(...cumulativeValues) : 0;
+  const visualPadding = Math.max(Math.abs(cumulativeMin), Math.abs(cumulativeMax), 1) * 0.08;
+  const minValue = cumulativeMin - visualPadding;
+  const maxValue = cumulativeMax + visualPadding;
   const range = Math.max(maxValue - minValue, 1);
   const maxFlow = Math.max(...flowValues.map((value) => Math.abs(value)), 1);
   const finalCumulative =
     points[points.length - 1]?.projected_cumulative_cashflow_base ?? cashflowOutlook.total_net_cashflow_base;
   const positiveFlowCount = flowValues.filter((value) => value > 0).length;
   const negativeFlowCount = flowValues.filter((value) => value < 0).length;
+  const largestInflow = points.reduce<
+    NonNullable<PortfolioWorkspace["cashflow_outlook"]>["upcoming_points"][number] | null
+  >((largest, point) => {
+    if (point.net_cashflow_base <= 0) {
+      return largest;
+    }
+    return !largest || point.net_cashflow_base > largest.net_cashflow_base ? point : largest;
+  }, null);
+  const largestOutflow = points.reduce<
+    NonNullable<PortfolioWorkspace["cashflow_outlook"]>["upcoming_points"][number] | null
+  >((largest, point) => {
+    if (point.net_cashflow_base >= 0) {
+      return largest;
+    }
+    return !largest || point.net_cashflow_base < largest.net_cashflow_base ? point : largest;
+  }, null);
+  const focusPoint = largestInflow ?? largestOutflow ?? points.at(-1) ?? null;
   const chartPoints = points.map((point, index) => {
     const x = points.length === 1 ? 28 : 28 + (index / (points.length - 1)) * 264;
     const y = 172 - (((point.projected_cumulative_cashflow_base - minValue) / range) * 112 + 24);
@@ -197,30 +217,46 @@ export function PortfolioProjectedCashflowPanel({
   });
   const areaPath = buildAreaPath(chartPoints);
   const linePath = buildLinePath(chartPoints);
-  const zeroLineY = roundSvg(172 - (((0 - minValue) / range) * 112 + 24));
+  const zeroLineY = minValue <= 0 && maxValue >= 0
+    ? roundSvg(172 - (((0 - minValue) / range) * 112 + 24))
+    : null;
 
-    const flatCashflow = positiveFlowCount === 0 && negativeFlowCount === 0;
+  const flatCashflow = positiveFlowCount === 0 && negativeFlowCount === 0;
+  const focusChartPoint = focusPoint
+    ? chartPoints.find((item) => item.point.projection_date === focusPoint.projection_date)
+    : null;
+  const focusX = focusChartPoint ? Math.min(Math.max(focusChartPoint.x + 8, 46), 222) : 152;
+  const focusY = focusChartPoint ? Math.max(focusChartPoint.y - 40, 12) : 24;
 
-    return (
-      <div
-        className={
-          flatCashflow
-            ? "portfolio-chart-card portfolio-cashflow-card portfolio-cashflow-card-flat"
-            : "portfolio-chart-card portfolio-cashflow-card"
-        }
-      >
+  return (
+    <div
+      className={
+        flatCashflow
+          ? "portfolio-chart-card portfolio-cashflow-card portfolio-cashflow-card-flat"
+          : "portfolio-chart-card portfolio-cashflow-card"
+      }
+    >
       <div className="portfolio-cashflow-summary-strip" aria-label="Projected cashflow summary">
         <div className="portfolio-cashflow-summary-stat">
           <span>Net Flow</span>
           <strong>{formatCurrency(cashflowOutlook.total_net_cashflow_base, baseCurrency)}</strong>
         </div>
         <div className="portfolio-cashflow-summary-stat">
-          <span>End Horizon</span>
-          <strong>{formatCurrency(finalCumulative, baseCurrency)}</strong>
+          <span>Projection Horizon</span>
+          <strong>{`${cashflowOutlook.projection_days} days`}</strong>
         </div>
         <div className="portfolio-cashflow-summary-stat">
-          <span>Forecast Mix</span>
-          <strong>{`${positiveFlowCount} in / ${negativeFlowCount} out`}</strong>
+          <span>Largest Inflow</span>
+          <strong>
+            {largestInflow
+              ? formatCurrency(largestInflow.net_cashflow_base, baseCurrency)
+              : "No inflow"}
+          </strong>
+          {largestInflow ? <em>{formatDate(largestInflow.projection_date)}</em> : null}
+        </div>
+        <div className="portfolio-cashflow-summary-stat portfolio-cashflow-summary-stat-dark">
+          <span>Ending Cumulative</span>
+          <strong>{formatCurrency(finalCumulative, baseCurrency)}</strong>
         </div>
       </div>
       <div className="portfolio-cashflow-chart">
@@ -230,19 +266,32 @@ export function PortfolioProjectedCashflowPanel({
           role="img"
           aria-label={`Projected cashflow chart in ${baseCurrency}`}
         >
-          <line
-            x1="24"
-            x2="296"
-            y1={zeroLineY}
-            y2={zeroLineY}
-            className="portfolio-cashflow-zero-line"
-          />
+          {[36, 68, 100, 132, 164].map((gridY) => (
+            <line
+              key={`grid-${gridY}`}
+              x1="24"
+              x2="296"
+              y1={gridY}
+              y2={gridY}
+              className="portfolio-cashflow-grid-line"
+            />
+          ))}
+          {zeroLineY == null ? null : (
+            <line
+              x1="24"
+              x2="296"
+              y1={zeroLineY}
+              y2={zeroLineY}
+              className="portfolio-cashflow-zero-line"
+            />
+          )}
           {points.map((point, index) => {
             const x = points.length === 1 ? 28 : 28 + (index / (points.length - 1)) * 264;
             const width = points.length === 1 ? 28 : Math.max(12, 188 / points.length);
             const height = (Math.abs(point.net_cashflow_base) / maxFlow) * 46;
+            const flowBaselineY = 156;
             const y =
-              point.net_cashflow_base >= 0 ? zeroLineY - height : zeroLineY;
+              point.net_cashflow_base >= 0 ? flowBaselineY - height : flowBaselineY;
             return (
               <g key={`flow-${point.projection_date}`}>
                 <rect
@@ -282,7 +331,22 @@ export function PortfolioProjectedCashflowPanel({
               </circle>
             </g>
           ))}
+          {focusPoint ? (
+            <g className="portfolio-cashflow-focus-callout" aria-hidden="true">
+              <rect x={focusX} y={focusY} width="86" height="34" rx="2" />
+              <circle cx={focusX + 76} cy={focusY + 8} r="2.4" />
+              <text x={focusX + 8} y={focusY + 12}>{formatDate(focusPoint.projection_date)}</text>
+              <text x={focusX + 8} y={focusY + 24}>
+                {formatCurrency(focusPoint.net_cashflow_base, baseCurrency)}
+              </text>
+            </g>
+          ) : null}
         </svg>
+      </div>
+      <div className="portfolio-cashflow-forecast-mix" aria-label="Projected cashflow mix">
+        <span>{`${positiveFlowCount} inflow${positiveFlowCount === 1 ? "" : "s"}`}</span>
+        <span>{`${negativeFlowCount} outflow${negativeFlowCount === 1 ? "" : "s"}`}</span>
+        <span>{`Through ${formatDate(cashflowOutlook.range_end_date)}`}</span>
       </div>
       <div className="portfolio-cashflow-axis-grid">
         {points.map((point) => (

--- a/src/apps/portfolio/components/portfolio-projected-cashflow-module.tsx
+++ b/src/apps/portfolio/components/portfolio-projected-cashflow-module.tsx
@@ -145,7 +145,7 @@ export default function PortfolioProjectedCashflowModule({
   return (
     <AnalyticsModule>
       <SectionHeader
-        title="Projected Cashflow"
+        title="Cumulative Cashflow Projection"
         subtitle={subtitle}
         actions={
           <>

--- a/src/apps/portfolio/components/portfolio-record-evidence-rail.tsx
+++ b/src/apps/portfolio/components/portfolio-record-evidence-rail.tsx
@@ -29,6 +29,8 @@ export default function PortfolioRecordEvidenceRail({
   const sourcePostureItems =
     screen === "transactions"
       ? buildTransactionSourcePosture(workspace, portfolioId)
+      : screen === "cashflow"
+        ? buildCashflowSourcePosture(workspace)
       : buildPositionSourcePosture({
           workspace,
           portfolioId,
@@ -86,6 +88,38 @@ export default function PortfolioRecordEvidenceRail({
       </WorkbenchRailCard>
     </div>
   );
+}
+
+function buildCashflowSourcePosture(workspace: PortfolioWorkspace): SourcePostureProps[] {
+  const cashflow = workspace.cashflow_outlook;
+  const pointCount = cashflow?.upcoming_points.length ?? 0;
+  const positiveCount =
+    cashflow?.upcoming_points.filter((point) => point.net_cashflow_base > 0).length ?? 0;
+  const negativeCount =
+    cashflow?.upcoming_points.filter((point) => point.net_cashflow_base < 0).length ?? 0;
+  const reportingReady = workspace.readiness.reporting.status?.toUpperCase() === "READY";
+
+  return [
+    {
+      label: "Projection Source",
+      source: "Gateway portfolio workspace",
+      detail: cashflow
+        ? `${formatCount(pointCount, "projected point")} through ${formatDate(cashflow.range_end_date)}`
+        : "No projected cashflow outlook returned for this portfolio",
+      tone: cashflow ? "success" : "warn",
+      status: cashflow ? "Available" : "Unavailable",
+    },
+    {
+      label: "Forecast Horizon",
+      source: cashflow ? `${cashflow.projection_days} day projection` : "Not provided",
+      detail: cashflow
+        ? `${formatCount(positiveCount, "inflow")} and ${formatCount(negativeCount, "outflow")} in the returned forecast`
+        : "Horizon cannot be displayed until the source outlook is available",
+      tone: cashflow ? "success" : "default",
+      status: cashflow ? "Ready" : "N/A",
+    },
+    buildReportingSourcePosture(workspace, reportingReady),
+  ];
 }
 
 function buildPositionSourcePosture({

--- a/src/apps/portfolio/components/portfolio-record-screen-client.tsx
+++ b/src/apps/portfolio/components/portfolio-record-screen-client.tsx
@@ -48,7 +48,7 @@ export default function PortfolioRecordScreenClient({
   }, [workspace]);
   const copy = getPortfolioRecordScreenCopy(screen);
   const resolvedPortfolioId = portfolioId ?? "No portfolio";
-  const headerKpis = workspace ? buildPortfolioRecordHeaderKpis(workspace) : [];
+  const headerKpis = workspace ? buildPortfolioRecordHeaderKpis(workspace, "30D", screen) : [];
 
   return (
     <PortfolioPageLayout>

--- a/src/apps/portfolio/portfolio-record-screen-view-model.ts
+++ b/src/apps/portfolio/portfolio-record-screen-view-model.ts
@@ -29,8 +29,8 @@ export const PORTFOLIO_RECORD_SCREEN_COPY: Record<
     kicker: "Ledger",
   },
   cashflow: {
-    title: "Cashflow",
-    subtitle: "Forward liquidity path, projected net flows, and cumulative cash movement.",
+    title: "Cashflow Workspace",
+    subtitle: "Forward liquidity path, projected settlements, and cumulative cash movement.",
     kicker: "Liquidity forecast",
   },
 };
@@ -61,8 +61,36 @@ export function buildPortfolioRecordHeaderMeta(workspace: PortfolioWorkspace): s
 
 export function buildPortfolioRecordHeaderKpis(
   workspace: PortfolioWorkspace,
-  windowLabel = "30D"
+  windowLabel = "30D",
+  screen?: PortfolioRecordScreenKind
 ): PortfolioRecordHeaderKpi[] {
+  if (screen === "cashflow") {
+    const cashflow = workspace.cashflow_outlook;
+    const finalCumulative =
+      cashflow?.upcoming_points.at(-1)?.projected_cumulative_cashflow_base ??
+      cashflow?.total_net_cashflow_base;
+
+    return [
+      {
+        label: "Net Flow",
+        value: cashflow
+          ? formatCurrency(cashflow.total_net_cashflow_base, workspace.portfolio.base_currency)
+          : "N/A",
+      },
+      {
+        label: "Horizon",
+        value: cashflow ? `${cashflow.projection_days}D` : windowLabel,
+      },
+      {
+        label: "Ending Cumulative",
+        value:
+          finalCumulative == null
+            ? "N/A"
+            : formatCurrency(finalCumulative, workspace.portfolio.base_currency),
+      },
+    ];
+  }
+
   return [
     {
       label: "Total Market Value",

--- a/tests/unit/portfolio-chart-panels.test.tsx
+++ b/tests/unit/portfolio-chart-panels.test.tsx
@@ -140,6 +140,8 @@ describe("portfolio chart panels", () => {
     expect(screen.getByLabelText("Activity chart")).toBeInTheDocument();
     expect(screen.getByLabelText("Income chart")).toBeInTheDocument();
     expect(screen.getByLabelText("Projected cashflow chart in USD")).toBeInTheDocument();
+    expect(screen.getByLabelText("Projected cashflow mix")).toHaveTextContent("1 inflow");
+    expect(screen.getByLabelText("Projected cashflow summary")).toHaveTextContent("Largest Inflow");
     expect(screen.getByText("Inflows")).toBeInTheDocument();
     expect(screen.getByText("Dividend")).toBeInTheDocument();
     expect(screen.getByText("Window inflow")).toBeInTheDocument();

--- a/tests/unit/portfolio-projected-cashflow-module.test.tsx
+++ b/tests/unit/portfolio-projected-cashflow-module.test.tsx
@@ -88,6 +88,10 @@ describe("PortfolioProjectedCashflowModule", () => {
     );
 
     expect(screen.getByRole("button", { name: "Collapse" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Projected cashflow summary")).toHaveTextContent("Net Flow");
+    expect(screen.getByLabelText("Projected cashflow summary")).toHaveTextContent("Projection Horizon");
+    expect(screen.getByLabelText("Projected cashflow summary")).toHaveTextContent("Largest Inflow");
+    expect(screen.getByLabelText("Projected cashflow summary")).toHaveTextContent("Ending Cumulative");
     expect(screen.getByRole("table", { name: "Cashflow outlook" })).toBeInTheDocument();
   });
 
@@ -152,7 +156,7 @@ describe("PortfolioProjectedCashflowModule", () => {
       />
     );
 
-    expect(screen.getByRole("heading", { name: "Projected Cashflow" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Cumulative Cashflow Projection" })).toBeInTheDocument();
     expect(screen.getByText("Loading projected cashflow")).toBeInTheDocument();
     expect(
       screen.getByText("Projected liquidity is loading for the selected horizon.")

--- a/tests/unit/portfolio-record-screen-view-model.test.ts
+++ b/tests/unit/portfolio-record-screen-view-model.test.ts
@@ -33,6 +33,34 @@ describe("portfolio record screen view model", () => {
       { label: "Positions", value: "11" },
       { label: "Window", value: "30D" },
     ]);
+
+    expect(
+      buildPortfolioRecordHeaderKpis(
+        {
+          ...workspace,
+          cashflow_outlook: {
+            as_of_date: "2026-05-12",
+            range_end_date: "2026-06-11",
+            total_net_cashflow_base: 45200,
+            projection_days: 30,
+            include_projected: true,
+            upcoming_points: [
+              {
+                projection_date: "2026-05-20",
+                net_cashflow_base: 45200,
+                projected_cumulative_cashflow_base: 8457200,
+              },
+            ],
+          },
+        },
+        "30D",
+        "cashflow"
+      )
+    ).toEqual([
+      { label: "Net Flow", value: "45,200 USD" },
+      { label: "Horizon", value: "30D" },
+      { label: "Ending Cumulative", value: "8,457,200 USD" },
+    ]);
   });
 
   it("resolves the canonical thirty-day record window from the portfolio as-of date", () => {


### PR DESCRIPTION
## Summary
- Refines the standalone cashflow route as a Cashflow Workspace with contract-backed KPI copy.
- Improves the cumulative cashflow projection chart, summary strip, and sparse/flat forecast scaling.
- Adds cashflow-specific evidence/source posture in the right rail without inventing liquidity or scoring truth.

## Validation
- npm test -- --run tests/unit/portfolio-projected-cashflow-module.test.tsx tests/unit/portfolio-chart-panels.test.tsx tests/unit/portfolio-record-screen-view-model.test.ts
- make typecheck
- make lint
- npm run build
- Playwright browser check: /cashflow?portfolioId=PB_SG_GLOBAL_BAL_001, screenshot output/playwright/diagnostic-cashflow-workspace-uplift/cashflow-workspace.png

## Docs/Wiki
- No wiki change: existing supported cashflow route behavior was visually/view-model refined; no new operator-facing product support was introduced.