### PR TITLE
Add portfolio income activity workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Route mounting comes from `src/app/`, while app-local ownership lives under `src
 Current main surfaces:
 
 - `portfolio`
-  `/portfolio`, `/portfolios`, `/intake`
+  `/portfolio`, `/portfolios`, `/positions`, `/transactions`, `/income`, `/cashflow`, `/intake`
 - `performance`
   `/performance` with performance, risk, advisor-brief, and evidence modes
 - `workbench`

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3446,6 +3446,7 @@ a:hover {
   font-weight: 700;
   line-height: 32px;
   letter-spacing: 0;
+  overflow-wrap: anywhere;
 }
 
 .portfolio-record-standalone-header p {
@@ -3457,6 +3458,8 @@ a:hover {
 
 .portfolio-record-standalone-kpis {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   border: 1px solid #d8dde5;
   background: #f8fafc;
 }
@@ -15832,5 +15835,350 @@ a:hover {
   border-left: 2px solid #fcdc9a;
   color: #fcdc9a;
   background: rgba(255, 255, 255, 0.08);
+}
+
+.portfolio-income-activity-workspace {
+  display: grid;
+  gap: 24px;
+}
+
+.portfolio-income-activity-section {
+  display: grid;
+  gap: 12px;
+}
+
+.portfolio-income-activity-section-title {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.portfolio-income-activity-section-title h2 {
+  margin: 0;
+  color: #191c1e;
+  font-size: 13px;
+  font-weight: 750;
+  line-height: 18px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.portfolio-income-activity-section-title span {
+  color: #59616f;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.portfolio-income-activity-grid {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+.portfolio-income-grid {
+  grid-template-columns: minmax(280px, 5fr) minmax(360px, 7fr);
+}
+
+.portfolio-activity-grid {
+  grid-template-columns: minmax(420px, 8fr) minmax(280px, 4fr);
+}
+
+.portfolio-income-card {
+  min-width: 0;
+  border: 1px solid #c6c6cd;
+  border-radius: 6px;
+  background: #ffffff;
+  box-shadow: none;
+}
+
+.portfolio-income-card-visual {
+  display: grid;
+  align-content: space-between;
+  gap: 28px;
+  min-height: 280px;
+  padding: 20px;
+}
+
+.portfolio-income-metric-bar {
+  display: grid;
+  gap: 10px;
+}
+
+.portfolio-income-metric-bar > div:first-child {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.portfolio-income-metric-bar span,
+.portfolio-income-table-footer,
+.portfolio-activity-buckets h3,
+.portfolio-activity-reserve span,
+.portfolio-income-handoff-card span {
+  color: #45464d;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 16px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.portfolio-income-metric-bar strong {
+  color: #000000;
+  font-size: 20px;
+  font-weight: 750;
+  line-height: 26px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.portfolio-income-bar,
+.portfolio-activity-bucket-bar {
+  overflow: hidden;
+  height: 8px;
+  border-radius: 999px;
+  background: #e6e8ea;
+}
+
+.portfolio-income-bar-fill,
+.portfolio-activity-bucket-bar div {
+  height: 100%;
+  background: #000000;
+}
+
+.portfolio-income-bar-fill-muted {
+  background: #7c839b;
+}
+
+.portfolio-income-source-note {
+  padding-top: 16px;
+  border-top: 1px solid #c6c6cd;
+  color: #59616f;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.portfolio-income-table-card,
+.portfolio-activity-table-card {
+  overflow: hidden;
+}
+
+.portfolio-income-table,
+.portfolio-activity-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.portfolio-income-table th,
+.portfolio-activity-table th {
+  height: 32px;
+  padding: 0 16px;
+  border-bottom: 1px solid #c6c6cd;
+  background: #f2f4f6;
+  color: #45464d;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 16px;
+  letter-spacing: 0.05em;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+.portfolio-income-table th:not(:first-child),
+.portfolio-income-table td:not(:first-child),
+.portfolio-activity-table th:not(:first-child),
+.portfolio-activity-table td:not(:first-child) {
+  text-align: right;
+}
+
+.portfolio-income-table td,
+.portfolio-activity-table td {
+  height: 40px;
+  padding: 8px 16px;
+  border-bottom: 1px solid #e0e3e5;
+  color: #191c1e;
+  font-size: 13px;
+  line-height: 18px;
+  font-variant-numeric: tabular-nums;
+}
+
+.portfolio-activity-table td:first-child {
+  display: grid;
+  gap: 2px;
+}
+
+.portfolio-activity-table small {
+  color: #59616f;
+  font-size: 11px;
+  line-height: 14px;
+}
+
+.portfolio-income-table-footer {
+  padding: 8px 16px;
+  border-top: 1px solid #c6c6cd;
+  background: #f2f4f6;
+}
+
+.portfolio-activity-table tfoot td {
+  height: 44px;
+  border-top: 2px solid #000000;
+  border-bottom: 0;
+  background: #f7f9fb;
+  color: #000000;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.portfolio-activity-table .positive {
+  color: #047857;
+}
+
+.portfolio-activity-table .negative {
+  color: #ba1a1a;
+}
+
+.portfolio-activity-side-stack {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.portfolio-activity-buckets {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.portfolio-activity-buckets h3 {
+  margin: 0;
+}
+
+.portfolio-activity-bucket-list {
+  display: grid;
+  gap: 18px;
+}
+
+.portfolio-activity-bucket-row {
+  display: grid;
+  gap: 8px;
+}
+
+.portfolio-activity-bucket-row > div:first-child {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.portfolio-activity-bucket-row span,
+.portfolio-activity-bucket-row strong {
+  color: #191c1e;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.portfolio-activity-bucket-row strong {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.portfolio-activity-reserve {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 72px;
+  padding: 16px 20px;
+  border: 1px solid #131b2e;
+  border-left: 4px solid #fcdc9a;
+  border-radius: 6px;
+  background: #131b2e;
+  color: #ffffff;
+}
+
+.portfolio-activity-reserve strong {
+  display: block;
+  margin-top: 4px;
+  color: #ffffff;
+  font-size: 24px;
+  font-weight: 750;
+  line-height: 28px;
+}
+
+.portfolio-activity-reserve-mark {
+  width: 28px;
+  height: 28px;
+  border: 2px solid #fcdc9a;
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 5px #131b2e;
+  background: linear-gradient(135deg, #fcdc9a 0 45%, transparent 45% 55%, #fcdc9a 55% 100%);
+}
+
+.portfolio-income-handoff-section {
+  gap: 12px;
+}
+
+.portfolio-income-handoff-card {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid #c6c6cd;
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.portfolio-income-handoff-card strong {
+  display: block;
+  margin-top: 2px;
+  color: #191c1e;
+  font-size: 16px;
+  line-height: 22px;
+}
+
+.portfolio-income-handoff-card p {
+  max-width: 780px;
+  margin: 0;
+  color: #59616f;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+@media (max-width: 1280px) {
+  .portfolio-income-grid,
+  .portfolio-activity-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 1500px) {
+  .portfolio-record-standalone-header {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .portfolio-record-standalone-kpis {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .portfolio-income-activity-section-title {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .portfolio-income-metric-bar > div:first-child {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .portfolio-income-table,
+  .portfolio-activity-table {
+    min-width: 680px;
+  }
 }
 

--- a/src/app/income/page.tsx
+++ b/src/app/income/page.tsx
@@ -1,0 +1,9 @@
+import PortfolioRecordScreen from "@/apps/portfolio/portfolio-record-screen";
+
+export default function IncomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ portfolioId?: string }>;
+}) {
+  return <PortfolioRecordScreen searchParams={searchParams} screen="income" />;
+}

--- a/src/apps/portfolio/components/portfolio-changes-section.tsx
+++ b/src/apps/portfolio/components/portfolio-changes-section.tsx
@@ -1,45 +1,48 @@
 "use client";
 
-import PortfolioPairedAnalyticsSection from "./portfolio-paired-analytics-section";
+import { ActionLink, SectionHeader } from "@/design-system";
+
 import { formatPortfolioPeriodContext } from "./portfolio-analytical-section-state";
 import type { PortfolioChangesSectionProps } from "./portfolio-analytical-section-types";
 
 export function PortfolioChangesSection({
   workspace,
   context,
-  capabilities,
   showChanges,
-  incomeDisplayCurrency,
-  activityDisplayCurrency,
-  transactionDrilldown,
-  isDetailedView,
-  onSelectActivityBucket,
-  getSectionExpanded,
-  toggleSection,
 }: PortfolioChangesSectionProps) {
   if (!showChanges) {
     return null;
   }
 
+  const portfolioId = encodeURIComponent(workspace.portfolio.portfolio_id);
+
   return (
-    <PortfolioPairedAnalyticsSection
-      workspace={workspace}
-      context={context}
-      capabilities={capabilities}
-      detailsLoading={false}
-      isDetailedView={isDetailedView}
-      incomeDisplayCurrency={incomeDisplayCurrency}
-      activityDisplayCurrency={activityDisplayCurrency}
-      transactionDrilldown={transactionDrilldown}
-      onSelectActivityBucket={onSelectActivityBucket}
-      getSectionExpanded={getSectionExpanded}
-      toggleSection={toggleSection}
-      sectionId="portfolio-changes"
-      title="Recent Flows"
-      subtitle={`Income and client activity for ${formatPortfolioPeriodContext(context)}.`}
-      sectionClassName="portfolio-detailed-cluster-section"
-      shellLabel="Income and activity"
-      shellValue="Current-period movement, event mix, and drill-down readiness"
-    />
+    <section
+      id="portfolio-changes"
+      className="portfolio-workspace-section portfolio-detailed-cluster-section portfolio-income-handoff-section"
+    >
+      <SectionHeader
+        title="Income & Activity"
+        subtitle={`Income classification and source-defined cash movement have moved to a dedicated workspace for ${formatPortfolioPeriodContext(
+          context
+        )}.`}
+        actions={
+          <ActionLink href={`/income?portfolioId=${portfolioId}`}>
+            Open Income &amp; Activity
+          </ActionLink>
+        }
+      />
+      <div className="portfolio-income-handoff-card">
+        <div>
+          <span>Dedicated record screen</span>
+          <strong>Income, activity buckets, cash movement, and source posture</strong>
+        </div>
+        <p>
+          The detailed portfolio view now routes income and activity review to the
+          source-backed record screen instead of duplicating the same figures inside the
+          summary workflow.
+        </p>
+      </div>
+    </section>
   );
 }

--- a/src/apps/portfolio/components/portfolio-income-activity-workspace.tsx
+++ b/src/apps/portfolio/components/portfolio-income-activity-workspace.tsx
@@ -1,0 +1,276 @@
+import { SemanticBadge } from "@/design-system";
+
+import { formatCurrency, formatDate, formatPct, formatStatus } from "../formatters";
+import type {
+  PortfolioActivitySummaryView,
+  PortfolioIncomePeriodSummary,
+  PortfolioIncomeSummaryView,
+  PortfolioWorkspace,
+} from "../types";
+import PortfolioModuleState from "./portfolio-module-state";
+
+type PortfolioIncomeActivityWorkspaceProps = {
+  workspace: PortfolioWorkspace;
+};
+
+type ActivityRow = {
+  bucket: string;
+  amount: number;
+  count: number;
+  pct: number;
+};
+
+export default function PortfolioIncomeActivityWorkspace({
+  workspace,
+}: PortfolioIncomeActivityWorkspaceProps) {
+  const income = workspace.income_summary;
+  const activity = workspace.activity_summary;
+  const incomeCurrency = income?.reporting_currency ?? workspace.portfolio.base_currency;
+  const activityCurrency = activity?.reporting_currency ?? workspace.portfolio.base_currency;
+  const incomeWindowLabel = income
+    ? `${formatDate(income.window_start_date)} - ${formatDate(income.window_end_date)}`
+    : "Current source window";
+  const activityRows = buildActivityRows(activity);
+
+  return (
+    <div className="portfolio-income-activity-workspace">
+      <section className="portfolio-income-activity-section" aria-labelledby="income-summary-heading">
+        <div className="portfolio-income-activity-section-title">
+          <h2 id="income-summary-heading">Income Summary</h2>
+          <span>{incomeWindowLabel}</span>
+        </div>
+        {income ? (
+          <div className="portfolio-income-activity-grid portfolio-income-grid">
+            <IncomeSummaryCard income={income} currency={incomeCurrency} />
+            <IncomeTypeTable income={income} currency={incomeCurrency} />
+          </div>
+        ) : (
+          <PortfolioModuleState
+            variant="status"
+            state="empty"
+            title="Income is not classified yet"
+            body="The gateway-backed portfolio workspace did not return an income summary for the selected reporting window."
+            hint="Publish classified income events upstream to populate the dedicated Income and Activity screen."
+          />
+        )}
+      </section>
+
+      <section className="portfolio-income-activity-section" aria-labelledby="activity-summary-heading">
+        <div className="portfolio-income-activity-section-title">
+          <h2 id="activity-summary-heading">Activity &amp; Cash Movements</h2>
+          <span>{activity ? `${formatDate(activity.window_start_date)} - ${formatDate(activity.window_end_date)}` : "Current source window"}</span>
+        </div>
+        {activity ? (
+          <div className="portfolio-income-activity-grid portfolio-activity-grid">
+            <ActivityMovementTable rows={activityRows} currency={activityCurrency} />
+            <div className="portfolio-activity-side-stack">
+              <ActivityBucketCard rows={activityRows} />
+              <div className="portfolio-activity-reserve">
+                <div>
+                  <span>Cash Weight</span>
+                  <strong>{formatPct(workspace.summary.cash_weight_pct)}</strong>
+                </div>
+                <span className="portfolio-activity-reserve-mark" aria-hidden="true" />
+              </div>
+            </div>
+          </div>
+        ) : (
+          <PortfolioModuleState
+            variant="status"
+            state="empty"
+            title="Activity totals are incomplete"
+            body="The gateway-backed portfolio workspace did not return activity buckets for the selected reporting window."
+            hint="Publish source-defined activity buckets upstream to populate cash movement totals."
+          />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function IncomeSummaryCard({
+  income,
+  currency,
+}: {
+  income: PortfolioIncomeSummaryView;
+  currency: string;
+}) {
+  const requestedNet = income.totals_requested_window.net.reporting_currency_amount;
+  const ytdNet = income.totals_year_to_date.net.reporting_currency_amount;
+  const requestedPct = ytdNet > 0 ? Math.min(Math.max((requestedNet / ytdNet) * 100, 0), 100) : 0;
+
+  return (
+    <div className="portfolio-income-card portfolio-income-card-visual">
+      <MetricBar
+        label="Totals Requested Window"
+        value={formatCurrency(requestedNet, currency)}
+        pct={requestedPct}
+      />
+      <MetricBar
+        label="Year-to-Date (YTD)"
+        value={formatCurrency(ytdNet, currency)}
+        pct={100}
+        muted
+      />
+      <div className="portfolio-income-source-note">
+        Source-backed income only. Forward income forecast is not part of the current portfolio workspace contract.
+      </div>
+    </div>
+  );
+}
+
+function MetricBar({
+  label,
+  value,
+  pct,
+  muted = false,
+}: {
+  label: string;
+  value: string;
+  pct: number;
+  muted?: boolean;
+}) {
+  return (
+    <div className="portfolio-income-metric-bar">
+      <div>
+        <span>{label}</span>
+        <strong>{value}</strong>
+      </div>
+      <div className="portfolio-income-bar" aria-hidden="true">
+        <div
+          className={muted ? "portfolio-income-bar-fill portfolio-income-bar-fill-muted" : "portfolio-income-bar-fill"}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function IncomeTypeTable({
+  income,
+  currency,
+}: {
+  income: PortfolioIncomeSummaryView;
+  currency: string;
+}) {
+  return (
+    <div className="portfolio-income-card portfolio-income-table-card">
+      <table className="portfolio-income-table" aria-label="Income summary">
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Current Period</th>
+            <th>YTD Total</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {income.income_types.map((item) => (
+            <tr key={item.income_type}>
+              <td>{formatStatus(item.income_type)}</td>
+              <td>{formatCurrency(item.requested_window.net.reporting_currency_amount, currency)}</td>
+              <td>{formatCurrency(item.year_to_date.net.reporting_currency_amount, currency)}</td>
+              <td>
+                <ReadinessBadge period={item.requested_window} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="portfolio-income-table-footer">
+        Last updated from gateway workspace source for {formatDate(income.window_end_date)}
+      </div>
+    </div>
+  );
+}
+
+function ReadinessBadge({ period }: { period: PortfolioIncomePeriodSummary }) {
+  const label = period.net.transaction_count > 0 ? "Ready" : "Partial";
+  return <SemanticBadge tone={label === "Ready" ? "success" : "warn"}>{label}</SemanticBadge>;
+}
+
+function ActivityMovementTable({ rows, currency }: { rows: ActivityRow[]; currency: string }) {
+  const total = rows.reduce((sum, row) => sum + row.amount, 0);
+
+  return (
+    <div className="portfolio-income-card portfolio-activity-table-card">
+      <table className="portfolio-activity-table" aria-label="Activity and cash movements">
+        <thead>
+          <tr>
+            <th>Activity Type</th>
+            <th>Inflow</th>
+            <th>Outflow</th>
+            <th>Net Movement</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.bucket}>
+              <td>
+                <span>{formatStatus(row.bucket)}</span>
+                <small>{row.count} events</small>
+              </td>
+              <td className={row.amount > 0 ? "positive" : undefined}>
+                {row.amount > 0 ? formatCurrency(row.amount, currency) : formatCurrency(0, currency)}
+              </td>
+              <td className={row.amount < 0 ? "negative" : undefined}>
+                {row.amount < 0 ? formatCurrency(Math.abs(row.amount), currency) : formatCurrency(0, currency)}
+              </td>
+              <td className={row.amount < 0 ? "negative" : "positive"}>
+                {formatCurrency(row.amount, currency)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td>Total Net Cashflow</td>
+            <td colSpan={3}>{formatCurrency(total, currency)}</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}
+
+function ActivityBucketCard({ rows }: { rows: ActivityRow[] }) {
+  return (
+    <div className="portfolio-income-card portfolio-activity-buckets">
+      <h3>Activity Buckets</h3>
+      <div className="portfolio-activity-bucket-list">
+        {rows.map((row) => (
+          <div key={row.bucket} className="portfolio-activity-bucket-row">
+            <div>
+              <span>{formatStatus(row.bucket)}</span>
+              <strong>{row.pct.toFixed(0)}%</strong>
+            </div>
+            <div className="portfolio-activity-bucket-bar" aria-hidden="true">
+              <div style={{ width: `${row.pct}%` }} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function buildActivityRows(activity: PortfolioActivitySummaryView | null | undefined): ActivityRow[] {
+  if (!activity) {
+    return [];
+  }
+
+  const grossMovement = activity.buckets.reduce(
+    (sum, bucket) => sum + Math.abs(bucket.requested_window.reporting_currency_amount),
+    0
+  );
+
+  return activity.buckets.map((bucket) => {
+    const amount = bucket.requested_window.reporting_currency_amount;
+    return {
+      bucket: bucket.bucket,
+      amount,
+      count: bucket.requested_window.transaction_count,
+      pct: grossMovement > 0 ? (Math.abs(amount) / grossMovement) * 100 : 0,
+    };
+  });
+}

--- a/src/apps/portfolio/components/portfolio-insights-section.tsx
+++ b/src/apps/portfolio/components/portfolio-insights-section.tsx
@@ -7,7 +7,6 @@ import { formatDate } from "../formatters";
 import PortfolioInsightsStrip from "../modules/portfolio-insights/portfolio-insights-strip";
 import PortfolioCollapsibleModule from "./portfolio-collapsible-module";
 import PortfolioModuleState from "./portfolio-module-state";
-import PortfolioPairedAnalyticsSection from "./portfolio-paired-analytics-section";
 import PortfolioPerformanceSnapshotModule from "./portfolio-performance-snapshot-module";
 import PortfolioLiquiditySummaryModule from "./portfolio-liquidity-summary-module";
 import type { PortfolioInsightsSectionProps } from "./portfolio-analytical-section-types";
@@ -19,17 +18,12 @@ export function PortfolioInsightsSection({
   detailsLoading,
   showInsights,
   showLiquidityModule,
-  showChangeHighlights,
-  incomeDisplayCurrency,
-  activityDisplayCurrency,
   visibleInsights,
   holdingsDrilldown,
   filteredPositions,
-  transactionDrilldown,
   onDismissInsight,
   onSelectAllocation,
   onSelectTopHolding,
-  onSelectActivityBucket,
   getSectionExpanded,
   toggleSection,
   DeferredPortfolioAllocationPanel,
@@ -50,7 +44,7 @@ export function PortfolioInsightsSection({
     <section className="portfolio-workspace-section portfolio-summary-cluster-section">
       <SectionHeader
         title="Portfolio Insights"
-        subtitle="Allocation, concentration, liquidity, and recent activity."
+        subtitle="Allocation, concentration, liquidity, and performance context."
       />
       <div className="portfolio-analytical-surface">
         {showInsightsSummaryBand ? (
@@ -243,24 +237,6 @@ export function PortfolioInsightsSection({
           </div>
         ) : null}
 
-        {showChangeHighlights ? (
-          <PortfolioPairedAnalyticsSection
-            workspace={workspace}
-            context={context}
-            capabilities={capabilities}
-            detailsLoading={detailsLoading}
-            isDetailedView={false}
-            incomeDisplayCurrency={incomeDisplayCurrency}
-            activityDisplayCurrency={activityDisplayCurrency}
-            transactionDrilldown={transactionDrilldown}
-            onSelectActivityBucket={onSelectActivityBucket}
-            getSectionExpanded={getSectionExpanded}
-            toggleSection={toggleSection}
-            gridClassName="portfolio-analytical-zone-grid portfolio-analytical-zone-grid-balanced"
-            shellLabel="Income and activity"
-            shellValue="Current-period cash generation and money movement"
-          />
-        ) : null}
       </div>
     </section>
   );

--- a/src/apps/portfolio/components/portfolio-record-evidence-rail.tsx
+++ b/src/apps/portfolio/components/portfolio-record-evidence-rail.tsx
@@ -29,16 +29,18 @@ export default function PortfolioRecordEvidenceRail({
   const sourcePostureItems =
     screen === "transactions"
       ? buildTransactionSourcePosture(workspace, portfolioId)
-      : screen === "cashflow"
-        ? buildCashflowSourcePosture(workspace)
-      : buildPositionSourcePosture({
-          workspace,
-          portfolioId,
-          unpricedCount,
-          reprocessingCount,
-          staleCount,
-          reportingReady,
-        });
+      : screen === "income"
+        ? buildIncomeActivitySourcePosture(workspace)
+        : screen === "cashflow"
+          ? buildCashflowSourcePosture(workspace)
+          : buildPositionSourcePosture({
+              workspace,
+              portfolioId,
+              unpricedCount,
+              reprocessingCount,
+              staleCount,
+              reportingReady,
+            });
 
   return (
     <div className="portfolio-record-evidence-rail" aria-label="Portfolio record data governance">
@@ -78,6 +80,9 @@ export default function PortfolioRecordEvidenceRail({
           <ActionLink href={`/transactions?portfolioId=${encodeURIComponent(portfolioId)}`}>
             Transactions
           </ActionLink>
+          <ActionLink href={`/income?portfolioId=${encodeURIComponent(portfolioId)}`}>
+            Income &amp; Activity
+          </ActionLink>
           <ActionLink href={`/cashflow?portfolioId=${encodeURIComponent(portfolioId)}`}>
             Cashflow
           </ActionLink>
@@ -88,6 +93,49 @@ export default function PortfolioRecordEvidenceRail({
       </WorkbenchRailCard>
     </div>
   );
+}
+
+function buildIncomeActivitySourcePosture(workspace: PortfolioWorkspace): SourcePostureProps[] {
+  const income = workspace.income_summary;
+  const activity = workspace.activity_summary;
+  const incomeTypeCount = income?.income_types.length ?? 0;
+  const incomeEventCount =
+    income?.totals_requested_window.net.transaction_count ?? 0;
+  const activityBucketCount = activity?.buckets.length ?? 0;
+  const activityEventCount =
+    activity?.buckets.reduce(
+      (total, bucket) => total + bucket.requested_window.transaction_count,
+      0
+    ) ?? 0;
+  const reportingReady = workspace.readiness.reporting.status?.toUpperCase() === "READY";
+
+  return [
+    {
+      label: "Income Source",
+      source: "Gateway portfolio workspace",
+      detail: income
+        ? `${formatCount(incomeTypeCount, "income type")} and ${formatCount(
+            incomeEventCount,
+            "income event"
+          )} through ${formatDate(income.window_end_date)}`
+        : "No income summary returned for the selected reporting window",
+      tone: income ? "success" : "warn",
+      status: income ? "Available" : "Unavailable",
+    },
+    {
+      label: "Activity Buckets",
+      source: "Source-defined activity classification",
+      detail: activity
+        ? `${formatCount(activityBucketCount, "bucket")} and ${formatCount(
+            activityEventCount,
+            "activity event"
+          )} through ${formatDate(activity.window_end_date)}`
+        : "No activity bucket summary returned for the selected reporting window",
+      tone: activity ? "success" : "warn",
+      status: activity ? "Ready" : "Unavailable",
+    },
+    buildReportingSourcePosture(workspace, reportingReady),
+  ];
 }
 
 function buildCashflowSourcePosture(workspace: PortfolioWorkspace): SourcePostureProps[] {

--- a/src/apps/portfolio/components/portfolio-record-screen-client.tsx
+++ b/src/apps/portfolio/components/portfolio-record-screen-client.tsx
@@ -17,6 +17,7 @@ import PortfolioScreenRail from "./portfolio-screen-rail";
 import PortfolioHoldingsGrid from "./portfolio-holdings-grid";
 import PortfolioTransactionsGrid from "./portfolio-transactions-grid";
 import PortfolioProjectedCashflowModule from "./portfolio-projected-cashflow-module";
+import PortfolioIncomeActivityWorkspace from "./portfolio-income-activity-workspace";
 import type { PortfolioRecordScreenKind } from "../portfolio-record-screen-view-model";
 import {
   buildPortfolioRecordHeaderKpis,
@@ -112,6 +113,9 @@ export default function PortfolioRecordScreenClient({
                       defaultEndDate={endDate ?? context.effectivePeriodEndDate}
                       initialTransactions={workspace.recent_transactions}
                     />
+                  ) : null}
+                  {screen === "income" ? (
+                    <PortfolioIncomeActivityWorkspace workspace={workspace} />
                   ) : null}
                   {screen === "cashflow" ? (
                     <PortfolioProjectedCashflowModule

--- a/src/apps/portfolio/portfolio-record-screen-view-model.ts
+++ b/src/apps/portfolio/portfolio-record-screen-view-model.ts
@@ -1,7 +1,7 @@
 import { formatCurrency, formatDate, formatStatus } from "./formatters";
 import type { PortfolioWorkspace } from "./types";
 
-export type PortfolioRecordScreenKind = "positions" | "transactions" | "cashflow";
+export type PortfolioRecordScreenKind = "positions" | "transactions" | "income" | "cashflow";
 
 export type PortfolioRecordScreenCopy = {
   title: string;
@@ -27,6 +27,11 @@ export const PORTFOLIO_RECORD_SCREEN_COPY: Record<
     title: "Transactions",
     subtitle: "Booked activity, settlement state, transaction components, and source lineage.",
     kicker: "Ledger",
+  },
+  income: {
+    title: "Income & Activity",
+    subtitle: "Income composition, booked activity, cash movement, and source posture.",
+    kicker: "Income and activity",
   },
   cashflow: {
     title: "Cashflow Workspace",
@@ -64,6 +69,44 @@ export function buildPortfolioRecordHeaderKpis(
   windowLabel = "30D",
   screen?: PortfolioRecordScreenKind
 ): PortfolioRecordHeaderKpi[] {
+  if (screen === "income") {
+    const income = workspace.income_summary;
+    const activity = workspace.activity_summary;
+    const activityAmount =
+      activity?.buckets.reduce(
+        (total, bucket) => total + bucket.requested_window.reporting_currency_amount,
+        0
+      ) ?? null;
+    const eventCount =
+      (income?.totals_requested_window.net.transaction_count ?? 0) +
+      (activity?.buckets.reduce(
+        (total, bucket) => total + bucket.requested_window.transaction_count,
+        0
+      ) ?? 0);
+
+    return [
+      {
+        label: "Net Income",
+        value: income
+          ? formatCurrency(
+              income.totals_requested_window.net.reporting_currency_amount,
+              income.reporting_currency
+            )
+          : "N/A",
+      },
+      {
+        label: "Net Activity",
+        value: activityAmount == null
+          ? "N/A"
+          : formatCurrency(activityAmount, activity?.reporting_currency ?? workspace.portfolio.base_currency),
+      },
+      {
+        label: "Events",
+        value: String(eventCount),
+      },
+    ];
+  }
+
   if (screen === "cashflow") {
     const cashflow = workspace.cashflow_outlook;
     const finalCumulative =

--- a/src/apps/portfolio/portfolio-screen-navigation.ts
+++ b/src/apps/portfolio/portfolio-screen-navigation.ts
@@ -2,6 +2,7 @@ export type PortfolioScreenNavigationKey =
   | "portfolio"
   | "positions"
   | "transactions"
+  | "income"
   | "cashflow"
   | "performance"
   | "risk"
@@ -20,6 +21,7 @@ const PORTFOLIO_SCREEN_NAVIGATION_ITEMS: PortfolioScreenNavigationItem[] = [
   { key: "portfolio", label: "Portfolio", detail: "Summary and decision context", href: "/portfolio" },
   { key: "positions", label: "Positions", detail: "Holdings, valuation, and P&L", href: "/positions" },
   { key: "transactions", label: "Transactions", detail: "Booked activity and settlement", href: "/transactions" },
+  { key: "income", label: "Income", detail: "Income and activity", href: "/income" },
   { key: "cashflow", label: "Cashflow", detail: "Forward liquidity path", href: "/cashflow" },
   { key: "performance", label: "Performance", detail: "Return and attribution workspace", href: "/performance" },
   { key: "risk", label: "Risk", detail: "Risk review workspace", href: "/performance?mode=risk" },

--- a/src/shell/app-registry.ts
+++ b/src/shell/app-registry.ts
@@ -8,7 +8,17 @@ export type ShellAppId =
 
 const SHELL_APP_MATCHERS: Record<ShellAppId, string[]> = {
   home: ["/", "/suite"],
-  portfolio: ["/portfolio", "/portfolios", "/positions", "/transactions", "/cashflow", "/manage", "/workbench", "/intake"],
+  portfolio: [
+    "/portfolio",
+    "/portfolios",
+    "/positions",
+    "/transactions",
+    "/income",
+    "/cashflow",
+    "/manage",
+    "/workbench",
+    "/intake",
+  ],
   performance: ["/performance"],
   risk: ["/performance"],
   proposal: ["/proposals"],

--- a/tests/e2e/portfolio-workbench.smoke.spec.ts
+++ b/tests/e2e/portfolio-workbench.smoke.spec.ts
@@ -90,7 +90,7 @@ async function openDetailedPortfolio(
   await detailedViewTab.click();
   await expect(detailedViewTab).toHaveAttribute('aria-selected', 'true');
 
-  await expect(page.locator('.portfolio-paired-analytics-grid-detailed')).toBeVisible({
+  await expect(page.getByRole('heading', { name: /^Income & Activity$/i })).toBeVisible({
     timeout: 15000,
   });
   await expect(page.locator('.portfolio-data-grid').first()).toBeVisible({ timeout: 15000 });
@@ -98,6 +98,29 @@ async function openDetailedPortfolio(
     page.getByLabel(/Projected cashflow chart in /i)
   ).toBeVisible({ timeout: 15000 });
 
+  return { portfolioId, available: true };
+}
+
+async function openIncomePortfolio(
+  page: import('@playwright/test').Page,
+  request: import('@playwright/test').APIRequestContext
+) {
+  const portfolioId = await resolveSmokePortfolioId(request);
+  if (!portfolioId) {
+    await page.goto('/income', { waitUntil: 'domcontentloaded' });
+    return { portfolioId: null, available: false };
+  }
+
+  await page.goto(`/income?portfolioId=${portfolioId}`, { waitUntil: 'domcontentloaded' });
+  const unavailableHeading = page.getByRole('heading', { name: /^Portfolio records unavailable$/i });
+  const unavailableVisible = await unavailableHeading.isVisible().catch(() => false);
+  if (unavailableVisible) {
+    return { portfolioId, available: false };
+  }
+
+  await expect(page.getByRole('heading', { name: /^Income & Activity$/i })).toBeVisible({
+    timeout: 15000,
+  });
   return { portfolioId, available: true };
 }
 
@@ -110,10 +133,9 @@ test.describe('Portfolio workbench smoke', () => {
     await expect(page.getByRole('heading', { name: /Portfolio Allocation/i })).toBeVisible();
     await expect(page.getByRole('heading', { name: /Top Holdings/i })).toBeVisible();
     await expect(page.getByRole('heading', { name: /Performance Snapshot/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /^Income$/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /^Activity$/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Income/i })).toBeVisible();
 
-    await expect(page.locator('.portfolio-paired-analytics-grid')).toBeVisible();
+    await expect(page.locator('.portfolio-paired-analytics-grid')).toHaveCount(0);
     await expect(page.locator('.portfolio-paired-analytics-grid-detailed')).toHaveCount(0);
     await expect(page.locator('.portfolio-data-grid')).toHaveCount(0);
     await expect(page.getByLabel('Income summary')).toHaveCount(0);
@@ -123,10 +145,8 @@ test.describe('Portfolio workbench smoke', () => {
     await expect(page.getByRole('heading', { name: /^Transactions$/i })).toHaveCount(0);
     await expect(page.getByRole('heading', { name: /Projected Cashflow/i })).toHaveCount(0);
 
-    const pairedAnalyticsMetrics = await measureGrid(page.locator('.portfolio-paired-analytics-grid'));
-    expect(pairedAnalyticsMetrics.columns).toContain(' ');
-    expect(pairedAnalyticsMetrics.childCount).toBe(2);
-    expect(pairedAnalyticsMetrics.width).toBeGreaterThan(900);
+    const summaryModuleMetrics = await measureGrid(page.locator('.portfolio-summary-cluster').first());
+    expect(summaryModuleMetrics.width).toBeGreaterThan(900);
   });
 
   test('detailed analytics keep grids usable and analytical surfaces proportionate', async ({ page, request }) => {
@@ -134,27 +154,18 @@ test.describe('Portfolio workbench smoke', () => {
     const session = await openDetailedPortfolio(page, request);
     test.skip(!session.available, 'Portfolio foundation upstream unavailable in standalone smoke environment.');
 
-    const detailedAnalyticsGrid = page.locator('.portfolio-paired-analytics-grid-detailed');
-    await expect(detailedAnalyticsGrid).toBeVisible();
-
-    const analyticsGridMetrics = await measureGrid(detailedAnalyticsGrid);
-    expect(analyticsGridMetrics.childCount).toBe(2);
-    expect(analyticsGridMetrics.width).toBeGreaterThan(900);
-    expect(analyticsGridMetrics.childWidths.every((width) => width >= 900)).toBeTruthy();
+    await expect(page.locator('.portfolio-paired-analytics-grid-detailed')).toHaveCount(0);
+    await expect(page.getByRole('link', { name: /Open Income & Activity/i })).toBeVisible();
 
     const holdingsGrid = page.locator('.portfolio-data-grid').first();
     await expect(holdingsGrid).toBeVisible();
     const holdingsGridMetrics = await measureAgGridViewport(holdingsGrid);
     expect(holdingsGridMetrics.centerClientWidth).toBeGreaterThan(700);
 
-    const incomeTable = page.getByLabel('Income summary').locator('xpath=ancestor::*[contains(@class,"analytics-table-frame")][1]');
-    const activityTable = page.getByLabel('Activity summary').locator('xpath=ancestor::*[contains(@class,"analytics-table-frame")][1]');
     const cashflowTable = page.getByLabel('Cashflow outlook').locator('xpath=ancestor::*[contains(@class,"analytics-table-frame")][1]');
-    await expect(incomeTable).toBeVisible();
-    await expect(activityTable).toBeVisible();
     await expect(cashflowTable).toBeVisible();
 
-    for (const table of [incomeTable, activityTable, cashflowTable]) {
+    for (const table of [cashflowTable]) {
       const metrics = await measureTableFrame(table);
       expect(metrics.scrollWidth - metrics.clientWidth).toBeLessThanOrEqual(8);
     }
@@ -165,9 +176,22 @@ test.describe('Portfolio workbench smoke', () => {
     expect(cashflowChartMetrics.height).toBeLessThanOrEqual(260);
     expect(cashflowChartMetrics.width).toBeGreaterThan(700);
 
-    await expect(page.getByText('Window inflow')).toBeVisible();
-    await expect(page.getByText('Window outflow')).toBeVisible();
-    await expect(page.getByText('Window fees')).toBeVisible();
-    await expect(page.getByText('Window taxes')).toBeVisible();
+  });
+
+  test('income route renders the dedicated income and activity workspace', async ({ page, request }) => {
+    await page.setViewportSize({ width: 1800, height: 1400 });
+    const session = await openIncomePortfolio(page, request);
+    test.skip(!session.available, 'Portfolio income upstream unavailable in standalone smoke environment.');
+
+    await expect(page.getByRole('heading', { name: /^Income Summary$/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /^Activity & Cash Movements$/i })).toBeVisible();
+    await expect(page.locator('.portfolio-income-activity-workspace')).toBeVisible();
+    await expect(page.getByRole('table', { name: 'Income summary' })).toBeVisible();
+    await expect(page.getByRole('table', { name: 'Activity and cash movements' })).toBeVisible();
+    await expect(page.getByText('Cash Weight')).toBeVisible();
+
+    const incomeGridMetrics = await measureGrid(page.locator('.portfolio-income-grid'));
+    expect(incomeGridMetrics.childCount).toBe(2);
+    expect(incomeGridMetrics.width).toBeGreaterThan(900);
   });
 });

--- a/tests/integration/portfolios-page.test.tsx
+++ b/tests/integration/portfolios-page.test.tsx
@@ -338,7 +338,7 @@ describe("PortfolioFoundationPage", () => {
     render(await PortfolioFoundationPage({ searchParams: Promise.resolve({}) }));
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: /Recent Flows/i })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /Income & Activity/i })).toBeInTheDocument();
     });
 
     expect(screen.getByRole("heading", { name: /Portfolio Context/i })).toBeInTheDocument();
@@ -353,7 +353,7 @@ describe("PortfolioFoundationPage", () => {
     expect(screen.getAllByText("As of").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByRole("heading", { name: /Mandate Overview/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Portfolio Health Snapshot/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Recent Flows/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Income & Activity/i })).toBeInTheDocument();
     expect(
       screen
         .getAllByRole("link", { name: /Positions/i })
@@ -366,17 +366,23 @@ describe("PortfolioFoundationPage", () => {
     ).toBe(true);
     expect(
       screen
+        .getAllByRole("link", { name: /Income & Activity/i })
+        .some((link) => link.getAttribute("href")?.includes("/income"))
+    ).toBe(true);
+    expect(
+      screen
         .getAllByRole("link", { name: /Cashflow/i })
         .some((link) => link.getAttribute("href")?.includes("/cashflow"))
     ).toBe(true);
     expect(screen.getByText("Performance not available yet")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Why performance is unavailable" })).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: /Expand|Collapse/i }).length).toBeGreaterThanOrEqual(1);
-    expect(document.querySelector(".portfolio-paired-analytics-grid")).toBeTruthy();
-    expect(document.querySelector(".portfolio-paired-analytics-grid-detailed")).toBeTruthy();
+    expect(document.querySelector(".portfolio-paired-analytics-grid")).toBeFalsy();
+    expect(document.querySelector(".portfolio-paired-analytics-grid-detailed")).toBeFalsy();
     expect(screen.getByRole("heading", { name: /Advisor Guidance/i })).toBeInTheDocument();
-    expect(screen.getByText("Income is not classified yet")).toBeInTheDocument();
-    expect(screen.getByText("Activity totals are incomplete")).toBeInTheDocument();
+    expect(screen.getByText(/Dedicated record screen/i)).toBeInTheDocument();
+    expect(screen.queryByText("Income is not classified yet")).not.toBeInTheDocument();
+    expect(screen.queryByText("Activity totals are incomplete")).not.toBeInTheDocument();
 
     expect(screen.getByRole("tab", { name: "Detailed" })).toHaveAttribute(
       "aria-selected",
@@ -396,7 +402,7 @@ describe("PortfolioFoundationPage", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Summary" }));
 
     expect(window.localStorage.getItem("lotus:portfolio:view-mode")).toBe("summary");
-    expect(screen.queryByRole("heading", { name: /Recent Flows/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /Income & Activity/i })).not.toBeInTheDocument();
 
     const requestedUrls = fetchSpy.mock.calls.map((call) => String(call[0]));
     expect(requestedUrls.some((url) => url.includes("/liquidity"))).toBe(true);

--- a/tests/unit/portfolio-income-activity-workspace.test.tsx
+++ b/tests/unit/portfolio-income-activity-workspace.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import PortfolioIncomeActivityWorkspace from "../../src/apps/portfolio/components/portfolio-income-activity-workspace";
+import type { PortfolioWorkspace } from "../../src/apps/portfolio/types";
+
+describe("PortfolioIncomeActivityWorkspace", () => {
+  it("renders income and activity from the gateway-backed workspace without local forecasts", () => {
+    render(<PortfolioIncomeActivityWorkspace workspace={buildWorkspace()} />);
+
+    expect(screen.getByRole("heading", { name: "Income Summary" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Activity & Cash Movements" })).toBeInTheDocument();
+    expect(screen.getByText(/Source-backed income only/i)).toBeInTheDocument();
+
+    const incomeTable = screen.getByRole("table", { name: "Income summary" });
+    expect(within(incomeTable).getByText("Dividends")).toBeInTheDocument();
+    expect(within(incomeTable).getByText("Fixed Income Coupons")).toBeInTheDocument();
+    expect(within(incomeTable).getAllByText("Ready").length).toBeGreaterThanOrEqual(2);
+
+    const activityTable = screen.getByRole("table", { name: "Activity and cash movements" });
+    expect(within(activityTable).getByText("External Funding")).toBeInTheDocument();
+    expect(within(activityTable).getByText("Trading Settlements")).toBeInTheDocument();
+    expect(within(activityTable).getByText("Total Net Cashflow")).toBeInTheDocument();
+    expect(screen.getByText("Cash Weight")).toBeInTheDocument();
+    expect(screen.getByText("4.20%")).toBeInTheDocument();
+  });
+
+  it("shows truthful empty states when source summaries are absent", () => {
+    render(
+      <PortfolioIncomeActivityWorkspace
+        workspace={{
+          ...buildWorkspace(),
+          income_summary: null,
+          activity_summary: null,
+        }}
+      />
+    );
+
+    expect(screen.getByText("Income is not classified yet")).toBeInTheDocument();
+    expect(screen.getByText("Activity totals are incomplete")).toBeInTheDocument();
+  });
+});
+
+function buildWorkspace(): PortfolioWorkspace {
+  return {
+    as_of_date: "2026-05-12",
+    portfolio: {
+      portfolio_id: "PB_SG_GLOBAL_BAL_001",
+      display_name: "Global Balanced Mandate",
+      client_id: "CIF_SG_000184",
+      base_currency: "USD",
+      booking_center_code: "SG",
+    },
+    profile: {
+      status: "ACTIVE",
+      portfolio_type: "DISCRETIONARY",
+      risk_exposure: "BALANCED",
+      investment_time_horizon: "LONG_TERM",
+      objective: "Growth and income",
+      is_leverage_allowed: false,
+    },
+    summary: {
+      market_value_base: 1000000,
+      invested_market_value_base: 958000,
+      total_cash_base: 42000,
+      cash_weight_pct: 4.2,
+      position_count: 12,
+      cash_balance_count: 1,
+    },
+    allocations: [],
+    allocation_views: [],
+    cash_balances: [],
+    top_positions: [],
+    positions: [],
+    recent_transactions: [],
+    income_summary: {
+      reporting_currency: "USD",
+      window_start_date: "2026-04-12",
+      window_end_date: "2026-05-12",
+      totals_requested_window: buildIncomePeriod(42901.4, 3),
+      totals_year_to_date: buildIncomePeriod(128450, 8),
+      income_types: [
+        {
+          income_type: "DIVIDENDS",
+          requested_window: buildIncomePeriod(24500, 2),
+          year_to_date: buildIncomePeriod(82100, 5),
+        },
+        {
+          income_type: "FIXED_INCOME_COUPONS",
+          requested_window: buildIncomePeriod(15201.4, 1),
+          year_to_date: buildIncomePeriod(38400, 2),
+        },
+      ],
+    },
+    activity_summary: {
+      reporting_currency: "USD",
+      window_start_date: "2026-04-12",
+      window_end_date: "2026-05-12",
+      buckets: [
+        {
+          bucket: "EXTERNAL_FUNDING",
+          requested_window: {
+            reporting_currency_amount: 150000,
+            transaction_count: 1,
+          },
+          year_to_date: {
+            reporting_currency_amount: 150000,
+            transaction_count: 1,
+          },
+        },
+        {
+          bucket: "TRADING_SETTLEMENTS",
+          requested_window: {
+            reporting_currency_amount: 3950,
+            transaction_count: 2,
+          },
+          year_to_date: {
+            reporting_currency_amount: 3950,
+            transaction_count: 2,
+          },
+        },
+      ],
+    },
+    cashflow_outlook: null,
+    performance: null,
+    rebalance: null,
+    control_capabilities: null,
+    readiness: {
+      has_positions: true,
+      reporting: {
+        status: "READY",
+        generated_at_utc: "2026-05-12T00:00:00Z",
+        row_count: 12,
+      },
+    },
+    workflow_cues: [],
+    workflow_actions: [],
+    warnings: [],
+    partial_failures: [],
+  };
+}
+
+function buildIncomePeriod(amount: number, transactionCount: number) {
+  return {
+    gross: {
+      reporting_currency_amount: amount,
+      transaction_count: transactionCount,
+    },
+    withholding_tax: {
+      reporting_currency_amount: 0,
+      transaction_count: 0,
+    },
+    other_deductions: {
+      reporting_currency_amount: 0,
+      transaction_count: 0,
+    },
+    net: {
+      reporting_currency_amount: amount,
+      transaction_count: transactionCount,
+    },
+  };
+}

--- a/tests/unit/portfolio-record-evidence-rail.test.tsx
+++ b/tests/unit/portfolio-record-evidence-rail.test.tsx
@@ -50,6 +50,10 @@ describe("PortfolioRecordEvidenceRail", () => {
       "href",
       "/transactions?portfolioId=PB_SG_GLOBAL_BAL_001"
     );
+    expect(screen.getByRole("link", { name: "Income & Activity" })).toHaveAttribute(
+      "href",
+      "/income?portfolioId=PB_SG_GLOBAL_BAL_001"
+    );
     expect(screen.getByRole("link", { name: "DPM Operations" })).toHaveAttribute(
       "href",
       "/workbench/PB_SG_GLOBAL_BAL_001"
@@ -101,4 +105,73 @@ describe("PortfolioRecordEvidenceRail", () => {
     expect(screen.getByText("1 component type represented in the current window")).toBeInTheDocument();
     expect(screen.getByText("Review")).toBeInTheDocument();
   });
+
+  it("renders income and activity source posture without local analytics claims", () => {
+    render(
+      <PortfolioRecordEvidenceRail
+        screen="income"
+        workspace={buildPortfolioWorkspace({
+          income_summary: {
+            reporting_currency: "USD",
+            window_start_date: "2026-04-12",
+            window_end_date: "2026-05-12",
+            totals_requested_window: buildIncomePeriod(42901.4, 3),
+            totals_year_to_date: buildIncomePeriod(128450, 8),
+            income_types: [
+              {
+                income_type: "DIVIDENDS",
+                requested_window: buildIncomePeriod(24500, 2),
+                year_to_date: buildIncomePeriod(82100, 5),
+              },
+            ],
+          },
+          activity_summary: {
+            reporting_currency: "USD",
+            window_start_date: "2026-04-12",
+            window_end_date: "2026-05-12",
+            buckets: [
+              {
+                bucket: "EXTERNAL_FUNDING",
+                requested_window: {
+                  reporting_currency_amount: 150000,
+                  transaction_count: 1,
+                },
+                year_to_date: {
+                  reporting_currency_amount: 150000,
+                  transaction_count: 1,
+                },
+              },
+            ],
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByText("Income Source")).toBeInTheDocument();
+    expect(screen.getByText(/1 income type and 3 income events through/i)).toBeInTheDocument();
+    expect(screen.getByText("Activity Buckets")).toBeInTheDocument();
+    expect(screen.getByText(/1 bucket and 1 activity event through/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Gateway portfolio workspace").length).toBeGreaterThanOrEqual(1);
+  });
 });
+
+function buildIncomePeriod(amount: number, transactionCount: number) {
+  return {
+    gross: {
+      reporting_currency_amount: amount,
+      transaction_count: transactionCount,
+    },
+    withholding_tax: {
+      reporting_currency_amount: 0,
+      transaction_count: 0,
+    },
+    other_deductions: {
+      reporting_currency_amount: 0,
+      transaction_count: 0,
+    },
+    net: {
+      reporting_currency_amount: amount,
+      transaction_count: transactionCount,
+    },
+  };
+}

--- a/tests/unit/portfolio-record-screen-view-model.test.ts
+++ b/tests/unit/portfolio-record-screen-view-model.test.ts
@@ -16,6 +16,7 @@ describe("portfolio record screen view model", () => {
       kicker: "Position inventory",
     });
     expect(getPortfolioRecordScreenCopy("transactions").subtitle).toContain("source lineage");
+    expect(getPortfolioRecordScreenCopy("income").subtitle).toContain("Income composition");
     expect(getPortfolioRecordScreenCopy("cashflow").subtitle).toContain("Forward liquidity");
   });
 
@@ -32,6 +33,57 @@ describe("portfolio record screen view model", () => {
       { label: "Total Market Value", value: "1,000,000 USD" },
       { label: "Positions", value: "11" },
       { label: "Window", value: "30D" },
+    ]);
+
+    expect(
+      buildPortfolioRecordHeaderKpis(
+        {
+          ...workspace,
+          income_summary: {
+            reporting_currency: "USD",
+            window_start_date: "2026-04-12",
+            window_end_date: "2026-05-12",
+            totals_requested_window: buildIncomePeriod(42901.4, 3),
+            totals_year_to_date: buildIncomePeriod(128450, 8),
+            income_types: [],
+          },
+          activity_summary: {
+            reporting_currency: "USD",
+            window_start_date: "2026-04-12",
+            window_end_date: "2026-05-12",
+            buckets: [
+              {
+                bucket: "external_funding",
+                requested_window: {
+                  reporting_currency_amount: 150000,
+                  transaction_count: 1,
+                },
+                year_to_date: {
+                  reporting_currency_amount: 150000,
+                  transaction_count: 1,
+                },
+              },
+              {
+                bucket: "fees",
+                requested_window: {
+                  reporting_currency_amount: -1450,
+                  transaction_count: 1,
+                },
+                year_to_date: {
+                  reporting_currency_amount: -1450,
+                  transaction_count: 1,
+                },
+              },
+            ],
+          },
+        },
+        "30D",
+        "income"
+      )
+    ).toEqual([
+      { label: "Net Income", value: "42,901.4 USD" },
+      { label: "Net Activity", value: "148,550 USD" },
+      { label: "Events", value: "5" },
     ]);
 
     expect(
@@ -123,5 +175,26 @@ function buildWorkspace(): PortfolioWorkspace {
     workflow_actions: [],
     warnings: [],
     partial_failures: [],
+  };
+}
+
+function buildIncomePeriod(amount: number, transactionCount: number) {
+  return {
+    gross: {
+      reporting_currency_amount: amount,
+      transaction_count: transactionCount,
+    },
+    withholding_tax: {
+      reporting_currency_amount: 0,
+      transaction_count: 0,
+    },
+    other_deductions: {
+      reporting_currency_amount: 0,
+      transaction_count: 0,
+    },
+    net: {
+      reporting_currency_amount: amount,
+      transaction_count: transactionCount,
+    },
   };
 }

--- a/tests/unit/portfolio-screen-navigation.test.ts
+++ b/tests/unit/portfolio-screen-navigation.test.ts
@@ -13,6 +13,7 @@ describe("portfolio screen navigation", () => {
       "portfolio",
       "positions",
       "transactions",
+      "income",
       "cashflow",
       "performance",
       "risk",
@@ -22,6 +23,9 @@ describe("portfolio screen navigation", () => {
     ]);
     expect(items.find((item) => item.key === "positions")?.href).toBe(
       "/positions?portfolioId=PB%20SG%2F001"
+    );
+    expect(items.find((item) => item.key === "income")?.href).toBe(
+      "/income?portfolioId=PB%20SG%2F001"
     );
     expect(items.find((item) => item.key === "risk")?.href).toBe(
       "/performance?mode=risk&portfolioId=PB%20SG%2F001"

--- a/tests/unit/shell-app-registry.test.ts
+++ b/tests/unit/shell-app-registry.test.ts
@@ -6,6 +6,7 @@ describe("resolveShellApp", () => {
   it("maps portfolio and intake routes into the Portfolio workspace", () => {
     expect(resolveShellApp("/portfolio").id).toBe("portfolio");
     expect(resolveShellApp("/portfolios").id).toBe("portfolio");
+    expect(resolveShellApp("/income").id).toBe("portfolio");
     expect(resolveShellApp("/intake").id).toBe("portfolio");
   });
 

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -8,6 +8,7 @@ It is intended for developers, business users, operations, sales/pre-sales, and 
 | Surface | Route | Backing contract | Current support |
 | --- | --- | --- | --- |
 | Portfolio summary and detail | `/portfolio`, `/portfolio?tab=detailed` | Gateway Workbench portfolio APIs | Supported with canonical live proof. |
+| Portfolio income and activity | `/income` | Gateway portfolio workspace `income_summary` and `activity_summary` | Supported as the dedicated source-backed screen for income composition, source-defined activity buckets, net movement, cash weight, and evidence posture. Workbench does not forecast income or calculate activity classifications locally. |
 | Performance and risk review | `/performance` route modes | Gateway performance/risk APIs | Supported with bounded observability and canonical proof. |
 | Data-product discovery | `/data-products` | Gateway domain-product APIs | Supported for catalog, dependencies, and live trust posture. |
 | DPM mandate command center | `/workbench/{portfolioId}`, `/workbench/{portfolioId}?mode=mandate` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit, PM-book-backed monitoring action, active exception queue, and governed exception-summary request through Gateway/Manage/lotus-ai. Workbench preserves Manage supportability posture: populated canonical `READY` is demo-ready, `PARTIAL`/`DEGRADED`/`BLOCKED` render as explicit partial states, and `EMPTY` stays an empty state rather than a false ready cockpit. |


### PR DESCRIPTION
## Summary
- adds `/income` as the dedicated portfolio Income & Activity record screen backed by the existing gateway portfolio workspace payload
- moves income/activity review out of embedded summary/detailed paired analytics and replaces detailed duplication with a route handoff
- adds source-posture rail coverage, shell/navigation support, docs/wiki supported-feature truth, and focused unit/integration/e2e coverage

## Validation
- `npm test -- --run tests/unit/portfolio-income-activity-workspace.test.tsx tests/unit/portfolio-record-screen-view-model.test.ts tests/unit/portfolio-screen-navigation.test.ts tests/unit/shell-app-registry.test.ts tests/unit/portfolio-record-evidence-rail.test.tsx tests/integration/portfolios-page.test.tsx` — passed
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run build` — passed
- `npx playwright test tests/e2e/portfolio-workbench.smoke.spec.ts --grep "income route"` — passed
- Diagnostic screenshot captured at `output/playwright/diagnostic-income-activity-screen/income-activity-workspace.png` (local artifact, not committed)

## Wiki
- repo-authored `wiki/Supported-Features.md` updated for `/income`
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` currently reports expected drift for `Supported-Features.md` until this PR merges and wiki publication runs