### PR TITLE
Show external hedge policy evidence in construction lab

### DIFF
--- a/src/features/workbench/components/construction-alternatives-panel.tsx
+++ b/src/features/workbench/components/construction-alternatives-panel.tsx
@@ -402,6 +402,81 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
                     body="Constraint rows are not available for the selected alternative."
                   />
                 )}
+                {model.currencyOverlayEvidence ? (
+                  <section className="construction-currency-overlay-evidence">
+                    <div className="construction-currency-overlay-header">
+                      <Text as="h3" variant="subsectionTitle">
+                        Currency Overlay Evidence
+                      </Text>
+                      <SemanticBadge tone={badgeTone(model.currencyOverlayEvidence.state)}>
+                        {businessStateLabel(model.currencyOverlayEvidence.state)}
+                      </SemanticBadge>
+                    </div>
+                    <dl>
+                      <div>
+                        <dt>Hedge policy source</dt>
+                        <dd>
+                          {model.currencyOverlayEvidence.sourceProductName}{" "}
+                          {model.currencyOverlayEvidence.sourceProductVersion}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>Source id</dt>
+                        <dd>{model.currencyOverlayEvidence.sourceId}</dd>
+                      </div>
+                      <div>
+                        <dt>Evidence hash</dt>
+                        <dd>{model.currencyOverlayEvidence.contentHash}</dd>
+                      </div>
+                      <div>
+                        <dt>Policy rules</dt>
+                        <dd>{model.currencyOverlayEvidence.ruleCount}</dd>
+                      </div>
+                    </dl>
+                    {model.currencyOverlayEvidence.rules.length > 0 ? (
+                      <div className="construction-currency-overlay-list">
+                        <strong>Returned rules</strong>
+                        {model.currencyOverlayEvidence.rules.map((rule, index) => (
+                          <span key={`${rule}-${index}`}>{rule}</span>
+                        ))}
+                      </div>
+                    ) : null}
+                    <div className="construction-currency-overlay-list">
+                      <strong>Missing data</strong>
+                      {model.currencyOverlayEvidence.missingDataFamilies.length > 0 ? (
+                        model.currencyOverlayEvidence.missingDataFamilies.map((family) => (
+                          <SemanticBadge key={family} tone="warn">
+                            {formatBusinessReason(family)}
+                          </SemanticBadge>
+                        ))
+                      ) : (
+                        <span>None reported</span>
+                      )}
+                    </div>
+                    <div className="construction-currency-overlay-list">
+                      <strong>Blocked capabilities</strong>
+                      {model.currencyOverlayEvidence.blockedCapabilities.length > 0 ? (
+                        model.currencyOverlayEvidence.blockedCapabilities.map((capability) => (
+                          <SemanticBadge key={capability} tone="danger">
+                            {formatBusinessReason(capability)}
+                          </SemanticBadge>
+                        ))
+                      ) : (
+                        <span>None reported</span>
+                      )}
+                    </div>
+                    {model.currencyOverlayEvidence.reasonCodes.length > 0 ? (
+                      <div className="construction-currency-overlay-list">
+                        <strong>Reason codes</strong>
+                        {model.currencyOverlayEvidence.reasonCodes.map((reason) => (
+                          <SemanticBadge key={reason} tone="warn">
+                            {formatBusinessReason(reason)}
+                          </SemanticBadge>
+                        ))}
+                      </div>
+                    ) : null}
+                  </section>
+                ) : null}
               </div>
             </div>
           </div>

--- a/src/features/workbench/construction-alternatives-view-model.ts
+++ b/src/features/workbench/construction-alternatives-view-model.ts
@@ -68,6 +68,19 @@ export type ConstructionSourceReadinessRow = {
   reasonCode: string;
 };
 
+export type ConstructionCurrencyOverlayEvidence = {
+  state: string;
+  sourceProductName: string;
+  sourceProductVersion: string;
+  sourceId: string;
+  contentHash: string;
+  ruleCount: string;
+  rules: string[];
+  missingDataFamilies: string[];
+  blockedCapabilities: string[];
+  reasonCodes: string[];
+};
+
 export type ConstructionPanelModel = {
   state: ConstructionPanelState;
   supportabilityState: string;
@@ -90,6 +103,7 @@ export type ConstructionPanelModel = {
   selectedAlternative: ConstructionAlternativeRow | null;
   constraints: ConstructionConstraintRow[];
   sourceReadiness: ConstructionSourceReadinessRow[];
+  currencyOverlayEvidence: ConstructionCurrencyOverlayEvidence | null;
 };
 
 export function buildConstructionPanelModel(
@@ -123,6 +137,7 @@ export function buildConstructionPanelModel(
       selectedAlternative: null,
       constraints: [],
       sourceReadiness: [],
+      currencyOverlayEvidence: null,
     };
   }
 
@@ -135,6 +150,11 @@ export function buildConstructionPanelModel(
   const selectedAlternativeId =
     (response.supportability.selected_alternative_id ??
       readString(response.data, "selected_alternative_id")) ||
+    null;
+  const selectedRecord =
+    records.find((record) => readString(record, "alternative_id") === selectedAlternativeId) ??
+    records.find((record) => readBoolean(record, "recommended")) ??
+    records[0] ??
     null;
   return {
     state: resolvePanelState(supportabilityState, records.length),
@@ -176,6 +196,7 @@ export function buildConstructionPanelModel(
     tradeImpact: buildTradeImpact(response.data, alternatives),
     constraints: buildConstraintRows(response.data, records),
     sourceReadiness: buildSourceReadinessRows(response.data),
+    currencyOverlayEvidence: buildCurrencyOverlayEvidence(selectedRecord),
   };
 }
 
@@ -364,6 +385,59 @@ function buildSourceReadinessRows(data: Record<string, unknown>): ConstructionSo
   });
 }
 
+function buildCurrencyOverlayEvidence(
+  record: Record<string, unknown> | null,
+): ConstructionCurrencyOverlayEvidence | null {
+  if (!record) {
+    return null;
+  }
+  const diagnostics = readRecord(record.diagnostics);
+  const authorityContext = readRecord(diagnostics.authority_context);
+  const context = readRecord(authorityContext.currency_overlay_context);
+  if (Object.keys(context).length === 0) {
+    return null;
+  }
+  const sourceProductName = readString(
+    context,
+    "external_hedge_policy_source_product_name",
+  );
+  const sourceId = readString(context, "external_hedge_policy_source_id");
+  const contentHash = readString(context, "external_hedge_policy_content_hash");
+  const missingDataFamilies = extractStringArray(context.missing_data_families);
+  const blockedCapabilities = extractStringArray(context.blocked_capabilities);
+  const reasonCodes = extractStringArray(context.reason_codes);
+  const rules = extractDisplayArray(context.external_hedge_policy_rules);
+
+  if (
+    !sourceProductName &&
+    !sourceId &&
+    !contentHash &&
+    missingDataFamilies.length === 0 &&
+    blockedCapabilities.length === 0 &&
+    reasonCodes.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    state:
+      readString(context, "supportability_status") ||
+      readString(context, "state") ||
+      "UNKNOWN",
+    sourceProductName: sourceProductName || "External hedge policy",
+    sourceProductVersion:
+      readString(context, "external_hedge_policy_source_product_version") ||
+      "N/A",
+    sourceId: sourceId || "N/A",
+    contentHash: contentHash || "N/A",
+    ruleCount: readCountLabel(context.external_hedge_policy_rule_count),
+    rules,
+    missingDataFamilies,
+    blockedCapabilities,
+    reasonCodes,
+  };
+}
+
 function recommendedPathLabel(alternatives: ConstructionAlternativeRow[]): string {
   return alternatives.find((alternative) => alternative.isRecommended)?.label ?? alternatives[0]?.label ?? "Not available";
 }
@@ -502,8 +576,27 @@ function extractStringArray(value: unknown): string[] {
   );
 }
 
+function extractDisplayArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((item) =>
+    typeof item === "string" ? item : JSON.stringify(item),
+  );
+}
+
 function uniqueStrings(values: string[]): string[] {
   return Array.from(new Set(values));
+}
+
+function readCountLabel(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value.toLocaleString();
+  }
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  return "N/A";
 }
 
 function readRecord(value: unknown): Record<string, unknown> {

--- a/src/features/workbench/manage-workspace.module.css
+++ b/src/features/workbench/manage-workspace.module.css
@@ -3402,6 +3402,84 @@
   justify-self: end;
 }
 
+.manageScope :global(.construction-currency-overlay-evidence) {
+  display: grid;
+  gap: 12px;
+  padding-top: 16px;
+  border-top: 1px solid #e0e3e5;
+}
+
+.manageScope :global(.construction-currency-overlay-header) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.manageScope :global(.construction-currency-overlay-evidence dl) {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  border: 1px solid #c6c6cd;
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.manageScope :global(.construction-currency-overlay-evidence dl > div) {
+  display: grid;
+  grid-template-columns: minmax(94px, 0.4fr) minmax(0, 0.6fr);
+  gap: 10px;
+  padding: 9px 10px;
+  border-bottom: 1px solid #e6e8ea;
+}
+
+.manageScope :global(.construction-currency-overlay-evidence dl > div:last-child) {
+  border-bottom: 0;
+}
+
+.manageScope :global(.construction-currency-overlay-evidence dt) {
+  color: #5b6068;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.construction-currency-overlay-evidence dd) {
+  min-width: 0;
+  margin: 0;
+  color: #191c1e;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 16px;
+  overflow-wrap: anywhere;
+}
+
+.manageScope :global(.construction-currency-overlay-list) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.manageScope :global(.construction-currency-overlay-list strong) {
+  flex: 0 0 100%;
+  color: #45464d;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.construction-currency-overlay-list span) {
+  color: #45464d;
+  font-size: 12px;
+  line-height: 16px;
+  overflow-wrap: anywhere;
+}
+
 .manageScope :global(.construction-source-readiness-list > div) {
   display: flex;
   align-items: center;

--- a/tests/unit/construction-alternatives-panel.test.tsx
+++ b/tests/unit/construction-alternatives-panel.test.tsx
@@ -91,6 +91,29 @@ const readyResponse: DpmConstructionGatewayResponse = {
         },
         objective_trace: [{ term: "turnover" }],
         constraint_trace: [{ constraint: "cash_band" }],
+        diagnostics: {
+          authority_context: {
+            currency_overlay_context: {
+              supportability_status: "BLOCKED",
+              source_system: "lotus-core",
+              external_hedge_policy_source_product_name: "ExternalHedgePolicy",
+              external_hedge_policy_source_product_version: "v1",
+              external_hedge_policy_source_id: "sha256:external-hedge-policy",
+              external_hedge_policy_content_hash:
+                "sha256:external-hedge-policy-content",
+              external_hedge_policy_rule_count: 0,
+              external_hedge_policy_rules: [],
+              missing_data_families: ["external_hedge_policy"],
+              blocked_capabilities: [
+                "hedge_policy_approval",
+                "treasury_instruction",
+                "counterparty_selection",
+                "oms_acknowledgement",
+              ],
+              reason_codes: ["EXTERNAL_HEDGE_POLICY_FAIL_CLOSED"],
+            },
+          },
+        },
       },
       {
         alternative_id: "alt_low_turnover",
@@ -162,6 +185,12 @@ describe("ConstructionAlternativesPanel", () => {
     expect(screen.getByText("Mandate Integrity Checks")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Review" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Apply Selection" })).toBeEnabled();
+    expect(screen.getByText("Currency Overlay Evidence")).toBeInTheDocument();
+    expect(screen.getByText("ExternalHedgePolicy v1")).toBeInTheDocument();
+    expect(screen.getByText("sha256:external-hedge-policy")).toBeInTheDocument();
+    expect(screen.getByText("sha256:external-hedge-policy-content")).toBeInTheDocument();
+    expect(screen.getByText("Hedge Policy Approval")).toBeInTheDocument();
+    expect(screen.getByText("External Hedge Policy Fail Closed")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open evidence pack" })).toHaveAttribute(
       "href",
       "/workbench/PB_SG_GLOBAL_BAL_001?mode=proof",

--- a/tests/unit/construction-alternatives-view-model.test.ts
+++ b/tests/unit/construction-alternatives-view-model.test.ts
@@ -53,6 +53,27 @@ const readyResponse: DpmConstructionGatewayResponse = {
         objective_trace: [{ term: "turnover" }],
         constraint_trace: [{ constraint: "cash_band" }],
         diagnostics: {
+          authority_context: {
+            currency_overlay_context: {
+              supportability_status: "BLOCKED",
+              source_system: "lotus-core",
+              external_hedge_policy_source_product_name: "ExternalHedgePolicy",
+              external_hedge_policy_source_product_version: "v1",
+              external_hedge_policy_source_id: "sha256:external-hedge-policy",
+              external_hedge_policy_content_hash:
+                "sha256:external-hedge-policy-content",
+              external_hedge_policy_rule_count: 0,
+              external_hedge_policy_rules: [],
+              missing_data_families: ["external_hedge_policy"],
+              blocked_capabilities: [
+                "hedge_policy_approval",
+                "treasury_instruction",
+                "counterparty_selection",
+                "oms_acknowledgement",
+              ],
+              reason_codes: ["EXTERNAL_HEDGE_POLICY_FAIL_CLOSED"],
+            },
+          },
           method_plan: { reason_codes: ["TARGET_METHOD_COMPARISON_AVAILABLE"] },
           enrichment_summary: { reason_codes: ["REGIME_SCENARIO_PACK_READY"] },
         },
@@ -154,6 +175,23 @@ describe("construction alternatives view model", () => {
         reasonCode: "PRICE_STALE",
       },
     ]);
+    expect(model.currencyOverlayEvidence).toEqual({
+      state: "BLOCKED",
+      sourceProductName: "ExternalHedgePolicy",
+      sourceProductVersion: "v1",
+      sourceId: "sha256:external-hedge-policy",
+      contentHash: "sha256:external-hedge-policy-content",
+      ruleCount: "0",
+      rules: [],
+      missingDataFamilies: ["external_hedge_policy"],
+      blockedCapabilities: [
+        "hedge_policy_approval",
+        "treasury_instruction",
+        "counterparty_selection",
+        "oms_acknowledgement",
+      ],
+      reasonCodes: ["EXTERNAL_HEDGE_POLICY_FAIL_CLOSED"],
+    });
   });
 
   it("uses an idle state before Gateway returns an alternative set", () => {


### PR DESCRIPTION
## Summary
- Add a construction view-model for Manage-owned currency-overlay hedge-policy evidence.
- Render hedge-policy source, source id, evidence hash, rule count, missing data, blocked capabilities, and reason codes in the existing Construction Alternatives surface.
- Keep Workbench gateway-only and display-only; no browser hedge-policy calculation or treasury action.

## Boundaries
- No direct Manage/Core/AI calls from Workbench.
- No hedge-policy approval, treasury instruction, counterparty selection, order generation, best execution, OMS acknowledgement, fills, settlement, or autonomous treasury action.

## Validation
- npm test -- --run tests/unit/construction-alternatives-view-model.test.ts tests/unit/construction-alternatives-panel.test.tsx
- npm run typecheck
- npm run lint
- git diff --check
- npm run build