### PR TITLE
Render construction execution acknowledgement evidence

### DIFF
--- a/src/features/workbench/components/construction-alternatives-panel.tsx
+++ b/src/features/workbench/components/construction-alternatives-panel.tsx
@@ -105,6 +105,26 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
   const selectedAlternative = model.selectedAlternative;
   const eligibleInstrumentEvidence =
     model.currencyOverlayEvidence?.eligibleInstrumentEvidence;
+  const executionAcknowledgementEvidence =
+    model.executionAcknowledgementEvidence;
+  const authorityMissingDataFamilies = Array.from(
+    new Set([
+      ...(model.currencyOverlayEvidence?.missingDataFamilies ?? []),
+      ...(executionAcknowledgementEvidence?.missingDataFamilies ?? []),
+    ]),
+  );
+  const authorityBlockedCapabilities = Array.from(
+    new Set([
+      ...(model.currencyOverlayEvidence?.blockedCapabilities ?? []),
+      ...(executionAcknowledgementEvidence?.blockedCapabilities ?? []),
+    ]),
+  );
+  const authorityReasonCodes = Array.from(
+    new Set([
+      ...(model.currencyOverlayEvidence?.reasonCodes ?? []),
+      ...(executionAcknowledgementEvidence?.reasonCodes ?? []),
+    ]),
+  );
   const canSelectSelectedAlternative = Boolean(
     selectedAlternative &&
       model.alternativeSetId !== "N/A" &&
@@ -404,38 +424,42 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
                     body="Constraint rows are not available for the selected alternative."
                   />
                 )}
-                {model.currencyOverlayEvidence ? (
+                {model.currencyOverlayEvidence || executionAcknowledgementEvidence ? (
                   <section className="construction-currency-overlay-evidence">
                     <div className="construction-currency-overlay-header">
                       <Text as="h3" variant="subsectionTitle">
-                        Currency Overlay Evidence
+                        Construction Authority Evidence
                       </Text>
-                      <SemanticBadge tone={badgeTone(model.currencyOverlayEvidence.state)}>
-                        {businessStateLabel(model.currencyOverlayEvidence.state)}
-                      </SemanticBadge>
+                      {model.currencyOverlayEvidence ? (
+                        <SemanticBadge tone={badgeTone(model.currencyOverlayEvidence.state)}>
+                          {businessStateLabel(model.currencyOverlayEvidence.state)}
+                        </SemanticBadge>
+                      ) : null}
                     </div>
-                    <dl>
-                      <div>
-                        <dt>Hedge policy source</dt>
-                        <dd>
-                          {model.currencyOverlayEvidence.sourceProductName}{" "}
-                          {model.currencyOverlayEvidence.sourceProductVersion}
-                        </dd>
-                      </div>
-                      <div>
-                        <dt>Source id</dt>
-                        <dd>{model.currencyOverlayEvidence.sourceId}</dd>
-                      </div>
-                      <div>
-                        <dt>Evidence hash</dt>
-                        <dd>{model.currencyOverlayEvidence.contentHash}</dd>
-                      </div>
-                      <div>
-                        <dt>Policy rules</dt>
-                        <dd>{model.currencyOverlayEvidence.ruleCount}</dd>
-                      </div>
-                    </dl>
-                    {model.currencyOverlayEvidence.rules.length > 0 ? (
+                    {model.currencyOverlayEvidence ? (
+                      <dl>
+                        <div>
+                          <dt>Hedge policy source</dt>
+                          <dd>
+                            {model.currencyOverlayEvidence.sourceProductName}{" "}
+                            {model.currencyOverlayEvidence.sourceProductVersion}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt>Source id</dt>
+                          <dd>{model.currencyOverlayEvidence.sourceId}</dd>
+                        </div>
+                        <div>
+                          <dt>Evidence hash</dt>
+                          <dd>{model.currencyOverlayEvidence.contentHash}</dd>
+                        </div>
+                        <div>
+                          <dt>Policy rules</dt>
+                          <dd>{model.currencyOverlayEvidence.ruleCount}</dd>
+                        </div>
+                      </dl>
+                    ) : null}
+                    {model.currencyOverlayEvidence?.rules.length ? (
                       <div className="construction-currency-overlay-list">
                         <strong>Returned rules</strong>
                         {model.currencyOverlayEvidence.rules.map((rule, index) => (
@@ -470,10 +494,40 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
                           : null}
                       </div>
                     ) : null}
+                    {executionAcknowledgementEvidence ? (
+                      <div className="construction-currency-overlay-list">
+                        <strong>OMS acknowledgement posture</strong>
+                        <SemanticBadge tone={badgeTone(executionAcknowledgementEvidence.state)}>
+                          {businessStateLabel(executionAcknowledgementEvidence.state)}
+                        </SemanticBadge>
+                        <span>
+                          {executionAcknowledgementEvidence.sourceProductName}{" "}
+                          {executionAcknowledgementEvidence.sourceProductVersion}
+                        </span>
+                        <span>
+                          Source id: {executionAcknowledgementEvidence.sourceId}
+                        </span>
+                        <span>
+                          Evidence hash:{" "}
+                          {executionAcknowledgementEvidence.contentHash}
+                        </span>
+                        <span>
+                          Acknowledgement rows:{" "}
+                          {executionAcknowledgementEvidence.acknowledgementCount}
+                        </span>
+                        {executionAcknowledgementEvidence.acknowledgements.length > 0
+                          ? executionAcknowledgementEvidence.acknowledgements.map((acknowledgement, index) => (
+                              <span key={`${acknowledgement}-${index}`}>
+                                {acknowledgement}
+                              </span>
+                            ))
+                          : null}
+                      </div>
+                    ) : null}
                     <div className="construction-currency-overlay-list">
                       <strong>Missing data</strong>
-                      {model.currencyOverlayEvidence.missingDataFamilies.length > 0 ? (
-                        model.currencyOverlayEvidence.missingDataFamilies.map((family) => (
+                      {authorityMissingDataFamilies.length > 0 ? (
+                        authorityMissingDataFamilies.map((family) => (
                           <SemanticBadge key={family} tone="warn">
                             {formatBusinessReason(family)}
                           </SemanticBadge>
@@ -484,8 +538,8 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
                     </div>
                     <div className="construction-currency-overlay-list">
                       <strong>Blocked capabilities</strong>
-                      {model.currencyOverlayEvidence.blockedCapabilities.length > 0 ? (
-                        model.currencyOverlayEvidence.blockedCapabilities.map((capability) => (
+                      {authorityBlockedCapabilities.length > 0 ? (
+                        authorityBlockedCapabilities.map((capability) => (
                           <SemanticBadge key={capability} tone="danger">
                             {formatBusinessReason(capability)}
                           </SemanticBadge>
@@ -494,10 +548,10 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
                         <span>None reported</span>
                       )}
                     </div>
-                    {model.currencyOverlayEvidence.reasonCodes.length > 0 ? (
+                    {authorityReasonCodes.length > 0 ? (
                       <div className="construction-currency-overlay-list">
                         <strong>Reason codes</strong>
-                        {model.currencyOverlayEvidence.reasonCodes.map((reason) => (
+                        {authorityReasonCodes.map((reason) => (
                           <SemanticBadge key={reason} tone="warn">
                             {formatBusinessReason(reason)}
                           </SemanticBadge>

--- a/src/features/workbench/construction-alternatives-view-model.ts
+++ b/src/features/workbench/construction-alternatives-view-model.ts
@@ -91,6 +91,19 @@ export type ConstructionEligibleInstrumentEvidence = {
   instruments: string[];
 };
 
+export type ConstructionExecutionAcknowledgementEvidence = {
+  state: string;
+  sourceProductName: string;
+  sourceProductVersion: string;
+  sourceId: string;
+  contentHash: string;
+  acknowledgementCount: string;
+  acknowledgements: string[];
+  missingDataFamilies: string[];
+  blockedCapabilities: string[];
+  reasonCodes: string[];
+};
+
 export type ConstructionPanelModel = {
   state: ConstructionPanelState;
   supportabilityState: string;
@@ -114,6 +127,7 @@ export type ConstructionPanelModel = {
   constraints: ConstructionConstraintRow[];
   sourceReadiness: ConstructionSourceReadinessRow[];
   currencyOverlayEvidence: ConstructionCurrencyOverlayEvidence | null;
+  executionAcknowledgementEvidence: ConstructionExecutionAcknowledgementEvidence | null;
 };
 
 export function buildConstructionPanelModel(
@@ -148,6 +162,7 @@ export function buildConstructionPanelModel(
       constraints: [],
       sourceReadiness: [],
       currencyOverlayEvidence: null,
+      executionAcknowledgementEvidence: null,
     };
   }
 
@@ -207,6 +222,7 @@ export function buildConstructionPanelModel(
     constraints: buildConstraintRows(response.data, records),
     sourceReadiness: buildSourceReadinessRows(response.data),
     currencyOverlayEvidence: buildCurrencyOverlayEvidence(selectedRecord),
+    executionAcknowledgementEvidence: buildExecutionAcknowledgementEvidence(selectedRecord),
   };
 }
 
@@ -493,6 +509,57 @@ function buildEligibleInstrumentEvidence(
       context.external_eligible_hedge_instrument_count,
     ),
     instruments,
+  };
+}
+
+function buildExecutionAcknowledgementEvidence(
+  record: Record<string, unknown> | null,
+): ConstructionExecutionAcknowledgementEvidence | null {
+  if (!record) {
+    return null;
+  }
+  const diagnostics = readRecord(record.diagnostics);
+  const authorityContext = readRecord(diagnostics.authority_context);
+  const context = readRecord(authorityContext.execution_acknowledgement_context);
+  if (Object.keys(context).length === 0) {
+    return null;
+  }
+  const sourceProductName = readString(context, "source_product_name");
+  const sourceProductVersion = readString(context, "source_product_version");
+  const sourceId = readString(context, "source_id");
+  const contentHash = readString(context, "content_hash");
+  const acknowledgements = extractDisplayArray(context.acknowledgements);
+  const missingDataFamilies = extractStringArray(context.missing_data_families);
+  const blockedCapabilities = extractStringArray(context.blocked_capabilities);
+  const reasonCodes = extractStringArray(context.reason_codes);
+
+  if (
+    !sourceProductName &&
+    !sourceProductVersion &&
+    !sourceId &&
+    !contentHash &&
+    acknowledgements.length === 0 &&
+    missingDataFamilies.length === 0 &&
+    blockedCapabilities.length === 0 &&
+    reasonCodes.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    state:
+      readString(context, "supportability_status") ||
+      readString(context, "state") ||
+      "UNKNOWN",
+    sourceProductName: sourceProductName || "External order execution acknowledgement",
+    sourceProductVersion: sourceProductVersion || "N/A",
+    sourceId: sourceId || "N/A",
+    contentHash: contentHash || "N/A",
+    acknowledgementCount: readCountLabel(context.acknowledgement_count),
+    acknowledgements,
+    missingDataFamilies,
+    blockedCapabilities,
+    reasonCodes,
   };
 }
 

--- a/tests/unit/construction-alternatives-panel.test.tsx
+++ b/tests/unit/construction-alternatives-panel.test.tsx
@@ -134,6 +134,34 @@ const readyResponse: DpmConstructionGatewayResponse = {
                 "EXTERNAL_ELIGIBLE_HEDGE_INSTRUMENTS_FAIL_CLOSED",
               ],
             },
+            execution_acknowledgement_context: {
+              supportability_status: "BLOCKED",
+              source_system: "lotus-core",
+              source_product_name: "ExternalOrderExecutionAcknowledgement",
+              source_product_version: "v1",
+              source_id: "sha256:external-order-execution-acknowledgement",
+              content_hash:
+                "sha256:external-order-execution-acknowledgement-content",
+              acknowledgement_count: 0,
+              missing_data_families: [
+                "external_oms_order_execution_acknowledgement",
+              ],
+              blocked_capabilities: [
+                "order_generation",
+                "venue_routing",
+                "best_execution",
+                "oms_acknowledgement",
+                "fills",
+                "settlement",
+                "execution_status_certification",
+                "autonomous_execution",
+              ],
+              acknowledgements: [],
+              reason_codes: [
+                "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+                "EXTERNAL_ORDER_EXECUTION_ACKNOWLEDGEMENT_FAIL_CLOSED",
+              ],
+            },
           },
         },
       },
@@ -207,7 +235,7 @@ describe("ConstructionAlternativesPanel", () => {
     expect(screen.getByText("Mandate Integrity Checks")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Review" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Apply Selection" })).toBeEnabled();
-    expect(screen.getByText("Currency Overlay Evidence")).toBeInTheDocument();
+    expect(screen.getByText("Construction Authority Evidence")).toBeInTheDocument();
     expect(screen.getByText("ExternalHedgePolicy v1")).toBeInTheDocument();
     expect(screen.getByText("sha256:external-hedge-policy")).toBeInTheDocument();
     expect(screen.getByText("sha256:external-hedge-policy-content")).toBeInTheDocument();
@@ -224,12 +252,31 @@ describe("ConstructionAlternativesPanel", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("Instrument rows: 0")).toBeInTheDocument();
+    expect(screen.getByText("OMS acknowledgement posture")).toBeInTheDocument();
+    expect(
+      screen.getByText("ExternalOrderExecutionAcknowledgement v1"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Source id: sha256:external-order-execution-acknowledgement"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Evidence hash: sha256:external-order-execution-acknowledgement-content",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Acknowledgement rows: 0")).toBeInTheDocument();
     expect(screen.getByText("Hedge Policy Approval")).toBeInTheDocument();
     expect(screen.getByText("Eligible Instrument Selection")).toBeInTheDocument();
     expect(screen.getByText("Product Recommendation")).toBeInTheDocument();
+    expect(screen.getByText("External OMS Order Execution Acknowledgement")).toBeInTheDocument();
+    expect(screen.getByText("Autonomous Execution")).toBeInTheDocument();
     expect(screen.getByText("External Hedge Policy Fail Closed")).toBeInTheDocument();
     expect(
       screen.getByText("External Eligible Hedge Instruments Fail Closed"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("External OMS Source Not Ingested")).toBeInTheDocument();
+    expect(
+      screen.getByText("External Order Execution Acknowledgement Fail Closed"),
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open evidence pack" })).toHaveAttribute(
       "href",

--- a/tests/unit/construction-alternatives-view-model.test.ts
+++ b/tests/unit/construction-alternatives-view-model.test.ts
@@ -95,6 +95,34 @@ const readyResponse: DpmConstructionGatewayResponse = {
                 "EXTERNAL_ELIGIBLE_HEDGE_INSTRUMENTS_FAIL_CLOSED",
               ],
             },
+            execution_acknowledgement_context: {
+              supportability_status: "BLOCKED",
+              source_system: "lotus-core",
+              source_product_name: "ExternalOrderExecutionAcknowledgement",
+              source_product_version: "v1",
+              source_id: "sha256:external-order-execution-acknowledgement",
+              content_hash:
+                "sha256:external-order-execution-acknowledgement-content",
+              acknowledgement_count: 0,
+              missing_data_families: [
+                "external_oms_order_execution_acknowledgement",
+              ],
+              blocked_capabilities: [
+                "order_generation",
+                "venue_routing",
+                "best_execution",
+                "oms_acknowledgement",
+                "fills",
+                "settlement",
+                "execution_status_certification",
+                "autonomous_execution",
+              ],
+              acknowledgements: [],
+              reason_codes: [
+                "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+                "EXTERNAL_ORDER_EXECUTION_ACKNOWLEDGEMENT_FAIL_CLOSED",
+              ],
+            },
           },
           method_plan: { reason_codes: ["TARGET_METHOD_COMPARISON_AVAILABLE"] },
           enrichment_summary: { reason_codes: ["REGIME_SCENARIO_PACK_READY"] },
@@ -233,6 +261,32 @@ describe("construction alternatives view model", () => {
       reasonCodes: [
         "EXTERNAL_HEDGE_POLICY_FAIL_CLOSED",
         "EXTERNAL_ELIGIBLE_HEDGE_INSTRUMENTS_FAIL_CLOSED",
+      ],
+    });
+    expect(model.executionAcknowledgementEvidence).toEqual({
+      state: "BLOCKED",
+      sourceProductName: "ExternalOrderExecutionAcknowledgement",
+      sourceProductVersion: "v1",
+      sourceId: "sha256:external-order-execution-acknowledgement",
+      contentHash: "sha256:external-order-execution-acknowledgement-content",
+      acknowledgementCount: "0",
+      acknowledgements: [],
+      missingDataFamilies: [
+        "external_oms_order_execution_acknowledgement",
+      ],
+      blockedCapabilities: [
+        "order_generation",
+        "venue_routing",
+        "best_execution",
+        "oms_acknowledgement",
+        "fills",
+        "settlement",
+        "execution_status_certification",
+        "autonomous_execution",
+      ],
+      reasonCodes: [
+        "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+        "EXTERNAL_ORDER_EXECUTION_ACKNOWLEDGEMENT_FAIL_CLOSED",
       ],
     });
   });


### PR DESCRIPTION
## Summary
- add a pure construction view-model for Manage-owned execution acknowledgement evidence
- render the evidence in the existing construction authority diagnostics panel
- keep OMS acknowledgement posture read-only and blocked-state oriented without new execution workflow

## Validation
- npm test -- --run tests/unit/construction-alternatives-view-model.test.ts tests/unit/construction-alternatives-panel.test.tsx
- npm run typecheck
- npm run lint
- npm run build
- git diff --check

## Boundaries
- Workbench consumes Gateway/BFF construction diagnostics only
- no order generation, venue routing, best execution, OMS acknowledgement ingestion, fills, settlement, execution-status certification, or autonomous execution