### PR TITLE
Render execution acknowledgement supportability

### DIFF
--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -226,6 +226,11 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
   },
   {
     route: "workbench.manage",
+    panel: "execution-acknowledgement-supportability",
+    operation: "source-products.external-order-execution-acknowledgement.get",
+  },
+  {
+    route: "workbench.manage",
     panel: "proof-pack-generate",
     operation: "dpm.proof-pack.generate",
   },

--- a/src/features/workbench/api.ts
+++ b/src/features/workbench/api.ts
@@ -20,6 +20,7 @@ import {
   DpmCampaignDefinitionGatewayResponse,
   DpmConstructionGatewayResponse,
   DpmExceptionSummaryResponse,
+  ExternalOrderExecutionAcknowledgementResponse,
   DpmOutcomeReviewGatewayResponse,
   DpmOutcomeReviewHandoffResponse,
   DpmOutcomeReviewNarrativeResponse,
@@ -1888,6 +1889,45 @@ export async function selectDpmConstructionAlternative(params: {
               comment: params.comment ?? "Selected from Workbench construction lab.",
             },
           }),
+        }
+      )
+  );
+}
+
+export async function getExternalOrderExecutionAcknowledgement(params: {
+  portfolio: WorkbenchPortfolio360;
+  executionIntentId?: string;
+  orderReferenceIds?: string[];
+}): Promise<ExternalOrderExecutionAcknowledgementResponse> {
+  const portfolioId = params.portfolio.portfolio.portfolio_id;
+  const callerContext = resolveDefaultCallerContext();
+  const dpmContext = resolveDefaultDpmContext();
+  const body: Record<string, unknown> = {
+    as_of_date: params.portfolio.as_of_date,
+    tenant_id: callerContext.tenantId,
+    mandate_id: dpmContext.mandateId,
+    order_reference_ids: params.orderReferenceIds ?? [],
+  };
+  if (params.executionIntentId) {
+    body.execution_intent_id = params.executionIntentId;
+  }
+
+  return await observeWorkbenchResource(
+    "source-products.external-order-execution-acknowledgement.get",
+    async () =>
+      await fetchWorkbenchJson<ExternalOrderExecutionAcknowledgementResponse>(
+        buildWorkbenchUrl(
+          "client",
+          `/source-products/portfolios/${encodeURIComponent(portfolioId)}/external-order-execution-acknowledgement`
+        ),
+        "external OMS acknowledgement supportability",
+        {
+          method: "POST",
+          headers: buildAnalyticsUiCorrelationHeaders({
+            "Content-Type": "application/json",
+            "X-Correlation-Id": `corr-workbench-execution-acknowledgement-${portfolioId}`,
+          }),
+          body: JSON.stringify(body),
         }
       )
   );

--- a/src/features/workbench/components/construction-alternatives-panel.tsx
+++ b/src/features/workbench/components/construction-alternatives-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   ActionButton,
   AnalyticsTable,
@@ -11,13 +11,16 @@ import {
   Text,
 } from "@/design-system";
 import {
+  getExternalOrderExecutionAcknowledgement,
   generateDpmConstructionAlternatives,
   selectDpmConstructionAlternative,
 } from "@/features/workbench/api";
 import type {
   DpmConstructionGatewayResponse,
+  ExternalOrderExecutionAcknowledgementResponse,
   WorkbenchPortfolio360,
 } from "@/features/workbench/types";
+import ExecutionAcknowledgementSupportabilityPanel from "@/features/workbench/components/execution-acknowledgement-supportability-panel";
 import {
   buildConstructionPanelModel,
   type ConstructionPanelState,
@@ -99,30 +102,33 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
   );
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [
+    executionAcknowledgementResponse,
+    setExecutionAcknowledgementResponse,
+  ] = useState<ExternalOrderExecutionAcknowledgementResponse | null>(null);
+  const [executionAcknowledgementLoading, setExecutionAcknowledgementLoading] =
+    useState(false);
+  const [executionAcknowledgementError, setExecutionAcknowledgementError] =
+    useState<string | null>(null);
   const model = buildConstructionPanelModel(response);
   const portfolioId = portfolio.portfolio.portfolio_id;
   const stateCopy = statePanelCopy(model.state, portfolioId);
   const selectedAlternative = model.selectedAlternative;
   const eligibleInstrumentEvidence =
     model.currencyOverlayEvidence?.eligibleInstrumentEvidence;
-  const executionAcknowledgementEvidence =
-    model.executionAcknowledgementEvidence;
   const authorityMissingDataFamilies = Array.from(
     new Set([
       ...(model.currencyOverlayEvidence?.missingDataFamilies ?? []),
-      ...(executionAcknowledgementEvidence?.missingDataFamilies ?? []),
     ]),
   );
   const authorityBlockedCapabilities = Array.from(
     new Set([
       ...(model.currencyOverlayEvidence?.blockedCapabilities ?? []),
-      ...(executionAcknowledgementEvidence?.blockedCapabilities ?? []),
     ]),
   );
   const authorityReasonCodes = Array.from(
     new Set([
       ...(model.currencyOverlayEvidence?.reasonCodes ?? []),
-      ...(executionAcknowledgementEvidence?.reasonCodes ?? []),
     ]),
   );
   const canSelectSelectedAlternative = Boolean(
@@ -139,6 +145,36 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
     model.state === "unsupported" ||
     model.state === "unavailable" ||
     Boolean(actionError);
+
+  useEffect(() => {
+    let cancelled = false;
+    setExecutionAcknowledgementLoading(true);
+    setExecutionAcknowledgementError(null);
+    void getExternalOrderExecutionAcknowledgement({ portfolio })
+      .then((nextResponse) => {
+        if (!cancelled) {
+          setExecutionAcknowledgementResponse(nextResponse);
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setExecutionAcknowledgementResponse(null);
+          setExecutionAcknowledgementError(
+            error instanceof Error
+              ? error.message
+              : "External OMS acknowledgement supportability could not be loaded.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setExecutionAcknowledgementLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [portfolio]);
 
   async function generateAlternatives() {
     if (generatePending) {
@@ -262,6 +298,12 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
           ))}
         </div>
       ) : null}
+
+      <ExecutionAcknowledgementSupportabilityPanel
+        response={executionAcknowledgementResponse}
+        loading={executionAcknowledgementLoading}
+        error={executionAcknowledgementError}
+      />
 
       <div className="construction-alternatives-grid">
         <div className="construction-alternatives-primary">
@@ -424,7 +466,7 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
                     body="Constraint rows are not available for the selected alternative."
                   />
                 )}
-                {model.currencyOverlayEvidence || executionAcknowledgementEvidence ? (
+                {model.currencyOverlayEvidence ? (
                   <section className="construction-currency-overlay-evidence">
                     <div className="construction-currency-overlay-header">
                       <Text as="h3" variant="subsectionTitle">
@@ -489,36 +531,6 @@ export default function ConstructionAlternativesPanel({ portfolio }: Props) {
                           ? eligibleInstrumentEvidence.instruments.map((instrument, index) => (
                               <span key={`${instrument}-${index}`}>
                                 {instrument}
-                              </span>
-                            ))
-                          : null}
-                      </div>
-                    ) : null}
-                    {executionAcknowledgementEvidence ? (
-                      <div className="construction-currency-overlay-list">
-                        <strong>OMS acknowledgement posture</strong>
-                        <SemanticBadge tone={badgeTone(executionAcknowledgementEvidence.state)}>
-                          {businessStateLabel(executionAcknowledgementEvidence.state)}
-                        </SemanticBadge>
-                        <span>
-                          {executionAcknowledgementEvidence.sourceProductName}{" "}
-                          {executionAcknowledgementEvidence.sourceProductVersion}
-                        </span>
-                        <span>
-                          Source id: {executionAcknowledgementEvidence.sourceId}
-                        </span>
-                        <span>
-                          Evidence hash:{" "}
-                          {executionAcknowledgementEvidence.contentHash}
-                        </span>
-                        <span>
-                          Acknowledgement rows:{" "}
-                          {executionAcknowledgementEvidence.acknowledgementCount}
-                        </span>
-                        {executionAcknowledgementEvidence.acknowledgements.length > 0
-                          ? executionAcknowledgementEvidence.acknowledgements.map((acknowledgement, index) => (
-                              <span key={`${acknowledgement}-${index}`}>
-                                {acknowledgement}
                               </span>
                             ))
                           : null}

--- a/src/features/workbench/components/execution-acknowledgement-supportability-panel.tsx
+++ b/src/features/workbench/components/execution-acknowledgement-supportability-panel.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import {
+  MetricRow,
+  ScreenStatePanel,
+  SemanticBadge,
+  Text,
+} from "@/design-system";
+import type { ExternalOrderExecutionAcknowledgementResponse } from "@/features/workbench/types";
+import { buildExecutionAcknowledgementSupportabilityModel } from "@/features/workbench/execution-acknowledgement-view-model";
+
+type Props = {
+  response: ExternalOrderExecutionAcknowledgementResponse | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export default function ExecutionAcknowledgementSupportabilityPanel({
+  response,
+  loading,
+  error,
+}: Props) {
+  const model = buildExecutionAcknowledgementSupportabilityModel(response);
+
+  return (
+    <section className="execution-acknowledgement-supportability-panel">
+      <div className="execution-acknowledgement-header">
+        <div>
+          <Text as="h3" variant="subsectionTitle">
+            Execution Acknowledgement Supportability
+          </Text>
+          <Text variant="secondary">
+            External OMS acknowledgement evidence is displayed as audit posture only.
+          </Text>
+        </div>
+        <SemanticBadge tone="danger">{model.state}</SemanticBadge>
+      </div>
+      {loading ? (
+        <ScreenStatePanel
+          kind="loading"
+          surface="portfolio"
+          title="Checking external OMS evidence"
+          body="Loading source-owned acknowledgement supportability."
+        />
+      ) : error ? (
+        <ScreenStatePanel
+          kind="partial"
+          surface="portfolio"
+          title="External OMS evidence is unavailable"
+          body={error}
+        />
+      ) : null}
+
+      <div className="execution-acknowledgement-summary">
+        <MetricRow label="Evidence Contract" value={model.evidenceLabel} />
+        <MetricRow label="Posture" value={model.state} />
+        <MetricRow label="Acknowledgements" value={model.acknowledgementCount} />
+        <MetricRow label="Data Quality" value={model.dataQualityStatus} />
+      </div>
+
+      <div className="execution-acknowledgement-message">
+        <Text variant="secondary">
+          {model.reason}. Workbench does not treat this portfolio as OMS-acknowledged, filled,
+          settled, or execution-ready.
+        </Text>
+      </div>
+
+      <div className="execution-acknowledgement-evidence-grid">
+        <div>
+          <Text as="h3" variant="subsectionTitle">
+            Blocked Capabilities
+          </Text>
+          <div className="execution-acknowledgement-badge-list">
+            {model.blockedCapabilities.length > 0 ? (
+              model.blockedCapabilities.map((capability) => (
+                <SemanticBadge key={capability} tone="danger">
+                  {capability}
+                </SemanticBadge>
+              ))
+            ) : (
+              <span>None reported</span>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <Text as="h3" variant="subsectionTitle">
+            Missing Evidence
+          </Text>
+          <div className="execution-acknowledgement-badge-list">
+            {model.missingDataFamilies.length > 0 ? (
+              model.missingDataFamilies.map((family) => (
+                <SemanticBadge key={family} tone="warn">
+                  {family}
+                </SemanticBadge>
+              ))
+            ) : (
+              <span>None reported</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {model.lineageRows.length > 0 ? (
+        <div className="execution-acknowledgement-lineage">
+          <Text as="h3" variant="subsectionTitle">
+            Audit Lineage
+          </Text>
+          <dl>
+            {model.lineageRows.map((row) => (
+              <div key={row.key}>
+                <dt>{row.label}</dt>
+                <dd>{row.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/workbench/execution-acknowledgement-view-model.ts
+++ b/src/features/workbench/execution-acknowledgement-view-model.ts
@@ -1,0 +1,57 @@
+import type { ExternalOrderExecutionAcknowledgementResponse } from "./types";
+import { formatBusinessReason } from "./manage-workspace-view-model";
+
+export type ExecutionAcknowledgementLineageRow = {
+  key: string;
+  label: string;
+  value: string;
+};
+
+export type ExecutionAcknowledgementSupportabilityModel = {
+  state: string;
+  reason: string;
+  acknowledgementCount: string;
+  missingDataFamilies: string[];
+  blockedCapabilities: string[];
+  lineageRows: ExecutionAcknowledgementLineageRow[];
+  evidenceLabel: string;
+  dataQualityStatus: string;
+};
+
+export function buildExecutionAcknowledgementSupportabilityModel(
+  response: ExternalOrderExecutionAcknowledgementResponse | null,
+): ExecutionAcknowledgementSupportabilityModel {
+  if (!response) {
+    return {
+      state: "Unavailable",
+      reason: "External OMS acknowledgement evidence has not loaded.",
+      acknowledgementCount: "0",
+      missingDataFamilies: [],
+      blockedCapabilities: [],
+      lineageRows: [],
+      evidenceLabel: "ExternalOrderExecutionAcknowledgement v1",
+      dataQualityStatus: "Unknown",
+    };
+  }
+
+  return {
+    state: formatBusinessReason(response.supportability.state),
+    reason: formatBusinessReason(response.supportability.reason),
+    acknowledgementCount: String(response.supportability.acknowledgement_count),
+    missingDataFamilies: response.supportability.missing_data_families.map(formatBusinessReason),
+    blockedCapabilities: response.supportability.blocked_capabilities.map(formatBusinessReason),
+    lineageRows: buildLineageRows(response.lineage),
+    evidenceLabel: `${response.product_name} ${response.product_version}`,
+    dataQualityStatus: formatBusinessReason(response.data_quality_status ?? "UNKNOWN"),
+  };
+}
+
+function buildLineageRows(lineage: Record<string, unknown>): ExecutionAcknowledgementLineageRow[] {
+  return Object.entries(lineage)
+    .filter(([, value]) => value !== null && value !== undefined && String(value).trim().length > 0)
+    .map(([key, value]) => ({
+      key,
+      label: formatBusinessReason(key),
+      value: String(value),
+    }));
+}

--- a/src/features/workbench/manage-workspace.module.css
+++ b/src/features/workbench/manage-workspace.module.css
@@ -3086,6 +3086,140 @@
   margin-top: 10px;
 }
 
+.manageScope :global(.execution-acknowledgement-supportability-panel) {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+  padding: 14px;
+  border: 1px solid #c6c6cd;
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.manageScope :global(.execution-acknowledgement-header) {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.manageScope :global(.execution-acknowledgement-header > div) {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.manageScope :global(.execution-acknowledgement-header h3),
+.manageScope :global(.execution-acknowledgement-lineage h3),
+.manageScope :global(.execution-acknowledgement-evidence-grid h3) {
+  color: #191c1e;
+  font-size: 14px;
+  font-weight: 800;
+  line-height: 18px;
+}
+
+.manageScope :global(.execution-acknowledgement-summary) {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.2fr) repeat(3, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.manageScope :global(.execution-acknowledgement-summary .suite-row) {
+  display: grid;
+  gap: 4px;
+  min-height: 58px;
+  padding: 10px 12px;
+  border: 1px solid #e0e3e5;
+  border-radius: 4px;
+  background: #f7f9fb;
+}
+
+.manageScope :global(.execution-acknowledgement-summary .suite-row span) {
+  color: #5b6068;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.execution-acknowledgement-summary .suite-row strong) {
+  color: #191c1e;
+  font-size: 13px;
+  font-weight: 800;
+  line-height: 17px;
+  overflow-wrap: anywhere;
+}
+
+.manageScope :global(.execution-acknowledgement-message) {
+  padding: 10px 12px;
+  border-left: 3px solid #a45c00;
+  background: #fff8eb;
+}
+
+.manageScope :global(.execution-acknowledgement-evidence-grid) {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.72fr);
+  gap: 12px;
+}
+
+.manageScope :global(.execution-acknowledgement-evidence-grid > div),
+.manageScope :global(.execution-acknowledgement-lineage) {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+}
+
+.manageScope :global(.execution-acknowledgement-badge-list) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.manageScope :global(.execution-acknowledgement-badge-list span) {
+  color: #45464d;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.manageScope :global(.execution-acknowledgement-lineage dl) {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  margin: 0;
+  border: 1px solid #e0e3e5;
+  border-radius: 4px;
+  background: #ffffff;
+}
+
+.manageScope :global(.execution-acknowledgement-lineage dl > div) {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 9px 10px;
+  border-right: 1px solid #e6e8ea;
+  border-bottom: 1px solid #e6e8ea;
+}
+
+.manageScope :global(.execution-acknowledgement-lineage dt) {
+  color: #5b6068;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.execution-acknowledgement-lineage dd) {
+  min-width: 0;
+  margin: 0;
+  color: #191c1e;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 16px;
+  overflow-wrap: anywhere;
+}
+
 .manageScope :global(.construction-alternatives-grid) {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(260px, 0.32fr);
@@ -3555,6 +3689,9 @@
   .manageScope :global(.pm-quality-detail-grid),
   .manageScope :global(.pm-quality-detail-stack),
   .manageScope :global(.construction-alternatives-summary),
+  .manageScope :global(.execution-acknowledgement-summary),
+  .manageScope :global(.execution-acknowledgement-evidence-grid),
+  .manageScope :global(.execution-acknowledgement-lineage dl),
   .manageScope :global(.construction-alternatives-grid),
   .manageScope :global(.construction-alternatives-detail-grid) {
     grid-template-columns: 1fr;

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1309,6 +1309,28 @@ export type DpmConstructionGatewayResponse = {
   data: Record<string, unknown>;
 };
 
+export type ExternalOrderExecutionAcknowledgementSupportability = {
+  state: "UNAVAILABLE" | string;
+  reason: string;
+  acknowledgement_count: number;
+  missing_data_families: string[];
+  blocked_capabilities: string[];
+};
+
+export type ExternalOrderExecutionAcknowledgementResponse = {
+  product_name: "ExternalOrderExecutionAcknowledgement" | string;
+  product_version: "v1" | string;
+  portfolio_id: string;
+  client_id?: string | null;
+  mandate_id?: string | null;
+  execution_intent_id?: string | null;
+  order_reference_ids: string[];
+  acknowledgements: Array<Record<string, unknown>>;
+  supportability: ExternalOrderExecutionAcknowledgementSupportability;
+  lineage: Record<string, unknown>;
+  data_quality_status?: string | null;
+};
+
 export type DpmProofPackSupportability = {
   source_service: string;
   authority: string;

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -376,6 +376,11 @@ describe("analytics UI observability metrics", () => {
       ],
       [
         "workbench.manage",
+        "execution-acknowledgement-supportability",
+        "source-products.external-order-execution-acknowledgement.get",
+      ],
+      [
+        "workbench.manage",
         "proof-pack-generate",
         "dpm.proof-pack.generate",
       ],

--- a/tests/unit/construction-alternatives-panel.test.tsx
+++ b/tests/unit/construction-alternatives-panel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import ConstructionAlternativesPanel from "../../src/features/workbench/components/construction-alternatives-panel";
 import type {
@@ -7,11 +7,13 @@ import type {
   WorkbenchPortfolio360,
 } from "../../src/features/workbench/types";
 import {
+  getExternalOrderExecutionAcknowledgement,
   generateDpmConstructionAlternatives,
   selectDpmConstructionAlternative,
 } from "../../src/features/workbench/api";
 
 vi.mock("../../src/features/workbench/api", () => ({
+  getExternalOrderExecutionAcknowledgement: vi.fn(),
   generateDpmConstructionAlternatives: vi.fn(),
   selectDpmConstructionAlternative: vi.fn(),
 }));
@@ -192,12 +194,52 @@ const readyResponse: DpmConstructionGatewayResponse = {
   },
 };
 
+const executionAcknowledgementResponse = {
+  product_name: "ExternalOrderExecutionAcknowledgement",
+  product_version: "v1",
+  portfolio_id: "PB_SG_GLOBAL_BAL_001",
+  order_reference_ids: [],
+  acknowledgements: [],
+  data_quality_status: "MISSING",
+  supportability: {
+    state: "UNAVAILABLE",
+    reason: "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+    acknowledgement_count: 0,
+    missing_data_families: [
+      "external_oms_order_execution_acknowledgement",
+    ],
+    blocked_capabilities: [
+      "order_generation",
+      "venue_routing",
+      "best_execution",
+      "oms_acknowledgement",
+      "fills",
+      "settlement",
+      "execution_status_certification",
+      "autonomous_execution",
+    ],
+  },
+  lineage: {
+    source_system: "external-bank-oms",
+    source_table: "not_ingested",
+    contract_version: "rfc_042_external_order_execution_acknowledgement_v1",
+    integration_status: "not_ingested",
+    runtime_posture: "fail_closed",
+  },
+};
+
 describe("ConstructionAlternativesPanel", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it("starts idle and does not claim alternatives before Gateway generation", () => {
+  beforeEach(() => {
+    vi.mocked(getExternalOrderExecutionAcknowledgement).mockResolvedValue(
+      executionAcknowledgementResponse,
+    );
+  });
+
+  it("starts idle and does not claim alternatives before Gateway generation", async () => {
     render(<ConstructionAlternativesPanel portfolio={portfolio} />);
 
     expect(
@@ -210,6 +252,41 @@ describe("ConstructionAlternativesPanel", () => {
       screen.getByRole("button", { name: "Generate alternatives" }),
     ).toBeEnabled();
     expect(screen.getAllByText("Not Generated").length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(getExternalOrderExecutionAcknowledgement).toHaveBeenCalledWith({
+        portfolio,
+      });
+    });
+  });
+
+  it("renders external OMS acknowledgement supportability through Gateway only", async () => {
+    render(<ConstructionAlternativesPanel portfolio={portfolio} />);
+
+    await waitFor(() => {
+      expect(getExternalOrderExecutionAcknowledgement).toHaveBeenCalledWith({
+        portfolio,
+      });
+    });
+    expect(
+      screen.getByText("Execution Acknowledgement Supportability"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("ExternalOrderExecutionAcknowledgement v1"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Unavailable").length).toBeGreaterThan(0);
+    expect(screen.getByText("Missing")).toBeInTheDocument();
+    expect(screen.getByText(/External OMS Source Not Ingested/)).toBeInTheDocument();
+    expect(screen.getByText("External OMS Order Execution Acknowledgement")).toBeInTheDocument();
+    expect(screen.getByText("Order Generation")).toBeInTheDocument();
+    expect(screen.getByText("OMS Acknowledgement")).toBeInTheDocument();
+    expect(screen.getByText("Fills")).toBeInTheDocument();
+    expect(screen.getByText("Settlement")).toBeInTheDocument();
+    expect(screen.getByText("Runtime Posture")).toBeInTheDocument();
+    expect(screen.getByText("fail_closed")).toBeInTheDocument();
+    expect(screen.getByText(/does not treat this portfolio as OMS-acknowledged/i)).toBeInTheDocument();
+    expect(screen.queryByText("Execution ready")).not.toBeInTheDocument();
+    expect(screen.queryByText("Filled")).not.toBeInTheDocument();
+    expect(screen.queryByText("Settled")).not.toBeInTheDocument();
   });
 
   it("generates alternatives and renders backed construction methods", async () => {
@@ -252,31 +329,12 @@ describe("ConstructionAlternativesPanel", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("Instrument rows: 0")).toBeInTheDocument();
-    expect(screen.getByText("OMS acknowledgement posture")).toBeInTheDocument();
-    expect(
-      screen.getByText("ExternalOrderExecutionAcknowledgement v1"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Source id: sha256:external-order-execution-acknowledgement"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Evidence hash: sha256:external-order-execution-acknowledgement-content",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Acknowledgement rows: 0")).toBeInTheDocument();
     expect(screen.getByText("Hedge Policy Approval")).toBeInTheDocument();
     expect(screen.getByText("Eligible Instrument Selection")).toBeInTheDocument();
     expect(screen.getByText("Product Recommendation")).toBeInTheDocument();
-    expect(screen.getByText("External OMS Order Execution Acknowledgement")).toBeInTheDocument();
-    expect(screen.getByText("Autonomous Execution")).toBeInTheDocument();
     expect(screen.getByText("External Hedge Policy Fail Closed")).toBeInTheDocument();
     expect(
       screen.getByText("External Eligible Hedge Instruments Fail Closed"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("External OMS Source Not Ingested")).toBeInTheDocument();
-    expect(
-      screen.getByText("External Order Execution Acknowledgement Fail Closed"),
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open evidence pack" })).toHaveAttribute(
       "href",

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -23,6 +23,7 @@ import {
   listDpmPmOperatingQualityPolicies,
   listDpmPmOperatingQualityScoreRuns,
   getDpmConstructionAlternativeSet,
+  getExternalOrderExecutionAcknowledgement,
   getDpmProofPack,
   getDpmProofPackAiEvidenceInput,
   getDpmProofPackMarkdown,
@@ -2728,6 +2729,71 @@ describe("workbench api", () => {
     expect(metricEventsJson).toContain("construction-selection");
     expect(metricEventsJson).not.toContain("cas_1");
     expect(metricEventsJson).not.toContain("alt_1");
+  });
+
+  it("loads external OMS acknowledgement supportability through the Gateway source-product route", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            product_name: "ExternalOrderExecutionAcknowledgement",
+            product_version: "v1",
+            portfolio_id: "PB_SG_GLOBAL_BAL_001",
+            order_reference_ids: [],
+            acknowledgements: [],
+            data_quality_status: "MISSING",
+            supportability: {
+              state: "UNAVAILABLE",
+              reason: "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+              acknowledgement_count: 0,
+              missing_data_families: [
+                "external_oms_order_execution_acknowledgement",
+              ],
+              blocked_capabilities: [
+                "oms_acknowledgement",
+                "fills",
+                "settlement",
+              ],
+            },
+            lineage: {
+              runtime_posture: "fail_closed",
+              integration_status: "not_ingested",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await getExternalOrderExecutionAcknowledgement({
+      portfolio: constructionPortfolio(),
+      orderReferenceIds: ["order-ref-001"],
+    });
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `${expectedBaseUrl}/source-products/portfolios/PB_SG_GLOBAL_BAL_001/external-order-execution-acknowledgement`
+    );
+    const options = fetchMock.mock.calls[0][1];
+    const headers = new Headers(options.headers);
+    expect(options.method).toBe("POST");
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("X-Correlation-Id")).toBe(
+      "corr-workbench-execution-acknowledgement-PB_SG_GLOBAL_BAL_001"
+    );
+    expect(JSON.parse(options.body)).toEqual({
+      as_of_date: "2026-02-24",
+      tenant_id: "tenant-sg",
+      mandate_id: "MANDATE_PB_SG_GLOBAL_BAL_001",
+      order_reference_ids: ["order-ref-001"],
+    });
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain(
+      "source-products.external-order-execution-acknowledgement.get"
+    );
+    expect(metricEventsJson).toContain("execution-acknowledgement-supportability");
+    expect(metricEventsJson).not.toContain("PB_SG_GLOBAL_BAL_001");
   });
 
   it("uses Gateway PM operating quality routes including fairness-analysis lifecycle reads", async () => {


### PR DESCRIPTION
## Summary
- add Workbench Gateway-backed external OMS acknowledgement supportability request
- render bounded unavailable execution-acknowledgement posture in construction diagnostics
- show blocked capabilities, missing evidence, and audit lineage without execution-ready claims

## Boundaries
- Workbench calls Gateway only; no direct Core, Manage, or AI calls
- no browser-side OMS acknowledgement, execution, best-execution, fills, settlement, or autonomous execution state is calculated or implied
- depends on the Gateway source-product route for ExternalOrderExecutionAcknowledgement:v1

## Validation
- npm test -- tests/unit/workbench-api.test.ts tests/unit/construction-alternatives-panel.test.tsx
- npm run typecheck
- npm run lint
- npm run build
- git diff --check