### PR TITLE
Tighten campaign launch history contract fidelity

### DIFF
--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -460,7 +460,7 @@ Workbench must consume these Gateway wave routes when implemented:
 | `GET /api/v1/dpm/command-center/waves/campaign-definitions` | Manage-owned bulk-review campaign definitions |
 | `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/lifecycle-events` | read-only Manage lifecycle evidence for a selected campaign definition |
 | `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch-history` | paged append-only `BulkReviewCampaignDefinitionLaunchHistory:v1` audit posture for a selected campaign definition |
-| `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch-package` | Manage-owned launch readiness and replay posture for a selected campaign definition |
+| `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch-package` | Manage-owned launch readiness and idempotency evidence for a selected campaign definition |
 | `POST /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch` | READY-gated durable campaign launch through Gateway |
 
 Implementation note as of 2026-05-14: the first RFC-0041 rebalance-wave command-center
@@ -485,7 +485,7 @@ or operating retire/supersede commands locally. It checks launch-package readine
 `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch-package`
 and exposes campaign launch through Gateway
 `POST /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch`
-only when Manage returns `READY`, preserving durable wave response and replay posture without
+only when Manage returns `READY`, preserving durable wave response and idempotency evidence without
 recomputing membership, launch readiness, idempotency, maker-checker workflow, trade approval,
 staging, or OMS execution locally. The panel renders
 manage-owned wave id, lifecycle state, item count, issue count, supportability reason codes,

--- a/src/features/workbench/components/dpm-wave-command-center-panel.tsx
+++ b/src/features/workbench/components/dpm-wave-command-center-panel.tsx
@@ -959,7 +959,7 @@ function CampaignDefinitionsSection({
           <SummaryCell label="Review Date" value={launchPosture.requestedAsOfDate} />
           <SummaryCell label="Reviewed By" value={launchPosture.actor} />
           <SummaryCell label="Durable Wave" value={launchPosture.launchedWaveId} />
-          <SummaryCell label="Replay Posture" value={launchPosture.replayPosture} />
+          <SummaryCell label="Idempotency Evidence" value={launchPosture.idempotencyEvidence} />
         </div>
         <div className="rebalance-action-row">
           <span>{formatBusinessReason(launchPosture.reason)}</span>

--- a/src/features/workbench/dpm-wave-command-center-view-model.ts
+++ b/src/features/workbench/dpm-wave-command-center-view-model.ts
@@ -107,7 +107,7 @@ export type DpmCampaignLaunchPosture = {
   requestedAsOfDate: string;
   actor: string;
   launchedWaveId: string;
-  replayPosture: string;
+  idempotencyEvidence: string;
 };
 
 export type DpmWaveCommandCenterPanelModel = {
@@ -250,6 +250,7 @@ function buildCampaignLaunchPosture(
 ): DpmCampaignLaunchPosture {
   const readiness = readRecord(launchPackage?.readiness);
   const createRequest = readRecord(launchPackage?.create_request);
+  const createHeaders = readRecord(launchPackage?.create_headers);
   const wave = readWaveRecord(launchResponse);
   const state = normalizeState(
     readString(launchPackage ?? {}, "launch_state") ||
@@ -259,7 +260,6 @@ function buildCampaignLaunchPosture(
   const reasonCodes = extractStringArray(
     launchPackage?.reason_codes ?? readiness.reason_codes ?? readiness.blocked_reason_codes
   );
-  const idempotentReplay = readValue(launchResponse ?? {}, "idempotent_replay");
   return {
     state,
     canLaunch: state === "READY",
@@ -273,12 +273,11 @@ function buildCampaignLaunchPosture(
       readString(createRequest, "actor_id") ||
       "N/A",
     launchedWaveId: readString(wave ?? {}, "wave_id") || "N/A",
-    replayPosture:
-      idempotentReplay === true
-        ? "Replay preserved"
-        : wave
-          ? "Launch recorded"
-          : "N/A",
+    idempotencyEvidence:
+      readString(createHeaders, "Idempotency-Key") ||
+      readString(createHeaders, "idempotency_key") ||
+      readString(createRequest, "idempotency_key") ||
+      "N/A",
   };
 }
 
@@ -529,25 +528,23 @@ function buildCampaignLifecycleEventRows(
 function buildCampaignLaunchHistoryRows(
   data: Record<string, unknown> | undefined
 ): DpmCampaignLaunchHistoryRow[] {
-  return extractRecordArray(data?.items ?? data?.launch_history ?? data?.history).map(
-    (record, index) => {
-      const waveId = readString(record, "wave_id") || `launch-${index + 1}`;
-      return {
-        key: [
-          waveId,
-          readString(record, "launched_at") || "launched",
-          readString(record, "requested_as_of_date") || String(index + 1),
-          readString(record, "idempotency_key") || "idempotency",
-        ].join(":"),
+  return extractRecordArray(data?.items).map((record, index) => {
+    const waveId = readString(record, "wave_id") || `launch-${index + 1}`;
+    return {
+      key: [
         waveId,
-        actor: readString(record, "launched_by") || readString(record, "actor_id") || "N/A",
-        launchedAt: readString(record, "launched_at") || "N/A",
-        requestedAsOfDate: readString(record, "requested_as_of_date") || "N/A",
-        correlationId: readString(record, "correlation_id") || "N/A",
-        idempotencyKey: readString(record, "idempotency_key") || "N/A",
-      };
-    }
-  );
+        readString(record, "launched_at") || "launched",
+        readString(record, "requested_as_of_date") || String(index + 1),
+        readString(record, "idempotency_key") || "idempotency",
+      ].join(":"),
+      waveId,
+      actor: readString(record, "launched_by") || "N/A",
+      launchedAt: readString(record, "launched_at") || "N/A",
+      requestedAsOfDate: readString(record, "requested_as_of_date") || "N/A",
+      correlationId: readString(record, "correlation_id") || "N/A",
+      idempotencyKey: readString(record, "idempotency_key") || "N/A",
+    };
+  });
 }
 
 function buildCampaignLaunchHistoryPage(

--- a/tests/unit/dpm-wave-command-center-panel.test.tsx
+++ b/tests/unit/dpm-wave-command-center-panel.test.tsx
@@ -241,6 +241,9 @@ const campaignLaunchPackageResponse: DpmCampaignDefinitionGatewayResponse = {
     actor_id: "pm_sg_1",
     launch_state: "READY",
     reason_codes: [],
+    create_headers: {
+      "Idempotency-Key": "campaign-launch:campaign-holdings-202605:2026.05:abc",
+    },
   },
 };
 
@@ -261,7 +264,6 @@ const campaignLaunchResponse: DpmWaveGatewayResponse = {
       trigger_type: "BULK_REVIEW_CAMPAIGN",
     },
     durable: true,
-    idempotent_replay: true,
   },
 };
 
@@ -453,7 +455,7 @@ describe("DpmWaveCommandCenterPanel", () => {
     );
 
     expect(screen.getByText("dwv_campaign_launch_001")).toBeInTheDocument();
-    expect(screen.getByText("Replay preserved")).toBeInTheDocument();
+    expect(screen.getByText("campaign-launch:campaign-holdings-202605:2026.05:abc")).toBeInTheDocument();
     expect(screen.queryByText("corr-campaign-launch")).not.toBeInTheDocument();
   });
 

--- a/tests/unit/dpm-wave-command-center-view-model.test.ts
+++ b/tests/unit/dpm-wave-command-center-view-model.test.ts
@@ -317,6 +317,9 @@ describe("DPM wave command-center view model", () => {
           requested_as_of_date: "2026-05-10",
           actor_id: "pm_sg_1",
           reason_codes: [],
+          create_headers: {
+            "Idempotency-Key": "campaign-launch:campaign-holdings-202605:2026.05:abc",
+          },
         },
       },
       campaignLaunchResponse: {
@@ -328,7 +331,6 @@ describe("DPM wave command-center view model", () => {
             state: "CREATED",
             trigger_type: "BULK_REVIEW_CAMPAIGN",
           },
-          idempotent_replay: true,
         },
       },
     });
@@ -340,7 +342,7 @@ describe("DPM wave command-center view model", () => {
       requestedAsOfDate: "2026-05-10",
       actor: "pm_sg_1",
       launchedWaveId: "dwv_campaign_launch_001",
-      replayPosture: "Replay preserved",
+      idempotencyEvidence: "campaign-launch:campaign-holdings-202605:2026.05:abc",
     });
   });
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -73,7 +73,7 @@ promote dormant labels into product ownership just because historical route file
   `/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch-package`
   and exposes
   `/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch`
-  only when the launch package is `READY`, preserving durable wave response and replay posture
+  only when the launch package is `READY`, preserving durable wave response and idempotency evidence
   without recalculating membership or readiness. It
   renders manage-owned wave lifecycle, item state, source-readiness state, supportability,
   report-input refs, proof-pack refs, handoff refs, lotus-ai workflow-pack run posture, and

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -74,7 +74,7 @@ Implemented:
    state, membership, readiness, idempotency, maker-checker, trade approval, order generation,
    routing, fills, settlement, or OMS execution,
 11. checks campaign launch-package readiness through Gateway and enables launch only when Manage
-   returns `READY`, preserving durable wave and replay posture without recomputing membership,
+   returns `READY`, preserving durable wave and idempotency evidence without recomputing membership,
    readiness, maker-checker workflow, trade approval, staging, or OMS execution locally,
 12. emits bounded Workbench observability labels without portfolio ids, wave ids, campaign ids,
    report-input refs,


### PR DESCRIPTION
## Summary
- tighten Workbench launch-history parsing to the Manage page contract items only, using launched_by and launched_at without legacy actor/history fallbacks
- replace replay posture UI wording with idempotency evidence from Manage launch-package headers
- update Workbench RFC/wiki wording to avoid replay-decision language

## Validation
- Gateway proof: python -m pytest tests/unit/test_dpm_wave_service.py tests/integration/test_dpm_wave_router.py tests/contract/test_dpm_wave_contract.py tests/unit/test_upstream_clients.py -q
- Workbench: npm run test -- --run tests/unit/dpm-wave-command-center-view-model.test.ts tests/unit/dpm-wave-command-center-panel.test.tsx tests/unit/workbench-api.test.ts
- Workbench: npm run typecheck
- Workbench: npm run lint
- Workbench: git diff --check
- Workbench: npm run build
- Workbench wiki check: expected pre-publication drift in API-Surface.md and Supported-Features.md due to this branch docs source changes

## Boundaries
- Gateway remains pass-through/composition only; no cohort, membership, readiness, idempotency, execution, routing, fills, settlement, or OMS inference
- Workbench consumes Gateway only and renders launch history as bounded audit evidence