### PR TITLE
Polish empty campaign launch history page

### DIFF
--- a/src/features/workbench/components/dpm-wave-command-center-panel.tsx
+++ b/src/features/workbench/components/dpm-wave-command-center-panel.tsx
@@ -883,9 +883,13 @@ function CampaignDefinitionsSection({
         <div className="rebalance-summary-strip" aria-label="Campaign launch history boundaries">
           <SummaryCell
             label="Page"
-            value={`${launchHistoryPage.offset + 1}-${launchHistoryPage.offset + launchHistoryPage.count} of ${
-              launchHistoryPage.totalCount
-            }`}
+            value={
+              launchHistoryPage.count > 0
+                ? `${launchHistoryPage.offset + 1}-${launchHistoryPage.offset + launchHistoryPage.count} of ${
+                    launchHistoryPage.totalCount
+                  }`
+                : `0 of ${launchHistoryPage.totalCount}`
+            }
           />
           <SummaryCell label="Page Size" value={String(launchHistoryPage.limit || CAMPAIGN_LAUNCH_HISTORY_PAGE_SIZE)} />
           <SummaryCell

--- a/tests/unit/dpm-wave-command-center-panel.test.tsx
+++ b/tests/unit/dpm-wave-command-center-panel.test.tsx
@@ -417,6 +417,8 @@ describe("DpmWaveCommandCenterPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open History" }));
 
     expect(await screen.findByText("No launch records")).toBeInTheDocument();
+    expect(screen.getByText("0 of 0")).toBeInTheDocument();
+    expect(screen.queryByText("1-0 of 0")).not.toBeInTheDocument();
     expect(screen.getByText("NO_ORDER_GENERATION, NO_OMS_EXECUTION_CLAIM")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
   });


### PR DESCRIPTION
## Summary
- render empty campaign launch-history pagination as 0 of 0 instead of 1-0 of 0
- preserve existing pagination controls and no-order/no-OMS operating-boundary display
- add a component assertion for the empty page summary

## Validation
- npm run test -- --run tests/unit/dpm-wave-command-center-view-model.test.ts tests/unit/dpm-wave-command-center-panel.test.tsx tests/unit/workbench-api.test.ts
- npm run typecheck
- npm run lint
- npm run build
- git diff --check
- Workbench wiki check: DiffCount 0; no wiki source changed

## Boundary
- Workbench-only UI polish; no Gateway changes
- Launch-history contract fidelity remains limited to Manage/Gateway fields and Workbench consumes Gateway only