### PR TITLE
Polish Workbench portfolio live validation

### DIFF
--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -115,26 +115,33 @@ export async function validatePortfolioPanels(
     waitUntil: "networkidle",
     timeout: timeoutMs,
   });
-  await expect(page.getByRole("heading", { name: "Portfolio Summary", exact: true })).toBeVisible({
+  await expect(page.getByRole("heading", { name: "Portfolio Review", exact: true })).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(page.getByRole("heading", { name: portfolioId, exact: true })).toBeVisible({
+  await expect(page.getByRole("region", { name: "Portfolio decision review" })).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(page.getByRole("heading", { name: "Asset Allocation" })).toBeVisible({
+  await expect(page.getByRole("heading", { name: "Balanced Mandate", exact: true })).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(page.getByRole("heading", { name: "Top Holdings" })).toBeVisible({
+  await expect(page.getByText("MTD Return")).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(page.getByLabel("Portfolio summary previews")).toBeVisible({ timeout: timeoutMs });
-  await expect(page.getByRole("heading", { name: "Recent Transactions" })).toBeVisible({
+  await expect(page.getByText("QTD Return")).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(page.getByRole("heading", { name: "Forward Cashflow" })).toBeVisible({
+  await expect(page.getByText("YTD Return")).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(page.getByLabel("Projected cashflow points")).toBeVisible({ timeout: timeoutMs });
+  await expect(page.getByRole("heading", { name: "Review priority attention" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Review Evidence" })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: "Performance Snapshot" })).toHaveCount(0);
+  await expect(page.getByRole("tab", { name: "Summary" })).toHaveCount(0);
+  await expect(page.getByRole("tab", { name: "Detailed" })).toHaveCount(0);
   await screenshotRegisteredPanel(page, "portfolio.summary");
 }
 
@@ -418,7 +425,7 @@ export async function validateOutcomeReviewPanel(
   await expect(outcomeReviewPanel.getByRole("button", { name: "Request report" })).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(outcomeReviewPanel.getByRole("button", { name: "Request advisor memo" })).toBeVisible({
+  await expect(outcomeReviewPanel.getByRole("button", { name: "Request advisor memo", exact: true })).toBeVisible({
     timeout: timeoutMs,
   });
   await screenshotRegisteredPanel(page, "dpm.outcome_review");
@@ -484,11 +491,11 @@ export async function validateDpmWaveCommandCenterPanel(
     "Open Evidence Pack",
     "Load Changes",
   ]) {
-    await expect(wavePanel.getByRole("button", { name: actionName })).toBeVisible({
+    await expect(wavePanel.getByRole("button", { name: actionName, exact: true })).toBeVisible({
       timeout: timeoutMs,
     });
   }
-  await wavePanel.getByRole("button", { name: "Preview" }).click({
+  await wavePanel.getByRole("button", { name: "Preview", exact: true }).click({
     timeout: timeoutMs,
   });
   await expect(wavePanel.getByText("Preview completed.")).toBeVisible({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2324,6 +2324,14 @@ a:hover {
   cursor: not-allowed;
 }
 
+.workspace-tab-nav-link-disabled.workspace-tab-nav-link-active {
+  opacity: 1;
+  border-color: rgba(23, 32, 43, 0.16);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--brand-strong);
+  box-shadow: 0 1px 2px rgba(23, 32, 43, 0.06);
+}
+
 .topbar {
   position: sticky;
   top: 0;
@@ -14948,21 +14956,25 @@ a:hover {
 }
 
 .portfolio-page .portfolio-summary-band {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 0;
   border-top: 1px solid var(--portfolio-ui-border);
 }
 
 .portfolio-page .portfolio-summary-band-item {
-  padding: 0.85rem 1rem 0 0;
+  min-width: 0;
+  padding: 0.85rem 0.75rem 0 0;
 }
 
 .portfolio-page .portfolio-summary-band-item strong {
   color: #06111f;
-  font-size: 1.45rem;
+  font-size: 1.16rem;
   font-weight: 735;
-  line-height: 1.75rem;
+  line-height: 1.35rem;
   letter-spacing: 0;
   font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .portfolio-page .portfolio-summary-band-item small,
@@ -15269,6 +15281,10 @@ a:hover {
 .portfolio-page .portfolio-evidence-card .portfolio-workflow-entry-list .action-link {
   min-height: 28px;
   padding-inline: 0.55rem;
+}
+
+.portfolio-page .portfolio-evidence-card .portfolio-workflow-entry-list {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .portfolio-page .portfolio-context-card,
@@ -16526,6 +16542,31 @@ a:hover {
 
 .portfolio-page .portfolio-workspace-toolbar-period-control .workbench-segmented-control-button:nth-child(7) {
   grid-column: auto;
+}
+
+.app-page-shell.portfolio-page .portfolio-workspace-toolbar-period-control.workbench-segmented-control {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(3.25rem, 1fr));
+  gap: 4px;
+  width: 100%;
+}
+
+.app-page-shell.portfolio-page .portfolio-workspace-toolbar-period-control .workbench-segmented-control-button {
+  justify-content: center;
+  min-width: 0;
+  padding-inline: 8px;
+  white-space: nowrap;
+}
+
+.app-page-shell.portfolio-page .portfolio-workspace-toolbar-sidecar {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    "period"
+    "actions";
+}
+
+.app-page-shell.portfolio-page .portfolio-workspace-toolbar-actions {
+  justify-self: start;
 }
 
 .portfolio-page .portfolio-decision-brief {

--- a/src/apps/portfolio/components/portfolio-summary-header-section.tsx
+++ b/src/apps/portfolio/components/portfolio-summary-header-section.tsx
@@ -63,7 +63,7 @@ export default function PortfolioSummaryHeaderSection({
             {
               key: "aum",
               label: "AUM",
-              value: formatCurrency(workspace.summary.market_value_base, workspace.portfolio.base_currency),
+              value: formatCurrency(workspace.summary.market_value_base, workspace.portfolio.base_currency, 0),
               definition:
                 "Total portfolio market value in the portfolio base currency as of the selected date.",
               support: `As of ${formatDate(context.selectedAsOfDate)}`,
@@ -74,7 +74,8 @@ export default function PortfolioSummaryHeaderSection({
               label: "Invested Assets",
               value: formatCurrency(
                 workspace.summary.invested_market_value_base,
-                workspace.portfolio.base_currency
+                workspace.portfolio.base_currency,
+                0
               ),
               definition:
                 "Market value currently invested in funded holdings, excluding operational cash inventory.",
@@ -84,7 +85,7 @@ export default function PortfolioSummaryHeaderSection({
             {
               key: "available_cash",
               label: "Cash",
-              value: formatCurrency(workspace.summary.total_cash_base, workspace.portfolio.base_currency),
+              value: formatCurrency(workspace.summary.total_cash_base, workspace.portfolio.base_currency, 0),
               definition:
                 "Available cash inventory in the portfolio base currency across published cash balances.",
               support: `${formatPct(workspace.summary.cash_weight_pct)} cash allocation`,

--- a/src/apps/portfolio/formatters.ts
+++ b/src/apps/portfolio/formatters.ts
@@ -11,12 +11,13 @@ export function formatPct(value: number | null | undefined): string {
 
 export function formatCurrency(
   value: number | null | undefined,
-  currency: string | undefined
+  currency: string | undefined,
+  maximumFractionDigits = 2
 ): string {
   return formatCurrencyValue(value, {
     currency: currency ?? "USD",
     display: "code",
-    maximumFractionDigits: 2,
+    maximumFractionDigits,
   });
 }
 

--- a/src/apps/portfolio/portfolio-summary-view-model.ts
+++ b/src/apps/portfolio/portfolio-summary-view-model.ts
@@ -217,7 +217,7 @@ export function buildPortfolioDecisionBrief(workspace: PortfolioWorkspace): Port
       {
         label: "Next action",
         value: nextAction?.title ?? "Review book",
-        support: nextAction?.impact?.split(".")[0] ?? "Use the active workflow links for drill-down.",
+        support: nextAction?.impact?.split(".")[0] ?? "Open the relevant workflow to resolve the attention item.",
       },
     ],
   };

--- a/src/design-system/components/workspace-tab-nav.tsx
+++ b/src/design-system/components/workspace-tab-nav.tsx
@@ -26,8 +26,13 @@ export default function WorkspaceTabNav({
         item.disabled || !item.href ? (
           <span
             key={item.key}
-            className="workspace-tab-nav-link workspace-tab-nav-link-disabled"
+            className={cx(
+              "workspace-tab-nav-link",
+              item.active && "workspace-tab-nav-link-active",
+              "workspace-tab-nav-link-disabled"
+            )}
             aria-disabled="true"
+            aria-current={item.active ? "page" : undefined}
             title={item.title}
           >
             {item.label}

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -396,12 +396,16 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain("hasAcceptedAdvisorBriefReviewPosture");
     expect(browserWorkflowModule).toContain("Supportability ACTION REQUIRED");
     expect(browserWorkflowModule).toContain("Supportability READY");
+    expect(browserWorkflowModule).toContain('"Portfolio Review"');
+    expect(browserWorkflowModule).toContain('"Portfolio decision review"');
+    expect(browserWorkflowModule).toContain('"Performance Snapshot" })).toHaveCount(0)');
+    expect(browserWorkflowModule).toContain('"Summary" })).toHaveCount(0)');
+    expect(browserWorkflowModule).toContain('"Detailed" })).toHaveCount(0)');
     expect(browserWorkflowModule).toContain("/^Performance Overview/");
     expect(browserWorkflowModule).toContain("/^Performance Analysis/");
     expect(browserWorkflowModule).toContain('"Asset Class attribution table"');
     expect(browserWorkflowModule).not.toContain('getByRole("group", { name: "Post-Trade Outcome Review"');
     expect(browserWorkflowModule).not.toContain('getByRole("group", { name: "Proof-Pack Evidence"');
-    expect(browserWorkflowModule).not.toContain('getByRole("tab", { name: "Summary"');
     expect(contractModule).toContain('panelId: "performance.risk.snapshot"');
     expect(contractModule).toContain('screenshotName: "performance-risk-live.png"');
     expect(browserWorkflowModule).toContain("panel: panelId");


### PR DESCRIPTION
## Summary
- align canonical live portfolio validation with the current Portfolio Review surface
- make live validator action locators exact for duplicate front-office action labels
- polish Portfolio Review nav/metric density and right-rail workflow layout
- replace internal drill-down phrasing with front-office next-action copy

## Validation
- npm run test -- --run tests/unit/portfolio-summary-view-model.test.ts tests/unit/live-canonical-validation-script.test.ts tests/unit/design-system-components.test.tsx
- npm run typecheck
- npm run lint
- git diff --check
- npm run build
- docker compose up -d --build
- scripts/live/Validate-LotusFrontOfficeCanonical.ps1 -ScreenshotDirectory output/diagnostic-canonical-front-office-20260517-final-kpi-polish

## Live evidence
- Canonical portfolio: PB_SG_GLOBAL_BAL_001
- Screenshot index: output/diagnostic-canonical-front-office-20260517-final-kpi-polish/SHOT-INDEX.md
- Validation summary: output/diagnostic-canonical-front-office-20260517-final-kpi-polish/live-validation-summary.json

## Wiki
- No wiki/source truth change. UI and validation-script polish only.