### PR TITLE
Render outcome client communication boundary

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -82,6 +82,9 @@ Current repository posture:
     `/api/v1/dpm/command-center/outcome-reviews*`, preserving manage-owned expected-versus-realized
     dimensions, source lineage, supportability, report-input posture, AI-evidence posture, and
     Gateway-backed governed AI narrative requests without client-side outcome calculation.
+    Manage-owned `client_communication_boundary` posture is rendered as a no-client-communication
+    boundary when present; Workbench must not create client messaging, approval, delivery, or
+    communication-audit workflows from outcome-review evidence.
 13. Manage `mode=proof` renders the RFC-0040 proof-pack evidence panel from Gateway
     `/api/v1/dpm/command-center/proof-packs*`, preserving manage-owned proof-pack identity,
     section posture, content hash, source hashes, Markdown availability, report-input readiness,

--- a/src/features/workbench/components/outcome-review-panel.tsx
+++ b/src/features/workbench/components/outcome-review-panel.tsx
@@ -17,7 +17,9 @@ import {
 } from "@/features/workbench/api";
 import type { DpmOutcomeReviewGatewayResponse } from "@/features/workbench/types";
 import {
+  buildOutcomeClientCommunicationBoundaryView,
   buildOutcomeReviewPanelModel,
+  type OutcomeReviewClientCommunicationBoundaryView,
 } from "@/features/workbench/outcome-review-view-model";
 import {
   buildOutcomeReviewHandoffMessages,
@@ -48,8 +50,12 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
   const [aiNarrativeStatus, setAiNarrativeStatus] = useState<string | null>(null);
   const [aiNarrativeError, setAiNarrativeError] = useState<string | null>(null);
   const [aiNarrativePending, setAiNarrativePending] = useState(false);
+  const [handoffBoundary, setHandoffBoundary] =
+    useState<OutcomeReviewClientCommunicationBoundaryView | null>(null);
   const model = buildOutcomeReviewPanelModel(response);
   const primaryReview = model.items[0] ?? null;
+  const clientCommunicationBoundary =
+    handoffBoundary ?? primaryReview?.clientCommunicationBoundary ?? null;
   const hasItems = model.items.length > 0;
   const shouldShowStatePanel = shouldShowOutcomeReviewStatePanel(
     model.state,
@@ -78,6 +84,7 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
     setReportJobError(null);
     try {
       const reportInput = await getDpmOutcomeReviewReportInput(primaryReview.outcomeReviewId);
+      setHandoffBoundary(buildOutcomeClientCommunicationBoundaryView(reportInput.data));
       const handle = await submitDpmOutcomeReviewReportJob({
         outcomeReviewId: primaryReview.outcomeReviewId,
         outcomeReportInput: reportInput.data,
@@ -100,6 +107,9 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
       const narrative = await requestDpmOutcomeReviewAiNarrative({
         outcomeReviewId: primaryReview.outcomeReviewId,
       });
+      setHandoffBoundary(
+        buildOutcomeClientCommunicationBoundaryView(narrative.ai_evidence_input)
+      );
       setAiNarrativeStatus(describeOutcomeNarrativeRun(narrative.data));
     } catch (error) {
       setAiNarrativeError(
@@ -217,7 +227,7 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
               </div>
               <div className="outcome-review-action-stack">
                 <a href="#outcome-review-detail">
-                  <strong>Review client impact</strong>
+                  <strong>Review mandate impact</strong>
                   <span>Assess outcome dimensions against the mandate objective.</span>
                 </a>
                 {primaryReview.proofPackId !== "N/A" ? (
@@ -303,10 +313,55 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
               </section>
 
               <section>
-                <h4>Client-Facing Rationale</h4>
+                <h4>Internal Outcome Rationale</h4>
                 <div className="outcome-review-rationale">
                   <p>{primaryReview.clientRationale}</p>
                 </div>
+                {clientCommunicationBoundary ? (
+                  <div
+                    className="outcome-review-client-boundary"
+                    aria-label="Client communication boundary"
+                  >
+                    <div className="outcome-review-client-boundary-header">
+                      <h4>Client Communication Boundary</h4>
+                      <SemanticBadge tone={outcomeReviewBadgeTone(clientCommunicationBoundary.state)}>
+                        {businessStateLabel(clientCommunicationBoundary.state)}
+                      </SemanticBadge>
+                    </div>
+                    <p>{clientCommunicationBoundary.summary}</p>
+                    <div className="outcome-review-client-boundary-grid">
+                      <span>
+                        <strong>Communication</strong>
+                        {clientCommunicationBoundary.clientCommunicationProjected
+                          ? "Projected"
+                          : "Not projected"}
+                      </span>
+                      <span>
+                        <strong>Approval</strong>
+                        {clientCommunicationBoundary.clientApprovalProjected
+                          ? "Projected"
+                          : "Not projected"}
+                      </span>
+                      <span>
+                        <strong>Required source</strong>
+                        {clientCommunicationBoundary.requiredSourceProduct}
+                      </span>
+                      <span>
+                        <strong>Reason</strong>
+                        {formatBusinessReason(clientCommunicationBoundary.reasonCode)}
+                      </span>
+                    </div>
+                    {clientCommunicationBoundary.blockedCapabilities.length > 0 ? (
+                      <div className="outcome-review-client-boundary-capabilities">
+                        {clientCommunicationBoundary.blockedCapabilities.map((capability) => (
+                          <SemanticBadge key={capability} tone="danger">
+                            {formatBusinessReason(capability)}
+                          </SemanticBadge>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
                 <h4>Evidence Availability</h4>
                 <div className="outcome-review-evidence-grid">
                   <span className={outcomeReviewAvailabilityClass(primaryReview.expectedSnapshotHash)}>

--- a/src/features/workbench/manage-workspace.module.css
+++ b/src/features/workbench/manage-workspace.module.css
@@ -2365,6 +2365,53 @@
   background: #f2f4f6;
 }
 
+.manageScope :global(.outcome-review-client-boundary) {
+  display: grid;
+  gap: 10px;
+  padding: 13px 14px;
+  border: 1px solid #d0d7de;
+  border-left: 3px solid #9a6700;
+  border-radius: 4px;
+  background: #fff8e5;
+}
+
+.manageScope :global(.outcome-review-client-boundary-header) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.manageScope :global(.outcome-review-client-boundary-grid) {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.manageScope :global(.outcome-review-client-boundary-grid span) {
+  display: grid;
+  gap: 3px;
+  padding: 8px 10px;
+  border: 1px solid #e6dbb9;
+  border-radius: 4px;
+  background: #fff;
+  color: #45464d;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.manageScope :global(.outcome-review-client-boundary-grid strong) {
+  color: #5f6368;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.manageScope :global(.outcome-review-client-boundary-capabilities) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
 .manageScope :global(.outcome-review-evidence-grid) {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/features/workbench/outcome-review-view-model.ts
+++ b/src/features/workbench/outcome-review-view-model.ts
@@ -26,6 +26,20 @@ export type OutcomeReviewLineageRow = {
   hash: string;
 };
 
+export type OutcomeReviewClientCommunicationBoundaryView = {
+  boundaryId: string;
+  state: string;
+  reasonCode: string;
+  summary: string;
+  clientCommunicationProjected: boolean;
+  clientApprovalProjected: boolean;
+  blockedCapabilities: string[];
+  requiredOwner: string;
+  requiredSourceProduct: string;
+  sourceProduct: string;
+  contentHash: string;
+};
+
 export type OutcomeReviewListItem = {
   outcomeReviewId: string;
   reviewLabel: string;
@@ -47,6 +61,7 @@ export type OutcomeReviewListItem = {
   updatedAt: string;
   reportInputBlocked: boolean;
   aiEvidenceBlocked: boolean;
+  clientCommunicationBoundary: OutcomeReviewClientCommunicationBoundaryView | null;
   dimensions: OutcomeReviewDimensionRow[];
   lineage: OutcomeReviewLineageRow[];
 };
@@ -98,6 +113,31 @@ export function buildOutcomeReviewPanelModel(
     authority: response.supportability.authority,
     correlationId: response.correlation_id,
     items,
+  };
+}
+
+export function buildOutcomeClientCommunicationBoundaryView(
+  payload: unknown
+): OutcomeReviewClientCommunicationBoundaryView | null {
+  const boundary = isRecord(payload) ? readRecord(payload, "client_communication_boundary") : {};
+  const boundaryId = readString(boundary, "boundary_id");
+  if (!boundaryId) {
+    return null;
+  }
+  const sourceProductName = readString(boundary, "source_product_name") || "N/A";
+  const sourceProductVersion = readString(boundary, "source_product_version") || "N/A";
+  return {
+    boundaryId,
+    state: readString(boundary, "supportability_state") || "UNKNOWN",
+    reasonCode: readString(boundary, "reason_code") || "N/A",
+    summary: readString(boundary, "summary") || "No boundary summary returned.",
+    clientCommunicationProjected: readBoolean(boundary, "client_communication_projected"),
+    clientApprovalProjected: readBoolean(boundary, "client_approval_projected"),
+    blockedCapabilities: readStringArray(boundary, "blocked_capabilities"),
+    requiredOwner: readString(boundary, "required_owner") || "N/A",
+    requiredSourceProduct: readString(boundary, "required_source_product") || "N/A",
+    sourceProduct: `${sourceProductName}:${sourceProductVersion}`,
+    contentHash: readString(boundary, "content_hash") || "N/A",
   };
 }
 
@@ -171,6 +211,7 @@ function buildOutcomeReviewListItem(
     updatedAt: readString(record, "updated_at") || readString(record, "created_at") || "N/A",
     reportInputBlocked: blockedActions.includes("CREATE_REPORT_INPUT"),
     aiEvidenceBlocked: blockedActions.includes("REQUEST_AI_NARRATIVE"),
+    clientCommunicationBoundary: buildOutcomeClientCommunicationBoundaryView(record),
     dimensions,
     lineage: [
       ...extractRecordArray(record.source_lineage),
@@ -258,6 +299,17 @@ function readString(record: Record<string, unknown>, key: string): string {
     return String(value);
   }
   return "";
+}
+
+function readBoolean(record: Record<string, unknown>, key: string): boolean {
+  return record[key] === true;
+}
+
+function readStringArray(record: Record<string, unknown>, key: string): string[] {
+  const value = record[key];
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
 }
 
 function formatOutcomeValue(value: unknown): string {

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1281,6 +1281,22 @@ export type DpmOutcomeReviewSupportability = {
   remediation_owner?: string | null;
 };
 
+export type DpmOutcomeClientCommunicationBoundary = {
+  boundary_id?: string | null;
+  supportability_state?: string | null;
+  source_system?: string | null;
+  source_product_name?: string | null;
+  source_product_version?: string | null;
+  client_communication_projected?: boolean | null;
+  client_approval_projected?: boolean | null;
+  reason_code?: string | null;
+  blocked_capabilities?: string[];
+  required_owner?: string | null;
+  required_source_product?: string | null;
+  summary?: string | null;
+  content_hash?: string | null;
+};
+
 export type DpmOutcomeReviewGatewayResponse = {
   correlation_id: string;
   contract_version: string;

--- a/tests/unit/outcome-review-panel-helpers.test.ts
+++ b/tests/unit/outcome-review-panel-helpers.test.ts
@@ -34,6 +34,7 @@ const review: OutcomeReviewListItem = {
   updatedAt: "2026-05-13T09:35:00Z",
   reportInputBlocked: false,
   aiEvidenceBlocked: false,
+  clientCommunicationBoundary: null,
   dimensions: [],
   lineage: [
     {

--- a/tests/unit/outcome-review-panel.test.tsx
+++ b/tests/unit/outcome-review-panel.test.tsx
@@ -45,6 +45,7 @@ const readyResponse: DpmOutcomeReviewGatewayResponse = {
         supportability: {
           explanation: "Outcome remains within mandate tolerance for advisor handoff.",
         },
+        client_communication_boundary: clientCommunicationBoundary(),
         dimension_results: [
           {
             dimension: "DRIFT_REDUCTION",
@@ -98,7 +99,7 @@ describe("OutcomeReviewPanel", () => {
     expect(screen.getByText("Drift Reduction")).toBeInTheDocument();
     expect(screen.queryByText("sha256:risk")).not.toBeInTheDocument();
     expect(screen.getAllByText("Available").length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByRole("link", { name: /Review client impact/ })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /Review mandate impact/ })).toHaveAttribute(
       "href",
       "#outcome-review-detail"
     );
@@ -107,6 +108,14 @@ describe("OutcomeReviewPanel", () => {
       "/workbench/PB_SG_GLOBAL_BAL_001?mode=proof"
     );
     expect(screen.queryByText("Record advisor note")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Client communication boundary")).toHaveTextContent(
+      "Not projected"
+    );
+    expect(screen.getByText("ClientCommunicationRecord:v1")).toBeInTheDocument();
+    expect(screen.getByText("Client Message Generation")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /client|communication|approval|delivery/i })
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Request report" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Request advisor memo" })).toBeEnabled();
   });
@@ -114,7 +123,14 @@ describe("OutcomeReviewPanel", () => {
   it("requests an outcome-review report job from available report input", async () => {
     vi.mocked(getDpmOutcomeReviewReportInput).mockResolvedValue({
       ...readyResponse,
-      data: { outcome_review_id: "or_1", content_hash: "sha256:report-input" },
+      data: {
+        outcome_review_id: "or_1",
+        content_hash: "sha256:report-input",
+        client_communication_boundary: {
+          ...clientCommunicationBoundary(),
+          content_hash: "sha256:report-boundary",
+        },
+      },
     });
     vi.mocked(submitDpmOutcomeReviewReportJob).mockResolvedValue({
       report_request_id: "rrq_outcome_1",
@@ -131,10 +147,20 @@ describe("OutcomeReviewPanel", () => {
       expect(getDpmOutcomeReviewReportInput).toHaveBeenCalledWith("or_1");
       expect(submitDpmOutcomeReviewReportJob).toHaveBeenCalledWith({
         outcomeReviewId: "or_1",
-        outcomeReportInput: { outcome_review_id: "or_1", content_hash: "sha256:report-input" },
+        outcomeReportInput: {
+          outcome_review_id: "or_1",
+          content_hash: "sha256:report-input",
+          client_communication_boundary: {
+            ...clientCommunicationBoundary(),
+            content_hash: "sha256:report-boundary",
+          },
+        },
       });
     });
     expect(screen.getByText("Report request Accepted.")).toBeInTheDocument();
+    expect(screen.getByLabelText("Client communication boundary")).toHaveTextContent(
+      "ClientCommunicationRecord:v1"
+    );
   });
 
   it("requests an outcome-review narrative", async () => {
@@ -149,6 +175,10 @@ describe("OutcomeReviewPanel", () => {
       ai_evidence_input: {
         outcome_review_id: "or_1",
         content_hash: "sha256:ai-evidence",
+        client_communication_boundary: {
+          ...clientCommunicationBoundary(),
+          content_hash: "sha256:ai-boundary",
+        },
       },
       narrative_request: {
         requested_outputs: ["pm_summary", "cio_summary", "control_summary", "evidence_gaps"],
@@ -169,6 +199,9 @@ describe("OutcomeReviewPanel", () => {
       });
     });
     expect(screen.getByText("Review request Completed.")).toBeInTheDocument();
+    expect(screen.getByLabelText("Client communication boundary")).toHaveTextContent(
+      "Delivery Confirmation"
+    );
   });
 
   it("keeps report and AI handoff run posture visible after both actions", async () => {
@@ -245,3 +278,27 @@ describe("OutcomeReviewPanel", () => {
     expect(screen.getByText("Failed to fetch DPM outcome reviews (503)")).toBeInTheDocument();
   });
 });
+
+function clientCommunicationBoundary(): Record<string, unknown> {
+  return {
+    boundary_id: "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY",
+    supportability_state: "BLOCKED",
+    source_system: "lotus-manage",
+    source_product_name: "DpmPostTradeOutcomeReview",
+    source_product_version: "v1",
+    client_communication_projected: false,
+    client_approval_projected: false,
+    reason_code: "OUTCOME_CLIENT_COMMUNICATION_NOT_SUPPORTED",
+    blocked_capabilities: [
+      "client_approval",
+      "client_contact",
+      "client_message_generation",
+      "communication_audit",
+      "delivery_confirmation",
+    ],
+    required_owner: "future client-communication owner",
+    required_source_product: "ClientCommunicationRecord:v1",
+    summary: "Manage does not publish client communication events for this outcome review.",
+    content_hash: "sha256:client-communication-boundary",
+  };
+}

--- a/tests/unit/outcome-review-view-model.test.ts
+++ b/tests/unit/outcome-review-view-model.test.ts
@@ -159,6 +159,34 @@ describe("outcome review view model", () => {
     expect(model.items[0].aiEvidenceBlocked).toBe(true);
   });
 
+  it("preserves source-owned client communication boundary without projecting capability", () => {
+    const model = buildOutcomeReviewPanelModel(
+      response({
+        items: [
+          {
+            outcome_review_id: "or_boundary",
+            state: "READY",
+            client_communication_boundary: clientCommunicationBoundary(),
+          },
+        ],
+      })
+    );
+
+    expect(model.items[0].clientCommunicationBoundary).toEqual(
+      expect.objectContaining({
+        boundaryId: "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY",
+        state: "BLOCKED",
+        clientCommunicationProjected: false,
+        clientApprovalProjected: false,
+        requiredSourceProduct: "ClientCommunicationRecord:v1",
+        reasonCode: "OUTCOME_CLIENT_COMMUNICATION_NOT_SUPPORTED",
+      })
+    );
+    expect(model.items[0].clientCommunicationBoundary?.blockedCapabilities).toContain(
+      "client_message_generation"
+    );
+  });
+
   it("keeps empty and unavailable states explicit", () => {
     expect(buildOutcomeReviewPanelModel(response({ items: [] })).state).toBe("empty");
     expect(buildOutcomeReviewPanelModel(null)).toEqual(
@@ -170,3 +198,27 @@ describe("outcome review view model", () => {
     );
   });
 });
+
+function clientCommunicationBoundary(): Record<string, unknown> {
+  return {
+    boundary_id: "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY",
+    supportability_state: "BLOCKED",
+    source_system: "lotus-manage",
+    source_product_name: "DpmPostTradeOutcomeReview",
+    source_product_version: "v1",
+    client_communication_projected: false,
+    client_approval_projected: false,
+    reason_code: "OUTCOME_CLIENT_COMMUNICATION_NOT_SUPPORTED",
+    blocked_capabilities: [
+      "client_approval",
+      "client_contact",
+      "client_message_generation",
+      "communication_audit",
+      "delivery_confirmation",
+    ],
+    required_owner: "future client-communication owner",
+    required_source_product: "ClientCommunicationRecord:v1",
+    summary: "Manage does not publish client communication events for this outcome review.",
+    content_hash: "sha256:client-communication-boundary",
+  };
+}

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -134,8 +134,9 @@ promote dormant labels into product ownership just because historical route file
 - RFC-0098/RFC-0042 post-trade outcome-review rendering is implemented on
   `/workbench/{portfolioId}?mode=reviews` through Gateway `/api/v1/dpm/command-center/outcome-reviews*`.
   Workbench renders manage-owned review state, expected-versus-realized dimensions, hashes,
-  source lineage, supportability, report-input posture, and AI-evidence posture without
-  calculating those values client-side. The panel can request a governed outcome-review PDF job by
+  source lineage, supportability, report-input posture, AI-evidence posture, and
+  `client_communication_boundary` posture without calculating those values client-side or creating
+  client communication capability. The panel can request a governed outcome-review PDF job by
   loading manage report input through Gateway and then submitting Gateway
   `POST /api/v1/reports/outcome-reviews`; report rendering and archive lifecycle remain owned by
   `lotus-report`, `lotus-render`, and `lotus-archive`. The panel can also request a governed

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -114,6 +114,8 @@ must travel through Gateway-shaped contracts.
     outcome-review search, detail, supportability, report-input, AI-evidence, preview, create, and
     source-refresh posture also remain manage-owned, while AI narrative execution remains
     `lotus-ai` owned; both must reach Workbench through Gateway outcome-review composition only.
+    Manage-owned `client_communication_boundary` is rendered as a fail-closed internal boundary
+    and must not become a Workbench client messaging, approval, delivery, or audit workflow.
     RFC40-WTBD-010 portfolio-memory timeline events, source refs, artifact refs, event counts,
     source systems, reason codes, supportability, and content hashes remain manage-owned and must
     reach Workbench through Gateway portfolio-memory composition only.


### PR DESCRIPTION
## Summary
- consume Gateway/Manage client_communication_boundary in the outcome-review view model and handoff responses
- render the fail-closed no-client-communication boundary in the existing outcome-review evidence UI
- remove client-facing copy from the outcome-review rationale/action labels and add no client communication workflow controls
- update Workbench context/wiki source for the Gateway-only boundary behavior

## Validation
- npm run lint
- npm run typecheck
- npm run test -- --run tests/unit/outcome-review-view-model.test.ts tests/unit/outcome-review-panel.test.tsx tests/unit/outcome-review-panel-helpers.test.ts tests/unit/workbench-api.test.ts tests/integration/workbench-page.test.tsx
- npm run build
- git diff --check
- Browser evidence: Playwright against local Workbench with mocked Gateway; boundary rendered with Communication/Approval Not projected, required source ClientCommunicationRecord:v1, and clientButtons=0. Screenshot: output/playwright/outcome-client-communication-boundary.png

## Wiki
- Repo-authored wiki source changed: wiki/API-Surface.md, wiki/Integrations.md
- Pre-merge CheckOnly reports expected drift until this PR is merged and published