### PR TITLE
Use capability supportability reasons in workspace nav

### DIFF
--- a/src/shell/workspace-supportability-copy.ts
+++ b/src/shell/workspace-supportability-copy.ts
@@ -5,12 +5,21 @@ import type { PlatformShellWorkspaceDescriptor } from "@/features/platform-capab
 export function getWorkspaceDisabledTitle(
   workspace: PlatformShellWorkspaceDescriptor
 ): string {
+  const sourceReason = workspace.supportability.reasons[0];
+  if (sourceReason) {
+    return `${workspace.label} workspace is unavailable: ${formatSupportabilityReason(sourceReason)}.`;
+  }
+
   switch (workspace.id) {
     case "proposal":
-      return "Proposal workspace is not available in this release.";
+      return "Proposal workspace is unavailable.";
     case "advisory":
-      return "Advisory workspace is not available in this release.";
+      return "Advisory workspace is unavailable.";
     default:
       return `${workspace.label} workspace is currently unavailable.`;
   }
+}
+
+function formatSupportabilityReason(reason: string): string {
+  return reason.replaceAll("_", " ").toLowerCase();
 }

--- a/tests/unit/app-switcher-nav.test.tsx
+++ b/tests/unit/app-switcher-nav.test.tsx
@@ -81,8 +81,8 @@ describe("AppSwitcherNav", () => {
               href: "/proposals",
               enabled: false,
               supportability: {
-                state: "unavailable",
-                reasons: ["proposal_disabled_by_contract"],
+                state: "degraded",
+                reasons: ["dependency_degraded"],
               },
             },
           ],
@@ -101,7 +101,7 @@ describe("AppSwitcherNav", () => {
     expect(screen.getByText("Proposal")).toHaveAttribute("aria-disabled", "true");
     expect(screen.getByText("Proposal")).toHaveAttribute(
       "title",
-      "Proposal workspace is not available in this release."
+      "Proposal workspace is unavailable: dependency degraded."
     );
   });
 

--- a/tests/unit/workspace-supportability-copy.test.ts
+++ b/tests/unit/workspace-supportability-copy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { getWorkspaceDisabledTitle } from "../../src/shell/workspace-supportability-copy";
+import type { PlatformShellWorkspaceDescriptor } from "../../src/features/platform-capabilities/types";
+
+function workspace(
+  overrides: Partial<PlatformShellWorkspaceDescriptor>
+): PlatformShellWorkspaceDescriptor {
+  return {
+    id: "advisory",
+    label: "Advisory",
+    href: "/recommendations",
+    enabled: false,
+    supportability: {
+      state: "unsupported",
+      reasons: ["lifecycle_disabled"],
+    },
+    freshness: {
+      state: "current",
+      freshnessClass: "workflow_truth",
+      evaluatedAt: "2026-05-21T00:00:00Z",
+      maxAgeSeconds: 0,
+    },
+    evidence: {
+      state: "source_backed",
+      lineageSources: ["lotus_advise"],
+      partialFailure: false,
+      sourceErrorServices: [],
+    },
+    versioning: {
+      shellContractVersion: "shell-bootstrap.v1",
+      capabilityContractVersion: "v1",
+      sourcePolicyVersion: "advisory.v1",
+    },
+    caching: {
+      cacheMode: "authoritative_read",
+      invalidationOwner: "lotus_advise",
+      staleReadTolerance: "none",
+      revalidateOnNavigation: true,
+      ttlSeconds: 0,
+      correctnessCritical: true,
+    },
+    ...overrides,
+  };
+}
+
+describe("getWorkspaceDisabledTitle", () => {
+  it("uses Gateway-provided supportability reasons before local fallback copy", () => {
+    expect(getWorkspaceDisabledTitle(workspace({}))).toBe(
+      "Advisory workspace is unavailable: lifecycle disabled."
+    );
+  });
+
+  it("falls back without inventing an advisory supportability reason", () => {
+    expect(
+      getWorkspaceDisabledTitle(
+        workspace({
+          supportability: {
+            state: "unavailable",
+            reasons: [],
+          },
+        })
+      )
+    ).toBe("Advisory workspace is unavailable.");
+  });
+});


### PR DESCRIPTION
## Summary
- use Gateway-provided workspace supportability reasons in disabled workspace nav copy
- remove local release-status wording for proposal/advisory disabled titles
- add focused tests proving Workbench renders capability supportability without inventing advisory posture

## Validation
- npm run lint
- npm run typecheck
- npm run test -- --run tests/unit/app-switcher-nav.test.tsx tests/unit/workspace-supportability-copy.test.ts tests/unit/use-platform-capabilities.test.tsx tests/integration/top-nav-capabilities.test.tsx
- git diff --check

## WTBD-004
Advances lotus-advise WTBD-004 by aligning Workbench as a capability consumer. Workbench consumes the Gateway shell descriptor supportability reason and does not infer advisory supportability locally.