### PR TITLE
Render campaign assignment memory transitions

### DIFF
--- a/src/features/workbench/portfolio-memory-view-model.ts
+++ b/src/features/workbench/portfolio-memory-view-model.ts
@@ -1,5 +1,8 @@
 import type { DpmPortfolioMemoryGatewayResponse } from "./types";
 
+const CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_EVENT =
+  "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION";
+
 export type PortfolioMemoryPanelState =
   | "complete"
   | "partial"
@@ -203,7 +206,8 @@ function buildEventRow(
       ) ||
       "N/A",
     summary:
-      eventType === "PM_QUALITY_REVIEW_ACTION"
+      eventType === "PM_QUALITY_REVIEW_ACTION" ||
+      eventType === CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_EVENT
         ? eventSummary(eventType)
         : readString(record, "title") ||
           readString(record, "summary") ||
@@ -249,6 +253,7 @@ function eventTypeLabel(eventType: string, record: Record<string, unknown> = {})
     OUTCOME_REVIEW_EVENT: "Outcome Review Updated",
     PM_QUALITY_SCORE_RUN: "PM Quality Review Recorded",
     PM_QUALITY_REVIEW_ACTION: "PM Quality Supervisory Review Action",
+    [CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_EVENT]: "Campaign Assignment Task Transition",
   };
   return labels[eventType] ?? businessCase(eventType);
 }
@@ -262,6 +267,9 @@ function eventCategory(eventType: string): string {
   }
   if (eventType.startsWith("WAVE")) {
     return "Rebalance";
+  }
+  if (eventType.startsWith("BULK_REVIEW_CAMPAIGN")) {
+    return "Campaign Workflow";
   }
   if (eventType.startsWith("OUTCOME")) {
     return "Outcome Review";
@@ -285,6 +293,8 @@ function eventSummary(eventType: string): string {
     OUTCOME_REVIEW_EVENT: "Outcome review activity was added to the record.",
     PM_QUALITY_SCORE_RUN: "PM operating quality lineage is available.",
     PM_QUALITY_REVIEW_ACTION: "A bounded PM operating quality supervisory review action is available.",
+    [CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_EVENT]:
+      "A campaign assignment task transition was recorded from Manage workflow evidence.",
   };
   return summaries[eventType] ?? "Portfolio memory event is available.";
 }
@@ -311,6 +321,7 @@ function eventBusinessImpact(eventType: string, record: Record<string, unknown>)
     OUTCOME_REVIEW_EVENT: "Review record updated",
     PM_QUALITY_SCORE_RUN: "Operating-quality lineage recorded",
     PM_QUALITY_REVIEW_ACTION: "Supervisory review action recorded",
+    [CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_EVENT]: "Campaign task posture recorded",
   };
   return impacts[eventType] ?? "Portfolio record updated";
 }
@@ -326,6 +337,10 @@ function eventActionLabel(eventType: string): string {
 }
 
 function metadataRows(record: Record<string, unknown>): PortfolioMemoryDetailMetric[] {
+  if (readString(record, "event_type") === CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_EVENT) {
+    return campaignAssignmentTaskTransitionRows(record);
+  }
+
   const metadata = readRecord(record.metadata);
   const rows: PortfolioMemoryDetailMetric[] = [];
   addMetadataRow(rows, "Status", readString(record, "status"));
@@ -337,6 +352,29 @@ function metadataRows(record: Record<string, unknown>): PortfolioMemoryDetailMet
   addMetadataRow(rows, "Recommended Action", readString(metadata, "recommended_action"));
   addMetadataRow(rows, "Dimension", readString(metadata, "dimension"));
   return rows.slice(0, 6);
+}
+
+function campaignAssignmentTaskTransitionRows(
+  record: Record<string, unknown>,
+): PortfolioMemoryDetailMetric[] {
+  const metadata = readRecord(record.metadata);
+  const rows: PortfolioMemoryDetailMetric[] = [];
+  addMetadataRow(rows, "Task Ref", readString(metadata, "task_ref") || readString(metadata, "assignment_task_id"));
+  addMetadataRow(rows, "Transition", readString(metadata, "transition_type"));
+  addMetadataRow(rows, "From Status", readString(metadata, "from_status"));
+  addMetadataRow(rows, "To Status", readString(metadata, "to_status") || readString(record, "status"));
+  addMetadataRow(rows, "SLA Posture", readString(metadata, "sla_posture"));
+  addMetadataRow(
+    rows,
+    "Supportability",
+    readString(metadata, "supportability_state") ||
+      readString(record, "supportability_state") ||
+      readString(record, "status"),
+  );
+  addMetadataRow(rows, "Evidence Items", String(extractRecordArray(record.artifact_refs).length));
+  addMetadataRow(rows, "Reason Codes", String(extractStringArray(record.reason_codes).length));
+  addMetadataRow(rows, "Content Hash", readString(record, "content_hash"));
+  return rows.slice(0, 9);
 }
 
 function addMetadataRow(rows: PortfolioMemoryDetailMetric[], label: string, value: string): void {

--- a/tests/unit/portfolio-memory-selected-event-detail.test.tsx
+++ b/tests/unit/portfolio-memory-selected-event-detail.test.tsx
@@ -102,4 +102,59 @@ describe("PortfolioMemorySelectedEventDetail", () => {
     expect(screen.queryByText("Generate Order")).not.toBeInTheDocument();
     expect(screen.queryByText("Route Order")).not.toBeInTheDocument();
   });
+
+  it("renders campaign assignment task transition detail with only bounded safe fields", () => {
+    render(
+      <PortfolioMemorySelectedEventDetail
+        event={{
+          ...outcomeReviewEvent,
+          eventId: "memory:campaign-assignment-task-transition:transition_001",
+          eventType: "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION",
+          eventLabel: "Campaign Assignment Task Transition",
+          category: "Campaign Workflow",
+          summary:
+            "A campaign assignment task transition was recorded from Manage workflow evidence.",
+          businessImpact: "Campaign task posture recorded",
+          reasonCodes: "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_RECORDED",
+          metadataRows: [
+            { key: "task-ref-0", label: "Task Ref", value: "task-ref-001" },
+            { key: "transition-1", label: "Transition", value: "ACKNOWLEDGE" },
+            { key: "from-status-2", label: "From Status", value: "OPEN" },
+            { key: "to-status-3", label: "To Status", value: "IN_PROGRESS" },
+            { key: "sla-posture-4", label: "SLA Posture", value: "ON_TRACK" },
+            {
+              key: "content-hash-5",
+              label: "Content Hash",
+              value: "sha256:assignment-task-transition",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Details: Campaign Assignment Task Transition" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "A campaign assignment task transition was recorded from Manage workflow evidence.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("task-ref-001")).toBeInTheDocument();
+    expect(screen.getByText("ACKNOWLEDGE")).toBeInTheDocument();
+    expect(screen.getByText("OPEN")).toBeInTheDocument();
+    expect(screen.getByText("IN_PROGRESS")).toBeInTheDocument();
+    expect(screen.getByText("ON_TRACK")).toBeInTheDocument();
+    expect(screen.getByText("sha256:assignment-task-transition")).toBeInTheDocument();
+    expect(screen.queryByText(/transition rationale/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/raw rationale/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/reviewer note/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/generated ai/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Message client")).not.toBeInTheDocument();
+    expect(screen.queryByText("Approve client communication")).not.toBeInTheDocument();
+    expect(screen.queryByText("Generate Order")).not.toBeInTheDocument();
+    expect(screen.queryByText("Route Order")).not.toBeInTheDocument();
+    expect(screen.queryByText("Mark Filled")).not.toBeInTheDocument();
+    expect(screen.queryByText("Settle")).not.toBeInTheDocument();
+  });
 });

--- a/tests/unit/portfolio-memory-view-model.test.ts
+++ b/tests/unit/portfolio-memory-view-model.test.ts
@@ -160,4 +160,99 @@ describe("portfolio-memory view model", () => {
     expect(JSON.stringify(model.events[0])).not.toContain("message client");
     expect(JSON.stringify(model.events[0])).not.toContain("route order");
   });
+
+  it("labels campaign assignment task transitions with bounded safe workflow detail", () => {
+    const model = buildPortfolioMemoryPanelModel({
+      ...memoryResponse,
+      supportability: {
+        ...memoryResponse.supportability,
+        event_count: 1,
+        event_type_counts: {
+          BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION: 1,
+        },
+      },
+      data: {
+        portfolio_id: "PB_SG_GLOBAL_BAL_001",
+        events: [
+          {
+            event_id: "memory:campaign-assignment-task-transition:transition_001",
+            event_type: "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION",
+            event_time: "2026-05-21T08:15:00Z",
+            title: "raw transition rationale should not render",
+            summary: "raw reviewer note should not render",
+            status: "IN_PROGRESS",
+            supportability_state: "PENDING_REVIEW",
+            source_refs: [
+              {
+                source_system: "lotus-manage",
+                source_type: "BulkReviewCampaignDefinition",
+                source_id: "campaign_001:v1",
+              },
+            ],
+            artifact_refs: [
+              {
+                source_system: "lotus-manage",
+                source_type: "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK",
+                source_id: "task_001",
+              },
+            ],
+            content_hash: "sha256:assignment-task-transition",
+            reason_codes: [
+              "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_RECORDED",
+            ],
+            metadata: {
+              task_ref: "task-ref-001",
+              assignment_task_id: "task_001",
+              transition_type: "ACKNOWLEDGE",
+              from_status: "OPEN",
+              to_status: "IN_PROGRESS",
+              sla_posture: "ON_TRACK",
+              supportability_state: "PENDING_REVIEW",
+              transition_reason: "unsafe transition rationale",
+              raw_rationale: "unsafe raw rationale",
+              reviewer_notes: "unsafe reviewer note",
+              generated_ai_text: "unsafe AI text",
+              client_contact: "message client",
+              oms_action: "route order",
+              order_instruction: "buy security",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(model.eventTypeRows[0]).toMatchObject({
+      eventType: "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION",
+      eventLabel: "Campaign Assignment Task Transition",
+    });
+    expect(model.events[0]).toEqual(
+      expect.objectContaining({
+        eventLabel: "Campaign Assignment Task Transition",
+        category: "Campaign Workflow",
+        summary:
+          "A campaign assignment task transition was recorded from Manage workflow evidence.",
+        businessImpact: "Bulk Review Campaign Assignment Task Transition Recorded",
+        actionLabel: "View",
+        status: "PENDING_REVIEW",
+        contentHash: "sha256:assignment-task-transition",
+      }),
+    );
+    expect(model.events[0].metadataRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Task Ref", value: "task-ref-001" }),
+        expect.objectContaining({ label: "Transition", value: "ACKNOWLEDGE" }),
+        expect.objectContaining({ label: "From Status", value: "OPEN" }),
+        expect.objectContaining({ label: "To Status", value: "IN_PROGRESS" }),
+        expect.objectContaining({ label: "SLA Posture", value: "ON_TRACK" }),
+        expect.objectContaining({ label: "Content Hash", value: "sha256:assignment-task-transition" }),
+      ]),
+    );
+    expect(JSON.stringify(model.events[0])).not.toContain("unsafe transition rationale");
+    expect(JSON.stringify(model.events[0])).not.toContain("unsafe raw rationale");
+    expect(JSON.stringify(model.events[0])).not.toContain("unsafe reviewer note");
+    expect(JSON.stringify(model.events[0])).not.toContain("unsafe AI text");
+    expect(JSON.stringify(model.events[0])).not.toContain("message client");
+    expect(JSON.stringify(model.events[0])).not.toContain("route order");
+    expect(JSON.stringify(model.events[0])).not.toContain("buy security");
+  });
 });


### PR DESCRIPTION
## Summary
- render BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION as Campaign Assignment Task Transition in the portfolio-memory view model
- categorize it as Campaign Workflow and show only bounded safe detail fields: task ref, transition type, from/to status, SLA/supportability posture, evidence counts, reason counts, and content hash
- add tests proving unsafe rationale, reviewer notes, generated AI text, client-contact, order, OMS, trade, fill, and settlement claims do not render

## Validation
- npm run lint
- npm run typecheck
- npm run test -- --run tests/unit/portfolio-memory-view-model.test.ts tests/unit/portfolio-memory-panel.test.tsx tests/unit/portfolio-memory-timeline-card.test.tsx tests/unit/portfolio-memory-selected-event-detail.test.tsx tests/integration/workbench-page.test.tsx
- npm run build
- git diff --check

## Docs
No Workbench wiki source changed; this is read-only display of an existing Gateway-backed portfolio-memory event family.