### PR TITLE
Realize campaign workflow command controls

### DIFF
--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -468,10 +468,11 @@ Workbench must consume these Gateway wave routes when implemented:
 | `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/preview-readiness` | Manage-owned `BulkReviewCampaignDefinitionPreviewReadiness:v1` posture for selected campaign preview and wave-create readiness |
 | `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch-package` | Manage-owned launch readiness and idempotency evidence for a selected campaign definition |
 | `POST /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch` | READY-gated durable campaign launch through Gateway |
-| `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/approval-decisions` | read-only approval-decision evidence |
-| `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-actions` | read-only assignment-action evidence |
-| `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-tasks` | read-only assignment-task and task-transition evidence |
-| `GET /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/maker-checker-controls` | read-only maker-checker evidence |
+| `GET/POST /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/approval-decisions` | approval-decision evidence list and bounded Gateway-backed record control |
+| `GET/POST /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-actions` | assignment-action evidence list and bounded Gateway-backed record control |
+| `GET/POST /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-tasks` | assignment-task evidence list and bounded Gateway-backed record control |
+| `POST /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-tasks/{task_ref}/transitions` | bounded Gateway-backed assignment-task transition evidence record control |
+| `GET/POST /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/maker-checker-controls` | maker-checker evidence list and bounded Gateway-backed record control |
 
 Implementation note as of 2026-05-14: the first RFC-0041 rebalance-wave command-center
 realization is embedded in `/workbench/{portfolioId}` through Gateway
@@ -500,11 +501,15 @@ and exposes campaign launch through Gateway
 `POST /api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch`
 only when Manage returns `READY`, preserving durable wave response and idempotency evidence without
 recomputing membership, launch readiness, idempotency, maker-checker workflow, trade approval,
-staging, or OMS execution locally. It also renders read-only campaign workflow audit posture from
-Gateway operating queue, approval inbox, workflow board, assignment plan, workflow automation,
+staging, or OMS execution locally. It also renders campaign workflow audit posture from Gateway
+operating queue, approval inbox, workflow board, assignment plan, workflow automation,
 approval-decision, assignment-action, assignment-task, and maker-checker reads, preserving
 source refs, count/page metadata, reason codes, content hashes, task-transition posture, and
-operating boundaries without mutating assignment or maker-checker state. The panel renders
+operating boundaries. Selected-campaign workflow controls can record bounded Gateway-backed
+approval-decision, assignment-action, assignment-task, assignment-task transition, and
+maker-checker-control evidence, then refresh the source-owned evidence lists and show
+Gateway-returned correlation, source, upstream-status, content-hash, reason-code, and boundary
+evidence without fabricating browser-owned workflow state. The panel renders
 manage-owned wave id, lifecycle state, item count, issue count, supportability reason codes,
 blocked actions, aggregate metrics, item states, source-readiness state, alternative refs,
 report-input refs, proof-pack refs, handoff refs, lotus-ai workflow-pack run posture, and

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -306,8 +306,18 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
   },
   {
     route: "workbench.manage",
+    panel: "wave-campaign-approval-decisions-create",
+    operation: "dpm.waves.campaign-approval-decisions.create",
+  },
+  {
+    route: "workbench.manage",
     panel: "wave-campaign-assignment-actions",
     operation: "dpm.waves.campaign-assignment-actions.list",
+  },
+  {
+    route: "workbench.manage",
+    panel: "wave-campaign-assignment-actions-create",
+    operation: "dpm.waves.campaign-assignment-actions.create",
   },
   {
     route: "workbench.manage",
@@ -316,8 +326,23 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
   },
   {
     route: "workbench.manage",
+    panel: "wave-campaign-assignment-tasks-create",
+    operation: "dpm.waves.campaign-assignment-tasks.create",
+  },
+  {
+    route: "workbench.manage",
+    panel: "wave-campaign-assignment-task-transitions-create",
+    operation: "dpm.waves.campaign-assignment-task-transitions.create",
+  },
+  {
+    route: "workbench.manage",
     panel: "wave-campaign-maker-checker-controls",
     operation: "dpm.waves.campaign-maker-checker-controls.list",
+  },
+  {
+    route: "workbench.manage",
+    panel: "wave-campaign-maker-checker-controls-create",
+    operation: "dpm.waves.campaign-maker-checker-controls.create",
   },
   {
     route: "workbench.manage",

--- a/src/features/workbench/components/dpm-campaign-definitions-section.tsx
+++ b/src/features/workbench/components/dpm-campaign-definitions-section.tsx
@@ -9,6 +9,10 @@ import DpmCampaignLaunchHistoryCard, {
 import DpmCampaignLaunchPostureCard from "@/features/workbench/components/dpm-campaign-launch-posture-card";
 import DpmCampaignWorkflowAuditCard from "@/features/workbench/components/dpm-campaign-workflow-audit-card";
 import type {
+  DpmCampaignWorkflowCommandEvidence,
+  DpmCampaignWorkflowCommandInput,
+} from "@/features/workbench/use-dpm-wave-command-center-actions";
+import type {
   DpmCampaignDefinitionRow,
   DpmCampaignLaunchHistoryPage,
   DpmCampaignLaunchHistoryRow,
@@ -50,6 +54,9 @@ type Props = {
   pendingPreviewReadinessKey?: string | null;
   pendingLaunchPackageKey?: string | null;
   pendingLaunchKey?: string | null;
+  pendingWorkflowCommand?: boolean;
+  workflowCommandError?: string | null;
+  workflowCommandEvidence?: DpmCampaignWorkflowCommandEvidence | null;
   selectedCampaign: DpmCampaignDefinitionRow | null;
   selectedCampaignKey?: string | null;
   errorMessage?: string | null;
@@ -57,6 +64,7 @@ type Props = {
   onLoadLaunchHistory: (row: DpmCampaignDefinitionRow, offset?: number) => void;
   onCheckLaunchReadiness: (row: DpmCampaignDefinitionRow) => void;
   onLaunchCampaign: (row: DpmCampaignDefinitionRow) => void;
+  onRecordWorkflowCommand?: (command: DpmCampaignWorkflowCommandInput) => Promise<void>;
 };
 
 export default function DpmCampaignDefinitionsSection({
@@ -78,6 +86,9 @@ export default function DpmCampaignDefinitionsSection({
   pendingPreviewReadinessKey,
   pendingLaunchPackageKey,
   pendingLaunchKey,
+  pendingWorkflowCommand,
+  workflowCommandError,
+  workflowCommandEvidence,
   selectedCampaign,
   selectedCampaignKey,
   errorMessage,
@@ -85,6 +96,7 @@ export default function DpmCampaignDefinitionsSection({
   onLoadLaunchHistory,
   onCheckLaunchReadiness,
   onLaunchCampaign,
+  onRecordWorkflowCommand = async () => {},
 }: Props) {
   const selectedLaunchPending = Boolean(selectedCampaign && selectedCampaign.key === pendingLaunchKey);
 
@@ -128,6 +140,11 @@ export default function DpmCampaignDefinitionsSection({
         summaryRows={workflowSummaryRows}
         evidenceRows={workflowEvidenceRows}
         error={workflowError}
+        selectedCampaign={selectedCampaign}
+        pendingCommand={pendingWorkflowCommand}
+        commandError={workflowCommandError}
+        commandEvidence={workflowCommandEvidence}
+        onRecordWorkflowCommand={onRecordWorkflowCommand}
       />
       <DpmCampaignLaunchHistoryCard
         rows={launchHistoryRows}

--- a/src/features/workbench/components/dpm-campaign-workflow-audit-card.tsx
+++ b/src/features/workbench/components/dpm-campaign-workflow-audit-card.tsx
@@ -1,23 +1,98 @@
 "use client";
 
-import { AnalyticsTable, ScreenStatePanel, SemanticBadge } from "@/design-system";
+import { useState } from "react";
+import { ActionButton, AnalyticsTable, MetricRow, ScreenStatePanel, SemanticBadge } from "@/design-system";
+import { resolveDefaultCallerContext } from "@/features/workbench/caller-context";
 import DpmWaveStateBadge from "@/features/workbench/components/dpm-wave-state-badge";
 import type {
+  DpmCampaignDefinitionRow,
   DpmCampaignWorkflowEvidenceRow,
   DpmCampaignWorkflowSummaryRow,
 } from "@/features/workbench/dpm-wave-command-center-view-model";
+import type {
+  DpmCampaignWorkflowCommandEvidence,
+  DpmCampaignWorkflowCommandInput,
+  DpmCampaignWorkflowCommandType,
+} from "@/features/workbench/use-dpm-wave-command-center-actions";
 
 type Props = {
   summaryRows: DpmCampaignWorkflowSummaryRow[];
   evidenceRows: DpmCampaignWorkflowEvidenceRow[];
   error?: string | null;
+  selectedCampaign: DpmCampaignDefinitionRow | null;
+  pendingCommand?: boolean;
+  commandError?: string | null;
+  commandEvidence?: DpmCampaignWorkflowCommandEvidence | null;
+  onRecordWorkflowCommand: (command: DpmCampaignWorkflowCommandInput) => Promise<void>;
 };
+
+const COMMAND_OPTIONS: Array<{
+  value: DpmCampaignWorkflowCommandType;
+  label: string;
+  referenceLabel: string;
+}> = [
+  {
+    value: "approval_decision",
+    label: "Approval Decision",
+    referenceLabel: "Decision ref",
+  },
+  {
+    value: "assignment_action",
+    label: "Assignment Action",
+    referenceLabel: "Action ref",
+  },
+  {
+    value: "assignment_task",
+    label: "Assignment Task",
+    referenceLabel: "Task ref",
+  },
+  {
+    value: "task_transition",
+    label: "Task Transition",
+    referenceLabel: "Task ref",
+  },
+  {
+    value: "maker_checker_control",
+    label: "Maker-Checker Control",
+    referenceLabel: "Control ref",
+  },
+];
 
 export default function DpmCampaignWorkflowAuditCard({
   summaryRows,
   evidenceRows,
   error,
+  selectedCampaign,
+  pendingCommand = false,
+  commandError = null,
+  commandEvidence = null,
+  onRecordWorkflowCommand,
 }: Props) {
+  const callerContext = resolveDefaultCallerContext();
+  const [commandType, setCommandType] =
+    useState<DpmCampaignWorkflowCommandType>("assignment_task");
+  const [actorId, setActorId] = useState(callerContext.actorId);
+  const [reference, setReference] = useState("");
+  const [transitionType, setTransitionType] = useState("MARK_SUPPORTABLE");
+  const selectedOption = COMMAND_OPTIONS.find((option) => option.value === commandType)!;
+  const commandUnavailable = !selectedCampaign;
+  const referenceRequired = reference.trim().length === 0;
+  const submitDisabled = commandUnavailable || pendingCommand || referenceRequired;
+
+  async function submitCommand() {
+    if (submitDisabled) {
+      return;
+    }
+    await onRecordWorkflowCommand(
+      buildCampaignWorkflowCommand({
+        commandType,
+        actorId: actorId.trim(),
+        reference: reference.trim(),
+        transitionType,
+      })
+    );
+  }
+
   return (
     <div className="rebalance-campaign-evidence" aria-labelledby="campaign-workflow-audit-title">
       <div className="rebalance-table-heading">
@@ -37,6 +112,108 @@ export default function DpmCampaignWorkflowAuditCard({
           body={error}
         />
       ) : null}
+      <div
+        className="rebalance-campaign-workflow-command"
+        aria-label="DPM campaign workflow command control"
+      >
+        <div className="rebalance-campaign-workflow-command-header">
+          <div>
+            <strong>Workflow Evidence Control</strong>
+            <span>
+              {selectedCampaign
+                ? `${selectedCampaign.displayName} version ${selectedCampaign.campaignVersion}`
+                : "Select a Manage campaign definition"}
+            </span>
+          </div>
+          <SemanticBadge tone={commandUnavailable ? "default" : commandError ? "warn" : "success"}>
+            {commandUnavailable ? "Unavailable" : commandError ? "Needs attention" : "Gateway backed"}
+          </SemanticBadge>
+        </div>
+        <div className="rebalance-campaign-workflow-command-grid">
+          <label className="workbench-field-label" htmlFor="dpm-campaign-workflow-command-type">
+            Command
+            <select
+              id="dpm-campaign-workflow-command-type"
+              className="workbench-input"
+              value={commandType}
+              onChange={(event) => setCommandType(event.target.value as DpmCampaignWorkflowCommandType)}
+              disabled={pendingCommand}
+            >
+              {COMMAND_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="workbench-field-label" htmlFor="dpm-campaign-workflow-actor">
+            Actor
+            <input
+              id="dpm-campaign-workflow-actor"
+              className="workbench-input"
+              value={actorId}
+              onChange={(event) => setActorId(event.target.value)}
+              disabled={pendingCommand}
+            />
+          </label>
+          <label className="workbench-field-label" htmlFor="dpm-campaign-workflow-reference">
+            {selectedOption.referenceLabel}
+            <input
+              id="dpm-campaign-workflow-reference"
+              className="workbench-input"
+              value={reference}
+              onChange={(event) => setReference(event.target.value)}
+              disabled={pendingCommand}
+            />
+          </label>
+          <label className="workbench-field-label" htmlFor="dpm-campaign-workflow-transition">
+            Transition
+            <select
+              id="dpm-campaign-workflow-transition"
+              className="workbench-input"
+              value={transitionType}
+              onChange={(event) => setTransitionType(event.target.value)}
+              disabled={pendingCommand || commandType !== "task_transition"}
+            >
+              <option value="MARK_SUPPORTABLE">Mark supportable</option>
+              <option value="REQUEST_EVIDENCE_REVIEW">Request evidence review</option>
+              <option value="RETURN_FOR_SOURCE_REVIEW">Return for source review</option>
+            </select>
+          </label>
+        </div>
+        <div className="rebalance-campaign-workflow-command-row">
+          <ActionButton priority="secondary" onClick={submitCommand} disabled={submitDisabled}>
+            {pendingCommand ? "Recording" : "Record Workflow Evidence"}
+          </ActionButton>
+          <span>
+            Source evidence only; no order, OMS, client-contact, or external workflow action is
+            enabled.
+          </span>
+        </div>
+        {commandError ? (
+          <ScreenStatePanel
+            kind="partial"
+            surface="portfolio"
+            title="Campaign workflow command needs attention"
+            body={commandError}
+          />
+        ) : null}
+        {commandEvidence ? (
+          <div
+            className="rebalance-campaign-workflow-command-evidence"
+            aria-label="DPM campaign workflow command evidence"
+          >
+            <MetricRow label="Command" value={commandEvidence.commandLabel} />
+            <MetricRow label="Evidence Ref" value={commandEvidence.evidenceRef} />
+            <MetricRow label="Correlation" value={commandEvidence.correlationId} />
+            <MetricRow label="Source" value={commandEvidence.sourceService} />
+            <MetricRow label="Upstream" value={commandEvidence.upstreamStatus} />
+            <MetricRow label="Content Hash" value={commandEvidence.contentHash} />
+            <MetricRow label="Reason Codes" value={commandEvidence.reasonCodes} />
+            <MetricRow label="Boundaries" value={commandEvidence.operatingBoundaries} />
+          </div>
+        ) : null}
+      </div>
       <AnalyticsTable
         ariaLabel="DPM campaign workflow audit summary"
         variant="portfolio"
@@ -107,4 +284,63 @@ export default function DpmCampaignWorkflowAuditCard({
       />
     </div>
   );
+}
+
+function buildCampaignWorkflowCommand(params: {
+  commandType: DpmCampaignWorkflowCommandType;
+  actorId: string;
+  reference: string;
+  transitionType: string;
+}): DpmCampaignWorkflowCommandInput {
+  const actorId = params.actorId || resolveDefaultCallerContext().actorId;
+  switch (params.commandType) {
+    case "approval_decision":
+      return {
+        commandType: params.commandType,
+        body: {
+          decision_ref: params.reference,
+          decision_type: "WORKFLOW_REVIEW_RECORDED",
+          actor_id: actorId,
+          reason_codes: ["WORKBENCH_CAMPAIGN_APPROVAL_DECISION_RECORDED"],
+        },
+      };
+    case "assignment_action":
+      return {
+        commandType: params.commandType,
+        body: {
+          action_ref: params.reference,
+          action_type: "ASSIGN_FOR_REVIEW",
+          actor_id: actorId,
+          reason_codes: ["WORKBENCH_CAMPAIGN_ASSIGNMENT_ACTION_RECORDED"],
+        },
+      };
+    case "assignment_task":
+      return {
+        commandType: params.commandType,
+        body: {
+          task_ref: params.reference,
+          actor_id: actorId,
+          reason_codes: ["WORKBENCH_CAMPAIGN_ASSIGNMENT_TASK_RECORDED"],
+        },
+      };
+    case "task_transition":
+      return {
+        commandType: params.commandType,
+        taskRef: params.reference,
+        body: {
+          transition_type: params.transitionType,
+          actor_id: actorId,
+        },
+      };
+    case "maker_checker_control":
+      return {
+        commandType: params.commandType,
+        body: {
+          control_ref: params.reference,
+          control_type: "MAKER_CHECKER_REVIEW",
+          actor_id: actorId,
+          reason_codes: ["WORKBENCH_CAMPAIGN_MAKER_CHECKER_CONTROL_RECORDED"],
+        },
+      };
+  }
 }

--- a/src/features/workbench/components/dpm-wave-command-center-panel.tsx
+++ b/src/features/workbench/components/dpm-wave-command-center-panel.tsx
@@ -76,12 +76,15 @@ export default function DpmWaveCommandCenterPanel({
     pendingCampaignPreviewReadinessKey,
     pendingCampaignLaunchPackageKey,
     pendingCampaignLaunchKey,
+    pendingCampaignWorkflowCommand,
     actionError,
     proofPackLoaded,
     campaignLifecycleError,
     campaignLaunchHistoryError,
     campaignPreviewReadinessError,
     campaignLaunchError,
+    campaignWorkflowCommandError,
+    campaignWorkflowCommandEvidence,
     actionMessage,
     previewRebalance,
     createRebalance,
@@ -96,6 +99,7 @@ export default function DpmWaveCommandCenterPanel({
     loadCampaignLaunchHistory,
     checkCampaignLaunchReadiness,
     launchCampaign,
+    recordCampaignWorkflowCommand,
   } = useDpmWaveCommandCenterActions({
     portfolioId,
     waveList,
@@ -192,6 +196,9 @@ export default function DpmWaveCommandCenterPanel({
         pendingPreviewReadinessKey={pendingCampaignPreviewReadinessKey}
         pendingLaunchPackageKey={pendingCampaignLaunchPackageKey}
         pendingLaunchKey={pendingCampaignLaunchKey}
+        pendingWorkflowCommand={pendingCampaignWorkflowCommand}
+        workflowCommandError={campaignWorkflowCommandError}
+        workflowCommandEvidence={campaignWorkflowCommandEvidence}
         selectedCampaign={selectedCampaign}
         selectedCampaignKey={selectedCampaignKey}
         errorMessage={campaignDefinitionsError ?? campaignDiscoveryError}
@@ -199,6 +206,7 @@ export default function DpmWaveCommandCenterPanel({
         onLoadLaunchHistory={loadCampaignLaunchHistory}
         onCheckLaunchReadiness={checkCampaignLaunchReadiness}
         onLaunchCampaign={launchCampaign}
+        onRecordWorkflowCommand={recordCampaignWorkflowCommand}
       />
 
       <div className="rebalance-main-grid">

--- a/src/features/workbench/dpm-wave-api.ts
+++ b/src/features/workbench/dpm-wave-api.ts
@@ -414,6 +414,37 @@ async function getDpmCampaignWorkflowEvidence(
   );
 }
 
+async function createDpmCampaignWorkflowEvidence(
+  operation: WorkbenchObservedOperation,
+  pathSuffix: string,
+  label: string,
+  params: {
+    campaignId: string;
+    campaignVersion: string;
+    body: Record<string, unknown>;
+    actorId?: string;
+  }
+): Promise<DpmCampaignWorkflowGatewayResponse> {
+  return await observeWorkbenchMutation(
+    operation,
+    async () =>
+      await fetchWorkbenchMutation<DpmCampaignWorkflowGatewayResponse>(
+        buildWorkbenchUrl(
+          "client",
+          `/dpm/command-center/waves/campaign-definitions/${encodeURIComponent(
+            params.campaignId
+          )}/versions/${encodeURIComponent(params.campaignVersion)}/${pathSuffix}`
+        ),
+        label,
+        {
+          method: "POST",
+          headers: buildDpmWaveCallerHeaders(params.actorId),
+          body: JSON.stringify({ body: params.body }),
+        }
+      )
+  );
+}
+
 export async function getDpmCampaignApprovalDecisions(params: {
   campaignId: string;
   campaignVersion: string;
@@ -424,6 +455,20 @@ export async function getDpmCampaignApprovalDecisions(params: {
     "dpm.waves.campaign-approval-decisions.list",
     "approval-decisions",
     "DPM campaign approval decisions",
+    params
+  );
+}
+
+export async function createDpmCampaignApprovalDecision(params: {
+  campaignId: string;
+  campaignVersion: string;
+  body: Record<string, unknown>;
+  actorId?: string;
+}): Promise<DpmCampaignWorkflowGatewayResponse> {
+  return await createDpmCampaignWorkflowEvidence(
+    "dpm.waves.campaign-approval-decisions.create",
+    "approval-decisions",
+    "create DPM campaign approval decision",
     params
   );
 }
@@ -442,6 +487,20 @@ export async function getDpmCampaignAssignmentActions(params: {
   );
 }
 
+export async function createDpmCampaignAssignmentAction(params: {
+  campaignId: string;
+  campaignVersion: string;
+  body: Record<string, unknown>;
+  actorId?: string;
+}): Promise<DpmCampaignWorkflowGatewayResponse> {
+  return await createDpmCampaignWorkflowEvidence(
+    "dpm.waves.campaign-assignment-actions.create",
+    "assignment-actions",
+    "create DPM campaign assignment action",
+    params
+  );
+}
+
 export async function getDpmCampaignAssignmentTasks(params: {
   campaignId: string;
   campaignVersion: string;
@@ -456,6 +515,35 @@ export async function getDpmCampaignAssignmentTasks(params: {
   );
 }
 
+export async function createDpmCampaignAssignmentTask(params: {
+  campaignId: string;
+  campaignVersion: string;
+  body: Record<string, unknown>;
+  actorId?: string;
+}): Promise<DpmCampaignWorkflowGatewayResponse> {
+  return await createDpmCampaignWorkflowEvidence(
+    "dpm.waves.campaign-assignment-tasks.create",
+    "assignment-tasks",
+    "create DPM campaign assignment task",
+    params
+  );
+}
+
+export async function createDpmCampaignAssignmentTaskTransition(params: {
+  campaignId: string;
+  campaignVersion: string;
+  taskRef: string;
+  body: Record<string, unknown>;
+  actorId?: string;
+}): Promise<DpmCampaignWorkflowGatewayResponse> {
+  return await createDpmCampaignWorkflowEvidence(
+    "dpm.waves.campaign-assignment-task-transitions.create",
+    `assignment-tasks/${encodeURIComponent(params.taskRef)}/transitions`,
+    "create DPM campaign assignment-task transition",
+    params
+  );
+}
+
 export async function getDpmCampaignMakerCheckerControls(params: {
   campaignId: string;
   campaignVersion: string;
@@ -466,6 +554,20 @@ export async function getDpmCampaignMakerCheckerControls(params: {
     "dpm.waves.campaign-maker-checker-controls.list",
     "maker-checker-controls",
     "DPM campaign maker-checker controls",
+    params
+  );
+}
+
+export async function createDpmCampaignMakerCheckerControl(params: {
+  campaignId: string;
+  campaignVersion: string;
+  body: Record<string, unknown>;
+  actorId?: string;
+}): Promise<DpmCampaignWorkflowGatewayResponse> {
+  return await createDpmCampaignWorkflowEvidence(
+    "dpm.waves.campaign-maker-checker-controls.create",
+    "maker-checker-controls",
+    "create DPM campaign maker-checker control",
     params
   );
 }

--- a/src/features/workbench/manage-workspace.module.css
+++ b/src/features/workbench/manage-workspace.module.css
@@ -3097,6 +3097,63 @@
   margin: 12px 16px;
 }
 
+.manageScope :global(.rebalance-campaign-workflow-command) {
+  display: grid;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid #e0e3e5;
+  background: #f7f9fb;
+}
+
+.manageScope :global(.rebalance-campaign-workflow-command-header) {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.manageScope :global(.rebalance-campaign-workflow-command-header div) {
+  display: grid;
+  gap: 4px;
+}
+
+.manageScope :global(.rebalance-campaign-workflow-command-header strong) {
+  color: #191c1e;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.manageScope :global(.rebalance-campaign-workflow-command-header span) {
+  color: #45464d;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.manageScope :global(.rebalance-campaign-workflow-command-grid) {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.manageScope :global(.rebalance-campaign-workflow-command-row) {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.manageScope :global(.rebalance-campaign-workflow-command-row span) {
+  color: #45464d;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.manageScope :global(.rebalance-campaign-workflow-command-evidence) {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
 .manageScope :global(.rebalance-action) {
   font-weight: 700;
 }

--- a/src/features/workbench/use-dpm-wave-command-center-actions.ts
+++ b/src/features/workbench/use-dpm-wave-command-center-actions.ts
@@ -3,11 +3,20 @@
 import { useEffect, useState } from "react";
 import {
   approveDpmWave,
+  createDpmCampaignApprovalDecision,
+  createDpmCampaignAssignmentAction,
+  createDpmCampaignAssignmentTask,
+  createDpmCampaignAssignmentTaskTransition,
+  createDpmCampaignMakerCheckerControl,
   createDpmWave,
+  getDpmCampaignApprovalDecisions,
+  getDpmCampaignAssignmentActions,
+  getDpmCampaignAssignmentTasks,
   getDpmCampaignDefinitionLaunchHistory,
   getDpmCampaignDefinitionLaunchPackage,
   getDpmCampaignDefinitionLifecycleEvents,
   getDpmCampaignDefinitionPreviewReadiness,
+  getDpmCampaignMakerCheckerControls,
   getDpmWaveItems,
   getDpmWaveProofPackPosture,
   handoffDpmWave,
@@ -45,6 +54,30 @@ type UseDpmWaveCommandCenterActionsInput = {
   campaignMakerCheckerControls?: DpmCampaignWorkflowGatewayResponse | null;
 };
 
+export type DpmCampaignWorkflowCommandType =
+  | "approval_decision"
+  | "assignment_action"
+  | "assignment_task"
+  | "task_transition"
+  | "maker_checker_control";
+
+export type DpmCampaignWorkflowCommandInput = {
+  commandType: DpmCampaignWorkflowCommandType;
+  body: Record<string, unknown>;
+  taskRef?: string;
+};
+
+export type DpmCampaignWorkflowCommandEvidence = {
+  commandLabel: string;
+  evidenceRef: string;
+  correlationId: string;
+  sourceService: string;
+  upstreamStatus: string;
+  contentHash: string;
+  reasonCodes: string;
+  operatingBoundaries: string;
+};
+
 type UseDpmWaveCommandCenterActionsResult = {
   model: DpmWaveCommandCenterPanelModel;
   selectedCampaign: DpmCampaignDefinitionRow | null;
@@ -55,12 +88,15 @@ type UseDpmWaveCommandCenterActionsResult = {
   pendingCampaignPreviewReadinessKey: string | null;
   pendingCampaignLaunchPackageKey: string | null;
   pendingCampaignLaunchKey: string | null;
+  pendingCampaignWorkflowCommand: boolean;
   actionError: string | null;
   proofPackLoaded: boolean;
   campaignLifecycleError: string | null;
   campaignLaunchHistoryError: string | null;
   campaignPreviewReadinessError: string | null;
   campaignLaunchError: string | null;
+  campaignWorkflowCommandError: string | null;
+  campaignWorkflowCommandEvidence: DpmCampaignWorkflowCommandEvidence | null;
   actionMessage: string | null;
   previewRebalance: () => void;
   createRebalance: () => void;
@@ -78,6 +114,9 @@ type UseDpmWaveCommandCenterActionsResult = {
   ) => Promise<void>;
   checkCampaignLaunchReadiness: (row: DpmCampaignDefinitionRow) => Promise<void>;
   launchCampaign: (row: DpmCampaignDefinitionRow) => Promise<void>;
+  recordCampaignWorkflowCommand: (
+    command: DpmCampaignWorkflowCommandInput
+  ) => Promise<void>;
 };
 
 export function useDpmWaveCommandCenterActions({
@@ -108,6 +147,14 @@ export function useDpmWaveCommandCenterActions({
     useState<DpmCampaignDefinitionGatewayResponse | null>(null);
   const [campaignLaunchResponse, setCampaignLaunchResponse] =
     useState<DpmWaveGatewayResponse | null>(null);
+  const [campaignApprovalDecisionsResponse, setCampaignApprovalDecisionsResponse] =
+    useState<DpmCampaignWorkflowGatewayResponse | null>(null);
+  const [campaignAssignmentActionsResponse, setCampaignAssignmentActionsResponse] =
+    useState<DpmCampaignWorkflowGatewayResponse | null>(null);
+  const [campaignAssignmentTasksResponse, setCampaignAssignmentTasksResponse] =
+    useState<DpmCampaignWorkflowGatewayResponse | null>(null);
+  const [campaignMakerCheckerControlsResponse, setCampaignMakerCheckerControlsResponse] =
+    useState<DpmCampaignWorkflowGatewayResponse | null>(null);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [pendingCampaignLifecycleKey, setPendingCampaignLifecycleKey] =
     useState<string | null>(null);
@@ -119,6 +166,8 @@ export function useDpmWaveCommandCenterActions({
     useState<string | null>(null);
   const [pendingCampaignLaunchKey, setPendingCampaignLaunchKey] =
     useState<string | null>(null);
+  const [pendingCampaignWorkflowCommand, setPendingCampaignWorkflowCommand] =
+    useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [campaignLifecycleError, setCampaignLifecycleError] = useState<string | null>(null);
   const [campaignLaunchHistoryError, setCampaignLaunchHistoryError] =
@@ -126,6 +175,10 @@ export function useDpmWaveCommandCenterActions({
   const [campaignPreviewReadinessError, setCampaignPreviewReadinessError] =
     useState<string | null>(null);
   const [campaignLaunchError, setCampaignLaunchError] = useState<string | null>(null);
+  const [campaignWorkflowCommandError, setCampaignWorkflowCommandError] =
+    useState<string | null>(null);
+  const [campaignWorkflowCommandEvidence, setCampaignWorkflowCommandEvidence] =
+    useState<DpmCampaignWorkflowCommandEvidence | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [autoLoadedWaveId, setAutoLoadedWaveId] = useState<string | null>(null);
   const [selectedCampaignKey, setSelectedCampaignKey] = useState<string | null>(null);
@@ -147,10 +200,11 @@ export function useDpmWaveCommandCenterActions({
     campaignWorkflowBoard,
     campaignAssignmentPlan,
     campaignWorkflowAutomation,
-    campaignApprovalDecisions,
-    campaignAssignmentActions,
-    campaignAssignmentTasks,
-    campaignMakerCheckerControls,
+    campaignApprovalDecisions: campaignApprovalDecisionsResponse ?? campaignApprovalDecisions,
+    campaignAssignmentActions: campaignAssignmentActionsResponse ?? campaignAssignmentActions,
+    campaignAssignmentTasks: campaignAssignmentTasksResponse ?? campaignAssignmentTasks,
+    campaignMakerCheckerControls:
+      campaignMakerCheckerControlsResponse ?? campaignMakerCheckerControls,
   });
   const selectedWaveId = model.selectedWaveId;
   const selectedCampaign =
@@ -382,6 +436,76 @@ export function useDpmWaveCommandCenterActions({
     }
   }
 
+  async function refreshCampaignWorkflowEvidence(row: DpmCampaignDefinitionRow) {
+    const params = {
+      campaignId: row.campaignId,
+      campaignVersion: row.campaignVersion,
+    };
+    const [
+      approvalDecisions,
+      assignmentActions,
+      assignmentTasks,
+      makerCheckerControls,
+    ] = await Promise.all([
+      getDpmCampaignApprovalDecisions(params),
+      getDpmCampaignAssignmentActions(params),
+      getDpmCampaignAssignmentTasks(params),
+      getDpmCampaignMakerCheckerControls(params),
+    ]);
+    setCampaignApprovalDecisionsResponse(approvalDecisions);
+    setCampaignAssignmentActionsResponse(assignmentActions);
+    setCampaignAssignmentTasksResponse(assignmentTasks);
+    setCampaignMakerCheckerControlsResponse(makerCheckerControls);
+  }
+
+  async function recordCampaignWorkflowCommand(command: DpmCampaignWorkflowCommandInput) {
+    if (pendingCampaignWorkflowCommand) {
+      return;
+    }
+    if (!selectedCampaign) {
+      setCampaignWorkflowCommandError("Select a Manage campaign definition before recording workflow evidence.");
+      return;
+    }
+    if (command.commandType === "task_transition" && !command.taskRef) {
+      setCampaignWorkflowCommandError("Task transition requires a Manage task reference.");
+      return;
+    }
+    setPendingCampaignWorkflowCommand(true);
+    setCampaignWorkflowCommandError(null);
+    setCampaignWorkflowCommandEvidence(null);
+    try {
+      const params = {
+        campaignId: selectedCampaign.campaignId,
+        campaignVersion: selectedCampaign.campaignVersion,
+        body: command.body,
+        actorId: readString(command.body.actor_id),
+      };
+      const response =
+        command.commandType === "approval_decision"
+          ? await createDpmCampaignApprovalDecision(params)
+          : command.commandType === "assignment_action"
+            ? await createDpmCampaignAssignmentAction(params)
+            : command.commandType === "assignment_task"
+              ? await createDpmCampaignAssignmentTask(params)
+              : command.commandType === "task_transition"
+                ? await createDpmCampaignAssignmentTaskTransition({
+                    ...params,
+                    taskRef: command.taskRef ?? "",
+                  })
+                : await createDpmCampaignMakerCheckerControl(params);
+      setCampaignWorkflowCommandEvidence(
+        buildCampaignWorkflowCommandEvidence(command.commandType, response)
+      );
+      await refreshCampaignWorkflowEvidence(selectedCampaign);
+    } catch (error) {
+      setCampaignWorkflowCommandError(
+        error instanceof Error ? error.message : "Campaign workflow command failed."
+      );
+    } finally {
+      setPendingCampaignWorkflowCommand(false);
+    }
+  }
+
   return {
     model,
     selectedCampaign,
@@ -392,12 +516,15 @@ export function useDpmWaveCommandCenterActions({
     pendingCampaignPreviewReadinessKey,
     pendingCampaignLaunchPackageKey,
     pendingCampaignLaunchKey,
+    pendingCampaignWorkflowCommand,
     actionError,
     proofPackLoaded: Boolean(proofPackResponse),
     campaignLifecycleError,
     campaignLaunchHistoryError,
     campaignPreviewReadinessError,
     campaignLaunchError,
+    campaignWorkflowCommandError,
+    campaignWorkflowCommandEvidence,
     actionMessage,
     previewRebalance,
     createRebalance,
@@ -412,5 +539,65 @@ export function useDpmWaveCommandCenterActions({
     loadCampaignLaunchHistory,
     checkCampaignLaunchReadiness,
     launchCampaign,
+    recordCampaignWorkflowCommand,
   };
+}
+
+function buildCampaignWorkflowCommandEvidence(
+  commandType: DpmCampaignWorkflowCommandType,
+  response: DpmCampaignWorkflowGatewayResponse
+): DpmCampaignWorkflowCommandEvidence {
+  const data = response.data;
+  return {
+    commandLabel: campaignWorkflowCommandLabel(commandType),
+    evidenceRef:
+      readString(data.evidence_ref) ||
+      readString(data.decision_ref) ||
+      readString(data.action_ref) ||
+      readString(data.task_ref) ||
+      readString(data.control_ref) ||
+      "N/A",
+    correlationId: response.correlation_id,
+    sourceService: response.source_service,
+    upstreamStatus: String(response.upstream_status),
+    contentHash: readString(data.content_hash) || response.supportability?.content_hash || "N/A",
+    reasonCodes: formatList(data.reason_codes),
+    operatingBoundaries: formatList(data.operating_boundaries),
+  };
+}
+
+function campaignWorkflowCommandLabel(commandType: DpmCampaignWorkflowCommandType): string {
+  switch (commandType) {
+    case "approval_decision":
+      return "Approval decision";
+    case "assignment_action":
+      return "Assignment action";
+    case "assignment_task":
+      return "Assignment task";
+    case "task_transition":
+      return "Task transition";
+    case "maker_checker_control":
+      return "Maker-checker control";
+  }
+}
+
+function readString(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+function formatList(value: unknown): string {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  if (!Array.isArray(value)) {
+    return "N/A";
+  }
+  const values = value.filter((item): item is string => typeof item === "string" && item.length > 0);
+  return values.length > 0 ? values.join(", ") : "N/A";
 }

--- a/tests/integration/workbench-page.test.tsx
+++ b/tests/integration/workbench-page.test.tsx
@@ -229,7 +229,7 @@ describe("WorkbenchPage", () => {
     expect(screen.getByRole("heading", { name: "Campaign Workflow Audit" })).toBeInTheDocument();
     expect(screen.getByText("Apple and Tesla holdings review")).toBeInTheDocument();
     expect(screen.getByText("Operating Queue")).toBeInTheDocument();
-    expect(screen.getByText("Assignment Task")).toBeInTheDocument();
+    expect(screen.getAllByText("Assignment Task").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Proposed Changes" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Construction Alternatives" })).not.toBeInTheDocument();
     expect(

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -452,8 +452,18 @@ describe("analytics UI observability metrics", () => {
       ],
       [
         "workbench.manage",
+        "wave-campaign-approval-decisions-create",
+        "dpm.waves.campaign-approval-decisions.create",
+      ],
+      [
+        "workbench.manage",
         "wave-campaign-assignment-actions",
         "dpm.waves.campaign-assignment-actions.list",
+      ],
+      [
+        "workbench.manage",
+        "wave-campaign-assignment-actions-create",
+        "dpm.waves.campaign-assignment-actions.create",
       ],
       [
         "workbench.manage",
@@ -462,8 +472,23 @@ describe("analytics UI observability metrics", () => {
       ],
       [
         "workbench.manage",
+        "wave-campaign-assignment-tasks-create",
+        "dpm.waves.campaign-assignment-tasks.create",
+      ],
+      [
+        "workbench.manage",
+        "wave-campaign-assignment-task-transitions-create",
+        "dpm.waves.campaign-assignment-task-transitions.create",
+      ],
+      [
+        "workbench.manage",
         "wave-campaign-maker-checker-controls",
         "dpm.waves.campaign-maker-checker-controls.list",
+      ],
+      [
+        "workbench.manage",
+        "wave-campaign-maker-checker-controls-create",
+        "dpm.waves.campaign-maker-checker-controls.create",
       ],
       [
         "workbench.manage",

--- a/tests/unit/dpm-campaign-workflow-audit-card.test.tsx
+++ b/tests/unit/dpm-campaign-workflow-audit-card.test.tsx
@@ -1,7 +1,24 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
 import DpmCampaignWorkflowAuditCard from "../../src/features/workbench/components/dpm-campaign-workflow-audit-card";
+import type { DpmCampaignDefinitionRow } from "../../src/features/workbench/dpm-wave-command-center-view-model";
+
+const selectedCampaign: DpmCampaignDefinitionRow = {
+  key: "campaign-holdings-202605:2026.05",
+  campaignId: "campaign-holdings-202605",
+  campaignVersion: "2026.05",
+  displayName: "Holdings campaign",
+  status: "ACTIVE",
+  asOfDate: "2026-05-10",
+  candidateCount: "1",
+  eligibleCandidateCount: "1",
+  eligiblePortfolioTypes: "DISCRETIONARY",
+  governanceState: "GOVERNED",
+  expiryState: "ACTIVE",
+  accessPurpose: "Portfolio review",
+  sourcePosture: "Source-backed",
+};
 
 describe("DpmCampaignWorkflowAuditCard", () => {
   it("renders bounded Manage workflow evidence and omits raw operational claims", () => {
@@ -35,17 +52,91 @@ describe("DpmCampaignWorkflowAuditCard", () => {
             transitionPosture: "ASSIGNED_FOR_REVIEW: OPEN to WAITING_FOR_REVIEW",
           },
         ]}
+        selectedCampaign={selectedCampaign}
+        onRecordWorkflowCommand={vi.fn()}
       />
     );
 
     expect(screen.getByText("Campaign Workflow Audit")).toBeInTheDocument();
     expect(screen.getByText("Operating Queue")).toBeInTheDocument();
-    expect(screen.getByText("Assignment Task")).toBeInTheDocument();
+    expect(screen.getAllByText("Assignment Task").length).toBeGreaterThan(0);
     expect(screen.getByText("sha256:task")).toBeInTheDocument();
     expect(screen.getByText("ASSIGNED_FOR_REVIEW: OPEN to WAITING_FOR_REVIEW")).toBeInTheDocument();
     const rendered = document.body.textContent ?? "";
     expect(rendered).not.toContain("order generated");
     expect(rendered).not.toContain("OMS execution");
     expect(rendered).not.toContain("client contacted");
+  });
+
+  it("keeps command control unavailable until a campaign definition is selected", () => {
+    render(
+      <DpmCampaignWorkflowAuditCard
+        summaryRows={[]}
+        evidenceRows={[]}
+        selectedCampaign={null}
+        onRecordWorkflowCommand={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Select a Manage campaign definition")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Record Workflow Evidence" })).toBeDisabled();
+  });
+
+  it("submits bounded task-transition evidence through the provided Gateway action", async () => {
+    const onRecordWorkflowCommand = vi.fn().mockResolvedValue(undefined);
+    render(
+      <DpmCampaignWorkflowAuditCard
+        summaryRows={[]}
+        evidenceRows={[]}
+        selectedCampaign={selectedCampaign}
+        onRecordWorkflowCommand={onRecordWorkflowCommand}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Command"), {
+      target: { value: "task_transition" },
+    });
+    fireEvent.change(screen.getByLabelText("Task ref"), {
+      target: { value: "task-review-001" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Record Workflow Evidence" }));
+
+    await waitFor(() => expect(onRecordWorkflowCommand).toHaveBeenCalledTimes(1));
+    expect(onRecordWorkflowCommand).toHaveBeenCalledWith({
+      commandType: "task_transition",
+      taskRef: "task-review-001",
+      body: {
+        transition_type: "MARK_SUPPORTABLE",
+        actor_id: expect.any(String),
+      },
+    });
+  });
+
+  it("renders submitting, failure, and Gateway-returned command evidence states", () => {
+    render(
+      <DpmCampaignWorkflowAuditCard
+        summaryRows={[]}
+        evidenceRows={[]}
+        selectedCampaign={selectedCampaign}
+        pendingCommand
+        commandError="Gateway rejected campaign workflow command."
+        commandEvidence={{
+          commandLabel: "Assignment task",
+          evidenceRef: "task-review-001",
+          correlationId: "corr-campaign-command",
+          sourceService: "lotus-manage",
+          upstreamStatus: "201",
+          contentHash: "sha256:task",
+          reasonCodes: "campaign_assignment_task_recorded",
+          operatingBoundaries: "NO_ORDER_GENERATION, NO_OMS_EXECUTION_CLAIM",
+        }}
+        onRecordWorkflowCommand={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Recording" })).toBeDisabled();
+    expect(screen.getByText("Gateway rejected campaign workflow command.")).toBeInTheDocument();
+    expect(screen.getByText("corr-campaign-command")).toBeInTheDocument();
+    expect(screen.getByText("sha256:task")).toBeInTheDocument();
   });
 });

--- a/tests/unit/use-dpm-wave-command-center-actions.test.ts
+++ b/tests/unit/use-dpm-wave-command-center-actions.test.ts
@@ -4,11 +4,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useDpmWaveCommandCenterActions } from "../../src/features/workbench/use-dpm-wave-command-center-actions";
 import {
   approveDpmWave,
+  createDpmCampaignApprovalDecision,
+  createDpmCampaignAssignmentAction,
+  createDpmCampaignAssignmentTask,
+  createDpmCampaignAssignmentTaskTransition,
+  createDpmCampaignMakerCheckerControl,
   createDpmWave,
+  getDpmCampaignApprovalDecisions,
+  getDpmCampaignAssignmentActions,
+  getDpmCampaignAssignmentTasks,
   getDpmCampaignDefinitionLaunchHistory,
   getDpmCampaignDefinitionLaunchPackage,
   getDpmCampaignDefinitionLifecycleEvents,
   getDpmCampaignDefinitionPreviewReadiness,
+  getDpmCampaignMakerCheckerControls,
   getDpmWaveItems,
   getDpmWaveProofPackPosture,
   handoffDpmWave,
@@ -20,16 +29,26 @@ import {
 } from "../../src/features/workbench/dpm-wave-api";
 import type {
   DpmCampaignDefinitionGatewayResponse,
+  DpmCampaignWorkflowGatewayResponse,
   DpmWaveGatewayResponse,
 } from "../../src/features/workbench/types";
 
 vi.mock("../../src/features/workbench/dpm-wave-api", () => ({
   approveDpmWave: vi.fn(),
+  createDpmCampaignApprovalDecision: vi.fn(),
+  createDpmCampaignAssignmentAction: vi.fn(),
+  createDpmCampaignAssignmentTask: vi.fn(),
+  createDpmCampaignAssignmentTaskTransition: vi.fn(),
+  createDpmCampaignMakerCheckerControl: vi.fn(),
   createDpmWave: vi.fn(),
+  getDpmCampaignApprovalDecisions: vi.fn(),
+  getDpmCampaignAssignmentActions: vi.fn(),
+  getDpmCampaignAssignmentTasks: vi.fn(),
   getDpmCampaignDefinitionLaunchHistory: vi.fn(),
   getDpmCampaignDefinitionLaunchPackage: vi.fn(),
   getDpmCampaignDefinitionLifecycleEvents: vi.fn(),
   getDpmCampaignDefinitionPreviewReadiness: vi.fn(),
+  getDpmCampaignMakerCheckerControls: vi.fn(),
   getDpmWaveItems: vi.fn(),
   getDpmWaveProofPackPosture: vi.fn(),
   handoffDpmWave: vi.fn(),
@@ -223,6 +242,45 @@ const campaignLaunchResponse: DpmWaveGatewayResponse = {
   },
 };
 
+const campaignWorkflowCommandResponse: DpmCampaignWorkflowGatewayResponse = {
+  correlation_id: "corr-campaign-command",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 201,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:campaign-workflow",
+    state: "READY",
+    reason_codes: ["campaign_assignment_task_transition_recorded"],
+  },
+  data: {
+    task_ref: "task-review-001",
+    transition_type: "MARK_SUPPORTABLE",
+    content_hash: "sha256:task-transition",
+    reason_codes: ["campaign_assignment_task_transition_recorded"],
+    operating_boundaries: ["NO_ORDER_GENERATION", "NO_OMS_EXECUTION_CLAIM"],
+  },
+};
+
+const campaignWorkflowEvidenceResponse: DpmCampaignWorkflowGatewayResponse = {
+  ...campaignWorkflowCommandResponse,
+  upstream_status: 200,
+  data: {
+    items: [
+      {
+        task_ref: "task-review-001",
+        status: "SUPPORTABLE",
+        content_hash: "sha256:task-transition",
+        reason_codes: ["campaign_assignment_task_transition_recorded"],
+      },
+    ],
+    count: 1,
+    total_count: 1,
+    limit: 10,
+    offset: 0,
+  },
+};
+
 function renderActions() {
   return renderHook(() =>
     useDpmWaveCommandCenterActions({
@@ -241,6 +299,21 @@ describe("useDpmWaveCommandCenterActions", () => {
     vi.mocked(getDpmCampaignDefinitionPreviewReadiness).mockResolvedValue(previewReadinessResponse);
     vi.mocked(getDpmCampaignDefinitionLaunchPackage).mockResolvedValue(launchPackageResponse);
     vi.mocked(launchDpmCampaignDefinition).mockResolvedValue(campaignLaunchResponse);
+    vi.mocked(createDpmCampaignApprovalDecision).mockResolvedValue(campaignWorkflowCommandResponse);
+    vi.mocked(createDpmCampaignAssignmentAction).mockResolvedValue(campaignWorkflowCommandResponse);
+    vi.mocked(createDpmCampaignAssignmentTask).mockResolvedValue(campaignWorkflowCommandResponse);
+    vi.mocked(createDpmCampaignAssignmentTaskTransition).mockResolvedValue(
+      campaignWorkflowCommandResponse
+    );
+    vi.mocked(createDpmCampaignMakerCheckerControl).mockResolvedValue(
+      campaignWorkflowCommandResponse
+    );
+    vi.mocked(getDpmCampaignApprovalDecisions).mockResolvedValue(campaignWorkflowEvidenceResponse);
+    vi.mocked(getDpmCampaignAssignmentActions).mockResolvedValue(campaignWorkflowEvidenceResponse);
+    vi.mocked(getDpmCampaignAssignmentTasks).mockResolvedValue(campaignWorkflowEvidenceResponse);
+    vi.mocked(getDpmCampaignMakerCheckerControls).mockResolvedValue(
+      campaignWorkflowEvidenceResponse
+    );
   });
 
   afterEach(() => {
@@ -377,5 +450,80 @@ describe("useDpmWaveCommandCenterActions", () => {
       await result.current.launchCampaign(result.current.selectedCampaign!);
     });
     expect(launchDpmCampaignDefinition).not.toHaveBeenCalled();
+  });
+
+  it("records campaign workflow commands and refreshes Manage-owned evidence lists", async () => {
+    const { result } = renderActions();
+
+    await waitFor(() => expect(result.current.selectedCampaign).not.toBeNull());
+    await act(async () => {
+      await result.current.recordCampaignWorkflowCommand({
+        commandType: "task_transition",
+        taskRef: "task-review-001",
+        body: {
+          transition_type: "MARK_SUPPORTABLE",
+          actor_id: "pm_sg_1",
+        },
+      });
+    });
+
+    expect(createDpmCampaignAssignmentTaskTransition).toHaveBeenCalledWith({
+      campaignId: "campaign-holdings-202605",
+      campaignVersion: "2026.05",
+      taskRef: "task-review-001",
+      actorId: "pm_sg_1",
+      body: {
+        transition_type: "MARK_SUPPORTABLE",
+        actor_id: "pm_sg_1",
+      },
+    });
+    expect(getDpmCampaignApprovalDecisions).toHaveBeenCalledWith({
+      campaignId: "campaign-holdings-202605",
+      campaignVersion: "2026.05",
+    });
+    expect(getDpmCampaignAssignmentActions).toHaveBeenCalledWith({
+      campaignId: "campaign-holdings-202605",
+      campaignVersion: "2026.05",
+    });
+    expect(getDpmCampaignAssignmentTasks).toHaveBeenCalledWith({
+      campaignId: "campaign-holdings-202605",
+      campaignVersion: "2026.05",
+    });
+    expect(getDpmCampaignMakerCheckerControls).toHaveBeenCalledWith({
+      campaignId: "campaign-holdings-202605",
+      campaignVersion: "2026.05",
+    });
+    expect(result.current.campaignWorkflowCommandEvidence).toMatchObject({
+      evidenceRef: "task-review-001",
+      correlationId: "corr-campaign-command",
+      sourceService: "lotus-manage",
+      contentHash: "sha256:task-transition",
+    });
+    expect(result.current.model.campaignWorkflowEvidenceRows[0]?.evidenceRef).toBe(
+      "task-review-001"
+    );
+  });
+
+  it("keeps campaign workflow command failures bounded and does not refresh local evidence", async () => {
+    vi.mocked(createDpmCampaignAssignmentTask).mockRejectedValueOnce(
+      new Error("Failed to fetch create DPM campaign assignment task (502)")
+    );
+    const { result } = renderActions();
+
+    await waitFor(() => expect(result.current.selectedCampaign).not.toBeNull());
+    await act(async () => {
+      await result.current.recordCampaignWorkflowCommand({
+        commandType: "assignment_task",
+        body: {
+          task_ref: "task-review-001",
+          actor_id: "pm_sg_1",
+        },
+      });
+    });
+
+    expect(result.current.campaignWorkflowCommandError).toBe(
+      "Failed to fetch create DPM campaign assignment task (502)"
+    );
+    expect(getDpmCampaignAssignmentTasks).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -7,6 +7,11 @@ import {
   buildDpmPmOperatingQualityReviewActionCorrelationId,
   buildDpmPmOperatingQualitySummaryInvocationCorrelationId,
   calculateCompositePerformanceTwrClient,
+  createDpmCampaignApprovalDecision,
+  createDpmCampaignAssignmentAction,
+  createDpmCampaignAssignmentTask,
+  createDpmCampaignAssignmentTaskTransition,
+  createDpmCampaignMakerCheckerControl,
   createDpmPmOperatingQualityFairnessAnalysis,
   createDpmPmOperatingQualityReviewAction,
   createDpmPmOperatingQualitySummaryInvocation,
@@ -2391,6 +2396,103 @@ describe("workbench api", () => {
     expect(metricEventsJson).not.toContain("campaign-holdings-202605");
     expect(metricEventsJson).not.toContain("corr-campaign-workflow-audit");
     expect(metricEventsJson).not.toContain("task-sensitive-001");
+  });
+
+  it("records DPM campaign workflow evidence through Gateway mutation helpers without leaking ids into metrics", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr-campaign-workflow-command",
+            contract_version: "v1",
+            source_service: "lotus-manage",
+            upstream_status: 201,
+            supportability: {
+              source_service: "lotus-manage",
+              authority: "lotus-manage:campaign-workflow",
+              state: "READY",
+              reason_codes: ["campaign_workflow_command_recorded"],
+            },
+            data: {
+              task_ref: "task-sensitive-001",
+              content_hash: "sha256:workflow-command",
+              reason_codes: ["campaign_workflow_command_recorded"],
+              operating_boundaries: ["NO_ORDER_GENERATION", "NO_OMS_EXECUTION_CLAIM"],
+              request_body: init?.body,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await createDpmCampaignApprovalDecision({
+      campaignId: "campaign-holdings-202605",
+      campaignVersion: "2026.05",
+      actorId: "pm_sg_1",
+      body: { decision_ref: "decision-sensitive-001", actor_id: "pm_sg_1" },
+    });
+    await createDpmCampaignAssignmentAction({
+      campaignId: "campaign-holdings-202605",
+      campaignVersion: "2026.05",
+      body: { action_ref: "action-sensitive-001", actor_id: "pm_sg_1" },
+    });
+    await createDpmCampaignAssignmentTask({
+      campaignId: "campaign-holdings-202605",
+      campaignVersion: "2026.05",
+      body: { task_ref: "task-sensitive-001", actor_id: "pm_sg_1" },
+    });
+    await createDpmCampaignAssignmentTaskTransition({
+      campaignId: "campaign-holdings-202605",
+      campaignVersion: "2026.05",
+      taskRef: "task-sensitive-001",
+      body: { transition_type: "MARK_SUPPORTABLE", actor_id: "pm_sg_1" },
+    });
+    await createDpmCampaignMakerCheckerControl({
+      campaignId: "campaign-holdings-202605",
+      campaignVersion: "2026.05",
+      body: { control_ref: "control-sensitive-001", actor_id: "pm_sg_1" },
+    });
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const calls = fetchMock.mock.calls.map((call) => ({
+      url: call[0].toString(),
+      body: JSON.parse(String(call[1]?.body)),
+    }));
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          url: expect.stringContaining("/approval-decisions"),
+          body: { body: { decision_ref: "decision-sensitive-001", actor_id: "pm_sg_1" } },
+        }),
+        expect.objectContaining({
+          url: expect.stringContaining("/assignment-actions"),
+          body: { body: { action_ref: "action-sensitive-001", actor_id: "pm_sg_1" } },
+        }),
+        expect.objectContaining({
+          url: expect.stringContaining("/assignment-tasks"),
+          body: { body: { task_ref: "task-sensitive-001", actor_id: "pm_sg_1" } },
+        }),
+        expect.objectContaining({
+          url: expect.stringContaining("/assignment-tasks/task-sensitive-001/transitions"),
+          body: {
+            body: { transition_type: "MARK_SUPPORTABLE", actor_id: "pm_sg_1" },
+          },
+        }),
+        expect.objectContaining({
+          url: expect.stringContaining("/maker-checker-controls"),
+          body: { body: { control_ref: "control-sensitive-001", actor_id: "pm_sg_1" } },
+        }),
+      ])
+    );
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("wave-campaign-approval-decisions-create");
+    expect(metricEventsJson).toContain("wave-campaign-assignment-task-transitions-create");
+    expect(metricEventsJson).toContain("wave-campaign-maker-checker-controls-create");
+    expect(metricEventsJson).not.toContain("campaign-holdings-202605");
+    expect(metricEventsJson).not.toContain("task-sensitive-001");
+    expect(metricEventsJson).not.toContain("corr-campaign-workflow-command");
   });
 
   it("loads DPM campaign-definition lifecycle and launch-history evidence through the Gateway BFF without leaking campaign identifiers into metrics", async () => {

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -77,7 +77,7 @@ promote dormant labels into product ownership just because historical route file
   and exposes
   `/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/launch`
   only when the launch package is `READY`, preserving durable wave response and idempotency evidence
-  without recalculating membership or readiness. It also renders read-only campaign workflow audit
+  without recalculating membership or readiness. It also renders campaign workflow audit
   posture from
   `/api/v1/dpm/command-center/waves/campaign-operating-queue`,
   `/api/v1/dpm/command-center/waves/campaign-approval-inbox`,
@@ -87,10 +87,15 @@ promote dormant labels into product ownership just because historical route file
   `/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/approval-decisions`,
   `/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-actions`,
   `/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-tasks`,
+  `/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-tasks/{task_ref}/transitions`,
   and
   `/api/v1/dpm/command-center/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/maker-checker-controls`,
   preserving source refs, count/page metadata, reason codes, content hashes, task-transition
-  posture, and operating boundaries without mutating assignment or maker-checker state. It
+  posture, and operating boundaries. Selected-campaign workflow controls can record bounded
+  Gateway-backed approval-decision, assignment-action, assignment-task, assignment-task
+  transition, and maker-checker-control evidence, then refresh the source-owned evidence lists
+  and show Gateway-returned correlation/source/upstream/content-hash evidence without browser-owned
+  workflow state. It
   renders manage-owned wave lifecycle, item state, source-readiness state, supportability,
   report-input refs, proof-pack refs, handoff refs, lotus-ai workflow-pack run posture, and
   `external_execution_claimed` posture without direct `lotus-manage` or `lotus-ai` calls, local


### PR DESCRIPTION
## Summary
- add Workbench Gateway mutation helpers for Manage campaign workflow approval-decision, assignment-action, assignment-task, task-transition, and maker-checker evidence records
- add selected-campaign workflow evidence controls that remain disabled without a Manage campaign, submit bounded source-contract fields, refresh source-owned evidence lists after success, and render Gateway-returned correlation/source/hash evidence
- update RFC/API-surface wiki source to mark the realized bounded workflow command controls while preserving no OMS/order/client-contact/external-orchestration claims

## Validation
- npm test -- tests/unit/workbench-api.test.ts tests/unit/use-dpm-wave-command-center-actions.test.ts tests/unit/dpm-campaign-workflow-audit-card.test.tsx
- npm test -- tests/unit/dpm-campaign-definitions-section.test.tsx tests/unit/dpm-wave-command-center-panel.test.tsx
- npm test -- tests/integration/workbench-page.test.tsx (passes; existing unrelated ConstructionAlternativesPanel act warning observed)
- npm run typecheck
- npm run lint
- npm run build
- git diff --check
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench reports expected API-Surface.md drift because this PR changes repo-authored wiki source; publish required after merge

## Boundaries
- Workbench consumes only Gateway routes
- no browser-owned campaign readiness, assignment state, maker-checker state, OMS/order/execution/fill/settlement/client-contact, external workflow orchestration, global portfolio-universe discovery, or broader cross-app event-search truth introduced