### PR TITLE
Render DPM source lineage facets

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -76,13 +76,19 @@ Current repository posture:
     supportability, objective/constraint traces, and selected-alternative state, and must not build
     stateless source bundles, optimizer logic, prices, or selection truth in the browser.
 11. Manage `mode=memory` renders the RFC40-WTBD-010 portfolio-memory panel through Gateway
-    `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`, preserving manage-owned
-    timeline order, event type counts, source systems, source refs, artifact refs, reason codes,
-    supportability state, and content hash without reconstructing timeline nodes locally.
+    `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory` and bounded source-family
+    posture through Gateway `/api/v1/dpm/command-center/portfolio-memory/search`, preserving
+    manage-owned timeline order, event type counts, source systems, source-system/source-type
+    facets, source refs, artifact refs, applied filters, reason codes, supportability state,
+    support boundary, and content hash without reconstructing timeline nodes locally, querying
+    source-owner stores, discovering the global portfolio universe, or running cross-app
+    source-event search.
 12. Manage `mode=reviews` renders the RFC-0042 DPM outcome-review panel from Gateway
     `/api/v1/dpm/command-center/outcome-reviews*`, preserving manage-owned expected-versus-realized
-    dimensions, source lineage, supportability, report-input posture, AI-evidence posture, and
-    Gateway-backed governed AI narrative requests without client-side outcome calculation.
+    dimensions, source lineage, source-owner/source-type facets, applied source-lineage filters,
+    support boundary, supportability, report-input posture, AI-evidence posture, and
+    Gateway-backed governed AI narrative requests without client-side outcome calculation or
+    source-owner store querying.
     Manage-owned `client_communication_boundary` posture is rendered as a no-client-communication
     boundary when present; Workbench must not create client messaging, approval, delivery, or
     communication-audit workflows from outcome-review evidence.

--- a/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
+++ b/docs/rfcs/RFC-0098-dpm-mandate-command-center-experience.md
@@ -237,16 +237,22 @@ The implemented panel:
 
 1. consumes only Gateway
    `GET /api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`,
-2. renders manage-owned supportability state, event count, event type counts, source systems,
-   reason codes, and content hash,
-3. preserves upstream event order, event type, event time, source refs, artifact refs, and reason
+2. consumes only Gateway `GET /api/v1/dpm/command-center/portfolio-memory/search` for bounded
+   Manage-local source-family posture over persisted memory lineage,
+3. renders manage-owned supportability state, event count, event type counts, source systems,
+   source-system/source-type facets, support boundary, reason codes, and content hash,
+4. preserves upstream event order, event type, event time, source refs, artifact refs, and reason
    codes,
-4. shows empty, partial, degraded, unsupported, unavailable, and error states explicitly,
-5. emits bounded `dpm.portfolio-memory.get` observability without portfolio ids, event ids, content
-   hashes, source refs, request payloads, response payloads, or screen content as metric labels,
-6. must not call `lotus-manage` directly,
-7. must not reconstruct timeline nodes from proof-pack, wave, outcome-review, report, archive, or
-   AI responses.
+5. shows empty, partial, degraded, unsupported, unavailable, and error states explicitly,
+6. emits bounded `dpm.portfolio-memory.get` and `dpm.portfolio-memory.search` observability without
+   portfolio ids, event ids, source ids, content hashes, source refs, request payloads, response
+   payloads, or screen content as metric labels,
+7. must not call `lotus-manage` directly,
+8. must not reconstruct timeline nodes from proof-pack, wave, outcome-review, report, archive, or
+   AI responses,
+9. must not query source-owner stores, discover the global portfolio universe, run cross-app
+   source-event search, or claim OMS execution, fills, settlement, or client communication
+   workflow.
 
 This panel is intentionally read-only in the current slice. Dedicated timeline filters, event
 detail drawers, retention/audit policy controls, cross-app lifecycle export, and client-demo
@@ -554,7 +560,9 @@ Implementation note as of 2026-05-05: the first RFC-0042 outcome-review realizat
 bounded analytics UI observability surfaces, deterministic view-model normalization, and a
 portfolio-linked panel that renders manage-owned review state, dimension rows, lineage rows,
 snapshot hashes, supportability reasons, blocked actions, report handoff posture, and
-Gateway-backed governed AI narrative request posture. Workbench does not call `lotus-ai` or
+Gateway-backed governed AI narrative request posture. Workbench now also renders Manage-published
+applied source-lineage filters, source-owner counts, source-type counts, and support boundary in a
+read-only posture. Workbench does not call `lotus-ai` or
 construct prompts; the narrative action uses Gateway
 `POST /api/v1/dpm/command-center/outcome-reviews/{outcome_review_id}/ai-narrative`, which composes
 manage-owned AI evidence with `lotus-ai` workflow-pack execution. Dedicated `/dpm/outcomes`

--- a/src/features/analytics-observability/metrics.ts
+++ b/src/features/analytics-observability/metrics.ts
@@ -186,6 +186,11 @@ export const WORKBENCH_ANALYTICS_UI_OBSERVED_SURFACES = [
   },
   {
     route: "workbench.manage",
+    panel: "portfolio-memory",
+    operation: "dpm.portfolio-memory.search",
+  },
+  {
+    route: "workbench.manage",
     panel: "outcome-review-list",
     operation: "dpm.outcome-reviews.list",
   },

--- a/src/features/workbench/components/outcome-review-panel.tsx
+++ b/src/features/workbench/components/outcome-review-panel.tsx
@@ -59,6 +59,7 @@ export default function OutcomeReviewPanel({ portfolioId, response, errorMessage
           items={model.items}
           primaryReview={primaryReview}
           clientCommunicationBoundary={clientCommunicationBoundary}
+          sourceBoundary={model.sourceBoundary}
           evidencePackHref={evidencePackHref}
           readyEvidenceCount={readyEvidenceCount}
           sourceEvidenceStatus={sourceEvidenceStatus}

--- a/src/features/workbench/components/outcome-review-source-lineage-card.tsx
+++ b/src/features/workbench/components/outcome-review-source-lineage-card.tsx
@@ -1,0 +1,73 @@
+import { SemanticBadge } from "@/design-system";
+import type { OutcomeReviewSourceBoundary } from "@/features/workbench/outcome-review-view-model";
+
+type Props = {
+  boundary: OutcomeReviewSourceBoundary;
+};
+
+export default function OutcomeReviewSourceLineageCard({ boundary }: Props) {
+  const hasFacets =
+    boundary.sourceOwnerFacets.length > 0 ||
+    boundary.sourceTypeFacets.length > 0 ||
+    boundary.supportBoundary.length > 0 ||
+    boundary.appliedFilters.length > 0;
+  if (!hasFacets) {
+    return null;
+  }
+
+  return (
+    <div className="outcome-review-actions-card">
+      <div className="outcome-review-card-header">
+        <div>
+          <span>Source Lineage</span>
+          <strong>Persisted Evidence Facets</strong>
+        </div>
+        <SemanticBadge tone="default">Manage-local</SemanticBadge>
+      </div>
+
+      <FacetGroup title="Source owners" values={boundary.sourceOwnerFacets} />
+      <FacetGroup title="Source types" values={boundary.sourceTypeFacets} />
+      <TextGroup title="Applied filters" values={boundary.appliedFilters} />
+      <TextGroup title="Support boundary" values={boundary.supportBoundary} />
+    </div>
+  );
+}
+
+function FacetGroup({
+  title,
+  values,
+}: {
+  title: string;
+  values: { key: string; label: string; count: string }[];
+}) {
+  if (values.length === 0) {
+    return null;
+  }
+  return (
+    <div className="outcome-review-action-stack">
+      <span className="outcome-review-muted-label">{title}</span>
+      {values.map((value) => (
+        <div className="outcome-review-action-item" key={value.key}>
+          <span>{value.label}</span>
+          <strong>{value.count}</strong>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TextGroup({ title, values }: { title: string; values: string[] }) {
+  if (values.length === 0) {
+    return null;
+  }
+  return (
+    <div className="outcome-review-action-stack">
+      <span className="outcome-review-muted-label">{title}</span>
+      {values.slice(0, 6).map((value) => (
+        <div className="outcome-review-action-item" key={`${title}-${value}`}>
+          <span>{value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/workbench/components/outcome-review-workspace.tsx
+++ b/src/features/workbench/components/outcome-review-workspace.tsx
@@ -3,16 +3,19 @@
 import type {
   OutcomeReviewClientCommunicationBoundaryView,
   OutcomeReviewListItem,
+  OutcomeReviewSourceBoundary,
 } from "@/features/workbench/outcome-review-view-model";
 import OutcomeReviewActionsCard from "./outcome-review-actions-card";
 import OutcomeReviewDetailPanel from "./outcome-review-detail-panel";
 import OutcomeReviewReadinessBand from "./outcome-review-readiness-band";
+import OutcomeReviewSourceLineageCard from "./outcome-review-source-lineage-card";
 import OutcomeReviewTimelineCard from "./outcome-review-timeline-card";
 
 type Props = {
   items: OutcomeReviewListItem[];
   primaryReview: OutcomeReviewListItem;
   clientCommunicationBoundary: OutcomeReviewClientCommunicationBoundaryView | null;
+  sourceBoundary?: OutcomeReviewSourceBoundary;
   evidencePackHref: string;
   readyEvidenceCount: number;
   sourceEvidenceStatus: string;
@@ -28,6 +31,12 @@ export default function OutcomeReviewWorkspace({
   items,
   primaryReview,
   clientCommunicationBoundary,
+  sourceBoundary = {
+    appliedFilters: [],
+    supportBoundary: [],
+    sourceOwnerFacets: [],
+    sourceTypeFacets: [],
+  },
   evidencePackHref,
   readyEvidenceCount,
   sourceEvidenceStatus,
@@ -57,6 +66,8 @@ export default function OutcomeReviewWorkspace({
           aiNarrativePending={aiNarrativePending}
           onRequestAiNarrative={onRequestAiNarrative}
         />
+
+        <OutcomeReviewSourceLineageCard boundary={sourceBoundary} />
       </div>
 
       <OutcomeReviewDetailPanel

--- a/src/features/workbench/components/portfolio-memory-panel.tsx
+++ b/src/features/workbench/components/portfolio-memory-panel.tsx
@@ -29,11 +29,18 @@ import PortfolioMemoryTimelineCard from "@/features/workbench/components/portfol
 
 type Props = {
   response: DpmPortfolioMemoryGatewayResponse | null;
+  searchResponse?: DpmPortfolioMemoryGatewayResponse | null;
   errorMessage?: string | null;
+  sourceSearchErrorMessage?: string | null;
 };
 
-export default function PortfolioMemoryPanel({ response, errorMessage = null }: Props) {
-  const model = buildPortfolioMemoryPanelModel(response);
+export default function PortfolioMemoryPanel({
+  response,
+  searchResponse = null,
+  errorMessage = null,
+  sourceSearchErrorMessage = null,
+}: Props) {
+  const model = buildPortfolioMemoryPanelModel(response, searchResponse);
   const [activeEventType, setActiveEventType] = useState<string>("ALL");
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const filteredEvents = useMemo(
@@ -88,6 +95,25 @@ export default function PortfolioMemoryPanel({ response, errorMessage = null }: 
               {formatBusinessReason(reason)}
             </SemanticBadge>
           ))}
+        </div>
+      ) : null}
+
+      {model.sourceFacetRows.length > 0 || model.sourceBoundaryRows.length > 0 ? (
+        <div className="portfolio-memory-status-strip" aria-label="Portfolio memory source facets">
+          {model.sourceFacetRows.slice(0, 4).map((row) => (
+            <MetricRow
+              key={row.key}
+              label={row.family === "system" ? "Source Owner" : "Source Type"}
+              value={`${row.label} (${row.count})`}
+            />
+          ))}
+          {model.sourceBoundaryRows.slice(0, 2).map((boundary) => (
+            <MetricRow key={boundary} label="Search Boundary" value={boundary} />
+          ))}
+        </div>
+      ) : sourceSearchErrorMessage ? (
+        <div className="portfolio-memory-reason-row">
+          <SemanticBadge tone="warn">Source-family posture unavailable</SemanticBadge>
         </div>
       ) : null}
 

--- a/src/features/workbench/dpm-command-center-api.ts
+++ b/src/features/workbench/dpm-command-center-api.ts
@@ -237,3 +237,46 @@ export async function getDpmPortfolioMemory(params: {
       )
   );
 }
+
+export async function searchDpmPortfolioMemory(params: {
+  portfolioIds?: string[];
+  eventType?: string;
+  supportabilityState?: string;
+  sourceSystem?: string;
+  sourceType?: string;
+  limit?: number;
+  offset?: number;
+  sourceScanLimit?: number;
+}): Promise<DpmPortfolioMemoryGatewayResponse> {
+  const query = new URLSearchParams();
+  for (const portfolioId of params.portfolioIds ?? []) {
+    query.append("portfolio_ids", portfolioId);
+  }
+  if (params.eventType) {
+    query.set("event_type", params.eventType);
+  }
+  if (params.supportabilityState) {
+    query.set("supportability_state", params.supportabilityState);
+  }
+  if (params.sourceSystem) {
+    query.set("source_system", params.sourceSystem);
+  }
+  if (params.sourceType) {
+    query.set("source_type", params.sourceType);
+  }
+  query.set("limit", String(params.limit ?? 10));
+  query.set("offset", String(params.offset ?? 0));
+  if (typeof params.sourceScanLimit === "number") {
+    query.set("source_scan_limit", String(params.sourceScanLimit));
+  }
+  return await observeWorkbenchResource(
+    "dpm.portfolio-memory.search",
+    async () =>
+      await fetchWorkbenchResource<DpmPortfolioMemoryGatewayResponse>(
+        "server",
+        "/dpm/command-center/portfolio-memory/search",
+        "DPM portfolio memory search",
+        query
+      )
+  );
+}

--- a/src/features/workbench/manage-workspace-data.ts
+++ b/src/features/workbench/manage-workspace-data.ts
@@ -26,6 +26,7 @@ import {
   listDpmPmOperatingQualityScoreRuns,
   listDpmPmOperatingQualitySummaryInvocations,
   listDpmWaves,
+  searchDpmPortfolioMemory,
 } from "@/features/workbench/api";
 import { getPortfolio360 } from "@/features/workbench/workbench-core-api";
 
@@ -37,7 +38,9 @@ export type ManageWorkspaceData = {
   mandateHealth: Awaited<ReturnType<typeof getDpmMandateHealth>> | null;
   commandCenterError: string | null;
   portfolioMemory: Awaited<ReturnType<typeof getDpmPortfolioMemory>> | null;
+  portfolioMemorySearch: Awaited<ReturnType<typeof searchDpmPortfolioMemory>> | null;
   portfolioMemoryError: string | null;
+  portfolioMemorySearchError: string | null;
   pmOperatingQualityPolicies: Awaited<ReturnType<typeof listDpmPmOperatingQualityPolicies>> | null;
   pmOperatingQualityPoliciesError: string | null;
   pmOperatingQualityScoreRuns: Awaited<ReturnType<typeof listDpmPmOperatingQualityScoreRuns>> | null;
@@ -105,6 +108,7 @@ export async function loadManageWorkspaceData(
     exceptionsResult,
     mandateResult,
     memoryResult,
+    memorySearchResult,
     wavesResult,
     campaignDefinitionsResult,
     campaignDiscoveryResult,
@@ -124,6 +128,7 @@ export async function loadManageWorkspaceData(
     getDpmCommandCenterExceptions({ state: "ACTIVE", limit: 25 }),
     getDpmMandateByPortfolio(portfolioId),
     getDpmPortfolioMemory({ portfolioId, limit: 100 }),
+    searchDpmPortfolioMemory({ portfolioIds: [portfolioId], limit: 10, sourceScanLimit: 250 }),
     listDpmWaves({ triggerType: "EXPLICIT_PORTFOLIO_LIST", limit: 10 }),
     listDpmCampaignDefinitions({ campaignStatus: "ACTIVE", limit: 10 }),
     listDpmCampaignDiscovery({ campaignStatus: "ACTIVE", limit: 10 }),
@@ -246,9 +251,14 @@ export async function loadManageWorkspaceData(
       "Mandate readiness is temporarily unavailable."
     ),
     portfolioMemory: readSettledValue(memoryResult),
+    portfolioMemorySearch: readSettledValue(memorySearchResult),
     portfolioMemoryError: readSettledError(
       memoryResult,
       "Portfolio-memory endpoint unavailable."
+    ),
+    portfolioMemorySearchError: readSettledError(
+      memorySearchResult,
+      "Portfolio-memory source-family search endpoint unavailable."
     ),
     pmOperatingQualityPolicies: readSettledValue(pmQualityPoliciesResult),
     pmOperatingQualityPoliciesError: readSettledError(

--- a/src/features/workbench/manage-workspace.tsx
+++ b/src/features/workbench/manage-workspace.tsx
@@ -174,7 +174,9 @@ function renderManageMode(
       return (
         <PortfolioMemoryPanel
           response={data.portfolioMemory}
+          searchResponse={data.portfolioMemorySearch}
           errorMessage={data.portfolioMemoryError}
+          sourceSearchErrorMessage={data.portfolioMemorySearchError}
         />
       );
     case "quality":

--- a/src/features/workbench/outcome-review-api.ts
+++ b/src/features/workbench/outcome-review-api.ts
@@ -16,7 +16,11 @@ import type {
 export async function getDpmOutcomeReviews(params: {
   portfolioId: string;
   state?: string;
+  sourceSystem?: string;
+  sourceType?: string;
+  sourceScanLimit?: number;
   limit?: number;
+  offset?: number;
   cursor?: string;
 }): Promise<DpmOutcomeReviewGatewayResponse> {
   const query = new URLSearchParams();
@@ -24,6 +28,18 @@ export async function getDpmOutcomeReviews(params: {
   query.set("limit", String(params.limit ?? 10));
   if (params.state) {
     query.set("state", params.state);
+  }
+  if (params.sourceSystem) {
+    query.set("source_system", params.sourceSystem);
+  }
+  if (params.sourceType) {
+    query.set("source_type", params.sourceType);
+  }
+  if (typeof params.sourceScanLimit === "number") {
+    query.set("source_scan_limit", String(params.sourceScanLimit));
+  }
+  if (typeof params.offset === "number") {
+    query.set("offset", String(params.offset));
   }
   if (params.cursor) {
     query.set("cursor", params.cursor);

--- a/src/features/workbench/outcome-review-view-model.ts
+++ b/src/features/workbench/outcome-review-view-model.ts
@@ -21,9 +21,24 @@ export type OutcomeReviewDimensionRow = {
 export type OutcomeReviewLineageRow = {
   key: string;
   source: string;
+  sourceType?: string;
   reference: string;
   freshness: string;
   hash: string;
+};
+
+export type OutcomeReviewSourceFacetRow = {
+  key: string;
+  label: string;
+  count: string;
+  family: "owner" | "type";
+};
+
+export type OutcomeReviewSourceBoundary = {
+  appliedFilters: string[];
+  supportBoundary: string[];
+  sourceOwnerFacets: OutcomeReviewSourceFacetRow[];
+  sourceTypeFacets: OutcomeReviewSourceFacetRow[];
 };
 
 export type OutcomeReviewClientCommunicationBoundaryView = {
@@ -75,6 +90,7 @@ export type OutcomeReviewPanelModel = {
   sourceService: string;
   authority: string;
   correlationId: string;
+  sourceBoundary?: OutcomeReviewSourceBoundary;
   items: OutcomeReviewListItem[];
 };
 
@@ -91,6 +107,7 @@ export function buildOutcomeReviewPanelModel(
       sourceService: "lotus-gateway",
       authority: "lotus-manage:RFC-0042",
       correlationId: "N/A",
+      sourceBoundary: emptySourceBoundary(),
       items: [],
     };
   }
@@ -112,6 +129,7 @@ export function buildOutcomeReviewPanelModel(
     sourceService: response.supportability.source_service || response.source_service,
     authority: response.supportability.authority,
     correlationId: response.correlation_id,
+    sourceBoundary: buildSourceBoundary(response),
     items,
   };
 }
@@ -252,6 +270,7 @@ function buildLineageRow(record: Record<string, unknown>, index: number): Outcom
   return {
     key: `${source}-${reference}-${index}`,
     source,
+    sourceType: readString(record, "source_type") || readString(record, "product_name") || "N/A",
     reference,
     freshness:
       readString(record, "freshness") ||
@@ -264,6 +283,65 @@ function buildLineageRow(record: Record<string, unknown>, index: number): Outcom
       readString(record, "content_hash") ||
       "N/A",
   };
+}
+
+function buildSourceBoundary(
+  response: DpmOutcomeReviewGatewayResponse,
+): OutcomeReviewSourceBoundary {
+  return {
+    appliedFilters: formatObjectEntries(response.supportability.applied_filters),
+    supportBoundary: formatObjectEntries(response.supportability.support_boundary),
+    sourceOwnerFacets: buildFacetRows(response.supportability.source_owner_counts, "owner"),
+    sourceTypeFacets: buildFacetRows(response.supportability.source_type_counts, "type"),
+  };
+}
+
+function emptySourceBoundary(): OutcomeReviewSourceBoundary {
+  return {
+    appliedFilters: [],
+    supportBoundary: [],
+    sourceOwnerFacets: [],
+    sourceTypeFacets: [],
+  };
+}
+
+function buildFacetRows(
+  counts: Record<string, number> | undefined,
+  family: "owner" | "type",
+): OutcomeReviewSourceFacetRow[] {
+  return Object.entries(counts ?? {})
+    .sort(([, leftCount], [, rightCount]) => rightCount - leftCount)
+    .slice(0, 6)
+    .map(([label, count]) => ({
+      key: `${family}-${label}`,
+      label,
+      count: count.toLocaleString(),
+      family,
+    }));
+}
+
+function formatObjectEntries(value: Record<string, unknown> | undefined): string[] {
+  return Object.entries(value ?? {})
+    .filter(([, entryValue]) => entryValue !== null && entryValue !== undefined && entryValue !== "")
+    .map(([key, entryValue]) => `${labelFromKey(key)}: ${formatFilterValue(entryValue)}`);
+}
+
+function formatFilterValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item)).join(", ");
+  }
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+  return String(value);
+}
+
+function labelFromKey(value: string): string {
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 }
 
 function extractOutcomeReviewRecords(data: Record<string, unknown>): Record<string, unknown>[] {

--- a/src/features/workbench/portfolio-memory-view-model.ts
+++ b/src/features/workbench/portfolio-memory-view-model.ts
@@ -44,6 +44,13 @@ export type PortfolioMemoryDetailMetric = {
   value: string;
 };
 
+export type PortfolioMemorySourceFacetRow = {
+  key: string;
+  label: string;
+  count: string;
+  family: "system" | "type";
+};
+
 export type PortfolioMemoryPanelModel = {
   state: PortfolioMemoryPanelState;
   supportabilityState: string;
@@ -64,6 +71,8 @@ export type PortfolioMemoryPanelModel = {
   memoryCoverage: string;
   openFollowUps: string;
   evidenceLinks: string;
+  sourceFacetRows: PortfolioMemorySourceFacetRow[];
+  sourceBoundaryRows: string[];
   recommendedActions: PortfolioMemoryRecommendedAction[];
 };
 
@@ -76,6 +85,7 @@ export type PortfolioMemoryRecommendedAction = {
 
 export function buildPortfolioMemoryPanelModel(
   response: DpmPortfolioMemoryGatewayResponse | null,
+  searchResponse: DpmPortfolioMemoryGatewayResponse | null = null,
 ): PortfolioMemoryPanelModel {
   if (!response) {
     return {
@@ -98,11 +108,14 @@ export function buildPortfolioMemoryPanelModel(
       memoryCoverage: "Unavailable",
       openFollowUps: "N/A",
       evidenceLinks: "N/A",
+      sourceFacetRows: [],
+      sourceBoundaryRows: [],
       recommendedActions: defaultRecommendedActions("UNAVAILABLE"),
     };
   }
 
   const supportability = response.supportability;
+  const searchSupportability = searchResponse?.supportability;
   const supportabilityState = normalizeState(supportability.state);
   const data = response.data;
   const eventRecords = extractRecordArray(data.events);
@@ -154,8 +167,34 @@ export function buildPortfolioMemoryPanelModel(
     memoryCoverage: resolveMemoryCoverage(supportabilityState, events.length),
     openFollowUps: formatFollowUpCount(events),
     evidenceLinks: `${artifactRefCount} Available`,
+    sourceFacetRows: [
+      ...buildSourceFacetRows(
+        searchSupportability?.source_system_counts ?? supportability.source_system_counts,
+        "system",
+      ),
+      ...buildSourceFacetRows(
+        searchSupportability?.source_type_counts ?? supportability.source_type_counts,
+        "type",
+      ),
+    ],
+    sourceBoundaryRows: formatObjectEntries(searchResponse?.data.support_boundary),
     recommendedActions: defaultRecommendedActions(supportabilityState),
   };
+}
+
+function buildSourceFacetRows(
+  counts: Record<string, number> | undefined,
+  family: "system" | "type",
+): PortfolioMemorySourceFacetRow[] {
+  return Object.entries(counts ?? {})
+    .sort(([, leftCount], [, rightCount]) => rightCount - leftCount)
+    .slice(0, 6)
+    .map(([label, count]) => ({
+      key: `${family}-${label}`,
+      label,
+      count: count.toLocaleString(),
+      family,
+    }));
 }
 
 function resolvePanelState(
@@ -560,6 +599,13 @@ function formatValue(value: unknown): string {
     return value ? "Yes" : "No";
   }
   return JSON.stringify(value);
+}
+
+function formatObjectEntries(value: unknown): string[] {
+  const record = readRecord(value);
+  return Object.entries(record)
+    .filter(([, entryValue]) => entryValue !== null && entryValue !== undefined && entryValue !== "")
+    .map(([key, entryValue]) => `${businessCase(key)}: ${formatValue(entryValue)}`);
 }
 
 function normalizeState(state: string): string {

--- a/src/features/workbench/types.ts
+++ b/src/features/workbench/types.ts
@@ -1259,6 +1259,8 @@ export type DpmPortfolioMemorySupportability = {
   event_count: number;
   event_type_counts: Record<string, number>;
   source_systems: string[];
+  source_system_counts?: Record<string, number>;
+  source_type_counts?: Record<string, number>;
   reason_codes: string[];
   content_hash?: string | null;
 };
@@ -1279,6 +1281,10 @@ export type DpmOutcomeReviewSupportability = {
   reason_codes: string[];
   blocked_actions: string[];
   remediation_owner?: string | null;
+  applied_filters?: Record<string, unknown>;
+  source_owner_counts?: Record<string, number>;
+  source_type_counts?: Record<string, number>;
+  support_boundary?: Record<string, unknown>;
 };
 
 export type DpmOutcomeClientCommunicationBoundary = {

--- a/tests/unit/analytics-observability-metrics.test.ts
+++ b/tests/unit/analytics-observability-metrics.test.ts
@@ -336,6 +336,11 @@ describe("analytics UI observability metrics", () => {
       ],
       [
         "workbench.manage",
+        "portfolio-memory",
+        "dpm.portfolio-memory.search",
+      ],
+      [
+        "workbench.manage",
         "outcome-review-list",
         "dpm.outcome-reviews.list",
       ],

--- a/tests/unit/manage-workspace-fixtures.ts
+++ b/tests/unit/manage-workspace-fixtures.ts
@@ -143,7 +143,32 @@ export function buildManageWorkspaceData(
       },
       data: { events: [] },
     },
+    portfolioMemorySearch: {
+      correlation_id: "corr_memory_search",
+      contract_version: "v1",
+      source_service: "lotus-manage",
+      upstream_status: 200,
+      supportability: {
+        source_service: "lotus-manage",
+        authority: "lotus-manage:portfolio-memory",
+        state: "SUPPORTED",
+        event_count: 1,
+        event_type_counts: { OUTCOME_REVIEW_SOURCE_LINEAGE_RECORDED: 1 },
+        source_systems: ["lotus-performance"],
+        source_system_counts: { "lotus-performance": 1 },
+        source_type_counts: { "PortfolioRealizedTaxSummary:v1": 1 },
+        reason_codes: ["PERSISTED_LINEAGE_SEARCH_ONLY"],
+      },
+      data: {
+        support_boundary: {
+          source_owner_store_query: false,
+          global_portfolio_discovery: false,
+        },
+        items: [],
+      },
+    },
     portfolioMemoryError: null,
+    portfolioMemorySearchError: null,
     pmOperatingQualityPolicies: {
       correlation_id: "corr_policy",
       contract_version: "v1",

--- a/tests/unit/outcome-review-panel.test.tsx
+++ b/tests/unit/outcome-review-panel.test.tsx
@@ -27,6 +27,17 @@ const readyResponse: DpmOutcomeReviewGatewayResponse = {
     reason_codes: ["READY_FOR_REPORT_INPUT"],
     blocked_actions: [],
     remediation_owner: null,
+    applied_filters: {
+      source_system: "lotus-performance",
+      source_type: "PortfolioRealizedTaxSummary:v1",
+    },
+    source_owner_counts: { "lotus-performance": 2 },
+    source_type_counts: { "PortfolioRealizedTaxSummary:v1": 2 },
+    support_boundary: {
+      manage_persisted_lineage_only: true,
+      source_owner_store_query: false,
+      global_portfolio_discovery: false,
+    },
   },
   data: {
     items: [
@@ -59,6 +70,7 @@ const readyResponse: DpmOutcomeReviewGatewayResponse = {
         source_lineage: [
           {
             source_service: "lotus-risk",
+            source_type: "PortfolioRiskSummary:v1",
             source_ref: "risk_1",
             freshness_bucket: "fresh",
             hash: "sha256:risk",
@@ -81,6 +93,9 @@ describe("OutcomeReviewPanel", () => {
     expect(screen.getByText("Supported")).toBeInTheDocument();
     expect(screen.getByText("Review Timeline")).toBeInTheDocument();
     expect(screen.getByText("Recommended Actions")).toBeInTheDocument();
+    expect(screen.getByText("Persisted Evidence Facets")).toBeInTheDocument();
+    expect(screen.getByText("PortfolioRealizedTaxSummary:v1")).toBeInTheDocument();
+    expect(screen.getByText("Source Owner Store Query: No")).toBeInTheDocument();
     expect(screen.getByText("Selected Review Detail")).toBeInTheDocument();
     expect(screen.getByText("Ready for Advisor Review")).toBeInTheDocument();
     expect(screen.getAllByText("Within Mandate").length).toBeGreaterThan(0);

--- a/tests/unit/outcome-review-view-model.test.ts
+++ b/tests/unit/outcome-review-view-model.test.ts
@@ -86,6 +86,7 @@ describe("outcome review view model", () => {
     expect(model.items[0].lineage[0]).toEqual(
       expect.objectContaining({
         source: "lotus-performance",
+        sourceType: "N/A",
         reference: "perf_1",
         freshness: "fresh",
         hash: "sha256:perf",
@@ -127,15 +128,63 @@ describe("outcome review view model", () => {
     expect(model.items[0].lineage).toEqual([
       expect.objectContaining({
         source: "lotus-manage",
+        sourceType: "DPM_SELECTED_ALTERNATIVE_EXPECTED_OUTCOME",
         reference: "selected-alternative-1",
         hash: "sha256:selected",
       }),
       expect.objectContaining({
         source: "lotus-core",
+        sourceType: "POST_TRADE_HOLDINGS_WINDOW",
         reference: "post-trade-holdings-1",
         hash: "sha256:realized",
       }),
     ]);
+  });
+
+  it("preserves Manage source-lineage filters, facets, and support boundary", () => {
+    const model = buildOutcomeReviewPanelModel(
+      response(
+        {
+          items: [{ outcome_review_id: "or_1", state: "READY" }],
+        },
+        {
+          applied_filters: {
+            portfolio_id: "PB_SG_GLOBAL_BAL_001",
+            source_system: "lotus-performance",
+            source_type: "PortfolioCashMovementSummary:v1",
+            source_scan_limit: 250,
+          },
+          source_owner_counts: { "lotus-performance": 2 },
+          source_type_counts: {
+            "PortfolioCashMovementSummary:v1": 1,
+            "PortfolioRealizedTaxSummary:v1": 1,
+          },
+          support_boundary: {
+            manage_persisted_lineage_only: true,
+            source_owner_store_query: false,
+            global_portfolio_discovery: false,
+          },
+        },
+      ),
+    );
+
+    const sourceBoundary = model.sourceBoundary!;
+    expect(sourceBoundary.sourceOwnerFacets).toEqual([
+      {
+        key: "owner-lotus-performance",
+        label: "lotus-performance",
+        count: "2",
+        family: "owner",
+      },
+    ]);
+    expect(sourceBoundary.sourceTypeFacets.map((row) => row.label)).toEqual([
+      "PortfolioCashMovementSummary:v1",
+      "PortfolioRealizedTaxSummary:v1",
+    ]);
+    expect(sourceBoundary.appliedFilters).toContain(
+      "Source Type: PortfolioCashMovementSummary:v1",
+    );
+    expect(sourceBoundary.supportBoundary).toContain("Source Owner Store Query: No");
   });
 
   it("marks blocked handoffs from manage supportability without inventing UI support", () => {

--- a/tests/unit/portfolio-memory-panel.test.tsx
+++ b/tests/unit/portfolio-memory-panel.test.tsx
@@ -34,14 +34,46 @@ const readyResponse: DpmPortfolioMemoryGatewayResponse = {
   },
 };
 
+const searchResponse: DpmPortfolioMemoryGatewayResponse = {
+  correlation_id: "corr-memory-search",
+  contract_version: "v1",
+  source_service: "lotus-manage",
+  upstream_status: 200,
+  supportability: {
+    source_service: "lotus-manage",
+    authority: "lotus-manage:RFC-0040/RFC-0041/RFC-0042",
+    state: "READY",
+    event_count: 2,
+    event_type_counts: { OUTCOME_REVIEW_SOURCE_LINEAGE_RECORDED: 2 },
+    source_systems: ["lotus-performance"],
+    source_system_counts: { "lotus-performance": 2 },
+    source_type_counts: {
+      "PortfolioRealizedTaxSummary:v1": 1,
+      "PortfolioCashMovementSummary:v1": 1,
+    },
+    reason_codes: ["PERSISTED_LINEAGE_SEARCH_ONLY"],
+    content_hash: "sha256:memory-search",
+  },
+  data: {
+    support_boundary: {
+      manage_persisted_lineage_only: true,
+      source_owner_store_query: false,
+    },
+    items: [],
+  },
+};
+
 describe("PortfolioMemoryPanel", () => {
   it("renders business-facing portfolio memory supportability and timeline", () => {
-    render(<PortfolioMemoryPanel response={readyResponse} />);
+    render(<PortfolioMemoryPanel response={readyResponse} searchResponse={searchResponse} />);
 
     expect(screen.getByRole("heading", { name: "Portfolio Memory" })).toBeInTheDocument();
     expect(screen.getAllByText("Ready").length).toBeGreaterThan(0);
     expect(screen.getByText("Latest Memory Event")).toBeInTheDocument();
     expect(screen.getByText("Memory Coverage")).toBeInTheDocument();
+    expect(screen.getByText("lotus-performance (2)")).toBeInTheDocument();
+    expect(screen.getByText("PortfolioRealizedTaxSummary:v1 (1)")).toBeInTheDocument();
+    expect(screen.getByText("Source Owner Store Query: No")).toBeInTheDocument();
     expect(screen.getAllByText("Outcome Review Created").length).toBeGreaterThan(1);
     expect(screen.getAllByText("Outcome Review Ready").length).toBeGreaterThan(0);
     expect(screen.getByText("Historical Event Log")).toBeInTheDocument();

--- a/tests/unit/portfolio-memory-view-model.test.ts
+++ b/tests/unit/portfolio-memory-view-model.test.ts
@@ -91,6 +91,65 @@ describe("portfolio-memory view model", () => {
     expect(JSON.stringify(model.recommendedActions)).not.toContain("client preference");
   });
 
+  it("preserves bounded source-family search facets without changing timeline authority", () => {
+    const model = buildPortfolioMemoryPanelModel(memoryResponse, {
+      ...memoryResponse,
+      supportability: {
+        ...memoryResponse.supportability,
+        event_count: 2,
+        event_type_counts: { OUTCOME_REVIEW_SOURCE_LINEAGE_RECORDED: 2 },
+        source_systems: ["lotus-performance"],
+        source_system_counts: { "lotus-performance": 2 },
+        source_type_counts: {
+          "PortfolioRealizedTaxSummary:v1": 1,
+          "PortfolioCashMovementSummary:v1": 1,
+        },
+        reason_codes: ["PERSISTED_LINEAGE_SEARCH_ONLY"],
+        content_hash: "sha256:memory-search",
+      },
+      data: {
+        support_boundary: {
+          manage_persisted_lineage_only: true,
+          source_owner_store_query: false,
+          global_portfolio_discovery: false,
+        },
+        items: [
+          {
+            event_id: "memory:tax:PMTAX_001",
+            source_id: "PMTAX_001",
+          },
+        ],
+      },
+    });
+
+    expect(model.events.map((row) => row.eventId)).toEqual([
+      "memory:proof-pack:ppack_1",
+      "memory:outcome-review:or_1",
+    ]);
+    expect(model.sourceFacetRows).toEqual([
+      {
+        key: "system-lotus-performance",
+        label: "lotus-performance",
+        count: "2",
+        family: "system",
+      },
+      {
+        key: "type-PortfolioRealizedTaxSummary:v1",
+        label: "PortfolioRealizedTaxSummary:v1",
+        count: "1",
+        family: "type",
+      },
+      {
+        key: "type-PortfolioCashMovementSummary:v1",
+        label: "PortfolioCashMovementSummary:v1",
+        count: "1",
+        family: "type",
+      },
+    ]);
+    expect(model.sourceBoundaryRows).toContain("Source Owner Store Query: No");
+    expect(JSON.stringify(model)).not.toContain("PMTAX_001");
+  });
+
   it("does not infer readiness from populated events when manage supportability is partial", () => {
     const model = buildPortfolioMemoryPanelModel({
       ...memoryResponse,

--- a/tests/unit/workbench-api.test.ts
+++ b/tests/unit/workbench-api.test.ts
@@ -38,6 +38,7 @@ import {
   getDpmPmOperatingQualityReviewAction,
   getDpmPmOperatingQualitySummaryInvocation,
   getDpmPortfolioMemory,
+  searchDpmPortfolioMemory,
   listDpmPmOperatingQualityFairnessAnalyses,
   listDpmPmOperatingQualityPolicies,
   listDpmPmOperatingQualityReviewActions,
@@ -2940,18 +2941,80 @@ describe("workbench api", () => {
     await getDpmOutcomeReviews({
       portfolioId: "PB_SG_GLOBAL_BAL_001",
       state: "READY",
+      sourceSystem: "lotus-performance",
+      sourceType: "PortfolioRealizedTaxSummary:v1",
+      sourceScanLimit: 250,
       limit: 5,
+      offset: 10,
       cursor: "cursor_1",
     });
 
     const requestedUrl = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].toString();
     expect(requestedUrl).toContain(
-      "/api/v1/dpm/command-center/outcome-reviews?portfolio_id=PB_SG_GLOBAL_BAL_001&limit=5&state=READY&cursor=cursor_1"
+      "/api/v1/dpm/command-center/outcome-reviews?portfolio_id=PB_SG_GLOBAL_BAL_001&limit=5&state=READY&source_system=lotus-performance&source_type=PortfolioRealizedTaxSummary%3Av1&source_scan_limit=250&offset=10&cursor=cursor_1"
     );
     const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
     expect(metricEventsJson).toContain("outcome-review-list");
     expect(metricEventsJson).not.toContain("PB_SG_GLOBAL_BAL_001");
     expect(metricEventsJson).not.toContain("or_1");
+  });
+
+  it("loads bounded DPM portfolio-memory source search without leaking source ids into metrics", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "corr-memory-search",
+            contract_version: "v1",
+            source_service: "lotus-manage",
+            upstream_status: 200,
+            supportability: {
+              source_service: "lotus-manage",
+              authority: "lotus-manage:RFC-0040/RFC-0041/RFC-0042",
+              state: "READY",
+              event_count: 1,
+              event_type_counts: { OUTCOME_REVIEW_SOURCE_LINEAGE_RECORDED: 1 },
+              source_systems: ["lotus-performance"],
+              source_system_counts: { "lotus-performance": 1 },
+              source_type_counts: { "PortfolioRealizedTaxSummary:v1": 1 },
+              reason_codes: ["PERSISTED_LINEAGE_SEARCH_ONLY"],
+              content_hash: "sha256:memory-search",
+            },
+            data: {
+              items: [
+                {
+                  event_id: "memory:tax:PMTAX_001",
+                  source_system: "lotus-performance",
+                  source_type: "PortfolioRealizedTaxSummary:v1",
+                  source_id: "PMTAX_001",
+                },
+              ],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await searchDpmPortfolioMemory({
+      portfolioIds: ["PB_SG_GLOBAL_BAL_001"],
+      sourceSystem: "lotus-performance",
+      sourceType: "PortfolioRealizedTaxSummary:v1",
+      sourceScanLimit: 250,
+      limit: 5,
+      offset: 0,
+    });
+
+    const requestedUrl = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].toString();
+    expect(requestedUrl).toContain(
+      "/api/v1/dpm/command-center/portfolio-memory/search?portfolio_ids=PB_SG_GLOBAL_BAL_001&source_system=lotus-performance&source_type=PortfolioRealizedTaxSummary%3Av1&limit=5&offset=0&source_scan_limit=250"
+    );
+    const metricEventsJson = JSON.stringify(getAnalyticsUiMetricEvents());
+    expect(metricEventsJson).toContain("dpm.portfolio-memory.search");
+    expect(metricEventsJson).not.toContain("PB_SG_GLOBAL_BAL_001");
+    expect(metricEventsJson).not.toContain("PMTAX_001");
+    expect(metricEventsJson).not.toContain("sha256:memory-search");
   });
 
   it("loads DPM report and AI handoff inputs through gateway-only client endpoints", async () => {

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -148,12 +148,16 @@ promote dormant labels into product ownership just because historical route file
   reports, or call `lotus-manage`, `lotus-report`, or `lotus-ai` directly.
 - RFC40-WTBD-010 portfolio-memory timeline rendering is implemented on
   `/workbench/{portfolioId}?mode=memory` through Gateway
-  `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory`. Workbench renders manage-owned
-  event order, event type counts, event time, source systems, source refs, artifact refs, reason
-  codes, supportability state, and content hash. It does not reconstruct timeline nodes from
-  proof-pack, wave, outcome-review, report, archive, or AI payloads; direct `lotus-manage` calls
-  remain forbidden. Dedicated timeline filters, event drawers, lifecycle export, and retention or
-  audit-policy controls remain future scope until separately implemented and proven.
+  `/api/v1/dpm/command-center/portfolios/{portfolio_id}/memory` and bounded source-family posture
+  through Gateway `/api/v1/dpm/command-center/portfolio-memory/search`. Workbench renders
+  manage-owned event order, event type counts, event time, source systems, source refs, artifact
+  refs, reason codes, supportability state, source-system/source-type facets, support boundary,
+  and content hash. It does not reconstruct timeline nodes from proof-pack, wave, outcome-review,
+  report, archive, or AI payloads; direct `lotus-manage` calls, global portfolio-universe
+  discovery, source-owner store querying, cross-app source-event search, OMS/fill/settlement
+  claims, and client communication workflow remain forbidden. Event drawers, lifecycle export,
+  and retention or audit-policy controls remain future scope until separately implemented and
+  proven.
 - RFC-0098/RFC-0041 action-register supportability is rendered on the Manage workspace from
   the Gateway portfolio overview `rebalance_snapshot`. The rebalance status panel shows
   manage-owned status, source support state, freshness, run count, operation count, workflow
@@ -164,9 +168,11 @@ promote dormant labels into product ownership just because historical route file
 - RFC-0098/RFC-0042 post-trade outcome-review rendering is implemented on
   `/workbench/{portfolioId}?mode=reviews` through Gateway `/api/v1/dpm/command-center/outcome-reviews*`.
   Workbench renders manage-owned review state, expected-versus-realized dimensions, hashes,
-  source lineage, supportability, report-input posture, AI-evidence posture, and
-  `client_communication_boundary` posture without calculating those values client-side or creating
-  client communication capability. The panel can request a governed outcome-review PDF job by
+  source lineage, source-owner/source-type facets, applied source-lineage filters, support
+  boundary, supportability, report-input posture, AI-evidence posture, and
+  `client_communication_boundary` posture without calculating those values client-side, querying
+  source-owner stores, or creating client communication capability. The panel can request a
+  governed outcome-review PDF job by
   loading manage report input through Gateway and then submitting Gateway
   `POST /api/v1/reports/outcome-reviews`; report rendering and archive lifecycle remain owned by
   `lotus-report`, `lotus-render`, and `lotus-archive`. The panel can also request a governed

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -127,8 +127,9 @@ must travel through Gateway-shaped contracts.
     Manage-owned `client_communication_boundary` is rendered as a fail-closed internal boundary
     and must not become a Workbench client messaging, approval, delivery, or audit workflow.
     RFC40-WTBD-010 portfolio-memory timeline events, source refs, artifact refs, event counts,
-    source systems, reason codes, supportability, and content hashes remain manage-owned and must
-    reach Workbench through Gateway portfolio-memory composition only.
+    source systems, source-system/source-type facets, applied filters, reason codes,
+    supportability, support boundaries, and content hashes remain manage-owned and must reach
+    Workbench through Gateway portfolio-memory composition and bounded memory search only.
     RFC-0043 monitoring-exception summary execution remains `lotus-ai` owned and must reach
     Workbench through Gateway exception-summary composition only.
     PM operating quality policies, score runs, score-run preview/create, fairness-analysis
@@ -155,7 +156,9 @@ must travel through Gateway-shaped contracts.
     recompute top-position weights or infer largest holdings locally.
     The implemented command-center exception queue consumes the Gateway exception-summary contract.
     The implemented portfolio-memory panel consumes the Gateway portfolio-memory contract and
-    preserves manage event order without reconstructing timeline nodes, and the implemented PM
+    bounded source search contract and preserves manage event order and source facets without
+    reconstructing timeline nodes, querying source-owner stores, discovering the global portfolio
+    universe, or running cross-app source-event search, and the implemented PM
     operating quality panel consumes Gateway policy, score-run, persisted fairness-analysis
     create/list/detail, fairness-analysis preview, review-action preview/create/list/detail, and score-run
     support-summary contracts when Manage/Gateway expose source-defined segment assignments,

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -57,17 +57,18 @@ Implemented:
 
 1. loads portfolio memory through Gateway only,
 2. renders manage-owned supportability, event count, event type counts, source systems, reason
-   codes, and content hash,
+   codes, source-system/source-type facets, bounded search boundary, and content hash,
 3. preserves event order, event type, event time, source refs, artifact refs, and reason codes,
 4. handles empty, partial, degraded, unsupported, unavailable, and endpoint error states without implying
    local reconstruction,
-5. emits bounded observability for `dpm.portfolio-memory.get` without portfolio ids, event ids,
-   source refs, content hashes, request bodies, response bodies, or screen content as labels.
+5. emits bounded observability for `dpm.portfolio-memory.get` and
+   `dpm.portfolio-memory.search` without portfolio ids, event ids, source refs, source ids,
+   content hashes, request bodies, response bodies, or screen content as labels.
 
 Not yet supported:
 
 1. event detail drawers,
-2. timeline filtering and search,
+2. global portfolio-universe discovery,
 3. retention or audit-policy controls,
 4. cross-app lifecycle export,
 5. client-demo script steps beyond the canonical Workbench screenshot after live validation.


### PR DESCRIPTION
## Summary
- extend Workbench Gateway-only outcome-review API filters for source_system, source_type, source_scan_limit, and offset
- add Gateway-only portfolio-memory search API support and bounded source-family posture in the memory panel
- render Manage-published outcome-review applied filters, source-owner/source-type facets, and support boundary read-only
- keep selected portfolio memory route as timeline authority and preserve no global/source-owner/OMS/client-contact claims
- update Workbench RFC/wiki/context docs for the realized bounded source-lineage behavior

## Validation
- npm run test -- --run tests/unit/workbench-api.test.ts tests/unit/outcome-review-view-model.test.ts tests/unit/outcome-review-panel.test.tsx tests/unit/portfolio-memory-view-model.test.ts tests/unit/portfolio-memory-panel.test.tsx tests/unit/analytics-observability-metrics.test.ts tests/unit/manage-overview-model.test.ts tests/integration/workbench-page.test.tsx
- npm run lint
- npm run build
- npm run typecheck (after build regenerated .next/types)
- git diff --check

## Governance
- Workbench consumes Gateway only; no direct Manage/source-owner calls added.
- Observability tests cover bounded operation labels and prove portfolio ids/source ids/content hashes do not enter metric labels.
- Wiki CheckOnly before merge reports expected drift in API-Surface.md, Integrations.md, and Supported-Features.md because repo-authored wiki source changed; publish after merge.
- The UI does not claim global portfolio-universe discovery, source-owner store querying, cross-app source-event search, OMS execution, fills, settlement, or client communication workflow.