### PR TITLE
test: prove RFC-0023 proposal narrative posture panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ Important current product and route truths:
     and request reviewed narrative report packaging through Gateway, but it must not generate
     narrative, infer client-ready publication, render documents, archive artifacts, contact
     clients, or call `lotus-advise`, `lotus-report`, `lotus-render`, or `lotus-archive` directly.
+    Canonical front-office validation now creates a seeded advisor-review narrative proposal,
+    exercises the panel, and captures governed `proposal.narrative_posture` screenshot evidence.
 
 Copy-paste route and runtime examples live in [wiki/API-Surface.md](wiki/API-Surface.md).
 

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -247,12 +247,15 @@ Validation layers:
    - risk attribution
    - advisor brief
    - advisor-brief workflow-pack review actions for `ACCEPT`, `REVISE`, and `SUPERSEDE`
+   - proposal creation with advisor-review narrative request
+   - proposal narrative review and reviewed report-package request
 5. browser-level validation for populated UI on:
    - Portfolio summary
    - Portfolio detailed
    - Performance summary
    - Performance analysis
    - Performance advisor brief
+   - Proposal narrative posture
    - Performance risk
    - Performance evidence
 
@@ -268,10 +271,13 @@ stable file name, absolute path, route, panel identifier, portfolio ID, benchmar
 and demo readiness state. The validator also writes `SHOT-INDEX.md` in the screenshot directory so
 demo reviewers can quickly identify the captured product surfaces.
 
-The machine-readable summary also records `workflowPackChecks` for the advisor-brief live path.
-Those checks prove initial workflow-pack run visibility plus bounded `ACCEPT`, `REVISE`, and
-`SUPERSEDE` review transitions with replacement lineage through the live
-`lotus-workbench` -> `lotus-gateway` -> `lotus-ai` contract chain.
+The machine-readable summary also records `workflowPackChecks` for the advisor-brief live path and
+RFC-0023 proposal narrative proof. Advisor-brief checks prove initial workflow-pack run visibility
+plus bounded `ACCEPT`, `REVISE`, and `SUPERSEDE` review transitions with replacement lineage
+through the live `lotus-workbench` -> `lotus-gateway` -> `lotus-ai` contract chain. Proposal
+narrative checks prove Gateway-backed proposal creation with an advisor-review narrative request,
+Workbench advisor-use narrative review, reviewed report-package request, source narrative hash
+visibility, and screenshot evidence for `proposal.narrative_posture`.
 
 Machine-readable validation evidence is written to:
 

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -7,6 +7,7 @@ param(
   [int]$SeedWaitSeconds = 900,
   [string[]]$LocalApps = @(),
   [switch]$CleanCoreState,
+  [switch]$SkipSeedCleanup,
   [switch]$BuildImages,
   [switch]$CoreManageOnly,
   [switch]$RunValidation
@@ -286,9 +287,22 @@ function Invoke-CanonicalCoreSeed {
   if ($IngestOnly) {
     $seedCommand = "$seedCommand --ingest-only"
   }
+  if ($SkipSeedCleanup) {
+    $seedCommand = "$seedCommand --skip-cleanup"
+  }
 
   Write-Host "Seeding governed front-office portfolio data for $PortfolioId ..."
   Invoke-RepoCommand $coreRepo $seedCommand
+}
+
+function Invoke-DpmCommandCenterSeed {
+  $dpmSeedCommand = (
+    "powershell -ExecutionPolicy Bypass -File automation\Invoke-DpmCommandCenterSeed.ps1 " +
+    "-PortfolioId $PortfolioId"
+  )
+
+  Write-Host "Seeding governed DPM command-center and action-register evidence for $PortfolioId ..."
+  Invoke-RepoCommand $platformRepo $dpmSeedCommand
 }
 
 Write-Host "Previewing managed canonical hosts block from lotus-platform ..."
@@ -365,6 +379,7 @@ if (Test-LocalApp "gateway") {
 }
 
 Invoke-CanonicalCoreSeed
+Invoke-DpmCommandCenterSeed
 
 if (Test-LocalApp "workbench") {
   Invoke-RepoCommand $workbenchRepo "docker compose down --remove-orphans"

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -12,7 +12,14 @@ import {
   writeShotIndex,
   writeValidationSummary,
 } from "./validation/evidence-summary-writer.mjs";
-import { checkDns, fetchJson, fetchJsonUntil, fetchText, postJson } from "./validation/probes.mjs";
+import {
+  checkDns,
+  fetchJson,
+  fetchJsonUntil,
+  fetchText,
+  postJson,
+  sendJson,
+} from "./validation/probes.mjs";
 import {
   assertPerformanceCalculationSanity,
   assertRiskCalculationSanity,
@@ -20,6 +27,7 @@ import {
 import {
   createBrowserValidationHelpers,
   validateAdvisorBriefPanel,
+  validateProposalNarrativePosturePanel,
   validateDpmCommandCenterPanel,
   validatePortfolioMemoryPanel,
   validateDpmWaveCommandCenterPanel,
@@ -189,6 +197,10 @@ function extractWorkflowPackRunId(payload) {
   );
 }
 
+function extractGatewayEnvelopeData(payload) {
+  return payload?.data ?? payload;
+}
+
 async function run() {
   await ensureDirectory(outputDir);
 
@@ -336,6 +348,57 @@ async function run() {
     timeoutMs,
     fetchJson,
     postJson,
+  });
+
+  const proposalCreate = await sendJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/proposals`,
+    "Create proposal narrative canonical proof",
+    timeoutMs,
+    {
+      method: "POST",
+      body: {
+        body: {
+          created_by: "workbench-canonical-validator",
+          input_mode: "stateful",
+          stateful_input: {
+            portfolio_id: portfolioId,
+            as_of: canonicalAsOfDate,
+            narrative_request: {
+              audience: "ADVISOR_REVIEW",
+              jurisdiction: "SG",
+              client_audience: "ADVISOR_REVIEW",
+              sections: ["EXECUTIVE_SUMMARY", "RISK_AND_CONCENTRATION"],
+              requested_by: "workbench-canonical-validator",
+            },
+          },
+          metadata: {
+            title: "Canonical advisor narrative proof",
+            advisor_notes: "Workbench canonical validation proposal for RFC-0023 Slice 12.",
+            jurisdiction: "SG",
+          },
+        },
+      },
+      headers: {
+        "Idempotency-Key": `workbench-canonical-narrative-${portfolioId}-${canonicalAsOfDate}`,
+      },
+    }
+  );
+  const proposalCreateData = extractGatewayEnvelopeData(proposalCreate);
+  const proposalId = readString(proposalCreateData?.proposal?.proposal_id);
+  const proposalVersionNo = proposalCreateData?.version?.version_no ?? null;
+  const proposalNarrative = proposalCreateData?.version?.artifact?.proposal_narrative;
+  if (!proposalId || !proposalNarrative?.narrative_id) {
+    throw new Error("Canonical proposal narrative proof did not create a narrative proposal.");
+  }
+  summary.workflowPackChecks.push({
+    actionType: "PROPOSAL_NARRATIVE_CREATED",
+    route: `/api/v1/proposals`,
+    sourceRunId: proposalNarrative.narrative_id,
+    resultReviewState: proposalNarrative.review_state,
+    resultSupportabilityStatus: proposalNarrative.generation_mode,
+    proposalId,
+    versionNo: proposalVersionNo,
   });
 
   const manageSupportabilitySummary = await fetchJson(
@@ -722,6 +785,13 @@ async function run() {
   panelGovernance.recordPanelClassification("performance.advisor_brief", "ready", "lotus-performance", {
     sourceMetricMinimum: 3,
   });
+  panelGovernance.recordPanelClassification("proposal.narrative_posture", "ready", "lotus-advise", {
+    route: `/proposals/${proposalId}`,
+    proposalId,
+    versionNo: proposalVersionNo,
+    narrativeId: proposalNarrative.narrative_id,
+    generationMode: proposalNarrative.generation_mode,
+  });
   panelGovernance.recordPanelClassification("dpm.outcome_review", "ready", "lotus-manage", {
     route: `/workbench/${portfolioId}`,
     outcomeReviewMinimum: 1,
@@ -822,6 +892,13 @@ async function run() {
       timeoutMs,
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
       performAcceptReviewActionProof: true,
+    });
+    await validateProposalNarrativePosturePanel(page, {
+      summary,
+      workbenchBaseUrl,
+      proposalId,
+      timeoutMs,
+      screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
     });
     await validateRiskPanel(page, {
       workbenchBaseUrl,

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -1,4 +1,5 @@
 import process from "node:process";
+import { createHash } from "node:crypto";
 import { chromium, expect } from "@playwright/test";
 import { resolveValidationConfig } from "./validation/args.mjs";
 import {
@@ -72,6 +73,11 @@ const summary = createValidationSummary({
   panelRegistry,
 });
 const panelGovernance = createPanelGovernance(summary, panelRegistry);
+
+function buildPayloadScopedIdempotencyKey(prefix, payload) {
+  const digest = createHash("sha256").update(JSON.stringify(payload)).digest("hex").slice(0, 16);
+  return `${prefix}-${digest}`.slice(0, 64);
+}
 
 async function fetchOptionalJson(description, url) {
   try {
@@ -350,6 +356,32 @@ async function run() {
     postJson,
   });
 
+  const proposalCreateBody = {
+    body: {
+      created_by: "workbench-canonical-validator",
+      input_mode: "stateful",
+      stateful_input: {
+        portfolio_id: portfolioId,
+        as_of: canonicalAsOfDate,
+        narrative_request: {
+          audience: "ADVISOR_REVIEW",
+          jurisdiction: "SG",
+          client_audience: "ADVISOR_REVIEW",
+          sections: ["EXECUTIVE_SUMMARY", "RISK_AND_CONCENTRATION"],
+          requested_by: "workbench-canonical-validator",
+        },
+      },
+      metadata: {
+        title: "Canonical advisor narrative proof",
+        advisor_notes: "Workbench canonical validation proposal for RFC-0023 Slice 12.",
+        jurisdiction: "SG",
+      },
+    },
+  };
+  const proposalCreateIdempotencyKey = buildPayloadScopedIdempotencyKey(
+    "wb-canonical-narrative",
+    proposalCreateBody
+  );
   const proposalCreate = await sendJson(
     summary,
     `${gatewayBaseUrl}/api/v1/proposals`,
@@ -357,30 +389,9 @@ async function run() {
     timeoutMs,
     {
       method: "POST",
-      body: {
-        body: {
-          created_by: "workbench-canonical-validator",
-          input_mode: "stateful",
-          stateful_input: {
-            portfolio_id: portfolioId,
-            as_of: canonicalAsOfDate,
-            narrative_request: {
-              audience: "ADVISOR_REVIEW",
-              jurisdiction: "SG",
-              client_audience: "ADVISOR_REVIEW",
-              sections: ["EXECUTIVE_SUMMARY", "RISK_AND_CONCENTRATION"],
-              requested_by: "workbench-canonical-validator",
-            },
-          },
-          metadata: {
-            title: "Canonical advisor narrative proof",
-            advisor_notes: "Workbench canonical validation proposal for RFC-0023 Slice 12.",
-            jurisdiction: "SG",
-          },
-        },
-      },
+      body: proposalCreateBody,
       headers: {
-        "Idempotency-Key": `workbench-canonical-narrative-${portfolioId}-${canonicalAsOfDate}`,
+        "Idempotency-Key": proposalCreateIdempotencyKey,
       },
     }
   );
@@ -450,7 +461,20 @@ async function run() {
   if (!rebalanceRunId) {
     throw new Error("Gateway workbench overview returned no manage rebalance-run reference for proof-pack generation.");
   }
-  const proofPackIdempotencyKey = `workbench-proof-pack-${rebalanceRunId}`;
+  const proofPackRequestBody = {
+    source_type: "REBALANCE_RUN",
+    rebalance_run_id: rebalanceRunId,
+    mandate_id: readString(proofPackSourceReview?.mandate_id) ?? undefined,
+    include_markdown: true,
+    include_report_input: true,
+    include_ai_evidence_input: true,
+    actor_id: "workbench-proof-pack-operator",
+    reason: "Workbench PM generated proof pack from Gateway-backed rebalance run.",
+  };
+  const proofPackIdempotencyKey = buildPayloadScopedIdempotencyKey(
+    "wb-proof-pack",
+    proofPackRequestBody
+  );
   const generatedProofPack = await postJson(
     summary,
     `${gatewayBaseUrl}/api/v1/dpm/command-center/proof-packs`,
@@ -458,16 +482,7 @@ async function run() {
     timeoutMs,
     {
       idempotency_key: proofPackIdempotencyKey,
-      body: {
-        source_type: "REBALANCE_RUN",
-        rebalance_run_id: rebalanceRunId,
-        mandate_id: readString(proofPackSourceReview?.mandate_id) ?? undefined,
-        include_markdown: true,
-        include_report_input: true,
-        include_ai_evidence_input: true,
-        actor_id: "workbench-proof-pack-operator",
-        reason: "Workbench PM generated proof pack from Gateway-backed rebalance run.",
-      },
+      body: proofPackRequestBody,
     }
   );
   const proofPackId = extractGeneratedProofPackId(generatedProofPack);

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -326,7 +326,7 @@ export async function validateProposalNarrativePosturePanel(
     "Live canonical validator approved this advisor-use narrative from Gateway evidence."
   );
   await narrativePanel.getByRole("button", { name: "Approve Advisor Narrative" }).click();
-  await expect(narrativePanel.getByText("Approved For Advisor Use")).toBeVisible({
+  await expect(narrativePanel.getByLabel("Status Approved For Advisor Use")).toBeVisible({
     timeout: timeoutMs,
   });
   await narrativePanel.getByRole("button", { name: "Request Reviewed Report" }).click();

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -298,6 +298,57 @@ export async function validateAdvisorBriefPanel(
   }
 }
 
+export async function validateProposalNarrativePosturePanel(
+  page,
+  {
+    summary,
+    workbenchBaseUrl,
+    proposalId,
+    timeoutMs,
+    screenshotRegisteredPanel,
+  }
+) {
+  await page.goto(`${workbenchBaseUrl}/proposals/${encodeURIComponent(proposalId)}`, {
+    waitUntil: "networkidle",
+    timeout: timeoutMs,
+  });
+  await expect(page.getByRole("heading", { name: new RegExp(`Proposal ${proposalId}`) })).toBeVisible({
+    timeout: timeoutMs,
+  });
+
+  const narrativePanel = workbenchPanelByClass(page, "proposal-narrative-posture-panel");
+  await expect(narrativePanel).toBeVisible({ timeout: timeoutMs });
+  await expect(narrativePanel.getByText("Advisor Narrative And Delivery")).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(narrativePanel.getByText("Review Posture")).toBeVisible({ timeout: timeoutMs });
+  await narrativePanel.getByLabel("Review rationale").fill(
+    "Live canonical validator approved this advisor-use narrative from Gateway evidence."
+  );
+  await narrativePanel.getByRole("button", { name: "Approve Advisor Narrative" }).click();
+  await expect(narrativePanel.getByText("Approved For Advisor Use")).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await narrativePanel.getByRole("button", { name: "Request Reviewed Report" }).click();
+  await expect(narrativePanel.getByText("Included Reviewed Narrative")).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(narrativePanel.getByText(/Source narrative hash: sha256:/)).toBeVisible({
+    timeout: timeoutMs,
+  });
+
+  summary.uiChecks.push({
+    description: "Proposal narrative posture review and report package",
+    kind: "proposal-narrative-posture",
+    proposalId,
+    reviewState: "APPROVED_FOR_ADVISOR_USE",
+    reportPackageState: "INCLUDED_REVIEWED_NARRATIVE",
+  });
+  await screenshotRegisteredPanel(page, "proposal.narrative_posture", {
+    route: `/proposals/${proposalId}`,
+  });
+}
+
 export async function validateRiskPanel(
   page,
   {

--- a/scripts/live/validation/calculation-sanity.mjs
+++ b/scripts/live/validation/calculation-sanity.mjs
@@ -33,6 +33,7 @@ function recordCalculationCheck(summary, description, evidence) {
 function readSourceSupportabilityItems(...payloads) {
   return payloads.flatMap((payload) => [
     ...(Array.isArray(payload?.source_supportability) ? payload.source_supportability : []),
+    ...(Array.isArray(payload?.supportability) ? payload.supportability : []),
     ...readContributionSourceEconomicsItems(payload),
   ]);
 }

--- a/scripts/live/validation/contract-metadata.mjs
+++ b/scripts/live/validation/contract-metadata.mjs
@@ -86,6 +86,17 @@ export const DEFAULT_PANEL_REGISTRY = {
       ownerFollowUpRfc: null,
     },
     {
+      panelId: "proposal.narrative_posture",
+      owningService: "lotus-advise",
+      gatewayEndpoint: "/api/v1/proposals/{proposal_id}/delivery-summary",
+      requiredSupportState: "ready",
+      route: "/proposals/{proposalId}",
+      allowedStates: ["ready", "loading", "empty", "partial", "unavailable", "error"],
+      screenshotName: "proposal-narrative-posture-live.png",
+      knownLimitations: [],
+      ownerFollowUpRfc: null,
+    },
+    {
       panelId: "performance.risk.snapshot",
       owningService: "lotus-risk",
       gatewayEndpoint: "/api/v1/workbench/{portfolio_id}/risk/summary",

--- a/src/apps/performance/use-performance-risk-contract.ts
+++ b/src/apps/performance/use-performance-risk-contract.ts
@@ -39,7 +39,10 @@ type PerformanceRiskContractState = {
   isAttributionLoading: boolean;
   isDrawdownDetailLoading: boolean;
   isRollingDetailLoading: boolean;
-  requestAttribution: (attributionType: string, groupingDimension: string) => void;
+  requestAttribution: (
+    attributionType: string,
+    groupingDimension: string,
+  ) => void;
   requestDrawdownDetail: () => void;
   requestRollingDetail: () => void;
 };
@@ -56,36 +59,53 @@ export function usePerformanceRiskContract({
   isDetailsPending: boolean;
 }): PerformanceRiskContractState {
   const workspaceRef = useRef(workspace);
-  const summaryCacheRef = useRef<Map<string, WorkbenchRiskSummaryResponse>>(new Map());
-  const concentrationCacheRef = useRef<Map<string, WorkbenchRiskConcentrationResponse>>(new Map());
-  const attributionCacheRef = useRef<Map<string, WorkbenchRiskAttributionResponse>>(new Map());
-  const drawdownCacheRef = useRef<Map<string, WorkbenchRiskDrawdownResponse>>(new Map());
-  const drawdownDetailCacheRef = useRef<Map<string, WorkbenchRiskDrawdownResponse>>(new Map());
-  const rollingCacheRef = useRef<Map<string, WorkbenchRiskRollingResponse>>(new Map());
-  const rollingDetailCacheRef = useRef<Map<string, WorkbenchRiskRollingResponse>>(new Map());
+  const summaryCacheRef = useRef<Map<string, WorkbenchRiskSummaryResponse>>(
+    new Map(),
+  );
+  const concentrationCacheRef = useRef<
+    Map<string, WorkbenchRiskConcentrationResponse>
+  >(new Map());
+  const attributionCacheRef = useRef<
+    Map<string, WorkbenchRiskAttributionResponse>
+  >(new Map());
+  const drawdownCacheRef = useRef<Map<string, WorkbenchRiskDrawdownResponse>>(
+    new Map(),
+  );
+  const drawdownDetailCacheRef = useRef<
+    Map<string, WorkbenchRiskDrawdownResponse>
+  >(new Map());
+  const rollingCacheRef = useRef<Map<string, WorkbenchRiskRollingResponse>>(
+    new Map(),
+  );
+  const rollingDetailCacheRef = useRef<
+    Map<string, WorkbenchRiskRollingResponse>
+  >(new Map());
   const requestSequenceRef = useRef(0);
   const drawdownDetailRequestSequenceRef = useRef(0);
   const rollingDetailRequestSequenceRef = useRef(0);
   const attributionRequestSequenceRef = useRef(0);
-  const [riskSummary, setRiskSummary] = useState<WorkbenchRiskSummaryResponse | null>(null);
-  const [riskConcentration, setRiskConcentration] = useState<WorkbenchRiskConcentrationResponse | null>(
-    null
-  );
-  const [riskAttribution, setRiskAttribution] = useState<WorkbenchRiskAttributionResponse | null>(null);
-  const [riskDrawdown, setRiskDrawdown] = useState<WorkbenchRiskDrawdownResponse | null>(null);
-  const [riskDrawdownDetail, setRiskDrawdownDetail] = useState<WorkbenchRiskDrawdownResponse | null>(
-    null
-  );
-  const [riskRolling, setRiskRolling] = useState<WorkbenchRiskRollingResponse | null>(null);
-  const [riskRollingDetail, setRiskRollingDetail] = useState<WorkbenchRiskRollingResponse | null>(
-    null
-  );
+  const [riskSummary, setRiskSummary] =
+    useState<WorkbenchRiskSummaryResponse | null>(null);
+  const [riskConcentration, setRiskConcentration] =
+    useState<WorkbenchRiskConcentrationResponse | null>(null);
+  const [riskAttribution, setRiskAttribution] =
+    useState<WorkbenchRiskAttributionResponse | null>(null);
+  const [riskDrawdown, setRiskDrawdown] =
+    useState<WorkbenchRiskDrawdownResponse | null>(null);
+  const [riskDrawdownDetail, setRiskDrawdownDetail] =
+    useState<WorkbenchRiskDrawdownResponse | null>(null);
+  const [riskRolling, setRiskRolling] =
+    useState<WorkbenchRiskRollingResponse | null>(null);
+  const [riskRollingDetail, setRiskRollingDetail] =
+    useState<WorkbenchRiskRollingResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isAttributionLoading, setIsAttributionLoading] = useState(false);
   const [isDrawdownDetailLoading, setIsDrawdownDetailLoading] = useState(false);
   const [isRollingDetailLoading, setIsRollingDetailLoading] = useState(false);
-  const [selectedAttributionType, setSelectedAttributionType] = useState("TOTAL_RISK");
-  const [selectedGroupingDimension, setSelectedGroupingDimension] = useState("SECTOR");
+  const [selectedAttributionType, setSelectedAttributionType] =
+    useState("TOTAL_RISK");
+  const [selectedGroupingDimension, setSelectedGroupingDimension] =
+    useState("SECTOR");
   const riskWindowParams = useMemo(
     () =>
       period === "EXPLICIT"
@@ -94,8 +114,9 @@ export function usePerformanceRiskContract({
             reportEndDate: workspace.report_end_date,
           }
         : {},
-    [period, workspace.report_end_date, workspace.report_start_date]
+    [period, workspace.report_end_date, workspace.report_start_date],
   );
+  const riskAsOfDate = getRiskAsOfDate(workspace);
 
   useEffect(() => {
     workspaceRef.current = workspace;
@@ -109,18 +130,18 @@ export function usePerformanceRiskContract({
         detailBasis,
         benchmark: workspace.benchmark_code ?? null,
         ...riskWindowParams,
-        asOfDate: workspace.as_of_date,
+        asOfDate: riskAsOfDate,
         reportingCurrency: workspace.portfolio.base_currency,
       }),
     [
       detailBasis,
       period,
       riskWindowParams,
-      workspace.as_of_date,
+      riskAsOfDate,
       workspace.benchmark_code,
       workspace.portfolio.base_currency,
       workspace.portfolio.portfolio_id,
-    ]
+    ],
   );
 
   const concentrationKey = useMemo(
@@ -130,17 +151,17 @@ export function usePerformanceRiskContract({
         period,
         benchmark: workspace.benchmark_code ?? null,
         ...riskWindowParams,
-        asOfDate: workspace.as_of_date,
+        asOfDate: riskAsOfDate,
         reportingCurrency: workspace.portfolio.base_currency,
       }),
     [
       period,
       riskWindowParams,
-      workspace.as_of_date,
+      riskAsOfDate,
       workspace.benchmark_code,
       workspace.portfolio.base_currency,
       workspace.portfolio.portfolio_id,
-    ]
+    ],
   );
 
   const drawdownKey = useMemo(
@@ -151,7 +172,7 @@ export function usePerformanceRiskContract({
         detailBasis,
         benchmark: workspace.benchmark_code ?? null,
         ...riskWindowParams,
-        asOfDate: workspace.as_of_date,
+        asOfDate: riskAsOfDate,
         reportingCurrency: workspace.portfolio.base_currency,
         includeUnderwaterSeries: false,
       }),
@@ -159,11 +180,11 @@ export function usePerformanceRiskContract({
       detailBasis,
       period,
       riskWindowParams,
-      workspace.as_of_date,
+      riskAsOfDate,
       workspace.benchmark_code,
       workspace.portfolio.base_currency,
       workspace.portfolio.portfolio_id,
-    ]
+    ],
   );
 
   const drawdownDetailKey = useMemo(
@@ -174,7 +195,7 @@ export function usePerformanceRiskContract({
         detailBasis,
         benchmark: workspace.benchmark_code ?? null,
         ...riskWindowParams,
-        asOfDate: workspace.as_of_date,
+        asOfDate: riskAsOfDate,
         reportingCurrency: workspace.portfolio.base_currency,
         includeUnderwaterSeries: true,
       }),
@@ -182,11 +203,11 @@ export function usePerformanceRiskContract({
       detailBasis,
       period,
       riskWindowParams,
-      workspace.as_of_date,
+      riskAsOfDate,
       workspace.benchmark_code,
       workspace.portfolio.base_currency,
       workspace.portfolio.portfolio_id,
-    ]
+    ],
   );
 
   const rollingKey = useMemo(
@@ -197,7 +218,7 @@ export function usePerformanceRiskContract({
         detailBasis,
         benchmark: workspace.benchmark_code ?? null,
         ...riskWindowParams,
-        asOfDate: workspace.as_of_date,
+        asOfDate: riskAsOfDate,
         reportingCurrency: workspace.portfolio.base_currency,
         includeTimeSeries: false,
       }),
@@ -205,11 +226,11 @@ export function usePerformanceRiskContract({
       detailBasis,
       period,
       riskWindowParams,
-      workspace.as_of_date,
+      riskAsOfDate,
       workspace.benchmark_code,
       workspace.portfolio.base_currency,
       workspace.portfolio.portfolio_id,
-    ]
+    ],
   );
 
   const rollingDetailKey = useMemo(
@@ -220,7 +241,7 @@ export function usePerformanceRiskContract({
         detailBasis,
         benchmark: workspace.benchmark_code ?? null,
         ...riskWindowParams,
-        asOfDate: workspace.as_of_date,
+        asOfDate: riskAsOfDate,
         reportingCurrency: workspace.portfolio.base_currency,
         includeTimeSeries: true,
       }),
@@ -228,11 +249,11 @@ export function usePerformanceRiskContract({
       detailBasis,
       period,
       riskWindowParams,
-      workspace.as_of_date,
+      riskAsOfDate,
       workspace.benchmark_code,
       workspace.portfolio.base_currency,
       workspace.portfolio.portfolio_id,
-    ]
+    ],
   );
 
   useEffect(() => {
@@ -252,22 +273,32 @@ export function usePerformanceRiskContract({
     }
 
     const cachedSummary = summaryCacheRef.current.get(summaryKey) ?? null;
-    const cachedConcentration = concentrationCacheRef.current.get(concentrationKey) ?? null;
+    const cachedConcentration =
+      concentrationCacheRef.current.get(concentrationKey) ?? null;
     const cachedDrawdown = drawdownCacheRef.current.get(drawdownKey) ?? null;
     const cachedRolling = rollingCacheRef.current.get(rollingKey) ?? null;
 
     setRiskSummary(cachedSummary);
     setRiskConcentration(cachedConcentration);
     setRiskDrawdown(cachedDrawdown);
-    setRiskDrawdownDetail(drawdownDetailCacheRef.current.get(drawdownDetailKey) ?? null);
+    setRiskDrawdownDetail(
+      drawdownDetailCacheRef.current.get(drawdownDetailKey) ?? null,
+    );
     setRiskRolling(cachedRolling);
-    setRiskRollingDetail(rollingDetailCacheRef.current.get(rollingDetailKey) ?? null);
+    setRiskRollingDetail(
+      rollingDetailCacheRef.current.get(rollingDetailKey) ?? null,
+    );
 
     const needsSummary = !cachedSummary;
     const needsConcentration = !cachedConcentration;
     const needsDrawdown = !cachedDrawdown;
     const needsRolling = !cachedRolling;
-    if (!needsSummary && !needsConcentration && !needsDrawdown && !needsRolling) {
+    if (
+      !needsSummary &&
+      !needsConcentration &&
+      !needsDrawdown &&
+      !needsRolling
+    ) {
       setIsLoading(false);
       return;
     }
@@ -282,7 +313,7 @@ export function usePerformanceRiskContract({
           detailBasis,
           benchmark: workspace.benchmark_code ?? undefined,
           ...riskWindowParams,
-          asOfDate: workspace.as_of_date,
+          asOfDate: riskAsOfDate,
           reportingCurrency: workspace.portfolio.base_currency,
         }).catch((error: unknown) =>
           buildUnavailableRiskSummary({
@@ -291,7 +322,7 @@ export function usePerformanceRiskContract({
             detailBasis,
             detail: buildRiskFetchFailureDetail(error, "Risk summary"),
             permissionBlocked: isWorkbenchPermissionBlockedError(error),
-          })
+          }),
         )
       : Promise.resolve(cachedSummary);
 
@@ -300,7 +331,7 @@ export function usePerformanceRiskContract({
           period,
           benchmark: workspace.benchmark_code ?? undefined,
           ...riskWindowParams,
-          asOfDate: workspace.as_of_date,
+          asOfDate: riskAsOfDate,
           reportingCurrency: workspace.portfolio.base_currency,
         }).catch((error: unknown) =>
           buildUnavailableRiskConcentration({
@@ -308,7 +339,7 @@ export function usePerformanceRiskContract({
             period,
             detail: buildRiskFetchFailureDetail(error, "Risk concentration"),
             permissionBlocked: isWorkbenchPermissionBlockedError(error),
-          })
+          }),
         )
       : Promise.resolve(cachedConcentration);
 
@@ -318,7 +349,7 @@ export function usePerformanceRiskContract({
           detailBasis,
           benchmark: workspace.benchmark_code ?? undefined,
           ...riskWindowParams,
-          asOfDate: workspace.as_of_date,
+          asOfDate: riskAsOfDate,
           reportingCurrency: workspace.portfolio.base_currency,
           includeUnderwaterSeries: false,
         }).catch((error: unknown) =>
@@ -329,7 +360,7 @@ export function usePerformanceRiskContract({
             detail: buildRiskFetchFailureDetail(error, "Risk drawdown"),
             includeUnderwaterSeries: false,
             permissionBlocked: isWorkbenchPermissionBlockedError(error),
-          })
+          }),
         )
       : Promise.resolve(cachedDrawdown);
 
@@ -339,7 +370,7 @@ export function usePerformanceRiskContract({
           detailBasis,
           benchmark: workspace.benchmark_code ?? undefined,
           ...riskWindowParams,
-          asOfDate: workspace.as_of_date,
+          asOfDate: riskAsOfDate,
           reportingCurrency: workspace.portfolio.base_currency,
           includeTimeSeries: false,
         }).catch((error: unknown) =>
@@ -350,34 +381,37 @@ export function usePerformanceRiskContract({
             detail: buildRiskFetchFailureDetail(error, "Risk rolling"),
             includeTimeSeries: false,
             permissionBlocked: isWorkbenchPermissionBlockedError(error),
-          })
+          }),
         )
       : Promise.resolve(cachedRolling);
 
-    void Promise.all([summaryPromise, concentrationPromise, drawdownPromise, rollingPromise]).then(
-      ([nextSummary, nextConcentration, nextDrawdown, nextRolling]) => {
-        if (requestSequenceRef.current !== requestId) {
-          return;
-        }
-        if (nextSummary) {
-          summaryCacheRef.current.set(summaryKey, nextSummary);
-          setRiskSummary(nextSummary);
-        }
-        if (nextConcentration) {
-          concentrationCacheRef.current.set(concentrationKey, nextConcentration);
-          setRiskConcentration(nextConcentration);
-        }
-        if (nextDrawdown) {
-          drawdownCacheRef.current.set(drawdownKey, nextDrawdown);
-          setRiskDrawdown(nextDrawdown);
-        }
-        if (nextRolling) {
-          rollingCacheRef.current.set(rollingKey, nextRolling);
-          setRiskRolling(nextRolling);
-        }
-        setIsLoading(false);
+    void Promise.all([
+      summaryPromise,
+      concentrationPromise,
+      drawdownPromise,
+      rollingPromise,
+    ]).then(([nextSummary, nextConcentration, nextDrawdown, nextRolling]) => {
+      if (requestSequenceRef.current !== requestId) {
+        return;
       }
-    );
+      if (nextSummary) {
+        summaryCacheRef.current.set(summaryKey, nextSummary);
+        setRiskSummary(nextSummary);
+      }
+      if (nextConcentration) {
+        concentrationCacheRef.current.set(concentrationKey, nextConcentration);
+        setRiskConcentration(nextConcentration);
+      }
+      if (nextDrawdown) {
+        drawdownCacheRef.current.set(drawdownKey, nextDrawdown);
+        setRiskDrawdown(nextDrawdown);
+      }
+      if (nextRolling) {
+        rollingCacheRef.current.set(rollingKey, nextRolling);
+        setRiskRolling(nextRolling);
+      }
+      setIsLoading(false);
+    });
   }, [
     concentrationKey,
     detailBasis,
@@ -389,7 +423,7 @@ export function usePerformanceRiskContract({
     rollingDetailKey,
     rollingKey,
     summaryKey,
-    workspace.as_of_date,
+    riskAsOfDate,
     workspace.benchmark_code,
     workspace.portfolio.base_currency,
     workspace.portfolio.portfolio_id,
@@ -403,7 +437,7 @@ export function usePerformanceRiskContract({
         detailBasis,
         benchmark: workspace.benchmark_code ?? null,
         ...riskWindowParams,
-        asOfDate: workspace.as_of_date,
+        asOfDate: riskAsOfDate,
         reportingCurrency: workspace.portfolio.base_currency,
         attributionType: selectedAttributionType,
         groupingDimension: selectedGroupingDimension,
@@ -414,11 +448,11 @@ export function usePerformanceRiskContract({
       riskWindowParams,
       selectedAttributionType,
       selectedGroupingDimension,
-      workspace.as_of_date,
+      riskAsOfDate,
       workspace.benchmark_code,
       workspace.portfolio.base_currency,
       workspace.portfolio.portfolio_id,
-    ]
+    ],
   );
 
   useEffect(() => {
@@ -426,9 +460,18 @@ export function usePerformanceRiskContract({
     setSelectedGroupingDimension("SECTOR");
     setRiskAttribution(null);
     setIsAttributionLoading(false);
-  }, [detailBasis, period, workspace.as_of_date, workspace.benchmark_code, workspace.portfolio.portfolio_id]);
+  }, [
+    detailBasis,
+    period,
+    riskAsOfDate,
+    workspace.benchmark_code,
+    workspace.portfolio.portfolio_id,
+  ]);
 
-  const requestAttribution = (attributionType: string, groupingDimension: string) => {
+  const requestAttribution = (
+    attributionType: string,
+    groupingDimension: string,
+  ) => {
     if (isDetailsPending) {
       return;
     }
@@ -440,7 +483,8 @@ export function usePerformanceRiskContract({
     if (isDetailsPending) {
       return;
     }
-    const cachedResponse = attributionCacheRef.current.get(attributionKey) ?? null;
+    const cachedResponse =
+      attributionCacheRef.current.get(attributionKey) ?? null;
     if (cachedResponse) {
       setRiskAttribution(cachedResponse);
       setIsAttributionLoading(false);
@@ -454,7 +498,7 @@ export function usePerformanceRiskContract({
       detailBasis,
       benchmark: workspace.benchmark_code ?? undefined,
       ...riskWindowParams,
-      asOfDate: workspace.as_of_date,
+      asOfDate: riskAsOfDate,
       reportingCurrency: workspace.portfolio.base_currency,
       attributionType: selectedAttributionType,
       groupingDimension: selectedGroupingDimension,
@@ -488,7 +532,7 @@ export function usePerformanceRiskContract({
     riskWindowParams,
     selectedAttributionType,
     selectedGroupingDimension,
-    workspace.as_of_date,
+    riskAsOfDate,
     workspace.benchmark_code,
     workspace.portfolio.base_currency,
     workspace.portfolio.portfolio_id,
@@ -498,7 +542,8 @@ export function usePerformanceRiskContract({
     if (isDetailsPending) {
       return;
     }
-    const cachedDetail = drawdownDetailCacheRef.current.get(drawdownDetailKey) ?? null;
+    const cachedDetail =
+      drawdownDetailCacheRef.current.get(drawdownDetailKey) ?? null;
     if (cachedDetail) {
       setRiskDrawdownDetail(cachedDetail);
       return;
@@ -506,24 +551,29 @@ export function usePerformanceRiskContract({
     const requestId = drawdownDetailRequestSequenceRef.current + 1;
     drawdownDetailRequestSequenceRef.current = requestId;
     setIsDrawdownDetailLoading(true);
-    void getWorkbenchRiskDrawdownClient(workspaceRef.current.portfolio.portfolio_id, {
-      period,
-      detailBasis,
-      benchmark: workspaceRef.current.benchmark_code ?? undefined,
-      ...getRiskWindowParams(workspaceRef.current, period),
-      asOfDate: workspaceRef.current.as_of_date,
-      reportingCurrency: workspaceRef.current.portfolio.base_currency,
-      includeUnderwaterSeries: true,
-    })
+    void getWorkbenchRiskDrawdownClient(
+      workspaceRef.current.portfolio.portfolio_id,
+      {
+        period,
+        detailBasis,
+        benchmark: workspaceRef.current.benchmark_code ?? undefined,
+        ...getRiskWindowParams(workspaceRef.current, period),
+        asOfDate: getRiskAsOfDate(workspaceRef.current),
+        reportingCurrency: workspaceRef.current.portfolio.base_currency,
+        includeUnderwaterSeries: true,
+      },
+    )
       .catch((error: unknown) =>
         buildUnavailableRiskDrawdown({
           workspace: workspaceRef.current,
           period,
           detailBasis,
           detail:
-            error instanceof Error ? error.message : "Risk drawdown detail fetch failed.",
+            error instanceof Error
+              ? error.message
+              : "Risk drawdown detail fetch failed.",
           includeUnderwaterSeries: true,
-        })
+        }),
       )
       .then((response) => {
         if (drawdownDetailRequestSequenceRef.current !== requestId) {
@@ -539,7 +589,8 @@ export function usePerformanceRiskContract({
     if (isDetailsPending) {
       return;
     }
-    const cachedDetail = rollingDetailCacheRef.current.get(rollingDetailKey) ?? null;
+    const cachedDetail =
+      rollingDetailCacheRef.current.get(rollingDetailKey) ?? null;
     if (cachedDetail) {
       setRiskRollingDetail(cachedDetail);
       return;
@@ -547,24 +598,29 @@ export function usePerformanceRiskContract({
     const requestId = rollingDetailRequestSequenceRef.current + 1;
     rollingDetailRequestSequenceRef.current = requestId;
     setIsRollingDetailLoading(true);
-    void getWorkbenchRiskRollingClient(workspaceRef.current.portfolio.portfolio_id, {
-      period,
-      detailBasis,
-      benchmark: workspaceRef.current.benchmark_code ?? undefined,
-      ...getRiskWindowParams(workspaceRef.current, period),
-      asOfDate: workspaceRef.current.as_of_date,
-      reportingCurrency: workspaceRef.current.portfolio.base_currency,
-      includeTimeSeries: true,
-    })
+    void getWorkbenchRiskRollingClient(
+      workspaceRef.current.portfolio.portfolio_id,
+      {
+        period,
+        detailBasis,
+        benchmark: workspaceRef.current.benchmark_code ?? undefined,
+        ...getRiskWindowParams(workspaceRef.current, period),
+        asOfDate: getRiskAsOfDate(workspaceRef.current),
+        reportingCurrency: workspaceRef.current.portfolio.base_currency,
+        includeTimeSeries: true,
+      },
+    )
       .catch((error: unknown) =>
         buildUnavailableRiskRolling({
           workspace: workspaceRef.current,
           period,
           detailBasis,
           detail:
-            error instanceof Error ? error.message : "Risk rolling detail fetch failed.",
+            error instanceof Error
+              ? error.message
+              : "Risk rolling detail fetch failed.",
           includeTimeSeries: true,
-        })
+        }),
       )
       .then((response) => {
         if (rollingDetailRequestSequenceRef.current !== requestId) {
@@ -594,13 +650,20 @@ export function usePerformanceRiskContract({
   };
 }
 
-function getRiskWindowParams(workspace: WorkbenchPerformanceWorkspace, period: string) {
+function getRiskWindowParams(
+  workspace: WorkbenchPerformanceWorkspace,
+  period: string,
+) {
   return period === "EXPLICIT"
     ? {
         reportStartDate: workspace.report_start_date,
         reportEndDate: workspace.report_end_date,
       }
     : {};
+}
+
+function getRiskAsOfDate(workspace: WorkbenchPerformanceWorkspace): string {
+  return workspace.report_end_date?.trim() || workspace.as_of_date;
 }
 
 function buildRiskFetchFailureDetail(error: unknown, label: string): string {

--- a/src/features/proposals/components/proposal-narrative-posture-panel.tsx
+++ b/src/features/proposals/components/proposal-narrative-posture-panel.tsx
@@ -111,6 +111,7 @@ export default function ProposalNarrativePosturePanel({
 
   return (
     <SectionBlock
+      className="proposal-narrative-posture-panel"
       title="Advisor Narrative And Delivery"
       subtitle="Review advisor-use narrative posture, request reviewed narrative report packaging, and inspect delivery events from the Gateway advisory contract."
       actions={

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -196,6 +196,9 @@ describe("canonical live validation script", () => {
     expect(script).toContain('from "./validation/workflow-pack-proof.mjs"');
     expect(script).toContain("validateAdvisorBriefWorkflowPackReviewChain");
     expect(script).toContain("workflowPackChecks.push");
+    expect(script).toContain("validateProposalNarrativePosturePanel");
+    expect(script).toContain("Create proposal narrative canonical proof");
+    expect(script).toContain("proposal.narrative_posture");
     expect(calculationModule).toContain("calculationChecks");
     expect(calculationModule).toContain("Contribution total does not reconcile with net portfolio return");
     expect(calculationModule).toContain("Historical risk attribution residual is too high");
@@ -407,7 +410,12 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).not.toContain('getByRole("group", { name: "Post-Trade Outcome Review"');
     expect(browserWorkflowModule).not.toContain('getByRole("group", { name: "Proof-Pack Evidence"');
     expect(contractModule).toContain('panelId: "performance.risk.snapshot"');
+    expect(contractModule).toContain('panelId: "proposal.narrative_posture"');
     expect(contractModule).toContain('screenshotName: "performance-risk-live.png"');
+    expect(contractModule).toContain('screenshotName: "proposal-narrative-posture-live.png"');
+    expect(browserWorkflowModule).toContain("Proposal narrative posture review and report package");
+    expect(browserWorkflowModule).toContain("Approve Advisor Narrative");
+    expect(browserWorkflowModule).toContain("Request Reviewed Report");
     expect(browserWorkflowModule).toContain("panel: panelId");
     expect(browserWorkflowModule).toContain('screenshotState = "demo_ready"');
     expect(browserWorkflowModule).toContain("state: screenshotState");

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -97,12 +97,14 @@ describe("canonical live validation script", () => {
     expect(script).toContain("[int]$SeedWaitSeconds = 900");
     expect(script).toContain('[string]$LotusAiEnvFile = ".env.example"');
     expect(script).toContain("[string[]]$LocalApps = @()");
+    expect(script).toContain("[switch]$SkipSeedCleanup");
     expect(script).toContain("function Test-LocalApp");
     expect(script).toContain("function Invoke-ComposeUp");
     expect(script).toContain("function Start-LocalUvicornService");
     expect(script).toContain("function Start-CanonicalManage");
     expect(script).toContain("function Start-DirectIngress");
     expect(script).toContain("function Invoke-CanonicalCoreSeed");
+    expect(script).toContain("function Invoke-DpmCommandCenterSeed");
     expect(script).toContain("Using lotus-ai env file for canonical proof");
     expect(script).toContain("[switch]$CleanCoreState");
     expect(script).toContain("[switch]$CoreManageOnly");
@@ -137,6 +139,9 @@ describe("canonical live validation script", () => {
     expect(script).toContain("--end-date 2026-04-10");
     expect(script).toContain("--benchmark-start-date 2025-01-06");
     expect(script).toContain("--wait-seconds $SeedWaitSeconds");
+    expect(script).toContain("$seedCommand = \"$seedCommand --skip-cleanup\"");
+    expect(script).toContain("automation\\Invoke-DpmCommandCenterSeed.ps1");
+    expect(script).toContain("Seeding governed DPM command-center and action-register evidence");
     expect(script).toContain("[string]$ScreenshotDirectory");
     expect(script).toContain("ScreenshotDirectory = $ScreenshotDirectory");
   });
@@ -185,6 +190,10 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validation", "calculation-sanity.mjs"),
       "utf8"
     );
+    const browserWorkflows = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "browser-workflows.mjs"),
+      "utf8"
+    );
 
     expect(script).toContain("assertPerformanceCalculationSanity");
     expect(script).toContain("assertRiskCalculationSanity");
@@ -198,7 +207,13 @@ describe("canonical live validation script", () => {
     expect(script).toContain("workflowPackChecks.push");
     expect(script).toContain("validateProposalNarrativePosturePanel");
     expect(script).toContain("Create proposal narrative canonical proof");
+    expect(script).toContain('import { createHash } from "node:crypto"');
+    expect(script).toContain("buildPayloadScopedIdempotencyKey");
+    expect(script).toContain("proposalCreateIdempotencyKey");
+    expect(script).toContain("proofPackIdempotencyKey");
     expect(script).toContain("proposal.narrative_posture");
+    expect(browserWorkflows).toContain('getByLabel("Status Approved For Advisor Use")');
+    expect(browserWorkflows).not.toContain('getByText("Approved For Advisor Use")');
     expect(calculationModule).toContain("calculationChecks");
     expect(calculationModule).toContain("Contribution total does not reconcile with net portfolio return");
     expect(calculationModule).toContain("Historical risk attribution residual is too high");

--- a/tests/unit/live-validation-calculation-sanity.test.ts
+++ b/tests/unit/live-validation-calculation-sanity.test.ts
@@ -241,12 +241,13 @@ describe("live validation calculation sanity helpers", () => {
             },
           ],
         },
-        source_supportability: [
+        supportability: [
           {
+            key: "portfolio_returns",
+            label: "Portfolio returns",
             source_service: "lotus-risk",
             operation: "risk.summary",
             state: "ready",
-            freshness_bucket: "fresh",
           },
         ],
       },

--- a/tests/unit/performance-risk-mode.test.tsx
+++ b/tests/unit/performance-risk-mode.test.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import PerformanceRiskMode from "../../src/apps/performance/components/performance-risk-mode";
@@ -17,7 +23,10 @@ import {
   getWorkbenchRiskRollingClient,
   getWorkbenchRiskSummaryClient,
 } from "../../src/features/workbench/api";
-import { buildBenchmarkUnassignedPerformanceScenario, buildSupportedPerformanceScenario } from "../fixtures/performance-workspace-fixtures";
+import {
+  buildBenchmarkUnassignedPerformanceScenario,
+  buildSupportedPerformanceScenario,
+} from "../fixtures/performance-workspace-fixtures";
 
 vi.mock("../../src/features/workbench/api", () => ({
   getWorkbenchRiskSummaryClient: vi.fn(),
@@ -26,13 +35,17 @@ vi.mock("../../src/features/workbench/api", () => ({
   getWorkbenchRiskDrawdownClient: vi.fn(),
   getWorkbenchRiskRollingClient: vi.fn(),
   isWorkbenchPermissionBlockedError: vi.fn((error: unknown) =>
-    error instanceof Error ? /\((401|403)\)$/.test(error.message) : false
+    error instanceof Error ? /\((401|403)\)$/.test(error.message) : false,
   ),
 }));
 
 function renderRiskMode(
   scenario = buildSupportedPerformanceScenario(),
-  options: { detailBasis?: "NET" | "GROSS"; period?: string; isDetailsPending?: boolean } = {}
+  options: {
+    detailBasis?: "NET" | "GROSS";
+    period?: string;
+    isDetailsPending?: boolean;
+  } = {},
 ) {
   return render(
     <PerformanceRiskMode
@@ -45,7 +58,7 @@ function renderRiskMode(
       chartFrequency="monthly"
       isUpdating={false}
       isDetailsPending={options.isDetailsPending ?? false}
-    />
+    />,
   );
 }
 
@@ -57,70 +70,100 @@ describe("PerformanceRiskMode", () => {
   it("fetches live Gateway-backed risk summary and concentration contracts", async () => {
     const scenario = buildSupportedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
     vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
-      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
-      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
-      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     );
 
     const { container } = renderRiskMode(scenario);
 
     expect(screen.getByText("Loading risk")).toBeInTheDocument();
     await waitFor(() => {
-      expect(screen.getByLabelText("Risk snapshot headline metrics")).toHaveTextContent("Volatility");
+      expect(
+        screen.getByLabelText("Risk snapshot headline metrics"),
+      ).toHaveTextContent("Volatility");
     });
-    expect(screen.getByLabelText("Risk coverage and review notes")).toHaveTextContent(
-      "Coverage and review notes"
+    expect(
+      screen.getByLabelText("Risk coverage and review notes"),
+    ).toHaveTextContent("Coverage and review notes");
+    expect(
+      screen.queryByLabelText("Risk snapshot business reading"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Risk executive overview")).toHaveTextContent(
+      "Risk posture",
     );
-    expect(screen.queryByLabelText("Risk snapshot business reading")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Risk executive overview")).toHaveTextContent("Risk posture");
-    expect(screen.getByLabelText("Risk executive overview")).not.toHaveTextContent("What matters now");
+    expect(
+      screen.getByLabelText("Risk executive overview"),
+    ).not.toHaveTextContent("What matters now");
     expect(screen.getByLabelText("Primary risk review")).toBeInTheDocument();
-    expect(screen.getByLabelText("Secondary risk analysis")).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: /methodology and coverage$/i })).toHaveLength(5);
-    expect(screen.queryByLabelText("Drawdown business reading")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Rolling risk business reading")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Historical risk attribution business reading")).not.toBeInTheDocument();
-    const concentrationHeading = screen.getByRole("heading", { name: "Concentration" });
-    const rollingHeading = screen.getByRole("heading", { name: "Rolling Risk" });
+    expect(
+      screen.getByLabelText("Secondary risk analysis"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: /methodology and coverage$/i }),
+    ).toHaveLength(5);
+    expect(
+      screen.queryByLabelText("Drawdown business reading"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Rolling risk business reading"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Historical risk attribution business reading"),
+    ).not.toBeInTheDocument();
+    const concentrationHeading = screen.getByRole("heading", {
+      name: "Concentration",
+    });
+    const rollingHeading = screen.getByRole("heading", {
+      name: "Rolling Risk",
+    });
     const attributionHeading = screen.getByRole("heading", {
       name: "Historical Risk Attribution",
     });
     expect(
       concentrationHeading.compareDocumentPosition(rollingHeading) &
-        Node.DOCUMENT_POSITION_FOLLOWING
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
       rollingHeading.compareDocumentPosition(attributionHeading) &
-        Node.DOCUMENT_POSITION_FOLLOWING
-    ).toBeTruthy();
-    expect(
-      container.querySelector(".performance-risk-secondary-group .performance-risk-rolling-panel")
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
       container.querySelector(
-        ".performance-risk-secondary-group .performance-risk-attribution-panel"
-      )
-    ).toBeTruthy();
-    expect(
-      container.querySelector(".performance-risk-secondary-group .performance-risk-secondary-main")
+        ".performance-risk-secondary-group .performance-risk-rolling-panel",
+      ),
     ).toBeTruthy();
     expect(
       container.querySelector(
-        ".performance-risk-secondary-group .performance-risk-secondary-sidecar"
-      )
+        ".performance-risk-secondary-group .performance-risk-attribution-panel",
+      ),
     ).toBeTruthy();
-    expect(container.querySelectorAll(".performance-risk-module-shell-compact")).toHaveLength(5);
-    expect(screen.queryByText("Coverage and methodology")).not.toBeInTheDocument();
+    expect(
+      container.querySelector(
+        ".performance-risk-secondary-group .performance-risk-secondary-main",
+      ),
+    ).toBeTruthy();
+    expect(
+      container.querySelector(
+        ".performance-risk-secondary-group .performance-risk-secondary-sidecar",
+      ),
+    ).toBeTruthy();
+    expect(
+      container.querySelectorAll(".performance-risk-module-shell-compact"),
+    ).toHaveLength(5);
+    expect(
+      screen.queryByText("Coverage and methodology"),
+    ).not.toBeInTheDocument();
 
     expect(getWorkbenchRiskSummaryClient).toHaveBeenCalledWith("PF_1001", {
       period: "YTD",
@@ -129,12 +172,15 @@ describe("PerformanceRiskMode", () => {
       asOfDate: "2026-02-24",
       reportingCurrency: "USD",
     });
-    expect(getWorkbenchRiskConcentrationClient).toHaveBeenCalledWith("PF_1001", {
-      period: "YTD",
-      benchmark: "BMK_GLOBAL_BALANCED_60_40",
-      asOfDate: "2026-02-24",
-      reportingCurrency: "USD",
-    });
+    expect(getWorkbenchRiskConcentrationClient).toHaveBeenCalledWith(
+      "PF_1001",
+      {
+        period: "YTD",
+        benchmark: "BMK_GLOBAL_BALANCED_60_40",
+        asOfDate: "2026-02-24",
+        reportingCurrency: "USD",
+      },
+    );
     expect(getWorkbenchRiskAttributionClient).toHaveBeenCalledWith("PF_1001", {
       period: "YTD",
       detailBasis: "NET",
@@ -162,22 +208,78 @@ describe("PerformanceRiskMode", () => {
     });
   });
 
+  it("uses the report end date as the risk as-of date for canonical historical analytics", async () => {
+    const scenario = buildSupportedPerformanceScenario();
+    const canonicalScenario = {
+      ...scenario,
+      workspace: {
+        ...scenario.workspace,
+        as_of_date: "2026-05-23",
+        report_end_date: "2026-04-10",
+      },
+    };
+    vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
+      buildFixtureRiskSummary(canonicalScenario.workspace, "YTD", "NET"),
+    );
+    vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
+      buildFixtureRiskConcentration(canonicalScenario.workspace, "YTD"),
+    );
+    vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
+      buildFixtureRiskAttribution(canonicalScenario.workspace, "YTD", "NET"),
+    );
+    vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
+      buildFixtureRiskDrawdown(canonicalScenario.workspace, "YTD", "NET"),
+    );
+    vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
+      buildFixtureRiskRolling(canonicalScenario.workspace, "YTD", "NET"),
+    );
+
+    renderRiskMode(canonicalScenario);
+
+    await waitFor(() => {
+      expect(getWorkbenchRiskAttributionClient).toHaveBeenCalledWith(
+        "PF_1001",
+        {
+          period: "YTD",
+          detailBasis: "NET",
+          benchmark: "BMK_GLOBAL_BALANCED_60_40",
+          asOfDate: "2026-04-10",
+          reportingCurrency: "USD",
+          attributionType: "TOTAL_RISK",
+          groupingDimension: "SECTOR",
+        },
+      );
+    });
+    expect(getWorkbenchRiskSummaryClient).toHaveBeenCalledWith(
+      "PF_1001",
+      expect.objectContaining({ asOfDate: "2026-04-10" }),
+    );
+    expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledWith(
+      "PF_1001",
+      expect.objectContaining({ asOfDate: "2026-04-10" }),
+    );
+    expect(getWorkbenchRiskRollingClient).toHaveBeenCalledWith(
+      "PF_1001",
+      expect.objectContaining({ asOfDate: "2026-04-10" }),
+    );
+  });
+
   it("reuses cached live responses for the same request shape and invalidates summary only when detail basis changes", async () => {
     const scenario = buildSupportedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
     vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
-      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
-      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
-      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     );
 
     const { rerender } = render(
@@ -191,11 +293,13 @@ describe("PerformanceRiskMode", () => {
         chartFrequency="monthly"
         isUpdating={false}
         isDetailsPending={false}
-      />
+      />,
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Risk snapshot headline metrics")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Risk snapshot headline metrics"),
+      ).toBeInTheDocument();
     });
 
     rerender(
@@ -209,11 +313,13 @@ describe("PerformanceRiskMode", () => {
         chartFrequency="monthly"
         isUpdating={false}
         isDetailsPending={false}
-      />
+      />,
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Risk concentration headline metrics")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Risk concentration headline metrics"),
+      ).toBeInTheDocument();
     });
 
     expect(getWorkbenchRiskSummaryClient).toHaveBeenCalledTimes(1);
@@ -223,7 +329,7 @@ describe("PerformanceRiskMode", () => {
     expect(getWorkbenchRiskRollingClient).toHaveBeenCalledTimes(1);
 
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "GROSS")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "GROSS"),
     );
 
     rerender(
@@ -237,7 +343,7 @@ describe("PerformanceRiskMode", () => {
         chartFrequency="monthly"
         isUpdating={false}
         isDetailsPending={false}
-      />
+      />,
     );
 
     await waitFor(() => {
@@ -252,59 +358,71 @@ describe("PerformanceRiskMode", () => {
   it("shows partial live supportability when benchmark-relative risk is unavailable", async () => {
     const scenario = buildBenchmarkUnassignedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
     vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
-      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
       buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET", {
         includeBenchmarkRelative: false,
-      })
+      }),
     );
     vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
-      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     );
 
     const { container } = renderRiskMode(scenario);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Risk drawdown headline metrics")).toHaveTextContent(
-        "Relative Max Drawdown"
-      );
+      expect(
+        screen.getByLabelText("Risk drawdown headline metrics"),
+      ).toHaveTextContent("Relative Max Drawdown");
     });
-    expect(screen.getByLabelText("Risk drawdown headline metrics")).toHaveTextContent("N/A");
-    expect(screen.getByLabelText("Risk executive overview")).toHaveTextContent("Evidence posture");
+    expect(
+      screen.getByLabelText("Risk drawdown headline metrics"),
+    ).toHaveTextContent("N/A");
+    expect(screen.getByLabelText("Risk executive overview")).toHaveTextContent(
+      "Evidence posture",
+    );
   });
 
   it("opens panel methodology and coverage on demand without changing data-fetch flow", async () => {
     const scenario = buildSupportedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
     vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
-      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
-      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
-      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     );
 
     renderRiskMode(scenario);
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Risk Snapshot methodology and coverage" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", {
+          name: "Risk Snapshot methodology and coverage",
+        }),
+      ).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Concentration methodology and coverage" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Concentration methodology and coverage",
+      }),
+    );
 
     const dialog = screen.getByRole("dialog", {
       name: "Concentration methodology and coverage",
@@ -320,42 +438,52 @@ describe("PerformanceRiskMode", () => {
   it("renders enriched concentration interpretation without a provenance footer", async () => {
     const scenario = buildSupportedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
     vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
-      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
-      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
-      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     );
 
     renderRiskMode(scenario);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Risk concentration headline metrics")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Risk concentration headline metrics"),
+      ).toBeInTheDocument();
     });
-    expect(screen.queryByLabelText("Risk concentration executive summary")).not.toBeInTheDocument();
-    const concentrationMetricStrip = screen.getByLabelText("Risk concentration headline metrics");
+    expect(
+      screen.queryByLabelText("Risk concentration executive summary"),
+    ).not.toBeInTheDocument();
+    const concentrationMetricStrip = screen.getByLabelText(
+      "Risk concentration headline metrics",
+    );
     expect(
       within(concentrationMetricStrip)
         .getByText("Portfolio Concentration Index")
-        .closest(".performance-risk-concentration-indicator-tile")
+        .closest(".performance-risk-concentration-indicator-tile"),
     ).toHaveAttribute(
       "title",
-      "Herfindahl-Hirschman Index for the current portfolio. Higher values indicate exposure concentrated in fewer holdings."
+      "Herfindahl-Hirschman Index for the current portfolio. Higher values indicate exposure concentrated in fewer holdings.",
     );
     expect(screen.getByLabelText("Risk concentration scale")).toHaveTextContent(
-      "Diversified"
+      "Diversified",
     );
-    expect(screen.queryByLabelText("Risk concentration driver analysis")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Risk concentration driver analysis"),
+    ).not.toBeInTheDocument();
     fireEvent.click(
-      screen.getByRole("button", { name: "Concentration methodology and coverage" })
+      screen.getByRole("button", {
+        name: "Concentration methodology and coverage",
+      }),
     );
 
     const concentrationDialog = screen.getByRole("dialog", {
@@ -363,51 +491,77 @@ describe("PerformanceRiskMode", () => {
     });
 
     expect(concentrationDialog).toHaveTextContent("Grouping Level");
-    expect(screen.queryByLabelText("Risk concentration diagnostic table")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Risk concentration diagnostic table"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Risk provenance")).not.toBeInTheDocument();
   });
 
   it("uses a single semantic status badge in the risk header", async () => {
     const scenario = buildSupportedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
     vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
-      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
-      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
-      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     );
 
     const { container } = renderRiskMode(scenario);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Risk mode status")).toHaveTextContent("Partial");
+      expect(screen.getByLabelText("Risk mode status")).toHaveTextContent(
+        "Partial",
+      );
     });
 
-    expect(screen.getByLabelText("Risk mode status")).toHaveTextContent("Partial");
-    expect(screen.getByLabelText("Risk mode status")).not.toHaveTextContent("Input mode");
-    expect(screen.getByLabelText("Risk mode status")).not.toHaveTextContent("Stateful only");
-    expect(screen.getByLabelText("Risk mode status")).not.toHaveTextContent("Evidence");
-    expect(screen.getByLabelText("Risk mode status")).not.toHaveTextContent("Review notes");
-    expect(screen.queryByLabelText("Status Stateful only")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Status Source-grounded")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Risk mode status")).toHaveTextContent(
+      "Partial",
+    );
+    expect(screen.getByLabelText("Risk mode status")).not.toHaveTextContent(
+      "Input mode",
+    );
+    expect(screen.getByLabelText("Risk mode status")).not.toHaveTextContent(
+      "Stateful only",
+    );
+    expect(screen.getByLabelText("Risk mode status")).not.toHaveTextContent(
+      "Evidence",
+    );
+    expect(screen.getByLabelText("Risk mode status")).not.toHaveTextContent(
+      "Review notes",
+    );
+    expect(
+      screen.queryByLabelText("Status Stateful only"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Status Source-grounded"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders controlled unavailable states when both live BFF requests fail", async () => {
-    vi.mocked(getWorkbenchRiskSummaryClient).mockRejectedValue(new Error("summary down"));
-    vi.mocked(getWorkbenchRiskConcentrationClient).mockRejectedValue(
-      new Error("concentration down")
+    vi.mocked(getWorkbenchRiskSummaryClient).mockRejectedValue(
+      new Error("summary down"),
     );
-    vi.mocked(getWorkbenchRiskAttributionClient).mockRejectedValue(new Error("attribution down"));
-    vi.mocked(getWorkbenchRiskDrawdownClient).mockRejectedValue(new Error("drawdown down"));
-    vi.mocked(getWorkbenchRiskRollingClient).mockRejectedValue(new Error("rolling down"));
+    vi.mocked(getWorkbenchRiskConcentrationClient).mockRejectedValue(
+      new Error("concentration down"),
+    );
+    vi.mocked(getWorkbenchRiskAttributionClient).mockRejectedValue(
+      new Error("attribution down"),
+    );
+    vi.mocked(getWorkbenchRiskDrawdownClient).mockRejectedValue(
+      new Error("drawdown down"),
+    );
+    vi.mocked(getWorkbenchRiskRollingClient).mockRejectedValue(
+      new Error("rolling down"),
+    );
 
     renderRiskMode();
 
@@ -415,51 +569,67 @@ describe("PerformanceRiskMode", () => {
       expect(screen.getByText("Risk unavailable")).toBeInTheDocument();
     });
     expect(screen.queryByLabelText("Risk provenance")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Risk snapshot headline metrics")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Risk snapshot headline metrics"),
+    ).not.toBeInTheDocument();
   });
 
   it("does not request underwater detail on first paint and fetches it only on drawer drill-down", async () => {
     const scenario = buildSupportedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
     vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
-      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient)
-      .mockResolvedValueOnce(buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"))
+      .mockResolvedValueOnce(
+        buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
+      )
       .mockResolvedValueOnce(
         buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET", {
           includeUnderwaterSeries: true,
-        })
+        }),
       );
     vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
-      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     );
 
     renderRiskMode(scenario);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Risk drawdown headline metrics")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Risk drawdown headline metrics"),
+      ).toBeInTheDocument();
     });
 
     expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(getWorkbenchRiskDrawdownClient).mock.calls[0][1]).toMatchObject({
+    expect(
+      vi.mocked(getWorkbenchRiskDrawdownClient).mock.calls[0][1],
+    ).toMatchObject({
       includeUnderwaterSeries: false,
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "View underwater path" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "View underwater path" }),
+    );
 
     await waitFor(() => {
-      expect(screen.getByRole("dialog", { name: "Underwater path detail" })).toBeInTheDocument();
-      expect(screen.getByLabelText("Risk underwater series table")).toBeInTheDocument();
+      expect(
+        screen.getByRole("dialog", { name: "Underwater path detail" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Risk underwater series table"),
+      ).toBeInTheDocument();
     });
 
     expect(getWorkbenchRiskDrawdownClient).toHaveBeenCalledTimes(2);
-    expect(vi.mocked(getWorkbenchRiskDrawdownClient).mock.calls[1][1]).toMatchObject({
+    expect(
+      vi.mocked(getWorkbenchRiskDrawdownClient).mock.calls[1][1],
+    ).toMatchObject({
       includeUnderwaterSeries: true,
     });
   });
@@ -467,45 +637,59 @@ describe("PerformanceRiskMode", () => {
   it("does not request rolling detail on first paint and fetches it only on drawer drill-down", async () => {
     const scenario = buildSupportedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
     vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
-      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
-      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskRollingClient)
-      .mockResolvedValueOnce(buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"))
+      .mockResolvedValueOnce(
+        buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
+      )
       .mockResolvedValueOnce(
         buildFixtureRiskRolling(scenario.workspace, "YTD", "NET", {
           includeTimeSeries: true,
-        })
+        }),
       );
 
     renderRiskMode(scenario);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Rolling risk summary table")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Rolling risk summary table"),
+      ).toBeInTheDocument();
     });
 
     expect(getWorkbenchRiskRollingClient).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(getWorkbenchRiskRollingClient).mock.calls[0][1]).toMatchObject({
+    expect(
+      vi.mocked(getWorkbenchRiskRollingClient).mock.calls[0][1],
+    ).toMatchObject({
       includeTimeSeries: false,
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "View rolling series" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "View rolling series" }),
+    );
 
     await waitFor(() => {
-      expect(screen.getByRole("dialog", { name: "Rolling series detail" })).toBeInTheDocument();
-      expect(screen.getByLabelText("Rolling risk series table")).toBeInTheDocument();
+      expect(
+        screen.getByRole("dialog", { name: "Rolling series detail" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Rolling risk series table"),
+      ).toBeInTheDocument();
     });
 
     expect(getWorkbenchRiskRollingClient).toHaveBeenCalledTimes(2);
-    expect(vi.mocked(getWorkbenchRiskRollingClient).mock.calls[1][1]).toMatchObject({
+    expect(
+      vi.mocked(getWorkbenchRiskRollingClient).mock.calls[1][1],
+    ).toMatchObject({
       includeTimeSeries: true,
     });
   });
@@ -513,23 +697,25 @@ describe("PerformanceRiskMode", () => {
   it("preserves the selected rolling window when opening rolling series detail", async () => {
     const scenario = buildSupportedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
     vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
-      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
-      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskRollingClient)
-      .mockResolvedValueOnce(buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"))
+      .mockResolvedValueOnce(
+        buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
+      )
       .mockResolvedValueOnce(
         buildFixtureRiskRolling(scenario.workspace, "YTD", "NET", {
           includeTimeSeries: true,
-        })
+        }),
       );
 
     renderRiskMode(scenario);
@@ -539,13 +725,19 @@ describe("PerformanceRiskMode", () => {
     });
 
     fireEvent.click(screen.getByRole("tab", { name: "63D" }));
-    fireEvent.click(screen.getByRole("button", { name: "View rolling series" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "View rolling series" }),
+    );
 
     await waitFor(() => {
-      expect(screen.getByRole("dialog", { name: "Rolling series detail" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("dialog", { name: "Rolling series detail" }),
+      ).toBeInTheDocument();
     });
 
-    const detailDialog = screen.getByRole("dialog", { name: "Rolling series detail" });
+    const detailDialog = screen.getByRole("dialog", {
+      name: "Rolling series detail",
+    });
     expect(within(detailDialog).getByText("Review window")).toBeInTheDocument();
     expect(within(detailDialog).getByText("63D")).toBeInTheDocument();
   });
@@ -553,64 +745,75 @@ describe("PerformanceRiskMode", () => {
   it("requests supported active-risk attribution directly and does not expose issuer as interactive", async () => {
     const scenario = buildSupportedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
-    vi.mocked(getWorkbenchRiskAttributionClient).mockImplementation(async (_portfolioId, params) =>
-      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET", {
-        attributionType:
-          params.attributionType === "ACTIVE_RISK" ? "ACTIVE_RISK" : "TOTAL_RISK",
-        groupingDimension:
-          params.groupingDimension === "ASSET_CLASS"
-            ? "ASSET_CLASS"
-            : params.groupingDimension === "POSITION"
-              ? "POSITION"
-              : params.groupingDimension === "ISSUER"
-                ? "ISSUER"
-                : "SECTOR",
-      })
+    vi.mocked(getWorkbenchRiskAttributionClient).mockImplementation(
+      async (_portfolioId, params) =>
+        buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET", {
+          attributionType:
+            params.attributionType === "ACTIVE_RISK"
+              ? "ACTIVE_RISK"
+              : "TOTAL_RISK",
+          groupingDimension:
+            params.groupingDimension === "ASSET_CLASS"
+              ? "ASSET_CLASS"
+              : params.groupingDimension === "POSITION"
+                ? "POSITION"
+                : params.groupingDimension === "ISSUER"
+                  ? "ISSUER"
+                  : "SECTOR",
+        }),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
-      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
-      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     );
 
     renderRiskMode(scenario);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Historical risk attribution table")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Historical risk attribution table"),
+      ).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole("tab", { name: "Active Risk" }));
     await waitFor(() => {
-      expect(getWorkbenchRiskAttributionClient).toHaveBeenCalledWith("PF_1001", {
-        period: "YTD",
-        detailBasis: "NET",
-        benchmark: "BMK_GLOBAL_BALANCED_60_40",
-        asOfDate: "2026-02-24",
-        reportingCurrency: "USD",
-        attributionType: "ACTIVE_RISK",
-        groupingDimension: "SECTOR",
-      });
+      expect(getWorkbenchRiskAttributionClient).toHaveBeenCalledWith(
+        "PF_1001",
+        {
+          period: "YTD",
+          detailBasis: "NET",
+          benchmark: "BMK_GLOBAL_BALANCED_60_40",
+          asOfDate: "2026-02-24",
+          reportingCurrency: "USD",
+          attributionType: "ACTIVE_RISK",
+          groupingDimension: "SECTOR",
+        },
+      );
     });
     fireEvent.click(screen.getByRole("tab", { name: "Asset Class" }));
 
     await waitFor(() => {
       expect(getWorkbenchRiskAttributionClient).toHaveBeenCalledTimes(3);
     });
-    expect(getWorkbenchRiskAttributionClient).toHaveBeenLastCalledWith("PF_1001", {
-      period: "YTD",
-      detailBasis: "NET",
-      benchmark: "BMK_GLOBAL_BALANCED_60_40",
-      asOfDate: "2026-02-24",
-      reportingCurrency: "USD",
-      attributionType: "ACTIVE_RISK",
-      groupingDimension: "ASSET_CLASS",
-    });
+    expect(getWorkbenchRiskAttributionClient).toHaveBeenLastCalledWith(
+      "PF_1001",
+      {
+        period: "YTD",
+        detailBasis: "NET",
+        benchmark: "BMK_GLOBAL_BALANCED_60_40",
+        asOfDate: "2026-02-24",
+        reportingCurrency: "USD",
+        attributionType: "ACTIVE_RISK",
+        groupingDimension: "ASSET_CLASS",
+      },
+    );
     await waitFor(() => {
       expect(screen.getByRole("tab", { name: "Issuer" })).toBeDisabled();
     });
@@ -619,67 +822,87 @@ describe("PerformanceRiskMode", () => {
   it("renders structured attribution blocked state instead of raw inline copy", async () => {
     const scenario = buildSupportedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
     vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
       buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET", {
         attributionType: "ACTIVE_RISK",
         groupingDimension: "ISSUER",
-      })
+      }),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient).mockResolvedValue(
-      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskRollingClient).mockResolvedValue(
-      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
     );
 
     renderRiskMode(scenario);
 
     await waitFor(() => {
-      expect(screen.getByText("Attribution selection blocked")).toBeInTheDocument();
+      expect(
+        screen.getByText("Attribution selection blocked"),
+      ).toBeInTheDocument();
     });
     expect(
-      screen.getByText("Choose a supported attribution type and grouping combination to continue.")
+      screen.getByText(
+        "Choose a supported attribution type and grouping combination to continue.",
+      ),
     ).toBeInTheDocument();
   });
 
   it("renders structured unavailable states for deferred detail panels", async () => {
     const scenario = buildSupportedPerformanceScenario();
     vi.mocked(getWorkbenchRiskSummaryClient).mockResolvedValue(
-      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskSummary(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskConcentrationClient).mockResolvedValue(
-      buildFixtureRiskConcentration(scenario.workspace, "YTD")
+      buildFixtureRiskConcentration(scenario.workspace, "YTD"),
     );
     vi.mocked(getWorkbenchRiskAttributionClient).mockResolvedValue(
-      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET")
+      buildFixtureRiskAttribution(scenario.workspace, "YTD", "NET"),
     );
     vi.mocked(getWorkbenchRiskDrawdownClient)
-      .mockResolvedValueOnce(buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"))
+      .mockResolvedValueOnce(
+        buildFixtureRiskDrawdown(scenario.workspace, "YTD", "NET"),
+      )
       .mockRejectedValueOnce(new Error("underwater unavailable"));
     vi.mocked(getWorkbenchRiskRollingClient)
-      .mockResolvedValueOnce(buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"))
+      .mockResolvedValueOnce(
+        buildFixtureRiskRolling(scenario.workspace, "YTD", "NET"),
+      )
       .mockRejectedValueOnce(new Error("rolling unavailable"));
 
     renderRiskMode(scenario);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Risk drawdown headline metrics")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Risk drawdown headline metrics"),
+      ).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "View underwater path" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "View underwater path" }),
+    );
     await waitFor(() => {
-      expect(screen.getByText("Underwater path unavailable")).toBeInTheDocument();
+      expect(
+        screen.getByText("Underwater path unavailable"),
+      ).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByRole("button", { name: "Close Underwater path detail" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Close Underwater path detail" }),
+    );
 
-    fireEvent.click(screen.getByRole("button", { name: "View rolling series" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "View rolling series" }),
+    );
     await waitFor(() => {
-      expect(screen.getByText("Rolling series unavailable")).toBeInTheDocument();
+      expect(
+        screen.getByText("Rolling series unavailable"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -190,6 +190,9 @@ promote dormant labels into product ownership just because historical route file
   not-requested, no-report, and no-event states when Gateway has not materialized evidence. It does
   not generate narrative, infer client-ready release, render documents, archive artifacts, contact
   clients, or call `lotus-advise`, `lotus-report`, `lotus-render`, or `lotus-archive` directly.
+  Canonical validation creates a Gateway-backed proposal with an advisor-review
+  `narrative_request`, records advisor-use review, requests reviewed report packaging, and captures
+  `proposal-narrative-posture-live.png` under the governed Workbench proof bundle.
 
 ## Route examples
 

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -11,7 +11,7 @@ It is intended for developers, business users, operations, sales/pre-sales, and 
 | Portfolio income and activity | `/income` | Gateway portfolio workspace `income_summary` and `activity_summary` | Supported as the dedicated source-backed screen for income composition, source-defined activity buckets, net movement, cash weight, and evidence posture. Workbench does not forecast income or calculate activity classifications locally. |
 | Performance and risk review | `/performance` route modes | Gateway performance/risk APIs | Supported with bounded observability and canonical proof. |
 | Data-product discovery | `/data-products` | Gateway domain-product APIs | Supported for catalog, dependencies, and live trust posture. |
-| Advisor proposal narrative posture | `/proposals`, `/proposals/{proposalId}` | Gateway `/api/v1/proposals*` | Implemented for advisor proposal queue/detail, advisor-use narrative review, reviewed narrative report-package request, delivery-summary posture, and delivery-event posture through Gateway only. The shell `Proposal` app entry remains disabled until broader product promotion is separately proven. |
+| Advisor proposal narrative posture | `/proposals`, `/proposals/{proposalId}` | Gateway `/api/v1/proposals*` | Implemented for advisor proposal queue/detail, advisor-use narrative review, reviewed narrative report-package request, delivery-summary posture, delivery-event posture, and governed canonical proof through Gateway only. Canonical validation creates a seeded advisor-review narrative proposal, exercises the panel, and captures `proposal-narrative-posture-live.png`. The shell `Proposal` app entry remains disabled until broader product promotion is separately proven. |
 | DPM mandate command center | `/workbench/{portfolioId}`, `/workbench/{portfolioId}?mode=mandate` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit, PM-book-backed monitoring action, active exception queue, and governed exception-summary request through Gateway/Manage/lotus-ai. Workbench preserves Manage supportability posture: populated canonical `READY` is demo-ready, `PARTIAL`/`DEGRADED`/`BLOCKED` render as explicit partial states, and `EMPTY` stays an empty state rather than a false ready cockpit. |
 | DPM rebalance-wave command center | `/workbench/{portfolioId}?mode=waves` | Gateway `/api/v1/dpm/command-center/waves*` | Implemented for wave queue, preview, create, detail, items, source-check, simulation, approval, staging, handoff, proof posture, supportability, report-input, governed AI PM memo, governed operations-handoff summary, active Manage-owned campaign-definition list rendering, lifecycle evidence, append-only launch history, preview-readiness review, launch-package readiness, and READY-gated campaign launch through Gateway only. |
 | DPM construction alternatives | `/workbench/{portfolioId}?mode=construction` | Gateway `/api/v1/dpm/command-center/construction/alternative-sets*` | Implemented for generation, comparison, and PM selection through Gateway only. |
@@ -38,7 +38,9 @@ Implemented:
    `include_reviewed_narrative=true`,
 5. displays review posture, report-package posture, delivery status, latest delivery event, policy
    version, and source narrative hash,
-6. renders missing evidence as explicit not-reviewed, not-requested, no-report, or no-event states
+6. participates in canonical Workbench proof as `proposal.narrative_posture` with a governed
+   screenshot after advisor-use review and reviewed report-package request pass,
+7. renders missing evidence as explicit not-reviewed, not-requested, no-report, or no-event states
    rather than inferring client-ready status.
 
 Not supported in Workbench:


### PR DESCRIPTION
## Summary
- Add RFC-0023 Slice 12 canonical Workbench proof for the Gateway-backed proposal narrative posture panel.
- Create a canonical proposal narrative through Gateway during live validation and prove advisor approval, reviewed report request, source hash continuity, and screenshot capture.
- Document the proposal narrative posture panel in README/wiki/runbook.

## Local validation
- `npm run test -- --run tests/unit/live-canonical-validation-script.test.ts tests/unit/proposal-narrative-posture-panel.test.tsx` -> 13 passed
- `npm run lint` -> passed
- `npm run typecheck` -> passed
- `make check` -> passed, 251 files / 1066 tests passed, build passed
- `git diff --check` -> passed

## Live proof status
- `npm run live:stack:up` is blocked locally because Docker Desktop's Linux engine pipe is unavailable and this shell cannot start `com.docker.service`.
- Draft until canonical runtime validation runs successfully after Docker service is available.