### PR TITLE
Add governed DPM copilot workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,18 @@ Boundary rules that matter:
    live trust discovery.
 5. `/workbench/{portfolioId}` is the Manage workspace. It uses the shared Workbench left rail and
    focused `mode` sub-surfaces instead of stacking every Manage/DPM panel into one long page:
-   overview, `mode=mandate`, `mode=waves`, `mode=construction`, `mode=memory`, `mode=reviews`,
-   and `mode=proof`.
+   overview, `mode=mandate`, `mode=waves`, `mode=construction`, `mode=memory`, `mode=copilot`,
+   `mode=reviews`, `mode=quality`, and `mode=proof`.
 6. Manage surfaces are Gateway-backed and cover RFC-0038 mandate command center, RFC-0041
    rebalance waves, RFC-0039 construction alternatives, RFC40-WTBD-010 portfolio memory,
    RFC-0042 outcome reviews, RFC-0040 proof-pack evidence, RFC-0043 exception-summary requests,
    and rebalance action-register supportability. Workbench renders Gateway/manage/lotus-ai truth
    and does not calculate mandate health, wave readiness, optimizer output, outcome variance,
    proof-pack hashes, report inputs, AI prompts, PM memos, narratives, or execution claims locally.
+   `mode=copilot` centralizes the existing Gateway-backed proof-pack PM memo, wave PM memo,
+   operations handoff summary, exception summary, outcome narrative, and PM quality support-summary
+   workflow-pack requests without browser-owned prompt construction, generated text storage,
+   PM ranking, client contact, order, or OMS claims.
 7. Recommendations remain compatibility paths. Proposals are now a bounded direct advisory
    workspace surface for the Gateway-backed proposal queue and RFC-0023 advisor narrative delivery
    posture, while the top-level `Proposal` shell entry remains disabled pending broader product
@@ -289,7 +293,14 @@ Important current product and route truths:
    but must not build report input, construct AI prompts, generate memo text locally, calculate
    campaign membership or readiness, mutate maker-checker or assignment state, score PMs, approve
    trades independently, contact clients, place orders, or call upstream services directly.
-12. RFC-0023 advisor proposal narrative posture is rendered on `/proposals/{proposalId}` through
+12. RFC-0043 PM copilot workspace rendering on `/workbench/{portfolioId}?mode=copilot` is backed
+    by existing Gateway BFF routes for proof-pack PM memo, wave PM memo, operations handoff
+    summary, monitoring-exception summary, outcome-review narrative, and PM operating-quality
+    support summary. Workbench presents one governed action surface over Manage-owned evidence and
+    lotus-ai workflow-pack execution posture, but does not construct prompts, persist generated
+    model output, rank PMs, infer missing source facts, contact clients, approve trades, generate
+    orders, route orders, or claim OMS execution.
+13. RFC-0023 advisor proposal narrative posture is rendered on `/proposals/{proposalId}` through
     Gateway proposal endpoints only:
     `/api/v1/proposals/{proposal_id}/versions/{version_no}/narrative/review`,
     `/api/v1/proposals/{proposal_id}/report-requests`,

--- a/src/features/workbench/components/dpm-copilot-workspace.tsx
+++ b/src/features/workbench/components/dpm-copilot-workspace.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  ActionButton,
+  MetricRow,
+  ScreenStatePanel,
+  SectionBlock,
+  SemanticBadge,
+} from "@/design-system";
+import { requestDpmExceptionSummary } from "@/features/workbench/dpm-command-center-api";
+import {
+  requestDpmOperationsHandoffSummary,
+  requestDpmWaveAiPmMemo,
+} from "@/features/workbench/dpm-wave-api";
+import { requestDpmOutcomeReviewAiNarrative } from "@/features/workbench/outcome-review-api";
+import { requestDpmPmOperatingQualitySummary } from "@/features/workbench/pm-operating-quality-api";
+import { requestDpmProofPackAiPmMemo } from "@/features/workbench/proof-pack-api";
+import type { ManageWorkspaceData } from "@/features/workbench/manage-workspace-data";
+
+type CopilotActionKey =
+  | "proof-pack-memo"
+  | "wave-memo"
+  | "operations-handoff"
+  | "exception-summary"
+  | "outcome-narrative"
+  | "pm-quality-summary";
+
+type CopilotAction = {
+  key: CopilotActionKey;
+  label: string;
+  detail: string;
+  reference: string | null;
+  blockedReason: string | null;
+  run: () => Promise<unknown>;
+};
+
+type ActionState = {
+  pending: CopilotActionKey | null;
+  message: string | null;
+  error: string | null;
+};
+
+export default function DpmCopilotWorkspace({
+  data,
+  mandateId,
+}: {
+  data: ManageWorkspaceData;
+  mandateId?: string | null;
+}) {
+  const portfolioId = data.portfolio.portfolio.portfolio_id;
+  const [actionState, setActionState] = useState<ActionState>({
+    pending: null,
+    message: null,
+    error: null,
+  });
+  const actions = useMemo(
+    () => buildCopilotActions({ data, portfolioId, mandateId: mandateId ?? null }),
+    [data, mandateId, portfolioId]
+  );
+  const readyCount = actions.filter((action) => !action.blockedReason).length;
+
+  async function runAction(action: CopilotAction) {
+    if (action.blockedReason || actionState.pending) {
+      return;
+    }
+    setActionState({ pending: action.key, message: null, error: null });
+    try {
+      const response = await action.run();
+      setActionState({
+        pending: null,
+        message: `${action.label} accepted by Gateway. ${summarizeWorkflowResponse(response)}`,
+        error: null,
+      });
+    } catch (error) {
+      setActionState({
+        pending: null,
+        message: null,
+        error: error instanceof Error ? error.message : `${action.label} failed.`,
+      });
+    }
+  }
+
+  return (
+    <SectionBlock
+      title="PM Copilot Workspace"
+      subtitle="Review-gated AI workflow-pack requests over Manage-owned evidence and Gateway composition."
+      className="dpm-copilot-workspace"
+      actions={
+        <div className="dpm-copilot-badge-row" aria-label="PM copilot posture">
+          <SemanticBadge tone={readyCount > 0 ? "success" : "warn"}>{readyCount} ready</SemanticBadge>
+          <SemanticBadge>Gateway only</SemanticBadge>
+          <SemanticBadge>No prompt storage</SemanticBadge>
+        </div>
+      }
+    >
+      <div className="dpm-copilot-status-strip">
+        <MetricRow label="Portfolio" value={portfolioId} />
+        <MetricRow label="Mandate" value={mandateId ?? "N/A"} />
+        <MetricRow label="Evidence Owner" value="lotus-manage" />
+        <MetricRow label="Workflow Owner" value="lotus-ai" />
+        <MetricRow label="Gateway Surface" value="lotus-gateway BFF" />
+        <MetricRow label="Forbidden Uses" value="client contact, orders, OMS" />
+      </div>
+
+      {actionState.error ? (
+        <ScreenStatePanel
+          kind="partial"
+          surface="portfolio"
+          title="Copilot request needs attention"
+          body={actionState.error}
+        />
+      ) : null}
+      {actionState.message ? (
+        <ScreenStatePanel
+          kind="partial"
+          surface="portfolio"
+          title="Copilot request accepted"
+          body={actionState.message}
+        />
+      ) : null}
+
+      <div className="dpm-copilot-action-grid">
+        {actions.map((action) => (
+          <section key={action.key} className="dpm-copilot-action-card">
+            <div>
+              <strong>{action.label}</strong>
+              <span>{action.detail}</span>
+            </div>
+            <MetricRow label="Source Ref" value={action.reference ?? "N/A"} />
+            <MetricRow
+              label="Readiness"
+              value={action.blockedReason ? action.blockedReason : "Ready through Gateway"}
+            />
+            <ActionButton
+              priority={action.blockedReason ? "quiet" : "secondary"}
+              disabled={Boolean(action.blockedReason) || Boolean(actionState.pending)}
+              onClick={() => void runAction(action)}
+            >
+              {actionState.pending === action.key ? "Requesting" : "Request"}
+            </ActionButton>
+          </section>
+        ))}
+      </div>
+
+      <ScreenStatePanel
+        kind="partial"
+        surface="portfolio"
+        title="Operating boundaries"
+        body={
+          "This workspace requests bounded workflow-pack runs only. It does not generate prompts in the browser, store generated summary text, rank PMs, contact clients, approve trades, route orders, claim OMS execution, or infer missing source facts."
+        }
+      />
+    </SectionBlock>
+  );
+}
+
+function buildCopilotActions({
+  data,
+  portfolioId,
+  mandateId,
+}: {
+  data: ManageWorkspaceData;
+  portfolioId: string;
+  mandateId: string | null;
+}): CopilotAction[] {
+  const proofPackId = readFirstString(data.proofPack?.data, ["proof_pack_id"]) ??
+    readFirstString(firstArrayItem(data.outcomeReviews?.data, "items"), ["proof_pack_id"]);
+  const waveId = readFirstString(firstArrayItem(data.waves?.data, "items"), ["wave_id"]);
+  const exceptionId = readFirstString(firstArrayItem(data.commandCenterExceptions?.data, "items"), [
+    "exception_id",
+  ]);
+  const outcomeReviewId = readFirstString(firstArrayItem(data.outcomeReviews?.data, "items"), [
+    "outcome_review_id",
+  ]);
+  const scoreRunId =
+    readFirstString(firstArrayItem(data.pmOperatingQualityScoreRuns?.data, "items"), [
+      "score_run_id",
+    ]) ?? readFirstString(data.pmOperatingQualityScoreRuns?.supportability, ["score_run_id"]);
+
+  return [
+    {
+      key: "proof-pack-memo",
+      label: "Proof-Pack PM Memo",
+      detail: "Request a review-required PM memo from proof-pack AI evidence.",
+      reference: proofPackId,
+      blockedReason: proofPackId ? null : "No proof pack available",
+      run: () => requestDpmProofPackAiPmMemo({ proofPackId: proofPackId ?? "" }),
+    },
+    {
+      key: "wave-memo",
+      label: "Wave PM Memo",
+      detail: "Request PM review commentary for a Manage-owned rebalance wave.",
+      reference: waveId,
+      blockedReason: waveId ? null : "No rebalance wave available",
+      run: () => requestDpmWaveAiPmMemo(waveId ?? ""),
+    },
+    {
+      key: "operations-handoff",
+      label: "Operations Handoff Summary",
+      detail: "Request support-only handoff posture for operations and investment control.",
+      reference: waveId,
+      blockedReason: waveId ? null : "No rebalance wave available",
+      run: () => requestDpmOperationsHandoffSummary(waveId ?? ""),
+    },
+    {
+      key: "exception-summary",
+      label: "Exception Summary",
+      detail: "Request triage support over a Manage monitoring exception.",
+      reference: exceptionId,
+      blockedReason: exceptionId ? null : "No monitoring exception available",
+      run: () =>
+        requestDpmExceptionSummary({
+          exceptionId: exceptionId ?? "",
+          portfolioId,
+          mandateId: mandateId ?? undefined,
+          state: "ACTIVE",
+        }),
+    },
+    {
+      key: "outcome-narrative",
+      label: "Outcome Narrative",
+      detail: "Request PM/CIO/control summary over realized outcome-review evidence.",
+      reference: outcomeReviewId,
+      blockedReason: outcomeReviewId ? null : "No outcome review available",
+      run: () => requestDpmOutcomeReviewAiNarrative({ outcomeReviewId: outcomeReviewId ?? "" }),
+    },
+    {
+      key: "pm-quality-summary",
+      label: "PM Quality Support Summary",
+      detail: "Request support-only summary posture over Manage PM operating-quality evidence.",
+      reference: scoreRunId,
+      blockedReason: scoreRunId ? null : "No PM quality score run available",
+      run: () => requestDpmPmOperatingQualitySummary({ scoreRunId: scoreRunId ?? "" }),
+    },
+  ];
+}
+
+function summarizeWorkflowResponse(response: unknown): string {
+  const record = asRecord(response);
+  const source = readFirstString(record, ["source_service"]) ?? "Gateway";
+  const status = readFirstString(record, ["upstream_status", "ai_upstream_status"]) ?? "accepted";
+  const data = asRecord(record.data);
+  const workflowRun =
+    readFirstString(asRecord(data.workflow_pack_run), ["run_id", "workflow_run_id"]) ??
+    readFirstString(record, ["workflow_run_id", "run_id"]) ??
+    "run posture returned";
+  return `${source} status ${status}; ${workflowRun}.`;
+}
+
+function firstArrayItem(source: unknown, key: string): Record<string, unknown> | null {
+  const values = asRecord(source)[key];
+  return Array.isArray(values) ? asRecord(values[0]) : null;
+}
+
+function readFirstString(source: unknown, keys: string[]): string | null {
+  const record = asRecord(source);
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+    if (typeof value === "number") {
+      return String(value);
+    }
+  }
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}

--- a/src/features/workbench/manage-workspace-navigation.ts
+++ b/src/features/workbench/manage-workspace-navigation.ts
@@ -6,6 +6,7 @@ export type ManageMode =
   | "waves"
   | "construction"
   | "memory"
+  | "copilot"
   | "quality"
   | "reviews"
   | "proof";
@@ -53,6 +54,13 @@ export const MANAGE_MODE_DEFINITIONS: ManageModeDefinition[] = [
     detail: "Portfolio memory",
     title: "Portfolio Memory",
     description: "Portfolio decision memory and operating history.",
+  },
+  {
+    key: "copilot",
+    label: "Copilot",
+    detail: "AI workflow packs",
+    title: "PM Copilot Workspace",
+    description: "Governed PM workflow-pack requests backed by Gateway, Manage, and lotus-ai.",
   },
   {
     key: "quality",

--- a/src/features/workbench/manage-workspace.module.css
+++ b/src/features/workbench/manage-workspace.module.css
@@ -148,6 +148,59 @@
   grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
 }
 
+.manageScope :global(.dpm-copilot-status-strip),
+.manageScope :global(.dpm-copilot-action-grid) {
+  display: grid;
+  gap: 12px;
+}
+
+.manageScope :global(.dpm-copilot-status-strip) {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.manageScope :global(.dpm-copilot-action-grid) {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.manageScope :global(.dpm-copilot-badge-row) {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.manageScope :global(.dpm-copilot-action-card) {
+  display: grid;
+  gap: 10px;
+  min-height: 190px;
+  padding: 14px;
+  border: 1px solid #d6dbe0;
+  border-left: 3px solid #725b26;
+  border-radius: 4px;
+  background: #ffffff;
+}
+
+.manageScope :global(.dpm-copilot-action-card > div:first-child) {
+  display: grid;
+  gap: 4px;
+}
+
+.manageScope :global(.dpm-copilot-action-card strong) {
+  color: #191c1e;
+  font-size: 14px;
+  line-height: 19px;
+}
+
+.manageScope :global(.dpm-copilot-action-card span) {
+  color: #45464d;
+  font-size: 12px;
+  line-height: 17px;
+}
+
+.manageScope :global(.dpm-copilot-action-card .action-button) {
+  justify-self: start;
+}
+
 .manageScope :global(.manage-recommended-action-list) {
   display: grid;
   gap: 10px;

--- a/src/features/workbench/manage-workspace.tsx
+++ b/src/features/workbench/manage-workspace.tsx
@@ -13,6 +13,7 @@ import {
 import ConstructionAlternativesPanel from "@/features/workbench/components/construction-alternatives-panel";
 import ManageMandateHealth from "@/features/workbench/components/manage-mandate-health";
 import DpmWaveCommandCenterPanel from "@/features/workbench/components/dpm-wave-command-center-panel";
+import DpmCopilotWorkspace from "@/features/workbench/components/dpm-copilot-workspace";
 import OutcomeReviewPanel from "@/features/workbench/components/outcome-review-panel";
 import PortfolioMemoryPanel from "@/features/workbench/components/portfolio-memory-panel";
 import PmOperatingQualityPanel from "@/features/workbench/components/pm-operating-quality-panel";
@@ -179,6 +180,8 @@ function renderManageMode(
           sourceSearchErrorMessage={data.portfolioMemorySearchError}
         />
       );
+    case "copilot":
+      return <DpmCopilotWorkspace data={data} mandateId={mandateId} />;
     case "quality":
       return (
         <PmOperatingQualityPanel

--- a/tests/unit/manage-workspace-components.test.tsx
+++ b/tests/unit/manage-workspace-components.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import ManageContextRail from "../../src/features/workbench/components/manage-context-rail";
+import DpmCopilotWorkspace from "../../src/features/workbench/components/dpm-copilot-workspace";
 import ManageOverview from "../../src/features/workbench/components/manage-overview";
 import { buildManageWorkspaceData } from "./manage-workspace-fixtures";
 
@@ -41,5 +42,22 @@ describe("manage workspace split components", () => {
       "/portfolio?portfolioId=PF_1001"
     );
     expect(screen.queryByRole("button", { name: /client/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the governed PM copilot workspace without execution or client-contact claims", () => {
+    render(<DpmCopilotWorkspace data={buildManageWorkspaceData()} mandateId="mandate_001" />);
+
+    expect(screen.getByRole("heading", { name: "PM Copilot Workspace" })).toBeInTheDocument();
+    expect(screen.getByText("Proof-Pack PM Memo")).toBeInTheDocument();
+    expect(screen.getByText("Wave PM Memo")).toBeInTheDocument();
+    expect(screen.getByText("Operations Handoff Summary")).toBeInTheDocument();
+    expect(screen.getByText("Exception Summary")).toBeInTheDocument();
+    expect(screen.getByText("Outcome Narrative")).toBeInTheDocument();
+    expect(screen.getByText("PM Quality Support Summary")).toBeInTheDocument();
+    expect(screen.getByText("Gateway only")).toBeInTheDocument();
+    expect(screen.getByText("No prompt storage")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Request" })).toHaveLength(6);
+    expect(screen.queryByRole("button", { name: /client/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /order/i })).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/manage-workspace-fixtures.ts
+++ b/tests/unit/manage-workspace-fixtures.ts
@@ -185,7 +185,29 @@ export function buildManageWorkspaceData(
       data: { policies: [], count: 1 },
     },
     pmOperatingQualityPoliciesError: null,
-    pmOperatingQualityScoreRuns: null,
+    pmOperatingQualityScoreRuns: {
+      correlation_id: "corr_score_run",
+      contract_version: "v1",
+      source_service: "lotus-manage",
+      upstream_status: 200,
+      supportability: {
+        source_service: "lotus-manage",
+        authority: "lotus-manage:pm-quality-score-run",
+        state: "READY",
+        reason_codes: ["READY"],
+        blocked_actions: [],
+      },
+      data: {
+        items: [
+          {
+            score_run_id: "pmq_run_001",
+            score_run_state: "READY",
+            policy_id: "pmq_sg_dpm",
+            policy_version: "2026.05",
+          },
+        ],
+      },
+    },
     pmOperatingQualityScoreRunsError: null,
     pmOperatingQualityFairnessAnalyses: null,
     pmOperatingQualityFairnessAnalysesError: null,

--- a/tests/unit/manage-workspace-navigation.test.ts
+++ b/tests/unit/manage-workspace-navigation.test.ts
@@ -31,6 +31,7 @@ describe("manage workspace navigation", () => {
       "waves",
       "construction",
       "memory",
+      "copilot",
       "quality",
       "reviews",
       "proof",
@@ -45,6 +46,7 @@ describe("manage workspace navigation", () => {
 
   it("keeps mode titles in private-banking language", () => {
     expect(getManageModeDefinition("mandate").title).toBe("Mandate Health");
+    expect(getManageModeDefinition("copilot").title).toBe("PM Copilot Workspace");
     expect(getManageModeDefinition("construction").description).toBe(
       "Supported construction alternatives for advisor and PM review."
     );

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -158,6 +158,14 @@ promote dormant labels into product ownership just because historical route file
   claims, and client communication workflow remain forbidden. Event drawers, lifecycle export,
   and retention or audit-policy controls remain future scope until separately implemented and
   proven.
+- RFC-0043 PM copilot workspace rendering is implemented on
+  `/workbench/{portfolioId}?mode=copilot` through existing Gateway BFF routes for proof-pack PM
+  memo, wave PM memo, operations handoff summary, monitoring-exception summary, outcome-review
+  narrative, and PM operating-quality support summary. Workbench centralizes these review-gated
+  workflow-pack requests over Manage-owned evidence and lotus-ai execution posture, but it does
+  not construct prompts, persist generated summary text or model responses, rank PMs, infer
+  missing source facts, contact clients, approve trades, generate orders, route orders, or claim
+  OMS execution.
 - RFC-0098/RFC-0041 action-register supportability is rendered on the Manage workspace from
   the Gateway portfolio overview `rebalance_snapshot`. The rebalance status panel shows
   manage-owned status, source support state, freshness, run count, operation count, workflow

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -18,8 +18,8 @@
 - `/data-products` provides gateway-backed domain-product discovery and live trust posture
 - `/workbench/{portfolioId}` is the Manage workspace, with focused Gateway-backed sub-surfaces for
   mandate command center, rebalance waves, construction alternatives, portfolio memory,
-  outcome reviews, proof-pack evidence with governed PM memo requests, and manage-owned operating
-  evidence
+  PM copilot workflow-pack requests, outcome reviews, proof-pack evidence with governed PM memo
+  requests, and manage-owned operating evidence
 - recommendations remain compatibility routes; proposals now have bounded direct Gateway-backed
   queue/detail routes for RFC-0023 advisor narrative delivery posture, while the top-level shell
   `Proposal` entry remains disabled

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -163,6 +163,10 @@ must travel through Gateway-shaped contracts.
     create/list/detail, fairness-analysis preview, review-action preview/create/list/detail, and score-run
     support-summary contracts when Manage/Gateway expose source-defined segment assignments,
     review actions, and a selected score run.
+    The implemented PM copilot workspace consumes the same Gateway-only proof-pack PM memo, wave
+    PM memo, operations handoff summary, exception summary, outcome narrative, and PM quality
+    support-summary contracts in one governed product surface without creating browser-owned
+    prompts, generated text retention, PM ranking, client-contact, order, execution, or OMS truth.
     Workbench must not calculate expected-versus-realized values. It must not rebuild proof-pack
     sections, compute proof-pack hashes, construct prompts, infer PM quality, calculate wave
     readiness, construct report input, generate memo or exception-summary narrative locally, reconstruct


### PR DESCRIPTION
## Summary
- add a Manage workspace mode=copilot surface for existing Gateway-backed DPM AI workflow-pack requests
- centralize proof-pack PM memo, wave PM memo, operations handoff summary, exception summary, outcome narrative, and PM quality support-summary requests without browser prompt construction or model-output retention
- update Workbench README/wiki truth and focused tests for the new governed surface

## Boundaries
- Workbench continues to consume Gateway/BFF routes only
- no client contact, PM ranking, trade approval, order generation, routing, OMS, fill, settlement, or execution claims
- no prompt or generated summary text storage in the browser

## Validation
- make lint
- make typecheck
- npm test -- --run tests/unit/manage-workspace-navigation.test.ts tests/unit/manage-workspace-components.test.tsx tests/unit/workbench-api.test.ts
- make test-coverage
- ../lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench (expected pre-merge drift: API-Surface.md, Home.md, Integrations.md changed in repo wiki source)
