### PR TITLE
Harden RFC36-43 canonical front-office validation

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -258,6 +258,14 @@ Validation layers:
    - Proposal narrative posture
    - Performance risk
    - Performance evidence
+   - DPM outcome review
+   - DPM proof pack
+   - DPM command center
+   - DPM portfolio memory
+   - DPM rebalance-wave command center
+   - DPM construction alternatives
+   - DPM PM operating quality
+   - DPM PM copilot workspace
 
 Screenshots are written to:
 
@@ -278,6 +286,13 @@ through the live `lotus-workbench` -> `lotus-gateway` -> `lotus-ai` contract cha
 narrative checks prove Gateway-backed proposal creation with an advisor-review narrative request,
 Workbench advisor-use narrative review, reviewed report-package request, source narrative hash
 visibility, and screenshot evidence for `proposal.narrative_posture`.
+
+For DPM PM operating quality, validation creates and re-reads Manage-backed evidence through
+Gateway before classifying the panel as ready: score run, source-defined fairness analysis,
+bounded supervisory review action, and governed summary invocation. The browser proof then checks
+the persisted summary-invocation detail and list surface. This prevents a false ready claim when
+the PM quality endpoints are reachable but the canonical stack has no persisted operating-quality
+evidence.
 
 Machine-readable validation evidence is written to:
 
@@ -347,6 +362,12 @@ supportability summary is recorded as source-supportability evidence, including 
 reason when present; DPM panel proof is gated by the command-center, wave, outcome-review, proof-pack,
 portfolio-memory, construction-alternatives, PM operating-quality, and PM copilot workspace contracts
 instead of failing on unrelated historical action-register freshness.
+
+When validating active Workbench source changes, use `npm run live:stack:up:workbench-local` or
+`Start-LotusFrontOfficeCanonical.ps1 -LocalApps workbench` before collecting final browser proof.
+That path keeps the canonical backend stack but serves Workbench from the current branch, avoiding
+stale Docker image evidence for newly added panels or selectors.
+
 The DPM mandate command-center panel is screenshot-ready only when Gateway returns a canonical
 populated `READY` supportability posture. Partial, degraded, blocked, and empty command-center
 supportability must not collapse into a false ready panel. Do not treat partial screenshot output

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -210,6 +210,336 @@ function extractGatewayEnvelopeData(payload) {
   return payload?.data ?? payload;
 }
 
+function buildPmQualitySourceRef({
+  sourceSystem,
+  sourceType,
+  sourceId,
+  sourceVersion,
+  contentHash,
+}) {
+  return {
+    source_system: sourceSystem,
+    source_type: sourceType,
+    source_id: sourceId,
+    source_version: sourceVersion,
+    content_hash: contentHash,
+  };
+}
+
+function buildCanonicalPmQualityPolicy(asOfDate) {
+  return {
+    policy_id: "pmq_canonical_dpm",
+    policy_version: "2026.05",
+    as_of_date: asOfDate,
+    access_purpose: "SUPERVISORY_CONTROL_REVIEW",
+    indicator_weights: [
+      {
+        indicator: "OUTCOME_DISCIPLINE",
+        weight: "70",
+        minimum_evidence_count: 1,
+      },
+      {
+        indicator: "SOURCE_QUALITY",
+        weight: "30",
+        minimum_evidence_count: 1,
+      },
+    ],
+    governance_evidence: {
+      approval_ref: "PMQ-CANONICAL-APPROVAL-2026-05",
+      approved_by: "pm_quality_committee",
+      approved_at: "2026-05-03T09:00:00Z",
+      fairness_review_ref: "PMQ-CANONICAL-FAIRNESS-2026-05",
+      fairness_reviewed_by: "model_risk_governance",
+      fairness_reviewed_at: "2026-05-03T10:00:00Z",
+      expires_on: "2026-06-30",
+      entitled_actor_ids: [
+        "workbench-system",
+        "workbench-pm-operating-quality-supervisor",
+        "ops",
+      ],
+      source_refs: [
+        buildPmQualitySourceRef({
+          sourceSystem: "bank-governance",
+          sourceType: "PM_QUALITY_POLICY_APPROVAL",
+          sourceId: "PMQ-CANONICAL-APPROVAL-2026-05",
+          sourceVersion: "2026.05",
+          contentHash: "sha256:pmq-canonical-approval",
+        }),
+      ],
+    },
+  };
+}
+
+function buildCanonicalPmQualityScoreRunRequest(asOfDate) {
+  return {
+    pm_id: dpmCommandCenterDefaults.portfolioManagerId,
+    book_id: dpmCommandCenterDefaults.bookId,
+    as_of_date: asOfDate,
+    policy: buildCanonicalPmQualityPolicy(asOfDate),
+    evidence_items: [
+      {
+        indicator: "OUTCOME_DISCIPLINE",
+        evidence_state: "READY",
+        score: "92",
+        source_system: "lotus-manage",
+        source_type: "DPM_OUTCOME_REVIEW_POSTURE",
+        source_id: "canonical-outcome-review-posture",
+        source_version: asOfDate,
+        content_hash: "sha256:pmq-canonical-outcome",
+      },
+      {
+        indicator: "SOURCE_QUALITY",
+        evidence_state: "READY",
+        score: "88",
+        source_system: "lotus-core",
+        source_type: "PortfolioManagerBookMembership",
+        source_id: dpmCommandCenterDefaults.bookId,
+        source_version: asOfDate,
+        content_hash: "sha256:pmq-canonical-source-quality",
+      },
+    ],
+    actor_id: "workbench-system",
+  };
+}
+
+function extractPmQualityScoreRunId(response) {
+  const data = extractGatewayEnvelopeData(response);
+  return (
+    readString(data?.score_run?.score_run_id) ||
+    readString(data?.score_run_id) ||
+    readString(data?.score_runs?.[0]?.score_run_id) ||
+    readString(response?.supportability?.score_run_id) ||
+    null
+  );
+}
+
+function extractPmQualityFairnessAnalysisId(response) {
+  const data = extractGatewayEnvelopeData(response);
+  return (
+    readString(data?.fairness_analysis?.fairness_analysis_id) ||
+    readString(data?.fairness_analysis_id) ||
+    readString(data?.fairness_analyses?.[0]?.fairness_analysis_id) ||
+    readString(response?.supportability?.fairness_analysis_id) ||
+    null
+  );
+}
+
+function extractPmQualityReviewActionId(response) {
+  const data = extractGatewayEnvelopeData(response);
+  return (
+    readString(data?.review_action?.review_action_id) ||
+    readString(data?.review_action_id) ||
+    readString(data?.review_actions?.[0]?.review_action_id) ||
+    readString(response?.supportability?.review_action_id) ||
+    null
+  );
+}
+
+function extractPmQualitySummaryInvocationId(response) {
+  const data = extractGatewayEnvelopeData(response);
+  return (
+    readString(data?.summary_invocation?.summary_invocation_id) ||
+    readString(data?.summary_invocation_id) ||
+    readString(data?.summary_invocations?.[0]?.summary_invocation_id) ||
+    readString(response?.supportability?.summary_invocation_id) ||
+    null
+  );
+}
+
+async function ensureCanonicalPmOperatingQualityEvidence() {
+  const asOfDate = dpmCommandCenterDefaults.asOfDate;
+  const pmQualityBaseUrl = `${gatewayBaseUrl}/api/v1/dpm/command-center/pm-operating-quality`;
+  const scoreRunRequest = buildCanonicalPmQualityScoreRunRequest(asOfDate);
+  const scoreRunResponse = await postJson(
+    summary,
+    `${pmQualityBaseUrl}/score-runs`,
+    "DPM PM operating-quality score-run create",
+    timeoutMs,
+    { body: scoreRunRequest }
+  );
+  const scoreRunId = extractPmQualityScoreRunId(scoreRunResponse);
+  if (!scoreRunId) {
+    throw new Error("DPM PM operating-quality score-run create returned no score-run id.");
+  }
+
+  const bookSourceRef = buildPmQualitySourceRef({
+    sourceSystem: "lotus-core",
+    sourceType: "PortfolioManagerBookMembership",
+    sourceId: dpmCommandCenterDefaults.bookId,
+    sourceVersion: asOfDate,
+    contentHash: "sha256:pmq-canonical-source-quality",
+  });
+  const fairnessResponse = await postJson(
+    summary,
+    `${pmQualityBaseUrl}/fairness-analyses`,
+    "DPM PM operating-quality fairness-analysis create",
+    timeoutMs,
+    {
+      body: {
+        policy_id: "pmq_canonical_dpm",
+        policy_version: "2026.05",
+        as_of_date: asOfDate,
+        actor_id: "workbench-system",
+        minimum_segment_score_run_count: 1,
+        maximum_average_score_spread: "5.00",
+        segments: [
+          {
+            segment_id: "canonical_sg_dpm_balanced",
+            segment_type: "BOOK_PROFILE",
+            display_name: "Singapore DPM balanced book",
+            score_run_ids: [scoreRunId],
+            source_refs: [bookSourceRef],
+          },
+          {
+            segment_id: "canonical_apac_balanced",
+            segment_type: "REGION",
+            display_name: "APAC balanced DPM",
+            score_run_ids: [scoreRunId],
+            source_refs: [bookSourceRef],
+          },
+        ],
+      },
+    }
+  );
+  const fairnessAnalysisId = extractPmQualityFairnessAnalysisId(fairnessResponse);
+  if (!fairnessAnalysisId) {
+    throw new Error(
+      "DPM PM operating-quality fairness-analysis create returned no fairness-analysis id."
+    );
+  }
+
+  const reviewResponse = await postJson(
+    summary,
+    `${pmQualityBaseUrl}/review-actions`,
+    "DPM PM operating-quality review-action create",
+    timeoutMs,
+    {
+      body: {
+        target_type: "SCORE_RUN",
+        target_id: scoreRunId,
+        action_type: "ACKNOWLEDGE",
+        action_state: "REVIEW_REQUIRED",
+        review_action_ref: `PMQ-CANONICAL-REVIEW-${scoreRunId}`,
+        review_reason: "Canonical live validation recorded bounded supervisory review evidence.",
+        actor_id: "workbench-system",
+        policy_id: "pmq_canonical_dpm",
+        policy_version: "2026.05",
+        as_of_date: asOfDate,
+        source_refs: [
+          buildPmQualitySourceRef({
+            sourceSystem: "lotus-workbench",
+            sourceType: "CANONICAL_FRONT_OFFICE_VALIDATION",
+            sourceId: "rfc36-43-audit-20260524",
+            sourceVersion: "2026-05-24",
+            contentHash: "sha256:pmq-canonical-review",
+          }),
+        ],
+      },
+    }
+  );
+  const reviewActionId = extractPmQualityReviewActionId(reviewResponse);
+  if (!reviewActionId) {
+    throw new Error("DPM PM operating-quality review-action create returned no review-action id.");
+  }
+
+  const summaryResponse = await postJson(
+    summary,
+    `${pmQualityBaseUrl}/summary-invocations`,
+    "DPM PM operating-quality summary-invocation create",
+    timeoutMs,
+    {
+      body: {
+        score_run_id: scoreRunId,
+        review_action_id: reviewActionId,
+        invocation_state: "COMPLETED",
+        summary_ref: `PMQ-CANONICAL-SUMMARY-${scoreRunId}`,
+        workflow_pack_name: "pm_quality_summary.pack",
+        workflow_pack_version: "v1",
+        workflow_run_id: `pmq-canonical-summary-${scoreRunId}`,
+        summary_artifact_ref: `pmq-canonical-summary-artifact-${scoreRunId}`,
+        summary_content_hash: "sha256:pmq-canonical-summary",
+        requested_by: "workbench-system",
+        source_refs: [
+          buildPmQualitySourceRef({
+            sourceSystem: "lotus-ai",
+            sourceType: "pm_quality_summary.pack",
+            sourceId: `pmq-canonical-summary-${scoreRunId}`,
+            sourceVersion: "v1",
+            contentHash: "sha256:pmq-canonical-summary",
+          }),
+        ],
+      },
+    }
+  );
+  const summaryInvocationId = extractPmQualitySummaryInvocationId(summaryResponse);
+  if (!summaryInvocationId) {
+    throw new Error(
+      "DPM PM operating-quality summary-invocation create returned no summary-invocation id."
+    );
+  }
+
+  const scoreRunList = await fetchJson(
+    summary,
+    `${pmQualityBaseUrl}/score-runs?book_id=${encodeURIComponent(
+      dpmCommandCenterDefaults.bookId
+    )}&as_of_date=${encodeURIComponent(asOfDate)}&limit=10&offset=0`,
+    "DPM PM operating-quality score-run list",
+    timeoutMs
+  );
+  const reviewActionList = await fetchJson(
+    summary,
+    `${pmQualityBaseUrl}/review-actions?target_type=SCORE_RUN&target_id=${encodeURIComponent(
+      scoreRunId
+    )}&as_of_date=${encodeURIComponent(asOfDate)}&limit=10&offset=0`,
+    "DPM PM operating-quality review-action list",
+    timeoutMs
+  );
+  const fairnessAnalysisList = await fetchJson(
+    summary,
+    `${pmQualityBaseUrl}/fairness-analyses?policy_id=pmq_canonical_dpm&policy_version=2026.05&as_of_date=${encodeURIComponent(
+      asOfDate
+    )}&limit=10&offset=0`,
+    "DPM PM operating-quality fairness-analysis list",
+    timeoutMs
+  );
+  const summaryInvocationList = await fetchJson(
+    summary,
+    `${pmQualityBaseUrl}/summary-invocations?score_run_id=${encodeURIComponent(
+      scoreRunId
+    )}&review_action_id=${encodeURIComponent(reviewActionId)}&as_of_date=${encodeURIComponent(
+      asOfDate
+    )}&limit=10&offset=0`,
+    "DPM PM operating-quality summary-invocation list",
+    timeoutMs
+  );
+  if (extractPmQualityScoreRunId(scoreRunList) !== scoreRunId) {
+    throw new Error("DPM PM operating-quality score-run list did not return the seeded score run.");
+  }
+  if (extractPmQualityReviewActionId(reviewActionList) !== reviewActionId) {
+    throw new Error(
+      "DPM PM operating-quality review-action list did not return the seeded review action."
+    );
+  }
+  if (extractPmQualityFairnessAnalysisId(fairnessAnalysisList) !== fairnessAnalysisId) {
+    throw new Error(
+      "DPM PM operating-quality fairness-analysis list did not return the seeded analysis."
+    );
+  }
+  if (extractPmQualitySummaryInvocationId(summaryInvocationList) !== summaryInvocationId) {
+    throw new Error(
+      "DPM PM operating-quality summary-invocation list did not return the seeded invocation."
+    );
+  }
+
+  return {
+    scoreRunId,
+    fairnessAnalysisId,
+    reviewActionId,
+    summaryInvocationId,
+    asOfDate,
+  };
+}
+
 async function run() {
   await ensureDirectory(outputDir);
 
@@ -755,6 +1085,8 @@ async function run() {
       "UNKNOWN",
   });
 
+  const pmOperatingQualityEvidence = await ensureCanonicalPmOperatingQualityEvidence();
+
   const reportCapabilities = await fetchJson(
     summary,
     "http://report.dev.lotus/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default",
@@ -847,6 +1179,11 @@ async function run() {
   panelGovernance.recordPanelClassification("dpm.pm_operating_quality", "ready", "lotus-manage", {
     route: `/workbench/${portfolioId}?mode=quality`,
     source: "Gateway DPM PM operating quality",
+    scoreRunId: pmOperatingQualityEvidence.scoreRunId,
+    fairnessAnalysisId: pmOperatingQualityEvidence.fairnessAnalysisId,
+    reviewActionId: pmOperatingQualityEvidence.reviewActionId,
+    summaryInvocationId: pmOperatingQualityEvidence.summaryInvocationId,
+    asOfDate: pmOperatingQualityEvidence.asOfDate,
   });
   panelGovernance.recordPanelClassification("dpm.copilot_workspace", "ready", "lotus-ai", {
     route: `/workbench/${portfolioId}?mode=copilot`,

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -627,7 +627,8 @@ export async function validateConstructionAlternativesPanel(
   await expect(constructionPanel.getByText("Alternatives Comparison")).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(constructionPanel.getByText("Recommended Path")).toBeVisible({
+  const constructionSummary = constructionPanel.locator(".construction-alternatives-summary");
+  await expect(constructionSummary.getByText("Recommended Path", { exact: true })).toBeVisible({
     timeout: timeoutMs,
   });
   await screenshotRegisteredPanel(page, "dpm.construction_alternatives");
@@ -645,6 +646,7 @@ export async function validatePmOperatingQualityPanel(
   await expect(qualityPanel.getByRole("heading", { name: "PM Operating Quality" })).toBeVisible({
     timeout: timeoutMs,
   });
+  const qualityStatusStrip = qualityPanel.locator(".pm-quality-status-strip");
   for (const label of [
     "Policy",
     "Latest Score Run",
@@ -652,7 +654,7 @@ export async function validatePmOperatingQualityPanel(
     "Summary Invocation",
     "Authority",
   ]) {
-    await expect(qualityPanel.getByText(label, { exact: true })).toBeVisible({
+    await expect(qualityStatusStrip.getByText(label, { exact: true })).toBeVisible({
       timeout: timeoutMs,
     });
   }

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -667,7 +667,10 @@ export async function validatePmOperatingQualityPanel(
   await expect(page.getByLabel("PM operating quality summary-invocation readiness")).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(page.getByLabel("PM operating quality persisted summary-invocation evidence")).toBeVisible({
+  await expect(qualityPanel.getByText("Summary Invocation Detail", { exact: true })).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(page.getByLabel("PM operating quality summary invocations")).toBeVisible({
     timeout: timeoutMs,
   });
   await screenshotRegisteredPanel(page, "dpm.pm_operating_quality");

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -370,8 +370,20 @@ describe("canonical live validation script", () => {
     expect(script).toContain('recordPanelClassification("dpm.pm_operating_quality"');
     expect(script).toContain('recordPanelClassification("dpm.copilot_workspace"');
     expect(browserWorkflowModule).toContain("Construction alternatives generated.");
+    expect(browserWorkflowModule).toContain(
+      'constructionPanel.locator(".construction-alternatives-summary")'
+    );
+    expect(browserWorkflowModule).toContain(
+      'getByText("Recommended Path", { exact: true })'
+    );
     expect(browserWorkflowModule).toContain('screenshotRegisteredPanel(page, "dpm.construction_alternatives")');
     expect(browserWorkflowModule).toContain("PM operating quality summary-invocation posture");
+    expect(browserWorkflowModule).toContain(
+      'qualityPanel.locator(".pm-quality-status-strip")'
+    );
+    expect(browserWorkflowModule).toContain(
+      'qualityStatusStrip.getByText(label, { exact: true })'
+    );
     expect(browserWorkflowModule).toContain('screenshotRegisteredPanel(page, "dpm.pm_operating_quality")');
     expect(browserWorkflowModule).toContain("PM copilot posture");
     expect(browserWorkflowModule).toContain('screenshotRegisteredPanel(page, "dpm.copilot_workspace")');

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -368,6 +368,13 @@ describe("canonical live validation script", () => {
     expect(script).toContain('recordPanelClassification("dpm.portfolio_memory"');
     expect(script).toContain('recordPanelClassification("dpm.construction_alternatives"');
     expect(script).toContain('recordPanelClassification("dpm.pm_operating_quality"');
+    expect(script).toContain("ensureCanonicalPmOperatingQualityEvidence");
+    expect(script).toContain("DPM PM operating-quality score-run create");
+    expect(script).toContain("DPM PM operating-quality fairness-analysis create");
+    expect(script).toContain("DPM PM operating-quality review-action create");
+    expect(script).toContain("DPM PM operating-quality summary-invocation create");
+    expect(script).toContain("pm_quality_summary.pack");
+    expect(script).toContain("summaryInvocationId: pmOperatingQualityEvidence.summaryInvocationId");
     expect(script).toContain('recordPanelClassification("dpm.copilot_workspace"');
     expect(browserWorkflowModule).toContain("Construction alternatives generated.");
     expect(browserWorkflowModule).toContain(
@@ -384,6 +391,8 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain(
       'qualityStatusStrip.getByText(label, { exact: true })'
     );
+    expect(browserWorkflowModule).toContain('getByText("Summary Invocation Detail", { exact: true })');
+    expect(browserWorkflowModule).toContain("PM operating quality summary invocations");
     expect(browserWorkflowModule).toContain('screenshotRegisteredPanel(page, "dpm.pm_operating_quality")');
     expect(browserWorkflowModule).toContain("PM copilot posture");
     expect(browserWorkflowModule).toContain('screenshotRegisteredPanel(page, "dpm.copilot_workspace")');

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -42,6 +42,9 @@
   `output/playwright/live-canonical/`
 - construction alternatives live proof writes focused machine-readable evidence and a panel
   screenshot under `output/rfc39-wtbd002-construction-lab/construction-live/`
+- DPM PM operating-quality live proof creates and re-reads Manage-backed score-run,
+  fairness-analysis, supervisory review-action, and summary-invocation evidence through Gateway
+  before the panel is classified as ready
 - observability evidence capture writes local non-functional proof packs under
   `output/observability-live/<timestamp>/`
 - final visual review should use canonical validated captures, not pre-validation diagnostics
@@ -54,3 +57,10 @@ The governed front-office validation flow checks the seeded `PB_SG_GLOBAL_BAL_00
 - performance summary and analysis surfaces
 - advisor-brief and risk modes inside the performance experience
 - evidence-oriented product validation paths that are part of the current governed runtime
+- DPM outcome review, proof pack, command center, portfolio memory, rebalance-wave command center,
+  construction alternatives, PM operating quality, and PM copilot workspace
+
+When validating active Workbench source changes, use the governed local-app bring-up
+`npm run live:stack:up:workbench-local` so `workbench.dev.lotus` serves the current branch while
+Gateway and backend Lotus apps remain on the canonical stack. Docker-backed Workbench evidence is
+valid for released images, but it must not be used to prove newly changed Workbench panels.


### PR DESCRIPTION
## Summary
- harden DPM construction and PM operating-quality browser selectors
- seed and re-read Manage-backed PM operating-quality score-run, fairness-analysis, review-action, and summary-invocation evidence during canonical live validation
- record PM quality evidence IDs in panel governance classification

## Validation
- npm test -- --run tests/unit/live-canonical-validation-script.test.ts
- npm run lint
- npm run typecheck
- powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1 -ScreenshotDirectory output\\playwright\\rfc36-43-audit-20260524

## Live Evidence
- Portfolio: PB_SG_GLOBAL_BAL_001
- Benchmark: BMK_PB_GLOBAL_BALANCED_60_40
- Summary: output\\playwright\\rfc36-43-audit-20260524\\live-validation-summary.json
- Screenshots: output\\playwright\\rfc36-43-audit-20260524

Draft while the broader RFC36-43 audit continues.