### PR TITLE
Harden canonical front-office evidence posture

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -388,6 +388,11 @@ The summary also includes `panelClassifications` for the product surfaces valida
 Panels must be classified as `ready`, `partial`, `unavailable`, or another explicit governed state.
 The validator fails if a supported panel is recorded as blank without a governed empty, partial, or
 unavailable posture.
+The summary also includes a `supportabilityMatrix` with registered versus classified panel counts,
+required and observed supportability-state counts, owning-service counts, non-ready panel evidence,
+and missing-panel evidence. Reviewers should inspect this matrix before accepting screenshots as
+demo-ready proof, because it shows whether the run covered both ready panels and governed bounded
+partial/degraded states.
 
 ## Gateway startup rule
 

--- a/scripts/live/validation/evidence-summary-writer.d.mts
+++ b/scripts/live/validation/evidence-summary-writer.d.mts
@@ -10,6 +10,7 @@ export type InitializedValidationSummary = ValidationSummary & {
   uiChecks: Array<Record<string, unknown>>;
   calculationChecks: Array<Record<string, unknown>>;
   panelClassifications: Array<Record<string, unknown>>;
+  supportabilityMatrix: Record<string, unknown> | null;
   supportabilityChecks: Array<Record<string, unknown>>;
   screenshots: Array<Record<string, unknown>>;
 };

--- a/scripts/live/validation/evidence-summary-writer.mjs
+++ b/scripts/live/validation/evidence-summary-writer.mjs
@@ -30,6 +30,7 @@ export function createValidationSummary({
     uiChecks: [],
     calculationChecks: [],
     panelClassifications: [],
+    supportabilityMatrix: null,
     supportabilityChecks: [],
     screenshots: [],
   };

--- a/scripts/live/validation/panel-governance.mjs
+++ b/scripts/live/validation/panel-governance.mjs
@@ -1,6 +1,58 @@
 export function createPanelGovernance(summary, panelRegistry) {
   const panelRegistryById = new Map(panelRegistry.panels.map((panel) => [panel.panelId, panel]));
 
+  function incrementCount(target, key) {
+    const normalizedKey = typeof key === "string" && key ? key : "unknown";
+    target[normalizedKey] = (target[normalizedKey] ?? 0) + 1;
+  }
+
+  function sortCountMap(counts) {
+    return Object.fromEntries(Object.entries(counts).sort(([left], [right]) => left.localeCompare(right)));
+  }
+
+  function buildSupportabilityMatrix() {
+    const classifiedPanels = new Set(summary.panelClassifications.map((panel) => panel.panel));
+    const requiredStateCounts = {};
+    const observedStateCounts = {};
+    const ownerCounts = {};
+    const nonReadyPanels = [];
+    const missingPanels = [];
+
+    for (const panelSpec of panelRegistry.panels) {
+      incrementCount(requiredStateCounts, panelSpec.requiredSupportState);
+      if (!classifiedPanels.has(panelSpec.panelId)) {
+        missingPanels.push(panelSpec.panelId);
+      }
+    }
+
+    for (const panel of summary.panelClassifications) {
+      const panelSpec = panelRegistryById.get(panel.panel);
+      incrementCount(observedStateCounts, panel.state);
+      incrementCount(ownerCounts, panel.owner);
+      if (panel.state !== "ready") {
+        nonReadyPanels.push({
+          panel: panel.panel,
+          state: panel.state,
+          requiredSupportState: panelSpec?.requiredSupportState ?? null,
+          owner: panel.owner,
+          reason: panel.reason ?? null,
+          knownLimitations: panelSpec?.knownLimitations ?? [],
+          ownerFollowUpRfc: panelSpec?.ownerFollowUpRfc ?? null,
+        });
+      }
+    }
+
+    return {
+      registeredPanelCount: panelRegistry.panels.length,
+      classifiedPanelCount: summary.panelClassifications.length,
+      requiredStateCounts: sortCountMap(requiredStateCounts),
+      observedStateCounts: sortCountMap(observedStateCounts),
+      ownerCounts: sortCountMap(ownerCounts),
+      nonReadyPanels: nonReadyPanels.sort((left, right) => left.panel.localeCompare(right.panel)),
+      missingPanels: missingPanels.sort(),
+    };
+  }
+
   function recordSupportabilityCheck(panel, evidence) {
     summary.supportabilityChecks.push({ panel, ...evidence });
   }
@@ -70,6 +122,8 @@ export function createPanelGovernance(summary, panelRegistry) {
         ownerFollowUpRfc: panelSpec.ownerFollowUpRfc,
       });
     }
+
+    summary.supportabilityMatrix = buildSupportabilityMatrix();
   }
 
   return {

--- a/scripts/live/validation/shared-types.d.ts
+++ b/scripts/live/validation/shared-types.d.ts
@@ -68,6 +68,7 @@ export interface ValidationSummary {
   uiChecks?: Array<Record<string, unknown>>;
   calculationChecks?: Array<Record<string, unknown>>;
   panelClassifications?: Array<Record<string, unknown>>;
+  supportabilityMatrix?: Record<string, unknown> | null;
   supportabilityChecks?: Array<Record<string, unknown>>;
   screenshots?: Array<Record<string, unknown>>;
 }

--- a/src/features/proposals/api.ts
+++ b/src/features/proposals/api.ts
@@ -8,6 +8,16 @@ import {
   ProposalEnvelopeResponse,
   ProposalListData,
   ProposalLineageData,
+  ProposalMemoAiCommentaryData,
+  ProposalMemoAiCommentaryRequest,
+  ProposalMemoCreateRequest,
+  ProposalMemoData,
+  ProposalMemoLineageData,
+  ProposalMemoProjectionData,
+  ProposalMemoReplayEvidenceData,
+  ProposalMemoReportPackageData,
+  ProposalMemoReportPackageRequest,
+  ProposalMemoReviewRequest,
   ProposalNarrativeReviewData,
   ProposalNarrativeReviewRequest,
   ProposalReportRequest,
@@ -185,6 +195,123 @@ export async function getProposalDeliveryEvents(
   }
   const envelope = (await response.json()) as ProposalEnvelopeResponse;
   return envelope.data as unknown as ProposalDeliveryEventsData;
+}
+
+export async function createProposalMemo(
+  proposalId: string,
+  versionNo: number,
+  payload: ProposalMemoCreateRequest,
+  idempotencyKey: string
+): Promise<ProposalMemoData> {
+  const envelope = await postJson(
+    `/proposals/${proposalId}/versions/${versionNo}/memo`,
+    payload,
+    idempotencyKey
+  );
+  return envelope.data as unknown as ProposalMemoData;
+}
+
+export async function getProposalMemo(
+  proposalId: string,
+  versionNo: number
+): Promise<ProposalMemoData> {
+  const response = await fetch(`${BFF_PROXY_BASE}/proposals/${proposalId}/versions/${versionNo}/memo`);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Proposal memo fetch failed (${response.status}): ${body}`);
+  }
+  const envelope = (await response.json()) as ProposalEnvelopeResponse;
+  return envelope.data as unknown as ProposalMemoData;
+}
+
+export async function getProposalMemoProjection(
+  proposalId: string,
+  versionNo: number,
+  audience?: string
+): Promise<ProposalMemoProjectionData> {
+  const params = new URLSearchParams();
+  if (audience) {
+    params.set("audience", audience);
+  }
+  const query = params.toString() ? `?${params.toString()}` : "";
+  const response = await fetch(
+    `${BFF_PROXY_BASE}/proposals/${proposalId}/versions/${versionNo}/memo/projection${query}`
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Proposal memo projection failed (${response.status}): ${body}`);
+  }
+  const envelope = (await response.json()) as ProposalEnvelopeResponse;
+  return envelope.data as unknown as ProposalMemoProjectionData;
+}
+
+export async function reviewProposalMemo(
+  proposalId: string,
+  versionNo: number,
+  payload: ProposalMemoReviewRequest,
+  idempotencyKey?: string
+): Promise<ProposalMemoData> {
+  const envelope = await postJson(
+    `/proposals/${proposalId}/versions/${versionNo}/memo/review`,
+    payload,
+    idempotencyKey
+  );
+  return envelope.data as unknown as ProposalMemoData;
+}
+
+export async function requestProposalMemoReportPackage(
+  proposalId: string,
+  versionNo: number,
+  payload: ProposalMemoReportPackageRequest,
+  idempotencyKey?: string
+): Promise<ProposalMemoReportPackageData> {
+  const envelope = await postJson(
+    `/proposals/${proposalId}/versions/${versionNo}/memo/report-packages`,
+    payload,
+    idempotencyKey
+  );
+  return envelope.data as unknown as ProposalMemoReportPackageData;
+}
+
+export async function requestProposalMemoAiCommentary(
+  proposalId: string,
+  versionNo: number,
+  payload: ProposalMemoAiCommentaryRequest,
+  idempotencyKey?: string
+): Promise<ProposalMemoAiCommentaryData> {
+  const envelope = await postJson(
+    `/proposals/${proposalId}/versions/${versionNo}/memo/ai-commentary`,
+    payload,
+    idempotencyKey
+  );
+  return envelope.data as unknown as ProposalMemoAiCommentaryData;
+}
+
+export async function getProposalMemoLineage(
+  proposalId: string
+): Promise<ProposalMemoLineageData> {
+  const response = await fetch(`${BFF_PROXY_BASE}/proposals/${proposalId}/memos/lineage`);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Proposal memo lineage failed (${response.status}): ${body}`);
+  }
+  const envelope = (await response.json()) as ProposalEnvelopeResponse;
+  return envelope.data as unknown as ProposalMemoLineageData;
+}
+
+export async function getProposalMemoReplayEvidence(
+  proposalId: string,
+  versionNo: number
+): Promise<ProposalMemoReplayEvidenceData> {
+  const response = await fetch(
+    `${BFF_PROXY_BASE}/proposals/${proposalId}/versions/${versionNo}/memo/replay-evidence`
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Proposal memo replay evidence failed (${response.status}): ${body}`);
+  }
+  const envelope = (await response.json()) as ProposalEnvelopeResponse;
+  return envelope.data as unknown as ProposalMemoReplayEvidenceData;
 }
 
 export async function submitProposal(

--- a/src/features/proposals/components/proposal-detail-view.tsx
+++ b/src/features/proposals/components/proposal-detail-view.tsx
@@ -36,6 +36,7 @@ import {
   ProposalWorkflowEventsData,
 } from "../types";
 import ProposalNarrativePosturePanel from "./proposal-narrative-posture-panel";
+import ProposalMemoPosturePanel from "./proposal-memo-posture-panel";
 import {
   buildProposalActionIdempotencyKey,
   isValidProposalId,
@@ -400,6 +401,12 @@ export default function ProposalDetailView({ proposalId }: Props) {
 
       <Divider sx={{ my: 1 }} />
       <ProposalNarrativePosturePanel
+        proposalId={data.proposal.proposal_id}
+        currentVersionNo={data.proposal.current_version_no}
+      />
+
+      <Divider sx={{ my: 1 }} />
+      <ProposalMemoPosturePanel
         proposalId={data.proposal.proposal_id}
         currentVersionNo={data.proposal.current_version_no}
       />

--- a/src/features/proposals/components/proposal-memo-posture-panel.tsx
+++ b/src/features/proposals/components/proposal-memo-posture-panel.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Alert, Button, Stack } from "@mui/material";
+
+import {
+  createProposalMemo,
+  getProposalMemo,
+  getProposalMemoLineage,
+  getProposalMemoProjection,
+  getProposalMemoReplayEvidence,
+  requestProposalMemoAiCommentary,
+  requestProposalMemoReportPackage,
+  reviewProposalMemo,
+} from "../api";
+import { buildProposalActionIdempotencyKey } from "../proposal-workflow-copy";
+import { workbenchStrictQueryDefaults } from "@/features/platform-runtime/query-policy";
+import { SectionBlock, SemanticBadge, Text } from "@/design-system";
+
+type Props = {
+  proposalId: string;
+  currentVersionNo?: number | null;
+};
+
+const projectionAudiences = ["ADVISOR", "COMPLIANCE", "OPERATIONS", "CLIENT_DRAFT"] as const;
+
+function textValue(value: unknown, fallback = "Not reported"): string {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value) && value.length > 0) {
+    return value.map((item) => String(item)).join(", ");
+  }
+  return fallback;
+}
+
+function recordValue(source: Record<string, unknown> | undefined, key: string): unknown {
+  return source?.[key];
+}
+
+function firstString(source: Record<string, unknown> | undefined, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = source?.[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+export default function ProposalMemoPosturePanel({ proposalId, currentVersionNo }: Props) {
+  const [versionNo, setVersionNo] = useState(currentVersionNo ?? 1);
+  const [actorId, setActorId] = useState("advisor_1");
+  const [reviewReason, setReviewReason] = useState("");
+  const [audience, setAudience] = useState<(typeof projectionAudiences)[number]>("ADVISOR");
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const memoQuery = useQuery({
+    queryKey: ["proposal-memo", proposalId, versionNo],
+    queryFn: async () => await getProposalMemo(proposalId, versionNo),
+    ...workbenchStrictQueryDefaults,
+  });
+  const projectionQuery = useQuery({
+    queryKey: ["proposal-memo-projection", proposalId, versionNo, audience],
+    queryFn: async () => await getProposalMemoProjection(proposalId, versionNo, audience),
+    ...workbenchStrictQueryDefaults,
+  });
+  const lineageQuery = useQuery({
+    queryKey: ["proposal-memo-lineage", proposalId],
+    queryFn: async () => await getProposalMemoLineage(proposalId),
+    ...workbenchStrictQueryDefaults,
+  });
+  const replayQuery = useQuery({
+    queryKey: ["proposal-memo-replay-evidence", proposalId, versionNo],
+    queryFn: async () => await getProposalMemoReplayEvidence(proposalId, versionNo),
+    ...workbenchStrictQueryDefaults,
+  });
+
+  const memoHash = useMemo(() => {
+    const memo = memoQuery.data?.memo as Record<string, unknown> | undefined;
+    return (
+      firstString(memoQuery.data, ["memo_hash", "source_memo_hash"]) ??
+      firstString(memo, ["memo_hash", "source_memo_hash"])
+    );
+  }, [memoQuery.data]);
+  const reviewPosture = memoQuery.data?.review_posture as Record<string, unknown> | undefined;
+  const reportPosture = memoQuery.data?.report_package_posture as Record<string, unknown> | undefined;
+  const aiPosture = memoQuery.data?.ai_commentary_posture as Record<string, unknown> | undefined;
+  const readPosture = memoQuery.data?.read_posture as Record<string, unknown> | undefined;
+  const projection = projectionQuery.data?.projection;
+  const projectionPosture = projectionQuery.data?.projection_posture;
+  const latestMemo = lineageQuery.data?.memos?.[0];
+  const replayHashes = replayQuery.data?.hashes;
+  const replaySupportability = replayQuery.data?.supportability;
+
+  async function refreshMemoState() {
+    await Promise.all([
+      memoQuery.refetch(),
+      projectionQuery.refetch(),
+      lineageQuery.refetch(),
+      replayQuery.refetch(),
+    ]);
+  }
+
+  async function handleCreateMemo() {
+    setPendingAction("create");
+    setActionError(null);
+    try {
+      await createProposalMemo(
+        proposalId,
+        versionNo,
+        {
+          created_by: actorId.trim() || "advisor_1",
+          lifecycle_status: "DRAFT",
+          reason: { source: "workbench", purpose: "advisor memo review" },
+        },
+        buildProposalActionIdempotencyKey(proposalId, `memo-create-${versionNo}`)
+      );
+      await refreshMemoState();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unknown memo creation error");
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function handleApproveMemo() {
+    if (!memoHash || reviewReason.trim().length === 0) {
+      return;
+    }
+    setPendingAction("review");
+    setActionError(null);
+    try {
+      await reviewProposalMemo(
+        proposalId,
+        versionNo,
+        {
+          action: "APPROVE_FOR_ADVISOR_USE",
+          reviewed_by: actorId.trim() || "advisor_1",
+          reason: reviewReason.trim(),
+          source_memo_hash: memoHash,
+          client_ready_release_requested: false,
+        },
+        buildProposalActionIdempotencyKey(proposalId, `memo-review-${versionNo}`)
+      );
+      setReviewReason("");
+      await refreshMemoState();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unknown memo review error");
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function handleRequestReportPackage() {
+    if (!memoHash) {
+      return;
+    }
+    setPendingAction("report");
+    setActionError(null);
+    try {
+      await requestProposalMemoReportPackage(
+        proposalId,
+        versionNo,
+        {
+          requested_by: actorId.trim() || "advisor_1",
+          source_memo_hash: memoHash,
+          requested_output_formats: ["pdf"],
+          client_ready_document_requested: false,
+          reason: { source: "workbench", purpose: "advisor-use memo package" },
+        },
+        buildProposalActionIdempotencyKey(proposalId, `memo-report-package-${versionNo}`)
+      );
+      await refreshMemoState();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unknown memo report-package error");
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function handleRequestAiCommentary() {
+    if (!memoHash) {
+      return;
+    }
+    setPendingAction("ai");
+    setActionError(null);
+    try {
+      await requestProposalMemoAiCommentary(
+        proposalId,
+        versionNo,
+        {
+          requested_by: actorId.trim() || "advisor_1",
+          source_memo_hash: memoHash,
+          requested_sections: ["EXECUTIVE_SUMMARY", "LIMITATIONS_AND_DISCLOSURES"],
+          reason: { source: "workbench", purpose: "advisor-use commentary" },
+        },
+        buildProposalActionIdempotencyKey(proposalId, `memo-ai-commentary-${versionNo}`)
+      );
+      await refreshMemoState();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unknown AI commentary error");
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  const hasMemo = Boolean(memoQuery.data?.memo_id || memoHash);
+  const supportability =
+    firstString(readPosture, ["supportability", "status"]) ??
+    firstString(projectionPosture, ["supportability", "status"]) ??
+    firstString(replaySupportability, ["supportability", "status"]);
+
+  return (
+    <SectionBlock
+      className="proposal-memo-posture-panel"
+      title="Advisor Memo Product Surface"
+      subtitle="Memo review, projection, report-package, archive-reference, replay, and AI-commentary posture from the Gateway advisory contract."
+      actions={
+        <SemanticBadge tone={hasMemo ? "success" : "warn"}>
+          {textValue(memoQuery.data?.memo_status, hasMemo ? "Memo Available" : "Memo Pending")}
+        </SemanticBadge>
+      }
+    >
+      {memoQuery.error || projectionQuery.error || lineageQuery.error || replayQuery.error ? (
+        <Alert severity="warning" sx={{ mb: 1 }}>
+          Memo posture is degraded or blocked by Gateway. Workbench keeps source-owned memo facts,
+          supportability, and readiness unchanged.
+        </Alert>
+      ) : null}
+      {actionError ? (
+        <Alert severity="warning" sx={{ mb: 1 }}>
+          {actionError}
+        </Alert>
+      ) : null}
+
+      <Stack direction={{ xs: "column", md: "row" }} spacing={1} sx={{ mb: 1 }}>
+        <div className="analytics-stat">
+          <Text variant="label">Review Posture</Text>
+          <Text variant="metricValueCompact">
+            {textValue(recordValue(reviewPosture, "advisor_use"), "Pending")}
+          </Text>
+          <Text variant="secondary">Memo hash: {memoHash ?? "Not available"}</Text>
+        </div>
+        <div className="analytics-stat">
+          <Text variant="label">Projection Audience</Text>
+          <Text variant="metricValueCompact">
+            {textValue(recordValue(projection, "audience"), audience)}
+          </Text>
+          <Text variant="secondary">
+            Client draft: {textValue(recordValue(projection, "client_ready_publication"), "Blocked")}
+          </Text>
+        </div>
+        <div className="analytics-stat">
+          <Text variant="label">Supportability</Text>
+          <Text variant="metricValueCompact">{supportability ?? "Not reported"}</Text>
+          <Text variant="secondary">
+            Replay hash: {textValue(recordValue(replayHashes, "memo_hash"), "Not available")}
+          </Text>
+        </div>
+      </Stack>
+
+      <Stack direction={{ xs: "column", md: "row" }} spacing={1} sx={{ mb: 1 }}>
+        <div className="analytics-stat">
+          <Text variant="label">Report Package</Text>
+          <Text variant="metricValueCompact">
+            {textValue(recordValue(reportPosture, "status"), "Not requested")}
+          </Text>
+          <Text variant="secondary">
+            Archive refs: {textValue(recordValue(reportPosture, "archive_refs"), "None")}
+          </Text>
+        </div>
+        <div className="analytics-stat">
+          <Text variant="label">AI Commentary</Text>
+          <Text variant="metricValueCompact">
+            {textValue(recordValue(aiPosture, "status"), "Not requested")}
+          </Text>
+          <Text variant="secondary">
+            Authority: {textValue(recordValue(aiPosture, "authority"), "Non-authoritative")}
+          </Text>
+        </div>
+        <div className="analytics-stat">
+          <Text variant="label">Lineage</Text>
+          <Text variant="metricValueCompact">
+            {textValue(latestMemo?.memo_status, "No lineage memo")}
+          </Text>
+          <Text variant="secondary">{latestMemo?.memo_hash ?? "No lineage hash"}</Text>
+        </div>
+      </Stack>
+
+      <Stack direction={{ xs: "column", md: "row" }} spacing={1} sx={{ mb: 1 }}>
+        <label className="proposal-review-field">
+          <Text variant="label">Version</Text>
+          <input
+            className="input"
+            type="number"
+            min={1}
+            value={versionNo}
+            onChange={(event) => {
+              const next = Number.parseInt(event.target.value, 10);
+              setVersionNo(Number.isNaN(next) ? 1 : next);
+            }}
+          />
+        </label>
+        <label className="proposal-review-field">
+          <Text variant="label">Actor</Text>
+          <input
+            className="input"
+            value={actorId}
+            onChange={(event) => setActorId(event.target.value)}
+            placeholder="advisor_1"
+            autoComplete="off"
+          />
+        </label>
+        <label className="proposal-review-field">
+          <Text variant="label">Projection</Text>
+          <select
+            className="input"
+            value={audience}
+            onChange={(event) =>
+              setAudience(event.target.value as (typeof projectionAudiences)[number])
+            }
+          >
+            {projectionAudiences.map((item) => (
+              <option key={item} value={item}>
+                {item}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="proposal-review-field proposal-review-field-wide">
+          <Text variant="label">Review rationale</Text>
+          <textarea
+            className="textarea"
+            rows={3}
+            value={reviewReason}
+            onChange={(event) => setReviewReason(event.target.value)}
+            placeholder="Evidence-backed memo is ready for advisor use."
+          />
+        </label>
+      </Stack>
+
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={1} sx={{ mb: 1 }}>
+        <Button type="button" variant="outlined" disabled={pendingAction !== null} onClick={handleCreateMemo}>
+          {pendingAction === "create" ? "Creating Memo..." : "Create Or Replay Memo"}
+        </Button>
+        <Button
+          type="button"
+          variant="contained"
+          disabled={!memoHash || reviewReason.trim().length === 0 || pendingAction !== null}
+          onClick={handleApproveMemo}
+        >
+          {pendingAction === "review" ? "Recording Review..." : "Approve Memo For Advisor Use"}
+        </Button>
+        <Button
+          type="button"
+          variant="outlined"
+          disabled={!memoHash || pendingAction !== null}
+          onClick={handleRequestReportPackage}
+        >
+          {pendingAction === "report" ? "Requesting Package..." : "Request Memo Report Package"}
+        </Button>
+        <Button
+          type="button"
+          variant="outlined"
+          disabled={!memoHash || pendingAction !== null}
+          onClick={handleRequestAiCommentary}
+        >
+          {pendingAction === "ai" ? "Requesting Commentary..." : "Request AI Commentary"}
+        </Button>
+      </Stack>
+
+      <Text variant="secondary">
+        Workbench uses Gateway memo endpoints only. It does not infer memo facts, promote
+        client-ready release, render documents, synthesize archive references, or treat AI
+        commentary as authoritative memo evidence.
+      </Text>
+    </SectionBlock>
+  );
+}

--- a/src/features/proposals/types.ts
+++ b/src/features/proposals/types.ts
@@ -219,3 +219,97 @@ export type ProposalDeliveryEventsData = {
   explanation?: Record<string, unknown>;
   [key: string]: unknown;
 };
+
+export type ProposalMemoCreateRequest = {
+  created_by: string;
+  lifecycle_status?: string;
+  reason?: Record<string, unknown>;
+};
+
+export type ProposalMemoReviewRequest = {
+  action: "APPROVE_FOR_ADVISOR_USE" | "REJECT" | "REQUEST_CHANGES";
+  reviewed_by: string;
+  reason: string;
+  source_memo_hash: string;
+  client_ready_release_requested?: boolean;
+};
+
+export type ProposalMemoReportPackageRequest = {
+  requested_by: string;
+  source_memo_hash: string;
+  requested_output_formats?: string[];
+  client_ready_document_requested?: boolean;
+  reason?: Record<string, unknown>;
+};
+
+export type ProposalMemoAiCommentaryRequest = {
+  requested_by: string;
+  source_memo_hash: string;
+  requested_sections?: string[];
+  reason?: Record<string, unknown>;
+};
+
+export type ProposalMemoData = {
+  proposal?: ProposalSummary;
+  proposal_version_no?: number;
+  memo_id?: string;
+  memo_status?: string;
+  lifecycle_status?: string;
+  memo_hash?: string;
+  memo?: Record<string, unknown>;
+  projection?: Record<string, unknown>;
+  review_posture?: Record<string, unknown>;
+  report_package_posture?: Record<string, unknown>;
+  ai_commentary_posture?: Record<string, unknown>;
+  replay_metadata?: Record<string, unknown>;
+  audit_events?: Array<Record<string, unknown>>;
+  event_count?: number;
+  read_posture?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type ProposalMemoProjectionData = {
+  proposal?: ProposalSummary;
+  projection?: Record<string, unknown>;
+  sections?: Array<Record<string, unknown>>;
+  projection_posture?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type ProposalMemoReportPackageData = {
+  memo?: Record<string, unknown>;
+  report_package_event?: Record<string, unknown>;
+  report?: Record<string, unknown>;
+  replayed?: boolean;
+  [key: string]: unknown;
+};
+
+export type ProposalMemoAiCommentaryData = {
+  memo?: Record<string, unknown>;
+  ai_event?: Record<string, unknown>;
+  commentary?: Record<string, unknown>;
+  replayed?: boolean;
+  [key: string]: unknown;
+};
+
+export type ProposalMemoLineageData = {
+  proposal?: ProposalSummary;
+  proposal_id?: string;
+  memos?: Array<{
+    memo_id?: string;
+    memo_hash?: string;
+    memo_status?: string;
+    report_package_posture?: Record<string, unknown>;
+    ai_commentary_posture?: Record<string, unknown>;
+    [key: string]: unknown;
+  }>;
+  [key: string]: unknown;
+};
+
+export type ProposalMemoReplayEvidenceData = {
+  proposal?: ProposalSummary;
+  hashes?: Record<string, unknown>;
+  audit_events?: Array<Record<string, unknown>>;
+  supportability?: Record<string, unknown>;
+  [key: string]: unknown;
+};

--- a/tests/e2e/proposal-memo-posture.spec.ts
+++ b/tests/e2e/proposal-memo-posture.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "@playwright/test";
+
+async function mockProposalDetail(page: import("@playwright/test").Page, blocked = false) {
+  await page.route("**/api/bff/api/v1/proposals/pp_1?include_evidence=false", async (route) => {
+    await route.fulfill({
+      json: {
+        correlation_id: "corr-detail",
+        contract_version: "v1",
+        data: {
+          proposal: {
+            proposal_id: "pp_1",
+            current_state: "DRAFT",
+            portfolio_id: "PF_1001",
+            current_version_no: 2,
+          },
+          current_version: {
+            simulate_request: { options: { enable_proposal_simulation: true } },
+          },
+        },
+      },
+    });
+  });
+  await page.route("**/api/bff/api/v1/proposals/pp_1/workflow-events", async (route) => {
+    await route.fulfill({
+      json: {
+        correlation_id: "corr-workflow",
+        contract_version: "v1",
+        data: { proposal_id: "pp_1", current_state: "DRAFT", events: [] },
+      },
+    });
+  });
+  await page.route("**/api/bff/api/v1/proposals/pp_1/approvals", async (route) => {
+    await route.fulfill({
+      json: {
+        correlation_id: "corr-approvals",
+        contract_version: "v1",
+        data: { proposal_id: "pp_1", current_state: "DRAFT", approvals: [] },
+      },
+    });
+  });
+  await page.route("**/api/bff/api/v1/proposals/pp_1/lineage", async (route) => {
+    await route.fulfill({
+      json: {
+        correlation_id: "corr-lineage",
+        contract_version: "v1",
+        data: { proposal_id: "pp_1", versions: [{ version_no: 2 }] },
+      },
+    });
+  });
+  await page.route("**/api/bff/api/v1/proposals/pp_1/delivery-summary", async (route) => {
+    await route.fulfill({
+      json: { correlation_id: "corr-delivery", contract_version: "v1", data: {} },
+    });
+  });
+  await page.route("**/api/bff/api/v1/proposals/pp_1/delivery-events", async (route) => {
+    await route.fulfill({
+      json: { correlation_id: "corr-events", contract_version: "v1", data: { event_count: 0 } },
+    });
+  });
+  await page.route("**/api/bff/api/v1/proposals/pp_1/versions/2/memo", async (route) => {
+    if (blocked && route.request().method() === "GET") {
+      await route.fulfill({ status: 409, body: "MEMO_BLOCKED_BY_SOURCE_EVIDENCE" });
+      return;
+    }
+    await route.fulfill({
+      json: {
+        correlation_id: "corr-memo",
+        contract_version: "v1",
+        data: {
+          memo_id: "memo_1",
+          memo_status: "APPROVED_FOR_ADVISOR_USE",
+          memo_hash: "sha256:memo-001",
+          review_posture: { advisor_use: "APPROVED_FOR_ADVISOR_USE" },
+          report_package_posture: {
+            status: "READY",
+            archive_refs: ["archive://memo/report/1"],
+          },
+          ai_commentary_posture: {
+            status: "AVAILABLE",
+            authority: "NON_AUTHORITATIVE",
+          },
+          read_posture: { supportability: "SUPPORTED_ADVISOR_USE" },
+        },
+      },
+    });
+  });
+  await page.route("**/api/bff/api/v1/proposals/pp_1/versions/2/memo/projection**", async (route) => {
+    const requestUrl = new URL(route.request().url());
+    const audience = requestUrl.searchParams.get("audience") ?? "ADVISOR";
+    await route.fulfill({
+      json: {
+        correlation_id: "corr-projection",
+        contract_version: "v1",
+        data: {
+          projection: {
+            audience,
+            client_ready_publication: blocked ? "BLOCKED_BY_SOURCE_EVIDENCE" : "BLOCKED",
+          },
+          projection_posture: {
+            supportability: blocked ? "DEGRADED_SOURCE_EVIDENCE" : "SUPPORTED_ADVISOR_USE",
+          },
+        },
+      },
+    });
+  });
+  await page.route("**/api/bff/api/v1/proposals/pp_1/memos/lineage", async (route) => {
+    await route.fulfill({
+      json: {
+        correlation_id: "corr-memo-lineage",
+        contract_version: "v1",
+        data: {
+          memos: [{ memo_hash: "sha256:memo-001", memo_status: "APPROVED_FOR_ADVISOR_USE" }],
+        },
+      },
+    });
+  });
+  await page.route("**/api/bff/api/v1/proposals/pp_1/versions/2/memo/replay-evidence", async (route) => {
+    await route.fulfill({
+      json: {
+        correlation_id: "corr-replay",
+        contract_version: "v1",
+        data: {
+          hashes: { memo_hash: "sha256:memo-001" },
+          supportability: { client_ready_publication: "BLOCKED" },
+        },
+      },
+    });
+  });
+}
+
+test.describe("proposal memo posture", () => {
+  test("renders Gateway-backed memo audiences and blocked client draft posture", async ({ page }) => {
+    await mockProposalDetail(page);
+    await page.goto("/proposals/pp_1", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Advisor Memo Product Surface" })).toBeVisible();
+    await expect(page.getByText("APPROVED_FOR_ADVISOR_USE").first()).toBeVisible();
+    await expect(page.getByText("SUPPORTED_ADVISOR_USE").first()).toBeVisible();
+    await expect(page.getByText(/Client draft: BLOCKED/)).toBeVisible();
+    await expect(page.getByText(/archive:\/\/memo\/report\/1/)).toBeVisible();
+
+    await page.locator("select.input").selectOption("COMPLIANCE");
+    await expect(page.getByText("COMPLIANCE").first()).toBeVisible();
+    await page.locator("select.input").selectOption("OPERATIONS");
+    await expect(page.getByText("OPERATIONS").first()).toBeVisible();
+    await page.locator("select.input").selectOption("CLIENT_DRAFT");
+    await expect(page.getByText("CLIENT_DRAFT").first()).toBeVisible();
+    await expect(page.getByRole("button", { name: /send to client/i })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /client-ready release/i })).toHaveCount(0);
+  });
+
+  test("renders degraded and blocked memo posture from Gateway responses", async ({ page }) => {
+    await mockProposalDetail(page, true);
+    await page.goto("/proposals/pp_1", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText(/Memo posture is degraded or blocked by Gateway/)).toBeVisible();
+    await expect(page.getByText("DEGRADED_SOURCE_EVIDENCE").first()).toBeVisible();
+    await expect(page.getByText(/Client draft: BLOCKED_BY_SOURCE_EVIDENCE/)).toBeVisible();
+    await expect(page.getByText(/ready for client/i)).toHaveCount(0);
+  });
+});

--- a/tests/integration/proposal-detail-view.test.tsx
+++ b/tests/integration/proposal-detail-view.test.tsx
@@ -15,6 +15,14 @@ const {
   getWorkflowEventsMock,
   getApprovalsMock,
   getLineageMock,
+  getProposalMemoMock,
+  getProposalMemoProjectionMock,
+  getProposalMemoLineageMock,
+  getProposalMemoReplayEvidenceMock,
+  createProposalMemoMock,
+  reviewProposalMemoMock,
+  requestProposalMemoReportPackageMock,
+  requestProposalMemoAiCommentaryMock,
 } = vi.hoisted(() => ({
   createProposalVersionMock: vi.fn(async () => ({
     data: {
@@ -92,6 +100,32 @@ const {
       },
     ],
   })),
+  getProposalMemoMock: vi.fn(async () => ({
+    memo_id: "memo_1",
+    memo_status: "APPROVED_FOR_ADVISOR_USE",
+    memo_hash: "sha256:memo-001",
+    review_posture: { advisor_use: "APPROVED_FOR_ADVISOR_USE" },
+    report_package_posture: { status: "READY" },
+    ai_commentary_posture: { status: "AVAILABLE" },
+    read_posture: { supportability: "SUPPORTED_ADVISOR_USE" },
+  })),
+  getProposalMemoProjectionMock: vi.fn(async () => ({
+    projection: { audience: "ADVISOR", client_ready_publication: "BLOCKED" },
+    projection_posture: { supportability: "SUPPORTED_ADVISOR_USE" },
+  })),
+  getProposalMemoLineageMock: vi.fn(async () => ({
+    memos: [{ memo_hash: "sha256:memo-001", memo_status: "APPROVED_FOR_ADVISOR_USE" }],
+  })),
+  getProposalMemoReplayEvidenceMock: vi.fn(async () => ({
+    hashes: { memo_hash: "sha256:memo-001" },
+    supportability: { client_ready_publication: "BLOCKED" },
+  })),
+  createProposalMemoMock: vi.fn(async () => ({ memo_hash: "sha256:memo-001" })),
+  reviewProposalMemoMock: vi.fn(async () => ({ memo_hash: "sha256:memo-001" })),
+  requestProposalMemoReportPackageMock: vi.fn(async () => ({ report: { status: "READY" } })),
+  requestProposalMemoAiCommentaryMock: vi.fn(async () => ({
+    commentary: { authority: "NON_AUTHORITATIVE" },
+  })),
 }));
 
 vi.mock("../../src/features/proposals/api", () => ({
@@ -104,6 +138,14 @@ vi.mock("../../src/features/proposals/api", () => ({
   getProposalWorkflowEvents: getWorkflowEventsMock,
   getProposalApprovals: getApprovalsMock,
   getProposalLineage: getLineageMock,
+  createProposalMemo: createProposalMemoMock,
+  getProposalMemo: getProposalMemoMock,
+  getProposalMemoProjection: getProposalMemoProjectionMock,
+  getProposalMemoLineage: getProposalMemoLineageMock,
+  getProposalMemoReplayEvidence: getProposalMemoReplayEvidenceMock,
+  reviewProposalMemo: reviewProposalMemoMock,
+  requestProposalMemoReportPackage: requestProposalMemoReportPackageMock,
+  requestProposalMemoAiCommentary: requestProposalMemoAiCommentaryMock,
 }));
 
 describe("ProposalDetailView", () => {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -477,6 +477,8 @@ describe("canonical live validation script", () => {
     expect(runbook).toContain("structured screenshot evidence");
     expect(runbook).toContain("SHOT-INDEX.md");
     expect(runbook).toContain("workflowPackChecks");
+    expect(runbook).toContain("supportabilityMatrix");
+    expect(runbook).toContain("registered versus classified panel counts");
     expect(runbook).toContain("ACCEPT`, `REVISE`, and");
   });
 });

--- a/tests/unit/live-validation-panel-governance.test.ts
+++ b/tests/unit/live-validation-panel-governance.test.ts
@@ -4,6 +4,7 @@ import type { ValidationPanelState } from "../../scripts/live/validation/shared-
 function createSummary() {
   return {
     panelClassifications: [],
+    supportabilityMatrix: null,
     supportabilityChecks: [],
   };
 }
@@ -59,6 +60,33 @@ describe("live validation panel governance", () => {
     governance.assertPanelSupportabilityAlignment();
 
     expect(summary.panelClassifications).toHaveLength(2);
+    expect(summary.supportabilityMatrix).toEqual({
+      registeredPanelCount: 2,
+      classifiedPanelCount: 2,
+      requiredStateCounts: {
+        partial: 1,
+        ready: 1,
+      },
+      observedStateCounts: {
+        partial: 1,
+        ready: 1,
+      },
+      ownerCounts: {
+        "lotus-gateway": 2,
+      },
+      nonReadyPanels: [
+        {
+          panel: "performance.evidence",
+          state: "partial",
+          requiredSupportState: "partial",
+          owner: "lotus-gateway",
+          reason: "lineage evidence remains partial",
+          knownLimitations: ["deferred to RFC-0079"],
+          ownerFollowUpRfc: "RFC-0079",
+        },
+      ],
+      missingPanels: [],
+    });
     expect(summary.supportabilityChecks).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/tests/unit/proposal-memo-posture-panel.test.tsx
+++ b/tests/unit/proposal-memo-posture-panel.test.tsx
@@ -1,0 +1,187 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ProposalMemoPosturePanel from "../../src/features/proposals/components/proposal-memo-posture-panel";
+import {
+  createProposalMemo,
+  getProposalMemo,
+  getProposalMemoLineage,
+  getProposalMemoProjection,
+  getProposalMemoReplayEvidence,
+  requestProposalMemoAiCommentary,
+  requestProposalMemoReportPackage,
+  reviewProposalMemo,
+} from "../../src/features/proposals/api";
+
+vi.mock("../../src/features/proposals/api", () => ({
+  createProposalMemo: vi.fn(),
+  getProposalMemo: vi.fn(),
+  getProposalMemoLineage: vi.fn(),
+  getProposalMemoProjection: vi.fn(),
+  getProposalMemoReplayEvidence: vi.fn(),
+  requestProposalMemoAiCommentary: vi.fn(),
+  requestProposalMemoReportPackage: vi.fn(),
+  reviewProposalMemo: vi.fn(),
+}));
+
+function renderPanel() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ProposalMemoPosturePanel proposalId="pp_1" currentVersionNo={2} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ProposalMemoPosturePanel", () => {
+  beforeEach(() => {
+    vi.mocked(getProposalMemo).mockResolvedValue({
+      memo_id: "memo_1",
+      memo_status: "APPROVED_FOR_ADVISOR_USE",
+      memo_hash: "sha256:memo-001",
+      review_posture: { advisor_use: "APPROVED_FOR_ADVISOR_USE" },
+      report_package_posture: {
+        status: "READY",
+        archive_refs: ["archive://memo/report/1"],
+      },
+      ai_commentary_posture: {
+        status: "AVAILABLE",
+        authority: "NON_AUTHORITATIVE",
+      },
+      read_posture: { supportability: "SUPPORTED_ADVISOR_USE" },
+    });
+    vi.mocked(getProposalMemoProjection).mockResolvedValue({
+      projection: {
+        audience: "ADVISOR",
+        client_ready_publication: "BLOCKED",
+      },
+      sections: [{ section_id: "DISCLOSURES", supportability: "SOURCE_BACKED" }],
+      projection_posture: { supportability: "SUPPORTED_ADVISOR_USE" },
+    });
+    vi.mocked(getProposalMemoLineage).mockResolvedValue({
+      memos: [
+        {
+          memo_id: "memo_1",
+          memo_hash: "sha256:memo-001",
+          memo_status: "APPROVED_FOR_ADVISOR_USE",
+        },
+      ],
+    });
+    vi.mocked(getProposalMemoReplayEvidence).mockResolvedValue({
+      hashes: {
+        memo_hash: "sha256:memo-001",
+        artifact_hash: "sha256:artifact-001",
+      },
+      audit_events: [{ event_type: "MEMO_CREATED" }],
+      supportability: { client_ready_publication: "BLOCKED" },
+    });
+    vi.mocked(createProposalMemo).mockResolvedValue({ memo_hash: "sha256:memo-001" });
+    vi.mocked(reviewProposalMemo).mockResolvedValue({ memo_hash: "sha256:memo-001" });
+    vi.mocked(requestProposalMemoReportPackage).mockResolvedValue({
+      report: { archive_refs: ["archive://memo/report/1"] },
+    });
+    vi.mocked(requestProposalMemoAiCommentary).mockResolvedValue({
+      commentary: { authority: "NON_AUTHORITATIVE" },
+    });
+  });
+
+  it("renders Gateway memo posture and keeps client-ready actions absent", async () => {
+    renderPanel();
+
+    expect(
+      screen.getByRole("heading", { name: "Advisor Memo Product Surface" }),
+    ).toBeInTheDocument();
+    expect((await screen.findAllByText("APPROVED_FOR_ADVISOR_USE")).length).toBeGreaterThan(0);
+    expect(await screen.findByText("SUPPORTED_ADVISOR_USE")).toBeInTheDocument();
+    expect(await screen.findByText(/Client draft: BLOCKED/)).toBeInTheDocument();
+    expect(await screen.findByText(/archive:\/\/memo\/report\/1/)).toBeInTheDocument();
+    expect(screen.getByText(/Workbench uses Gateway memo endpoints only/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /send to client/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /client-ready release/i })).not.toBeInTheDocument();
+  });
+
+  it("routes memo actions through Gateway APIs with source memo hash", async () => {
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Create Or Replay Memo" }));
+    await waitFor(() => {
+      expect(createProposalMemo).toHaveBeenCalledWith(
+        "pp_1",
+        2,
+        expect.objectContaining({
+          created_by: "advisor_1",
+          lifecycle_status: "DRAFT",
+        }),
+        expect.stringContaining("ui-memo-create-2-pp_1"),
+      );
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("Evidence-backed memo is ready for advisor use."), {
+      target: { value: "Evidence-backed memo is ready for advisor use." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Approve Memo For Advisor Use" }));
+    await waitFor(() => {
+      expect(reviewProposalMemo).toHaveBeenCalledWith(
+        "pp_1",
+        2,
+        expect.objectContaining({
+          action: "APPROVE_FOR_ADVISOR_USE",
+          source_memo_hash: "sha256:memo-001",
+          client_ready_release_requested: false,
+        }),
+        expect.stringContaining("ui-memo-review-2-pp_1"),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Request Memo Report Package" }));
+    await waitFor(() => {
+      expect(requestProposalMemoReportPackage).toHaveBeenCalledWith(
+        "pp_1",
+        2,
+        expect.objectContaining({
+          source_memo_hash: "sha256:memo-001",
+          client_ready_document_requested: false,
+        }),
+        expect.stringContaining("ui-memo-report-package-2-pp_1"),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Request AI Commentary" }));
+    await waitFor(() => {
+      expect(requestProposalMemoAiCommentary).toHaveBeenCalledWith(
+        "pp_1",
+        2,
+        expect.objectContaining({
+          source_memo_hash: "sha256:memo-001",
+          requested_sections: ["EXECUTIVE_SUMMARY", "LIMITATIONS_AND_DISCLOSURES"],
+        }),
+        expect.stringContaining("ui-memo-ai-commentary-2-pp_1"),
+      );
+    });
+  });
+
+  it("shows degraded Gateway posture without inventing readiness", async () => {
+    vi.mocked(getProposalMemo).mockRejectedValue(new Error("Proposal memo fetch failed (409)"));
+    vi.mocked(getProposalMemoProjection).mockResolvedValue({
+      projection: {
+        audience: "CLIENT_DRAFT",
+        client_ready_publication: "BLOCKED",
+      },
+      projection_posture: { supportability: "DEGRADED_SOURCE_EVIDENCE" },
+    });
+
+    renderPanel();
+
+    expect(
+      await screen.findByText(/Memo posture is degraded or blocked by Gateway/),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("DEGRADED_SOURCE_EVIDENCE")).toBeInTheDocument();
+    expect(screen.queryByText(/ready for client/i)).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/proposals-api.test.ts
+++ b/tests/unit/proposals-api.test.ts
@@ -5,13 +5,21 @@ import {
   approveRisk,
   createProposalVersion,
   createProposalReportRequest,
+  createProposalMemo,
   getProposalDeliveryEvents,
   getProposalDeliverySummary,
   getProposalApprovals,
+  getProposalMemo,
+  getProposalMemoLineage,
+  getProposalMemoProjection,
+  getProposalMemoReplayEvidence,
   getProposalVersion,
   getProposalWorkflowEvents,
   listProposals,
   recordClientConsent,
+  requestProposalMemoAiCommentary,
+  requestProposalMemoReportPackage,
+  reviewProposalMemo,
   reviewProposalNarrative,
   submitProposal,
 } from "../../src/features/proposals/api";
@@ -257,6 +265,115 @@ describe("proposal api", () => {
     );
     expect(fetchMock).toHaveBeenCalledWith(
       `${expectedBaseUrl}/proposals/pp_1/delivery-events`
+    );
+  });
+
+  it("calls proposal memo Gateway endpoints", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "c",
+            contract_version: "v1",
+            data: {
+              memo_hash: "sha256:memo-001",
+              projection: { audience: "COMPLIANCE" },
+              report: { archive_refs: ["archive://memo/report/1"] },
+              commentary: { authority: "NON_AUTHORITATIVE" },
+              hashes: { memo_hash: "sha256:memo-001" },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+    );
+
+    await createProposalMemo(
+      "pp_1",
+      2,
+      { created_by: "advisor_1", lifecycle_status: "DRAFT" },
+      "idem-memo-create-1"
+    );
+    await getProposalMemo("pp_1", 2);
+    await getProposalMemoProjection("pp_1", 2, "COMPLIANCE");
+    await reviewProposalMemo(
+      "pp_1",
+      2,
+      {
+        action: "APPROVE_FOR_ADVISOR_USE",
+        reviewed_by: "compliance_1",
+        reason: "Evidence-backed memo.",
+        source_memo_hash: "sha256:memo-001",
+        client_ready_release_requested: false,
+      },
+      "idem-memo-review-1"
+    );
+    await requestProposalMemoReportPackage(
+      "pp_1",
+      2,
+      {
+        requested_by: "advisor_1",
+        source_memo_hash: "sha256:memo-001",
+        requested_output_formats: ["pdf"],
+        client_ready_document_requested: false,
+      },
+      "idem-memo-report-1"
+    );
+    await requestProposalMemoAiCommentary(
+      "pp_1",
+      2,
+      {
+        requested_by: "advisor_1",
+        source_memo_hash: "sha256:memo-001",
+        requested_sections: ["EXECUTIVE_SUMMARY"],
+      },
+      "idem-memo-ai-1"
+    );
+    await getProposalMemoLineage("pp_1");
+    await getProposalMemoReplayEvidence("pp_1", 2);
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/proposals/pp_1/versions/2/memo`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "Idempotency-Key": "idem-memo-create-1" }),
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/proposals/pp_1/versions/2/memo`
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/proposals/pp_1/versions/2/memo/projection?audience=COMPLIANCE`
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/proposals/pp_1/versions/2/memo/review`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "Idempotency-Key": "idem-memo-review-1" }),
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/proposals/pp_1/versions/2/memo/report-packages`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "Idempotency-Key": "idem-memo-report-1" }),
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/proposals/pp_1/versions/2/memo/ai-commentary`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "Idempotency-Key": "idem-memo-ai-1" }),
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(`${expectedBaseUrl}/proposals/pp_1/memos/lineage`);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/proposals/pp_1/versions/2/memo/replay-evidence`
     );
   });
 });

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -40,6 +40,10 @@
 
 - canonical browser validation writes screenshots and structured summary output under
   `output/playwright/live-canonical/`
+- `live-validation-summary.json` includes a `supportabilityMatrix` with registered/classified
+  panel counts, required and observed supportability states, owning services, non-ready panel
+  evidence, and missing-panel checks; review this matrix before accepting screenshots as
+  demo-ready evidence
 - construction alternatives live proof writes focused machine-readable evidence and a panel
   screenshot under `output/rfc39-wtbd002-construction-lab/construction-live/`
 - DPM PM operating-quality live proof creates and re-reads Manage-backed score-run,


### PR DESCRIPTION
## Summary
- add a supportability matrix to canonical Workbench live-validation evidence so reviewers can see registered/classified panel counts, required and observed states, owner coverage, non-ready panels, and missing panels before accepting screenshots
- document the supportability matrix in the canonical runtime runbook and wiki validation guidance
- include the concurrent proposal-memo posture Workbench slice already present on this branch, with focused unit/integration/e2e coverage

## Evidence
- npm run lint
- npm run typecheck
- npm test -- --run tests/unit/live-validation-panel-governance.test.ts tests/unit/live-canonical-validation-script.test.ts tests/unit/proposal-memo-posture-panel.test.tsx tests/unit/proposals-api.test.ts tests/integration/proposal-detail-view.test.tsx
- npm run test:e2e -- tests/e2e/proposal-memo-posture.spec.ts
- powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1 -ScreenshotDirectory output\\playwright\\supportability-matrix-20260524

## Live canonical proof
- Portfolio: PB_SG_GLOBAL_BAL_001
- Evidence: output/playwright/supportability-matrix-20260524/live-validation-summary.json
- supportabilityMatrix: registeredPanelCount=21, classifiedPanelCount=21, observed ready=21, missingPanels=[], nonReadyPanels=[]

## Wiki
- Repo-authored wiki updated: wiki/Validation-and-CI.md
- Pre-merge wiki check expectedly reports drift on Validation-and-CI.md until this PR is merged and published