### PR TITLE
Add RFC36-43 live feature coverage proof

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -394,6 +394,13 @@ and missing-panel evidence. Reviewers should inspect this matrix before acceptin
 demo-ready proof, because it shows whether the run covered both ready panels and governed bounded
 partial/degraded states.
 
+The summary also includes `rfc3643FeatureCoverage`, a feature-by-feature evidence matrix for the
+implemented RFC-0036 through RFC-0043 front-office product paths. Each row maps the RFC feature to
+the API, workflow-pack, seeded entity, and Workbench panel evidence that made the feature
+demo-ready. The matrix is not a blanket future-scope certification: it records the current scenario
+scope and explicitly lists scenario expansion still needed, such as companion canonical DPM
+portfolios for broader multi-portfolio wave proof.
+
 ## Gateway startup rule
 
 Canonical local Gateway startup must use the governed script when `gateway` is listed in

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -44,6 +44,10 @@ import {
   validateRiskPanel,
 } from "./validation/browser-workflows.mjs";
 import { createPanelGovernance } from "./validation/panel-governance.mjs";
+import {
+  assertRfc3643FeatureCoverage,
+  buildRfc3643FeatureCoverage,
+} from "./validation/rfc36-43-feature-coverage.mjs";
 import { validateAdvisorBriefWorkflowPackReviewChain } from "./validation/workflow-pack-proof.mjs";
 
 const {
@@ -957,6 +961,7 @@ async function run() {
     dpmMandatePayload?.mandate?.mandate_id ??
     dpmMandatePayload?.mandate?.mandateId;
 
+  let mandateHealthObserved = false;
   if (mandateId) {
     const dpmMandateHealth = await fetchJson(
       summary,
@@ -968,6 +973,7 @@ async function run() {
     if (!dpmMandateHealthPayload?.health_state && !dpmMandateHealthPayload?.state) {
       throw new Error("DPM command-center mandate health returned no health state.");
     }
+    mandateHealthObserved = true;
   }
 
   const dpmWaveParams = new URLSearchParams({
@@ -1191,6 +1197,40 @@ async function run() {
   });
   panelGovernance.assertNoUnsupportedBlankPanels();
   panelGovernance.assertPanelSupportabilityAlignment();
+  summary.rfc3643FeatureCoverage = buildRfc3643FeatureCoverage(summary, {
+    foundationWorkspace,
+    manageSupportabilitySummary,
+    gatewayOverview,
+    commandCenterSummary: dpmCommandCenterPayload,
+    dpmCommandCenterPanel: true,
+    activeExceptions: true,
+    portfolioMemory: portfolioMemoryEvents,
+    mandateLookup: mandateId,
+    mandateHealth: mandateHealthObserved,
+    constructionAlternativesPanel: true,
+    proofPackId,
+    proofPackSections: proofPackSectionCount,
+    proofPackSourceEvidence: proofPackSourceHashCount,
+    proofPackPanel: true,
+    proofPackAiMemo: proofPackAiPmMemoRunId,
+    wavePreview: dpmWavePreviewSupportabilityState?.toLowerCase() === "ready",
+    waveId: dpmWaveId,
+    waveReportInput: dpmWaveReportInputRef,
+    waveAiMemo: dpmWaveAiPmMemoRunId,
+    wavePanel: true,
+    outcomeReviewRows: outcomeReviewItems,
+    outcomeReviewPanel: true,
+    pmQualityScoreRun: pmOperatingQualityEvidence.scoreRunId,
+    pmQualityFairnessAnalysis: pmOperatingQualityEvidence.fairnessAnalysisId,
+    pmQualityReviewAction: pmOperatingQualityEvidence.reviewActionId,
+    pmQualitySummaryInvocation: pmOperatingQualityEvidence.summaryInvocationId,
+    pmQualityPanel: true,
+    copilotWorkspace: true,
+    copilotPanel: true,
+    proposalNarrative: proposalNarrative.narrative_id,
+    proposalNarrativePanel: true,
+  });
+  assertRfc3643FeatureCoverage(summary);
 
   const portfolioShell = await fetchText(
     summary,

--- a/scripts/live/validation/evidence-summary-writer.d.mts
+++ b/scripts/live/validation/evidence-summary-writer.d.mts
@@ -10,6 +10,7 @@ export type InitializedValidationSummary = ValidationSummary & {
   uiChecks: Array<Record<string, unknown>>;
   calculationChecks: Array<Record<string, unknown>>;
   panelClassifications: Array<Record<string, unknown>>;
+  rfc3643FeatureCoverage: Record<string, unknown> | null;
   supportabilityMatrix: Record<string, unknown> | null;
   supportabilityChecks: Array<Record<string, unknown>>;
   screenshots: Array<Record<string, unknown>>;

--- a/scripts/live/validation/evidence-summary-writer.mjs
+++ b/scripts/live/validation/evidence-summary-writer.mjs
@@ -30,6 +30,7 @@ export function createValidationSummary({
     uiChecks: [],
     calculationChecks: [],
     panelClassifications: [],
+    rfc3643FeatureCoverage: null,
     supportabilityMatrix: null,
     supportabilityChecks: [],
     screenshots: [],

--- a/scripts/live/validation/rfc36-43-feature-coverage.d.mts
+++ b/scripts/live/validation/rfc36-43-feature-coverage.d.mts
@@ -1,0 +1,39 @@
+import type { ValidationSummary } from "./shared-types";
+
+export interface RfcFeatureCoverageEvidence {
+  [key: string]: unknown;
+}
+
+export interface RfcFeatureCoverageRow {
+  rfcId: string;
+  featureId: string;
+  featureName: string;
+  owner: string;
+  requiredEvidence: string[];
+  uiPanels: string[];
+  coverageStatus: "validated" | "gap";
+  missingEvidence: string[];
+  panelStates: Record<string, string>;
+  missingPanels: string[];
+  scenarioScope?: string;
+  scenarioExpansionNeeded?: string[];
+  unsupportedClaimsExcluded: string[];
+}
+
+export interface RfcFeatureCoverageMatrix {
+  contractId: string;
+  contractVersion: string;
+  portfolioId?: string;
+  benchmarkCode?: string;
+  coverageRows: RfcFeatureCoverageRow[];
+  validatedFeatureCount: number;
+  gapFeatureCount: number;
+  scenarioExpansionNeeded: string[];
+}
+
+export function buildRfc3643FeatureCoverage(
+  summary: ValidationSummary,
+  evidence: RfcFeatureCoverageEvidence
+): RfcFeatureCoverageMatrix;
+
+export function assertRfc3643FeatureCoverage(summary: ValidationSummary): void;

--- a/scripts/live/validation/rfc36-43-feature-coverage.mjs
+++ b/scripts/live/validation/rfc36-43-feature-coverage.mjs
@@ -1,0 +1,189 @@
+const RFC_FEATURE_COVERAGE_ROWS = [
+  {
+    rfcId: "RFC-0036",
+    featureId: "stateful_core_sourcing",
+    featureName: "Stateful core sourcing and canonical manage API boundary",
+    owner: "lotus-manage",
+    requiredEvidence: [
+      "foundationWorkspace",
+      "manageSupportabilitySummary",
+      "gatewayOverview",
+      "dpmCommandCenterPanel",
+    ],
+    uiPanels: ["dpm.command_center"],
+    unsupportedClaimsExcluded: [
+      "local portfolio reconstruction in Workbench",
+      "unversioned manage API proof",
+    ],
+  },
+  {
+    rfcId: "RFC-0037",
+    featureId: "dpm_operating_system",
+    featureName: "DPM operating system command-center realization",
+    owner: "lotus-manage",
+    requiredEvidence: [
+      "commandCenterSummary",
+      "activeExceptions",
+      "portfolioMemory",
+      "copilotWorkspace",
+    ],
+    uiPanels: ["dpm.command_center", "dpm.portfolio_memory", "dpm.copilot_workspace"],
+    unsupportedClaimsExcluded: ["OMS execution", "order routing", "client communication workflow"],
+  },
+  {
+    rfcId: "RFC-0038",
+    featureId: "mandate_digital_twin",
+    featureName: "Mandate digital twin and health command center",
+    owner: "lotus-manage",
+    requiredEvidence: ["mandateLookup", "mandateHealth", "commandCenterSummary"],
+    uiPanels: ["dpm.command_center"],
+    unsupportedClaimsExcluded: ["external bank workflow ownership"],
+  },
+  {
+    rfcId: "RFC-0039",
+    featureId: "construction_alternatives",
+    featureName: "Construction alternatives product path",
+    owner: "lotus-manage",
+    requiredEvidence: ["constructionAlternativesPanel"],
+    uiPanels: ["dpm.construction_alternatives"],
+    unsupportedClaimsExcluded: ["optimizer execution in Workbench", "trade execution", "OMS routing"],
+  },
+  {
+    rfcId: "RFC-0040",
+    featureId: "proof_pack_evidence",
+    featureName: "Pre-trade proof pack and evidence fabric",
+    owner: "lotus-manage",
+    requiredEvidence: ["proofPackId", "proofPackSections", "proofPackSourceEvidence", "proofPackPanel"],
+    uiPanels: ["dpm.proof_pack"],
+    unsupportedClaimsExcluded: ["Workbench hash generation", "local proof-pack construction"],
+  },
+  {
+    rfcId: "RFC-0041",
+    featureId: "rebalance_wave_single_portfolio_product_path",
+    featureName: "Rebalance-wave command center for the canonical explicit portfolio-list path",
+    owner: "lotus-manage",
+    requiredEvidence: ["wavePreview", "waveId", "waveReportInput", "waveAiMemo", "wavePanel"],
+    uiPanels: ["dpm.wave_command_center"],
+    scenarioScope: "single canonical portfolio explicit-list wave",
+    scenarioExpansionNeeded: [
+      "companion canonical DPM portfolios for multi-portfolio wave proof",
+      "source-owner cohort products for broader campaign discovery scenarios",
+    ],
+    unsupportedClaimsExcluded: ["global portfolio-universe discovery", "external OMS execution"],
+  },
+  {
+    rfcId: "RFC-0042",
+    featureId: "outcome_review_feedback_loop",
+    featureName: "Post-trade outcome review and feedback loop",
+    owner: "lotus-manage",
+    requiredEvidence: ["outcomeReviewRows", "outcomeReviewPanel"],
+    uiPanels: ["dpm.outcome_review"],
+    unsupportedClaimsExcluded: ["settlement truth", "client communication execution"],
+  },
+  {
+    rfcId: "RFC-0042",
+    featureId: "pm_operating_quality",
+    featureName: "PM operating-quality governance evidence",
+    owner: "lotus-manage",
+    requiredEvidence: [
+      "pmQualityScoreRun",
+      "pmQualityFairnessAnalysis",
+      "pmQualityReviewAction",
+      "pmQualitySummaryInvocation",
+      "pmQualityPanel",
+    ],
+    uiPanels: ["dpm.pm_operating_quality"],
+    unsupportedClaimsExcluded: [
+      "PM ranking",
+      "HR decisions",
+      "compensation decisions",
+      "conduct decisions",
+    ],
+  },
+  {
+    rfcId: "RFC-0043",
+    featureId: "governed_ai_pm_copilot",
+    featureName: "Governed AI PM copilot workflow-pack posture",
+    owner: "lotus-ai",
+    requiredEvidence: ["proofPackAiMemo", "waveAiMemo", "pmQualitySummaryInvocation", "copilotPanel"],
+    uiPanels: ["dpm.copilot_workspace"],
+    unsupportedClaimsExcluded: [
+      "raw prompt storage",
+      "generated summary retention in Workbench",
+      "autonomous approval",
+      "client contact",
+    ],
+  },
+  {
+    rfcId: "RFC-0043",
+    featureId: "proposal_narrative_posture_cross_front_office",
+    featureName: "Gateway-backed proposal narrative posture as adjacent front-office proof",
+    owner: "lotus-advise",
+    requiredEvidence: ["proposalNarrative", "proposalNarrativePanel"],
+    uiPanels: ["proposal.narrative_posture"],
+    unsupportedClaimsExcluded: ["client-ready release", "report archive publication by Workbench"],
+  },
+];
+
+function hasEvidence(evidence, key) {
+  const value = evidence[key];
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === "number") {
+    return value > 0;
+  }
+  return Boolean(value);
+}
+
+function panelStateById(summary) {
+  return new Map((summary.panelClassifications ?? []).map((panel) => [panel.panel, panel.state]));
+}
+
+export function buildRfc3643FeatureCoverage(summary, evidence) {
+  const panels = panelStateById(summary);
+  const rows = RFC_FEATURE_COVERAGE_ROWS.map((row) => {
+    const missingEvidence = row.requiredEvidence.filter((key) => !hasEvidence(evidence, key));
+    const panelStates = Object.fromEntries(
+      row.uiPanels.map((panelId) => [panelId, panels.get(panelId) ?? "missing"])
+    );
+    const missingPanels = Object.entries(panelStates)
+      .filter(([, state]) => state !== "ready")
+      .map(([panelId]) => panelId);
+
+    return {
+      ...row,
+      coverageStatus: missingEvidence.length === 0 && missingPanels.length === 0 ? "validated" : "gap",
+      missingEvidence,
+      panelStates,
+      missingPanels,
+    };
+  });
+
+  return {
+    contractId: "rfc36-43-front-office-feature-coverage",
+    contractVersion: "1.0.0",
+    portfolioId: summary.portfolioId,
+    benchmarkCode: summary.benchmarkCode,
+    coverageRows: rows,
+    validatedFeatureCount: rows.filter((row) => row.coverageStatus === "validated").length,
+    gapFeatureCount: rows.filter((row) => row.coverageStatus !== "validated").length,
+    scenarioExpansionNeeded: rows.flatMap((row) => row.scenarioExpansionNeeded ?? []),
+  };
+}
+
+export function assertRfc3643FeatureCoverage(summary) {
+  const coverage = summary.rfc3643FeatureCoverage;
+  if (!coverage) {
+    throw new Error("RFC36-43 feature coverage matrix was not recorded.");
+  }
+
+  const gaps = coverage.coverageRows.filter((row) => row.coverageStatus !== "validated");
+  if (gaps.length > 0) {
+    throw new Error(
+      `RFC36-43 feature coverage gaps remain: ${gaps
+        .map((row) => `${row.rfcId}/${row.featureId}`)
+        .join(", ")}.`
+    );
+  }
+}

--- a/scripts/live/validation/shared-types.d.ts
+++ b/scripts/live/validation/shared-types.d.ts
@@ -68,6 +68,7 @@ export interface ValidationSummary {
   uiChecks?: Array<Record<string, unknown>>;
   calculationChecks?: Array<Record<string, unknown>>;
   panelClassifications?: Array<Record<string, unknown>>;
+  rfc3643FeatureCoverage?: Record<string, unknown> | null;
   supportabilityMatrix?: Record<string, unknown> | null;
   supportabilityChecks?: Array<Record<string, unknown>>;
   screenshots?: Array<Record<string, unknown>>;

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -340,6 +340,10 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validation", "evidence-summary-writer.mjs"),
       "utf8"
     );
+    const rfcFeatureCoverageModule = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "rfc36-43-feature-coverage.mjs"),
+      "utf8"
+    );
     const browserWorkflowModule = readFileSync(
       join(process.cwd(), "scripts", "live", "validation", "browser-workflows.mjs"),
       "utf8"
@@ -403,6 +407,11 @@ describe("canonical live validation script", () => {
     expect(script).toContain("classifyCommandCenterPanelState");
     expect(script).toContain("DPM command-center summary did not return canonical populated posture");
     expect(script).toContain("supportabilityState: readSupportabilityState");
+    expect(script).toContain("buildRfc3643FeatureCoverage");
+    expect(script).toContain("assertRfc3643FeatureCoverage");
+    expect(script).toContain("summary.rfc3643FeatureCoverage");
+    expect(rfcFeatureCoverageModule).toContain("scenarioExpansionNeeded");
+    expect(rfcFeatureCoverageModule).toContain("companion canonical DPM portfolios");
     expect(browserWorkflowModule).toContain("Mandate Readiness");
     expect(browserWorkflowModule).toContain("Attention Required");
     expect(browserWorkflowModule).toContain("Recommended Actions");

--- a/tests/unit/live-validation-rfc-feature-coverage.test.ts
+++ b/tests/unit/live-validation-rfc-feature-coverage.test.ts
@@ -1,0 +1,115 @@
+import {
+  assertRfc3643FeatureCoverage,
+  buildRfc3643FeatureCoverage,
+} from "../../scripts/live/validation/rfc36-43-feature-coverage.mjs";
+
+function createReadySummary() {
+  const panels = [
+    "dpm.command_center",
+    "dpm.portfolio_memory",
+    "dpm.copilot_workspace",
+    "dpm.construction_alternatives",
+    "dpm.proof_pack",
+    "dpm.wave_command_center",
+    "dpm.outcome_review",
+    "dpm.pm_operating_quality",
+    "proposal.narrative_posture",
+  ];
+  return {
+    portfolioId: "PB_SG_GLOBAL_BAL_001",
+    benchmarkCode: "BMK_PB_GLOBAL_BALANCED_60_40",
+    panelClassifications: panels.map((panel) => ({ panel, state: "ready" })),
+  };
+}
+
+function createReadyEvidence() {
+  return {
+    foundationWorkspace: {},
+    manageSupportabilitySummary: {},
+    gatewayOverview: {},
+    commandCenterSummary: {},
+    dpmCommandCenterPanel: true,
+    activeExceptions: true,
+    portfolioMemory: [{ event_id: "evt-1" }],
+    mandateLookup: "MANDATE_PB_SG_GLOBAL_BAL_001",
+    mandateHealth: true,
+    constructionAlternativesPanel: true,
+    proofPackId: "proof-1",
+    proofPackSections: 2,
+    proofPackSourceEvidence: 3,
+    proofPackPanel: true,
+    proofPackAiMemo: "ai-proof-1",
+    wavePreview: true,
+    waveId: "wave-1",
+    waveReportInput: "report-input-1",
+    waveAiMemo: "ai-wave-1",
+    wavePanel: true,
+    outcomeReviewRows: [{ outcome_review_id: "review-1" }],
+    outcomeReviewPanel: true,
+    pmQualityScoreRun: "score-run-1",
+    pmQualityFairnessAnalysis: "fairness-1",
+    pmQualityReviewAction: "review-action-1",
+    pmQualitySummaryInvocation: "summary-invocation-1",
+    pmQualityPanel: true,
+    copilotWorkspace: true,
+    copilotPanel: true,
+    proposalNarrative: "proposal-narrative-1",
+    proposalNarrativePanel: true,
+  };
+}
+
+describe("RFC36-43 live validation feature coverage", () => {
+  it("records feature-by-feature coverage across implemented RFC36-43 product paths", () => {
+    const summary = createReadySummary();
+    const coverage = buildRfc3643FeatureCoverage(summary, createReadyEvidence());
+
+    expect(coverage.contractId).toBe("rfc36-43-front-office-feature-coverage");
+    expect(coverage.validatedFeatureCount).toBe(10);
+    expect(coverage.gapFeatureCount).toBe(0);
+    expect(coverage.coverageRows.map((row) => row.rfcId)).toEqual(
+      expect.arrayContaining([
+        "RFC-0036",
+        "RFC-0037",
+        "RFC-0038",
+        "RFC-0039",
+        "RFC-0040",
+        "RFC-0041",
+        "RFC-0042",
+        "RFC-0043",
+      ])
+    );
+    expect(coverage.coverageRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rfcId: "RFC-0041",
+          featureId: "rebalance_wave_single_portfolio_product_path",
+          coverageStatus: "validated",
+          scenarioScope: "single canonical portfolio explicit-list wave",
+          scenarioExpansionNeeded: expect.arrayContaining([
+            "companion canonical DPM portfolios for multi-portfolio wave proof",
+          ]),
+        }),
+        expect.objectContaining({
+          rfcId: "RFC-0043",
+          featureId: "governed_ai_pm_copilot",
+          coverageStatus: "validated",
+          unsupportedClaimsExcluded: expect.arrayContaining(["raw prompt storage"]),
+        }),
+      ])
+    );
+  });
+
+  it("fails when an implemented RFC feature has no backing live evidence", () => {
+    const summary = createReadySummary();
+    const evidence = createReadyEvidence();
+    delete (evidence as Record<string, unknown>).proofPackSourceEvidence;
+    (summary as Record<string, unknown>).rfc3643FeatureCoverage = buildRfc3643FeatureCoverage(
+      summary,
+      evidence
+    );
+
+    expect(() => assertRfc3643FeatureCoverage(summary)).toThrow(
+      "RFC36-43 feature coverage gaps remain: RFC-0040/proof_pack_evidence"
+    );
+  });
+});

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -44,6 +44,10 @@
   panel counts, required and observed supportability states, owning services, non-ready panel
   evidence, and missing-panel checks; review this matrix before accepting screenshots as
   demo-ready evidence
+- `live-validation-summary.json` also includes `rfc3643FeatureCoverage`, which maps implemented
+  RFC-0036 through RFC-0043 front-office features to live API, workflow-pack, seeded entity, and
+  panel evidence. Treat its scenario-expansion notes as open validation depth, not as implemented
+  product claims.
 - construction alternatives live proof writes focused machine-readable evidence and a panel
   screenshot under `output/rfc39-wtbd002-construction-lab/construction-live/`
 - DPM PM operating-quality live proof creates and re-reads Manage-backed score-run,


### PR DESCRIPTION
## Summary
- add an RFC36-43 feature-by-feature coverage matrix to canonical Workbench live-validation evidence
- fail live validation when an implemented RFC36-43 feature lacks required API, workflow-pack, seeded entity, or panel proof
- document the matrix in the canonical runtime runbook and wiki validation guidance

## Evidence
- npm test -- --run tests/unit/live-validation-rfc-feature-coverage.test.ts tests/unit/live-canonical-validation-script.test.ts tests/unit/live-validation-panel-governance.test.ts
- npm run lint
- npm run typecheck
- powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1 -ScreenshotDirectory output\\playwright\\rfc36-43-feature-coverage-20260524

## Live canonical proof
- Portfolio: PB_SG_GLOBAL_BAL_001
- Evidence: output/playwright/rfc36-43-feature-coverage-20260524/live-validation-summary.json
- rfc3643FeatureCoverage: validatedFeatureCount=10, gapFeatureCount=0
- supportabilityMatrix: registeredPanelCount=21, classifiedPanelCount=21, observed ready=21, missingPanels=[], nonReadyPanels=[]
- Scenario expansion preserved as future validation depth: companion canonical DPM portfolios for multi-portfolio wave proof, and source-owner cohort products for broader campaign-discovery scenarios

## Wiki
- Repo-authored wiki updated: wiki/Validation-and-CI.md
- Pre-merge wiki check expectedly reports drift on Validation-and-CI.md until this PR is merged and published