### PR TITLE
docs: document canonical AI stub proof mode

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -170,7 +170,9 @@ drain window than the default `900` seconds.
 
 The canonical bring-up script accepts `-LotusAiEnvFile` to make the `lotus-ai` provider posture
 explicit for proof runs. It defaults to `.env.example` for deterministic provider-disabled
-front-office proof, even when the local `lotus-ai/.env` requests a live or local provider. Use the
+front-office proof, even when the local `lotus-ai/.env` requests a live or local provider. Use
+`canonical-stub.env.example` when the proof target includes RFC-0023/RFC-0024 workflow-pack
+execution through `lotus-advise` and no local model server is intentionally running. Use the
 repo-local `.env` only when the required live provider dependency, such as the `local-llm` Ollama
 compose profile and model, is intentionally running.
 


### PR DESCRIPTION
## Summary
- document when to use `lotus-ai/canonical-stub.env.example` for canonical front-office proof involving RFC-0023/RFC-0024 workflow-pack execution through Advise

## Evidence
- `npm run typecheck` passed
- `npm run live:validate` passed for `PB_SG_GLOBAL_BAL_001`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` returned `DiffCount 0`

## Notes
- Repo-local wiki source did not change.
- Supports the cross-repo live proof in `lotus-advise` PR #171 and `lotus-ai` PR #72.