### PR TITLE
Fix advisory workbench queue layout follow-up

### DIFF
--- a/src/app/proposals/page.tsx
+++ b/src/app/proposals/page.tsx
@@ -14,6 +14,7 @@ export default async function ProposalsPage({
     <ProposalWorkspaceShell
       portfolioId={portfolioId}
       activeScreen="proposal"
+      activeMode="queue"
       title="Proposal Workspace"
       subtitle="Manage proposal drafts, lifecycle posture, and advisor-ready next actions."
     >

--- a/src/app/proposals/simulate/page.tsx
+++ b/src/app/proposals/simulate/page.tsx
@@ -14,6 +14,7 @@ export default async function ProposalSimulatePage({
     <ProposalWorkspaceShell
       portfolioId={portfolioId}
       activeScreen="proposal"
+      activeMode="draft"
       title="Proposal Workspace"
       subtitle="Build and test an advisor-use proposal before routing it for review."
     >

--- a/src/apps/recommendations/page.tsx
+++ b/src/apps/recommendations/page.tsx
@@ -14,6 +14,7 @@ export default async function RecommendationsAppPage({
     <ProposalWorkspaceShell
       portfolioId={portfolioId}
       activeScreen="advisory"
+      activeMode="advisory"
       title="Advisory Workspace"
       subtitle="Review live advisory proposals, readiness gates, and next actions in the portfolio workflow."
     >

--- a/src/features/proposals/components/proposal-list-view.module.css
+++ b/src/features/proposals/components/proposal-list-view.module.css
@@ -1,6 +1,6 @@
 .queueSummary {
   display: grid;
-  grid-template-columns: repeat(5, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 8px;
   margin-bottom: 12px;
 }

--- a/src/features/proposals/components/proposal-list-view.module.css
+++ b/src/features/proposals/components/proposal-list-view.module.css
@@ -31,7 +31,7 @@
 
 .queueGrid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 340px;
+  grid-template-columns: minmax(0, 1fr);
   gap: 12px;
   align-items: start;
 }
@@ -95,6 +95,7 @@
 
 .stageRail {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 8px;
 }
 

--- a/src/features/proposals/components/proposal-list-view.tsx
+++ b/src/features/proposals/components/proposal-list-view.tsx
@@ -157,12 +157,12 @@ export default function ProposalListView({
           />
           <TextField
             size="small"
-            label="Created By"
+            label="Advisor"
             value={createdByFilter}
             onChange={(event) => {
               setCreatedByFilter(event.target.value);
             }}
-            placeholder="advisor id"
+            placeholder="advisor"
             sx={{ minWidth: { md: 200 } }}
           />
           <TextField

--- a/src/features/proposals/components/proposal-list-view.tsx
+++ b/src/features/proposals/components/proposal-list-view.tsx
@@ -127,7 +127,13 @@ export default function ProposalListView({
           ))}
         </div>
 
-        <Stack direction={{ xs: "column", md: "row" }} spacing={1} sx={{ mb: 1 }}>
+        <Stack
+          direction={{ xs: "column", md: "row" }}
+          spacing={1}
+          useFlexGap
+          flexWrap="wrap"
+          sx={{ mb: 1 }}
+        >
           <TextField
             select
             size="small"
@@ -136,7 +142,7 @@ export default function ProposalListView({
             onChange={(event) => {
               setStateFilter(event.target.value);
             }}
-            sx={{ minWidth: { md: 180 } }}
+            sx={{ flex: "1 1 160px", minWidth: 0 }}
           >
             <MenuItem value="">All</MenuItem>
             {PROPOSAL_STAGES.map((stage) => (
@@ -153,7 +159,7 @@ export default function ProposalListView({
               setPortfolioFilter(event.target.value);
             }}
             placeholder="portfolio id"
-            sx={{ minWidth: { md: 220 } }}
+            sx={{ flex: "1 1 190px", minWidth: 0 }}
           />
           <TextField
             size="small"
@@ -163,7 +169,7 @@ export default function ProposalListView({
               setCreatedByFilter(event.target.value);
             }}
             placeholder="advisor"
-            sx={{ minWidth: { md: 200 } }}
+            sx={{ flex: "1 1 170px", minWidth: 0 }}
           />
           <TextField
             size="small"
@@ -173,7 +179,7 @@ export default function ProposalListView({
               setSearchText(event.target.value);
             }}
             placeholder="proposal id, portfolio, title, state"
-            sx={{ minWidth: { md: 360 } }}
+            sx={{ flex: "2 1 240px", minWidth: 0 }}
           />
         </Stack>
 

--- a/src/features/proposals/components/proposal-workspace-shell.tsx
+++ b/src/features/proposals/components/proposal-workspace-shell.tsx
@@ -24,12 +24,14 @@ export function resolveProposalPortfolioId(portfolioId?: string | null): string 
 export default function ProposalWorkspaceShell({
   portfolioId,
   activeScreen,
+  activeMode = activeScreen === "advisory" ? "advisory" : "queue",
   title,
   subtitle,
   children,
 }: {
   portfolioId: string;
   activeScreen: Extract<PortfolioScreenNavigationKey, "proposal" | "advisory">;
+  activeMode?: "queue" | "draft" | "advisory";
   title: string;
   subtitle: string;
   children: ReactNode;
@@ -47,7 +49,7 @@ export default function ProposalWorkspaceShell({
             <PortfolioScreenRail
               portfolioId={portfolioId}
               activeScreen={activeScreen}
-              modeItems={buildProposalModeItems(portfolioId, activeScreen)}
+              modeItems={buildProposalModeItems(portfolioId, activeMode)}
               modeNavigationLabel="Proposal and advisory workflow navigation"
             />
           }
@@ -76,7 +78,7 @@ export default function ProposalWorkspaceShell({
 
 function buildProposalModeItems(
   portfolioId: string,
-  activeScreen: Extract<PortfolioScreenNavigationKey, "proposal" | "advisory">
+  activeMode: "queue" | "draft" | "advisory"
 ): PortfolioScreenRailModeItem[] {
   const portfolioQuery = `portfolioId=${encodeURIComponent(portfolioId)}`;
   return [
@@ -84,21 +86,21 @@ function buildProposalModeItems(
       key: "proposal-queue",
       label: "Proposal Queue",
       detail: "Drafts and workflow state",
-      active: activeScreen === "proposal",
+      active: activeMode === "queue",
       href: `/proposals?${portfolioQuery}`,
     },
     {
       key: "proposal-draft",
       label: "Create Draft",
       detail: "Simulate and save proposal",
-      active: false,
+      active: activeMode === "draft",
       href: `/proposals/simulate?${portfolioQuery}`,
     },
     {
       key: "advisory-queue",
       label: "Advisory Queue",
       detail: "Advisor next actions",
-      active: activeScreen === "advisory",
+      active: activeMode === "advisory",
       href: `/recommendations?${portfolioQuery}`,
     },
   ];


### PR DESCRIPTION
## Summary\n- preserve and merge the post-PR advisory workspace follow-up commits from the shared branch\n- align proposal rail navigation state across advisory entrypoints\n- contain advisory queue layout so dense rows stay inside the shell\n\n## Validation\n- npm run test -- --run tests/unit/proposal-advisory-workspace-view-model.test.ts tests/integration/proposal-list-view.test.tsx tests/integration/proposal-simulate-page.test.tsx tests/unit/app-route-entrypoints.test.tsx\n- npm run typecheck\n- npm run lint\n\n## Wiki\n- No wiki source changes in this follow-up slice.