### PR TITLE
test: prove core candidate source live coverage

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -265,6 +265,7 @@ Validation layers:
    - DPM command center
    - DPM portfolio memory
    - DPM rebalance-wave command center
+   - DPM Core candidate-source wave preview and no-caller-portfolio guard
    - DPM construction alternatives
    - DPM PM operating quality
    - DPM PM copilot workspace
@@ -295,6 +296,15 @@ bounded supervisory review action, and governed summary invocation. The browser 
 the persisted summary-invocation detail and list surface. This prevents a false ready claim when
 the PM quality endpoints are reachable but the canonical stack has no persisted operating-quality
 evidence.
+
+For bounded RFC37-WTBD-004 candidate-source proof, validation now previews a
+`BULK_REVIEW_CAMPAIGN` wave through Gateway with
+`campaign_candidate_source=CORE_DPM_PORTFOLIO_UNIVERSE`, requires lotus-core
+`DpmPortfolioUniverseCandidate:v1` source refs and at least one candidate item, and separately
+proves that a mixed Core-discovery/manual-portfolio request is rejected. This validates the
+implemented source-consumer guard without claiming relationship householding, global portfolio
+universe ownership, PM ranking, client communication workflow, OMS, fills, settlement, or
+execution.
 
 Machine-readable validation evidence is written to:
 
@@ -401,8 +411,9 @@ implemented RFC-0036 through RFC-0043 front-office product paths. Each row maps 
 the API, workflow-pack, seeded entity, and Workbench panel evidence that made the feature
 demo-ready. The matrix is not a blanket future-scope certification: it records the current scenario
 scope, now including the governed RFC-0041 multi-portfolio explicit-list wave preview from the
-canonical contract. Broader source-owner cohort products remain listed as scenario expansion until
-their source products and downstream realization are proven.
+canonical contract and the RFC-0037 bounded Core `DpmPortfolioUniverseCandidate:v1`
+candidate-source preview/no-caller-portfolio guard. Broader source-owner cohort products remain
+listed as scenario expansion until their source products and downstream realization are proven.
 
 ## Gateway startup rule
 

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -20,6 +20,7 @@ import {
   fetchJsonUntil,
   fetchText,
   postJson,
+  postJsonExpectingStatus,
   sendJson,
 } from "./validation/probes.mjs";
 import {
@@ -183,6 +184,44 @@ function extractDpmWaveItemCount(response) {
     }
   }
   return 0;
+}
+
+function extractDpmWaveSourceRefs(response) {
+  const sourceRefs = [];
+  const visit = (candidate) => {
+    if (!candidate || typeof candidate !== "object") {
+      return;
+    }
+    if (Array.isArray(candidate)) {
+      for (const item of candidate) {
+        visit(item);
+      }
+      return;
+    }
+    if (Array.isArray(candidate.source_refs)) {
+      sourceRefs.push(...candidate.source_refs.filter((item) => item && typeof item === "object"));
+    }
+    for (const value of Object.values(candidate)) {
+      if (value && typeof value === "object") {
+        visit(value);
+      }
+    }
+  };
+  visit(response);
+  return sourceRefs;
+}
+
+function hasCoreDpmPortfolioUniverseSourceRef(response) {
+  return extractDpmWaveSourceRefs(response).some((sourceRef) => {
+    const sourceSystem = readString(sourceRef.source_system)?.toLowerCase();
+    const sourceType = readString(sourceRef.source_type);
+    return sourceSystem === "lotus-core" && sourceType === "DpmPortfolioUniverseCandidate";
+  });
+}
+
+function payloadTextIncludes(payload, expectedText) {
+  const text = typeof payload === "string" ? payload : JSON.stringify(payload);
+  return text.includes(expectedText);
 }
 
 function extractWorkbenchRebalanceRunId(gatewayOverview) {
@@ -1085,6 +1124,86 @@ async function run() {
       `DPM rebalance-wave multi-portfolio preview returned ${multiPortfolioWaveItemCount} item(s); expected at least ${multiPortfolioWaveScenario.minimumPortfolioCount}.`
     );
   }
+  const coreCandidateSourcePreviewBody = {
+    trigger_type: "BULK_REVIEW_CAMPAIGN",
+    trigger_id: `live-validation-core-candidates-${dpmCommandCenterDefaults.asOfDate}`,
+    rationale:
+      "Canonical Workbench live validation previewed bounded Core-owned DPM candidate discovery.",
+    as_of_date: dpmCommandCenterDefaults.asOfDate,
+    actor_id: "workbench-system",
+    campaign_candidate_source: "CORE_DPM_PORTFOLIO_UNIVERSE",
+    model_portfolio_ids: ["MODEL_PB_SG_GLOBAL_BAL_DPM"],
+    include_inactive_mandates: false,
+    campaign_candidate_page_size: 500,
+  };
+  const coreCandidateSourcePreview = await postJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/dpm/command-center/waves/preview`,
+    "DPM Core candidate-source wave preview",
+    timeoutMs,
+    {
+      body: coreCandidateSourcePreviewBody,
+    }
+  );
+  const coreCandidateSourcePreviewState = readSupportabilityState(
+    coreCandidateSourcePreview?.supportability
+  );
+  if (coreCandidateSourcePreviewState?.toLowerCase() !== "ready") {
+    throw new Error(
+      `DPM Core candidate-source preview did not return ready manage supportability; observed ${
+        coreCandidateSourcePreviewState ?? "missing"
+      }.`
+    );
+  }
+  const coreCandidateSourceItemCount = extractDpmWaveItemCount(coreCandidateSourcePreview);
+  if (coreCandidateSourceItemCount < 1) {
+    throw new Error("DPM Core candidate-source preview returned no candidate portfolios.");
+  }
+  if (!hasCoreDpmPortfolioUniverseSourceRef(coreCandidateSourcePreview)) {
+    throw new Error(
+      "DPM Core candidate-source preview did not preserve lotus-core DpmPortfolioUniverseCandidate source refs."
+    );
+  }
+  const coreCandidateSourceRejected = await postJsonExpectingStatus(
+    summary,
+    `${gatewayBaseUrl}/api/v1/dpm/command-center/waves/preview`,
+    "DPM Core candidate-source rejects caller portfolios",
+    timeoutMs,
+    422,
+    {
+      body: {
+        ...coreCandidateSourcePreviewBody,
+        trigger_id: `${coreCandidateSourcePreviewBody.trigger_id}-invalid-mixed-request`,
+        portfolios: [{ portfolio_id: portfolioId }],
+      },
+    }
+  );
+  if (
+    !payloadTextIncludes(
+      coreCandidateSourceRejected,
+      "CORE_DPM_PORTFOLIO_UNIVERSE candidate discovery supplies the portfolio set"
+    ) ||
+    !payloadTextIncludes(coreCandidateSourceRejected, "DpmPortfolioUniverseCandidate:v1")
+  ) {
+    throw new Error(
+      "DPM Core candidate-source invalid request did not return the governed no-caller-portfolio boundary message."
+    );
+  }
+  summary.supportabilityChecks.push({
+    checkId: "dpm-core-candidate-source-preview",
+    sourceProduct: "DpmPortfolioUniverseCandidate:v1",
+    supportabilityState: coreCandidateSourcePreviewState,
+    candidateCount: coreCandidateSourceItemCount,
+    invalidMixedRequestRejected: true,
+    unsupportedClaimsExcluded: [
+      "global portfolio-universe ownership",
+      "relationship householding",
+      "PM ranking",
+      "external workflow orchestration",
+      "client communication workflow",
+      "OMS execution",
+    ],
+  });
   if (!dpmWaveId) {
     const dpmWaveCreate = await postJson(
       summary,
@@ -1270,6 +1389,11 @@ async function run() {
     commandCenterSummary: dpmCommandCenterPayload,
     dpmCommandCenterPanel: true,
     activeExceptions: true,
+    coreCandidateSourcePreview:
+      coreCandidateSourcePreviewState?.toLowerCase() === "ready" &&
+      coreCandidateSourceItemCount > 0 &&
+      hasCoreDpmPortfolioUniverseSourceRef(coreCandidateSourcePreview),
+    coreCandidateSourceInvalidRequestRejected: true,
     portfolioMemory: portfolioMemoryEvents,
     mandateLookup: mandateId,
     mandateHealth: mandateHealthObserved,

--- a/scripts/live/validation/probes.d.mts
+++ b/scripts/live/validation/probes.d.mts
@@ -24,3 +24,22 @@ export function fetchText(
   timeoutMs: number,
   fetchImpl?: (input: string, init?: Record<string, unknown>) => Promise<Response>
 ): Promise<string>;
+
+export function postJson<T = unknown>(
+  summary: ValidationSummary,
+  url: string,
+  description: string,
+  timeoutMs: number,
+  body: unknown,
+  fetchImpl?: (input: string, init?: Record<string, unknown>) => Promise<Response>
+): Promise<T>;
+
+export function postJsonExpectingStatus<T = unknown>(
+  summary: ValidationSummary,
+  url: string,
+  description: string,
+  timeoutMs: number,
+  expectedStatus: number,
+  body: unknown,
+  fetchImpl?: (input: string, init?: Record<string, unknown>) => Promise<Response>
+): Promise<T>;

--- a/scripts/live/validation/probes.mjs
+++ b/scripts/live/validation/probes.mjs
@@ -95,6 +95,22 @@ export async function postJson(
   });
 }
 
+export async function postJsonExpectingStatus(
+  summary,
+  url,
+  description,
+  timeoutMs,
+  expectedStatus,
+  body,
+  fetchImpl = globalThis.fetch
+) {
+  return await sendJsonExpectingStatus(summary, url, description, timeoutMs, expectedStatus, {
+    method: "POST",
+    body,
+    fetchImpl,
+  });
+}
+
 export async function sendJson(
   summary,
   url,
@@ -145,6 +161,62 @@ export async function sendJson(
       url,
       status: response.status,
       kind: "json",
+      method,
+    });
+    return payload;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function sendJsonExpectingStatus(
+  summary,
+  url,
+  description,
+  timeoutMs,
+  expectedStatus,
+  { method = "GET", body: requestBody, headers = {}, fetchImpl = globalThis.fetch } = {}
+) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method,
+      signal: controller.signal,
+      headers:
+        requestBody === undefined
+          ? {
+              ...CANONICAL_CALLER_CONTEXT_HEADERS,
+              ...headers,
+            }
+          : {
+              "Content-Type": "application/json",
+              ...CANONICAL_CALLER_CONTEXT_HEADERS,
+              ...headers,
+            },
+      body: requestBody === undefined ? undefined : JSON.stringify(requestBody),
+    });
+    const responseBody = await response.text();
+    let payload = responseBody;
+    if (responseBody.trim()) {
+      try {
+        payload = JSON.parse(responseBody);
+      } catch {
+        payload = responseBody;
+      }
+    }
+    if (response.status !== expectedStatus) {
+      const detail = responseBody.trim() ? `: ${responseBody.trim()}` : "";
+      throw new Error(
+        `${description} returned HTTP ${response.status}; expected ${expectedStatus} at ${url}${detail}`
+      );
+    }
+    summary.apiChecks.push({
+      description,
+      url,
+      status: response.status,
+      expectedStatus,
+      kind: "json-expected-status",
       method,
     });
     return payload;

--- a/scripts/live/validation/rfc36-43-feature-coverage.mjs
+++ b/scripts/live/validation/rfc36-43-feature-coverage.mjs
@@ -24,10 +24,13 @@ const RFC_FEATURE_COVERAGE_ROWS = [
     requiredEvidence: [
       "commandCenterSummary",
       "activeExceptions",
+      "coreCandidateSourcePreview",
+      "coreCandidateSourceInvalidRequestRejected",
       "portfolioMemory",
       "copilotWorkspace",
     ],
     uiPanels: ["dpm.command_center", "dpm.portfolio_memory", "dpm.copilot_workspace"],
+    scenarioScope: "bounded Core DPM candidate-source preview and no-caller-portfolio guard",
     unsupportedClaimsExcluded: ["OMS execution", "order routing", "client communication workflow"],
   },
   {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -74,6 +74,11 @@ describe("canonical live validation script", () => {
     expect(browserValidator).toContain("DPM rebalance-wave preview did not return ready manage supportability");
     expect(browserValidator).toContain("DPM rebalance-wave multi-portfolio preview");
     expect(browserValidator).toContain("multiPortfolioWaveScenario.minimumPortfolioCount");
+    expect(browserValidator).toContain("DPM Core candidate-source wave preview");
+    expect(browserValidator).toContain("CORE_DPM_PORTFOLIO_UNIVERSE");
+    expect(browserValidator).toContain("postJsonExpectingStatus");
+    expect(browserValidator).toContain("dpm-core-candidate-source-preview");
+    expect(browserValidator).toContain("coreCandidateSourceInvalidRequestRejected");
     expect(browserValidator).toContain("supportedPortfolioMemoryStates");
     expect(browserValidator).toContain('"degraded"');
     expect(browserValidator).toContain("DPM portfolio memory did not return populated manage supportability");
@@ -416,7 +421,11 @@ describe("canonical live validation script", () => {
     expect(script).toContain("summary.rfc3643FeatureCoverage");
     expect(rfcFeatureCoverageModule).toContain("scenarioExpansionNeeded");
     expect(rfcFeatureCoverageModule).toContain("multiPortfolioWavePreview");
+    expect(rfcFeatureCoverageModule).toContain("coreCandidateSourcePreview");
+    expect(rfcFeatureCoverageModule).toContain("bounded Core DPM candidate-source preview");
     expect(rfcFeatureCoverageModule).toContain("single-portfolio and multi-portfolio explicit-list waves");
+    expect(runbook).toContain("DpmPortfolioUniverseCandidate:v1");
+    expect(runbook).toContain("candidate-source preview/no-caller-portfolio guard");
     expect(browserWorkflowModule).toContain("Mandate Readiness");
     expect(browserWorkflowModule).toContain("Attention Required");
     expect(browserWorkflowModule).toContain("Recommended Actions");

--- a/tests/unit/live-observability-evidence-capture.test.ts
+++ b/tests/unit/live-observability-evidence-capture.test.ts
@@ -70,6 +70,8 @@ describe("canonical observability evidence capture", () => {
     expect(wiki).toContain("offline client-demo preparation");
     expect(runbook).toContain("Observability evidence capture");
     expect(validation).toContain("post-validation observability");
+    expect(validation).toContain("DpmPortfolioUniverseCandidate:v1");
+    expect(validation).toContain("no-caller-portfolio guard");
     expect(sidebar).toContain("Observability-Evidence");
   });
 });

--- a/tests/unit/live-validation-probes.test.ts
+++ b/tests/unit/live-validation-probes.test.ts
@@ -1,6 +1,7 @@
 import * as probeHelpers from "../../scripts/live/validation/probes.mjs";
 
-const { checkDns, fetchJson, fetchJsonUntil, fetchText, postJson } = probeHelpers as {
+const { checkDns, fetchJson, fetchJsonUntil, fetchText, postJson, postJsonExpectingStatus } =
+  probeHelpers as {
   checkDns: (
     summary: { dns: unknown[]; apiChecks: unknown[] },
     hostname: string,
@@ -41,6 +42,15 @@ const { checkDns, fetchJson, fetchJsonUntil, fetchText, postJson } = probeHelper
     url: string,
     description: string,
     timeoutMs: number,
+    body: unknown,
+    fetchImpl?: typeof fetch
+  ) => Promise<T>;
+  postJsonExpectingStatus: <T = unknown>(
+    summary: { dns: unknown[]; apiChecks: unknown[] },
+    url: string,
+    description: string,
+    timeoutMs: number,
+    expectedStatus: number,
     body: unknown,
     fetchImpl?: typeof fetch
   ) => Promise<T>;
@@ -180,6 +190,58 @@ describe("live validation probe helpers", () => {
         method: "POST",
       },
     ]);
+  });
+
+  it("records expected bounded problem responses without failing validation", async () => {
+    const summary = createSummary();
+
+    const payload = await postJsonExpectingStatus<{ detail: string }>(
+      summary,
+      "http://gateway.dev.lotus/api/v1/dpm/command-center/waves/preview",
+      "DPM Core candidate-source rejects caller portfolios",
+      1000,
+      422,
+      { body: { campaign_candidate_source: "CORE_DPM_PORTFOLIO_UNIVERSE" } },
+      async () =>
+        new Response(
+          JSON.stringify({
+            detail:
+              "CORE_DPM_PORTFOLIO_UNIVERSE candidate discovery supplies the portfolio set from lotus-core DpmPortfolioUniverseCandidate:v1.",
+          }),
+          {
+            status: 422,
+            headers: { "content-type": "application/json" },
+          }
+        )
+    );
+
+    expect(payload.detail).toContain("DpmPortfolioUniverseCandidate:v1");
+    expect(summary.apiChecks).toEqual([
+      {
+        description: "DPM Core candidate-source rejects caller portfolios",
+        url: "http://gateway.dev.lotus/api/v1/dpm/command-center/waves/preview",
+        status: 422,
+        expectedStatus: 422,
+        kind: "json-expected-status",
+        method: "POST",
+      },
+    ]);
+  });
+
+  it("fails expected-status probes when the status differs", async () => {
+    const summary = createSummary();
+
+    await expect(
+      postJsonExpectingStatus(
+        summary,
+        "http://gateway.dev.lotus/api/v1/dpm/command-center/waves/preview",
+        "DPM Core candidate-source rejects caller portfolios",
+        1000,
+        422,
+        { body: {} },
+        async () => new Response(JSON.stringify({ ok: true }), { status: 200 })
+      )
+    ).rejects.toThrow("returned HTTP 200; expected 422");
   });
 
   it("polls JSON probes until live readiness evidence is available", async () => {

--- a/tests/unit/live-validation-rfc-feature-coverage.test.ts
+++ b/tests/unit/live-validation-rfc-feature-coverage.test.ts
@@ -30,6 +30,8 @@ function createReadyEvidence() {
     commandCenterSummary: {},
     dpmCommandCenterPanel: true,
     activeExceptions: true,
+    coreCandidateSourcePreview: true,
+    coreCandidateSourceInvalidRequestRejected: true,
     portfolioMemory: [{ event_id: "evt-1" }],
     mandateLookup: "MANDATE_PB_SG_GLOBAL_BAL_001",
     mandateHealth: true,
@@ -81,6 +83,12 @@ describe("RFC36-43 live validation feature coverage", () => {
     );
     expect(coverage.coverageRows).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          rfcId: "RFC-0037",
+          featureId: "dpm_operating_system",
+          coverageStatus: "validated",
+          scenarioScope: "bounded Core DPM candidate-source preview and no-caller-portfolio guard",
+        }),
         expect.objectContaining({
           rfcId: "RFC-0041",
           featureId: "rebalance_wave_explicit_portfolio_product_path",

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -47,8 +47,10 @@
 - `live-validation-summary.json` also includes `rfc3643FeatureCoverage`, which maps implemented
   RFC-0036 through RFC-0043 front-office features to live API, workflow-pack, seeded entity, and
   panel evidence. RFC-0041 coverage includes the governed multi-portfolio explicit-list wave
-  preview from the canonical contract. Treat remaining scenario-expansion notes as open validation
-  depth, not as implemented product claims.
+  preview from the canonical contract. RFC-0037 coverage includes bounded Core
+  `DpmPortfolioUniverseCandidate:v1` candidate-source preview and the required rejection of mixed
+  Core-discovery/manual-portfolio requests. Treat remaining scenario-expansion notes as open
+  validation depth, not as implemented product claims.
 - construction alternatives live proof writes focused machine-readable evidence and a panel
   screenshot under `output/rfc39-wtbd002-construction-lab/construction-live/`
 - DPM PM operating-quality live proof creates and re-reads Manage-backed score-run,
@@ -67,7 +69,8 @@ The governed front-office validation flow checks the seeded `PB_SG_GLOBAL_BAL_00
 - advisor-brief and risk modes inside the performance experience
 - evidence-oriented product validation paths that are part of the current governed runtime
 - DPM outcome review, proof pack, command center, portfolio memory, rebalance-wave command center,
-  construction alternatives, PM operating quality, and PM copilot workspace
+  Core candidate-source wave preview/no-caller-portfolio guard, construction alternatives,
+  PM operating quality, and PM copilot workspace
 
 When validating active Workbench source changes, use the governed local-app bring-up
 `npm run live:stack:up:workbench-local` so `workbench.dev.lotus` serves the current branch while


### PR DESCRIPTION
## Summary
- add canonical live validation for bounded Core `DpmPortfolioUniverseCandidate:v1` campaign candidate-source preview
- require the Gateway/Manage no-caller-portfolio guard by expecting the governed 422 response for mixed Core-discovery/manual-portfolio requests
- include the new evidence in RFC36-43 feature coverage and update operator/wiki validation documentation

## Validation
- `npm run test -- tests/unit/live-validation-probes.test.ts tests/unit/live-validation-rfc-feature-coverage.test.ts tests/unit/live-canonical-validation-script.test.ts tests/unit/live-observability-evidence-capture.test.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- `npm run live:stack:up`
- `npm run live:validate` passed for `PB_SG_GLOBAL_BAL_001`; summary contains `dpm-core-candidate-source-preview`, `DpmPortfolioUniverseCandidate:v1`, `validatedFeatureCount: 10`, and `gapFeatureCount: 0`
- `npm run live:evidence` captured observability pack at `output/observability-live/20260524-214234/`

## Boundary
This adds proof for the bounded candidate-source realization only. It does not close RFC37-WTBD-004 broader source-product depth and does not claim relationship householding, global portfolio-universe ownership, PM ranking, client communication workflow, OMS, fills, settlement, reconciliation, or execution.

## Wiki
- `wiki/Validation-and-CI.md` changed; publish after merge and verify drift zero.