### PR TITLE
Align proposal sell submission with preview

### DIFF
--- a/src/features/proposals/components/proposal-simulate-form.tsx
+++ b/src/features/proposals/components/proposal-simulate-form.tsx
@@ -18,6 +18,7 @@ import {
   handoffAdvisoryWorkspace,
 } from "../api";
 import {
+  buildExecutableTradeRows,
   buildProposalDraftPreview,
   createCashFlowIntent,
   createTradeIntent,
@@ -167,6 +168,13 @@ export default function ProposalSimulateForm({
     () => buildProposalDraftPreview(tradablePositions, sourceCashAmount, cashFlows, trades),
     [cashFlows, sourceCashAmount, tradablePositions, trades]
   );
+  const executableTradeRows = useMemo(
+    () => buildExecutableTradeRows(tradablePositions, trades),
+    [tradablePositions, trades]
+  );
+  const cappedTradeCount = executableTradeRows.filter(
+    (item) => item.cappedToAvailableQuantity
+  ).length;
 
   function updateCashFlow(id: string, patch: Partial<ProposalDraftCashFlowIntent>) {
     setCashFlows((current) => current.map((item) => (item.id === id ? { ...item, ...patch } : item)));
@@ -200,15 +208,15 @@ export default function ProposalSimulateForm({
   }
 
   function validTradeCount(): number {
-    return trades.filter((item) => item.instrumentId.trim().length > 0 && item.quantity > 0).length;
+    return executableTradeRows.length;
   }
 
   function validCashFlowRows(): ProposalDraftCashFlowIntent[] {
     return cashFlows.filter((item) => item.currency.trim().length > 0 && item.amount > 0);
   }
 
-  function validTradeRows(): ProposalDraftTradeIntent[] {
-    return trades.filter((item) => item.instrumentId.trim().length > 0 && item.quantity > 0);
+  function validTradeRows() {
+    return executableTradeRows;
   }
 
   function syncEvaluationFromWorkspace(envelope: AdvisoryWorkspaceEnvelopeResponse) {
@@ -271,7 +279,7 @@ export default function ProposalSimulateForm({
             intent_type: "SECURITY_TRADE",
             side: item.side,
             instrument_id: item.instrumentId.trim(),
-            quantity: decimalString(item.quantity, 4),
+            quantity: decimalString(item.executableQuantity, 4),
           },
         },
       });
@@ -398,6 +406,9 @@ export default function ProposalSimulateForm({
                 <li>Portfolio context captured</li>
                 <li>Cash movement model ready</li>
                 <li>{validTradeCount()} security order lines ready</li>
+                {cappedTradeCount ? (
+                  <li>{cappedTradeCount} sell line capped to source-backed available units</li>
+                ) : null}
                 {activeWorkspaceId ? <li>Workspace {activeWorkspaceId} evaluated by Advise</li> : null}
               </ul>
               <Stack spacing={1} className={styles.actionButtons}>

--- a/src/features/proposals/proposal-draft-preview.ts
+++ b/src/features/proposals/proposal-draft-preview.ts
@@ -14,6 +14,12 @@ export type ProposalDraftTradeIntent = TradeIntentInput & {
   referencePrice?: number;
 };
 
+export type ExecutableProposalDraftTradeIntent = ProposalDraftTradeIntent & {
+  requestedQuantity: number;
+  executableQuantity: number;
+  cappedToAvailableQuantity: boolean;
+};
+
 export type DraftPositionPreviewRow = {
   key: string;
   instrumentId: string;
@@ -116,6 +122,45 @@ export function formatUnitValue(value: number): string {
 
 export function formatPercentValue(value: number): string {
   return `${value.toFixed(1)}%`;
+}
+
+export function buildExecutableTradeRows(
+  positions: PortfolioPositionView[],
+  trades: ProposalDraftTradeIntent[]
+): ExecutableProposalDraftTradeIntent[] {
+  const quantityByInstrument = new Map<string, number>();
+  positions.forEach((position) => {
+    quantityByInstrument.set(position.security_id, Math.max(0, position.quantity));
+  });
+
+  const executableRows: ExecutableProposalDraftTradeIntent[] = [];
+  trades.forEach((trade) => {
+    const instrumentId = trade.instrumentId.trim();
+    if (!instrumentId || trade.quantity <= 0) {
+      return;
+    }
+
+    const availableQuantity = Math.max(0, quantityByInstrument.get(instrumentId) ?? 0);
+    const executableQuantity =
+      trade.side === "SELL" ? Math.min(trade.quantity, availableQuantity) : trade.quantity;
+    if (executableQuantity <= 0) {
+      return;
+    }
+
+    quantityByInstrument.set(
+      instrumentId,
+      Math.max(0, availableQuantity + (trade.side === "SELL" ? -executableQuantity : executableQuantity))
+    );
+    executableRows.push({
+      ...trade,
+      instrumentId,
+      requestedQuantity: trade.quantity,
+      executableQuantity,
+      cappedToAvailableQuantity: executableQuantity < trade.quantity,
+    });
+  });
+
+  return executableRows;
 }
 
 export function buildProposalDraftPreview(

--- a/tests/integration/proposal-simulate-form.test.tsx
+++ b/tests/integration/proposal-simulate-form.test.tsx
@@ -75,6 +75,7 @@ function renderForm(initialPortfolioId?: string) {
 
 describe("ProposalSimulateForm", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     advisoryApiMocks.createAdvisoryWorkspace.mockResolvedValue(workspaceEnvelope());
     advisoryApiMocks.applyAdvisoryWorkspaceDraftAction.mockResolvedValue(workspaceEnvelope());
     advisoryApiMocks.evaluateAdvisoryWorkspace.mockResolvedValue(workspaceEnvelope());
@@ -152,6 +153,37 @@ describe("ProposalSimulateForm", () => {
               side: "BUY",
               instrument_id: "AAPL",
               quantity: "10.0000",
+            }),
+          }),
+        }
+      )
+    );
+  });
+
+  it("caps submitted sell-down quantities to source-backed available units", async () => {
+    renderForm("PB_SG_GLOBAL_BAL_001");
+
+    expect(await screen.findByText("Apple Inc.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Sell Down" }));
+
+    const quantityInputs = screen.getAllByLabelText("Quantity") as HTMLInputElement[];
+    fireEvent.change(quantityInputs[quantityInputs.length - 1], { target: { value: "150" } });
+    expect(
+      screen.getByText("1 sell line capped to source-backed available units")
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Evaluate Workspace" }));
+
+    await waitFor(() =>
+      expect(advisoryApiMocks.applyAdvisoryWorkspaceDraftAction).toHaveBeenCalledWith(
+        "aws_test_001",
+        {
+          body: expect.objectContaining({
+            action_type: "ADD_TRADE",
+            trade: expect.objectContaining({
+              intent_type: "SECURITY_TRADE",
+              side: "SELL",
+              instrument_id: "AAPL",
+              quantity: "100.0000",
             }),
           }),
         }

--- a/tests/unit/proposal-draft-preview.test.ts
+++ b/tests/unit/proposal-draft-preview.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { PortfolioPositionView } from "../../src/apps/portfolio/types";
 import {
+  buildExecutableTradeRows,
   buildProposalDraftPreview,
   createCashFlowIntent,
   createTradeIntentFromPosition,
@@ -106,5 +107,21 @@ describe("proposal draft preview", () => {
     expect(preview.tradeNotional).toBe(-19000);
     expect(preview.proposedCash).toBe(24000);
     expect(preview.proposedPortfolioValue).toBe(24000);
+  });
+
+  it("caps submitted sell rows to the available source-backed holding quantity", () => {
+    const oversellApple = createTradeIntentFromPosition(1, applePosition, "SELL");
+    oversellApple.quantity = 150;
+
+    const executableRows = buildExecutableTradeRows([applePosition], [oversellApple]);
+
+    expect(executableRows).toHaveLength(1);
+    expect(executableRows[0]).toMatchObject({
+      instrumentId: "AAPL",
+      side: "SELL",
+      requestedQuantity: 150,
+      executableQuantity: 100,
+      cappedToAvailableQuantity: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- derive executable proposal trade rows from the source-backed portfolio book
- cap submitted sell-down quantities to available units so the Advise workspace action matches the Workbench preview
- show a bounded advisor note when sell lines are capped and align ready trade count to executable rows

## Boundary
- does not add OMS, order routing, fills, settlement, short selling, or client communication behavior
- keeps formal suitability, risk, allocation, and workflow authority in Gateway/Advise

## Validation
- npm run test -- --run tests/unit/proposal-draft-preview.test.ts tests/integration/proposal-simulate-form.test.tsx
- npm run lint
- npm run typecheck
- npm run build
- git diff --check