### PR TITLE
Align live proposal memo validation

### DIFF
--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -378,31 +378,30 @@ export async function validateProposalMemoEvidencePackPanel(
       timeout: timeoutMs,
     });
   }
-  await memoPanel.getByRole("button", { name: "Create Or Replay Memo" }).click();
-  await expect(memoPanel.getByText(/Memo hash: sha256:/)).toBeVisible({ timeout: timeoutMs });
+  await memoPanel.getByRole("button", { name: "Prepare Or Refresh Memo" }).click();
+  await expect(memoPanel.getByText(/Memo evidence: sha256:/)).toBeVisible({ timeout: timeoutMs });
   await memoPanel.getByLabel("Review rationale").fill(
-    "Live canonical validator approved this advisor-use memo from source evidence."
+    "Live canonical validator requested advisor-use memo review from source evidence."
   );
   await memoPanel.getByRole("button", { name: "Approve Memo For Advisor Use" }).click();
-  await expect(memoPanel.getByLabel("Status Approved For Advisor Use")).toBeVisible({
-    timeout: timeoutMs,
-  });
-  await memoPanel.getByRole("button", { name: "Request Memo Report Package" }).click();
-  await expect(memoPanel.getByRole("button", { name: "Request Memo Report Package" })).toBeVisible({
+  await expect(memoPanel.getByText("Review Posture")).toBeVisible({ timeout: timeoutMs });
+  await expect(memoPanel.getByText("Pending")).toBeVisible({ timeout: timeoutMs });
+  await memoPanel.getByRole("button", { name: "Prepare Report Package" }).click();
+  await expect(memoPanel.getByRole("button", { name: "Prepare Report Package" })).toBeVisible({
     timeout: timeoutMs,
   });
   await memoPanel.getByRole("button", { name: "Request Advisor Commentary" }).click();
   await expect(memoPanel.getByRole("button", { name: "Request Advisor Commentary" })).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(memoPanel.getByText(/Replay hash: sha256:/)).toBeVisible({ timeout: timeoutMs });
+  await expect(memoPanel.getByText(/Replay evidence: sha256:/)).toBeVisible({ timeout: timeoutMs });
 
   summary.uiChecks.push({
     description: "Proposal memo evidence-pack advisor-use review and support posture",
     kind: "proposal-memo-evidence-pack",
     proposalId,
     versionNo: proposalVersionNo,
-    reviewState: "APPROVED_FOR_ADVISOR_USE",
+    reviewState: "review-requested-source-posture-preserved",
     clientReadyRelease: "not-requested",
   });
   await screenshotRegisteredPanel(page, "proposal.memo_evidence_pack", {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -495,9 +495,12 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain("Proposal memo evidence-pack advisor-use review and support posture");
     expect(browserWorkflowModule).toContain("Approve Advisor Narrative");
     expect(browserWorkflowModule).toContain("Request Reviewed Report");
-    expect(browserWorkflowModule).toContain("Create Or Replay Memo");
+    expect(browserWorkflowModule).toContain("Prepare Or Refresh Memo");
+    expect(browserWorkflowModule).toContain("Memo evidence: sha256:");
     expect(browserWorkflowModule).toContain("Approve Memo For Advisor Use");
-    expect(browserWorkflowModule).toContain("Request Memo Report Package");
+    expect(browserWorkflowModule).toContain("Prepare Report Package");
+    expect(browserWorkflowModule).toContain("Request Advisor Commentary");
+    expect(browserWorkflowModule).toContain("Replay evidence: sha256:");
     expect(browserWorkflowModule).toContain("panel: panelId");
     expect(browserWorkflowModule).toContain('screenshotState = "demo_ready"');
     expect(browserWorkflowModule).toContain("state: screenshotState");


### PR DESCRIPTION
## Summary
- align canonical live proposal memo validation with current Workbench memo panel copy
- verify memo creation through visible source-backed memo evidence and replay evidence
- preserve source-owned blocked/pending posture after review request instead of claiming advisor approval

## Validation
- npm run test -- --run tests/unit/live-canonical-validation-script.test.ts
- npm run lint
- npm run build
- npm run typecheck (rerun serially after build regenerated .next/types)
- npm run live:validate

## Notes
- No wiki source change. Runtime evidence is under output/playwright/live-canonical and remains untracked.
