### PR TITLE
Prove DPM selection basis in live Workbench validation

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -444,7 +444,8 @@ separately from the RFC36-43 feature totals. RFC36-43 validation fails only on r
 counts without being treated as RFC36-43 implementation regressions. The matrix is not a blanket future-scope
 certification: it records the current scenario scope, now including the governed RFC-0041
 multi-portfolio explicit-list wave preview from the canonical contract and the RFC-0037 bounded
-Core `DpmPortfolioUniverseCandidate:v1` candidate-source preview/no-caller-portfolio guard. Broader
+Core `DpmPortfolioUniverseCandidate:v1` candidate-source preview/no-caller-portfolio guard and
+source-owned mandate-binding selection-basis evidence. Broader
 source-owner cohort products remain listed as scenario expansion until their source products and
 downstream realization are proven.
 

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -869,6 +869,7 @@ export async function validateDpmWaveCommandCenterPanel(
   await expect(candidateSourceReview).toBeVisible({ timeout: timeoutMs });
   for (const label of [
     "Source Product",
+    "Selection Basis",
     "Readiness",
     "Candidates",
     "Eligible",
@@ -885,6 +886,15 @@ export async function validateDpmWaveCommandCenterPanel(
   await expect(
     candidateSourceReview.getByText("DpmPortfolioUniverseCandidate:v1", { exact: true })
   ).toBeVisible({ timeout: timeoutMs });
+  await expect(
+    candidateSourceReview.getByText("Effective Discretionary Mandate Binding")
+  ).toBeVisible({ timeout: timeoutMs });
+  await expect(candidateSourceReview.getByText("portfolio_mandate_bindings")).toBeVisible({
+    timeout: timeoutMs,
+  });
+  await expect(candidateSourceReview.getByText("mandate_type=discretionary")).toBeVisible({
+    timeout: timeoutMs,
+  });
   await expect(candidateSourceReview.getByText("Check launch readiness through Gateway.")).toBeVisible({
     timeout: timeoutMs,
   });

--- a/src/features/workbench/dpm-wave-command-center-view-model.ts
+++ b/src/features/workbench/dpm-wave-command-center-view-model.ts
@@ -847,8 +847,10 @@ function resolveCampaignCandidateOperatingBoundaries(
   record: Record<string, unknown>,
   discovery: Record<string, unknown>
 ): string {
+  const universePosture = readRecord(discovery.universe_posture);
   const boundaries = [
     ...extractStringArray(discovery.operating_boundaries),
+    ...extractStringArray(universePosture.operating_boundaries),
     ...extractStringArray(record.operating_boundaries),
     "NO_OMS_EXECUTION_CLAIM",
     "NO_CLIENT_CONTACT_WORKFLOW",

--- a/tests/unit/dpm-wave-command-center-view-model.test.ts
+++ b/tests/unit/dpm-wave-command-center-view-model.test.ts
@@ -380,6 +380,9 @@ describe("DPM wave command-center view model", () => {
               campaign_version: "2026.05",
               supportability_state: "READY",
               source_ref_count: 1,
+              universe_posture: {
+                operating_boundaries: ["NO_ORDER_GENERATION", "NO_SOURCE_FACT_RECALCULATION"],
+              },
             },
           ],
         },
@@ -389,6 +392,9 @@ describe("DPM wave command-center view model", () => {
     expect(model.campaignRows[0].candidateSourceProduct).toBe("DpmPortfolioUniverseCandidate:v1");
     expect(model.campaignRows[0].candidateSelectionBasis).toBe(
       "Effective Discretionary Mandate Binding; Source: portfolio_mandate_bindings; Predicates: mandate_type=discretionary, effective_from<=as_of_date"
+    );
+    expect(model.campaignRows[0].operatingBoundaries).toBe(
+      "NO_ORDER_GENERATION, NO_SOURCE_FACT_RECALCULATION, NO_OMS_EXECUTION_CLAIM, NO_CLIENT_CONTACT_WORKFLOW"
     );
   });
 

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -429,6 +429,10 @@ describe("canonical live validation script", () => {
     expect(rfcFeatureCoverageModule).toContain("single-portfolio and multi-portfolio explicit-list waves");
     expect(browserWorkflowModule).toContain("Candidate Source Review");
     expect(browserWorkflowModule).toContain("DpmPortfolioUniverseCandidate:v1");
+    expect(browserWorkflowModule).toContain("Selection Basis");
+    expect(browserWorkflowModule).toContain("Effective Discretionary Mandate Binding");
+    expect(browserWorkflowModule).toContain("portfolio_mandate_bindings");
+    expect(browserWorkflowModule).toContain("mandate_type=discretionary");
     expect(browserWorkflowModule).toContain("Check launch readiness through Gateway.");
     expect(browserWorkflowModule).toContain("NO_ORDER_GENERATION");
     expect(browserWorkflowModule).toContain("NO_OMS_EXECUTION_CLAIM");


### PR DESCRIPTION
## Summary
- prove the DPM candidate-source card renders source-owned `DpmPortfolioUniverseCandidate:v1` selection-basis evidence in canonical live validation
- preserve `universe_posture.operating_boundaries` from Gateway/Manage in the Workbench campaign row view model
- document the canonical runtime proof scope for source-owned mandate-binding selection-basis evidence

## Evidence
- `npm run test -- --run tests/unit/dpm-wave-command-center-view-model.test.ts tests/unit/live-canonical-validation-script.test.ts tests/unit/dpm-campaign-candidate-source-card.test.tsx` -> 25 tests passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed (`next lint` deprecation warning only)
- `docker compose up -d --build lotus-workbench` -> passed; production `next build` completed with existing ag-grid autoprefixer warning
- `npm run live:validate` -> passed for `PB_SG_GLOBAL_BAL_001`; screenshots at `output/playwright/live-canonical`
- Upstream seed evidence: `lotus-platform` PR #360 merged, Main Releasability Gate run `26428982839` green

## Boundaries
- Workbench consumes Gateway/Manage/Core evidence only; no browser-side candidate discovery, source-fact recalculation, readiness calculation, order generation, OMS execution, or client-contact workflow is claimed.
- RFC37-WTBD-004 remains open for broader source-owner universe depth.

## Stranded Truth
- `git branch -r --no-merged origin/main` produced no unmerged remote branches in `lotus-workbench` before PR creation.