### PR TITLE
RFC-0025: Add suitability policy review queue

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -277,6 +277,12 @@ Important validation expectations:
     explicit about advisor-use review, reviewed narrative package inclusion, report delivery
     posture, and latest delivery event, without presenting report rendering, archive publication,
     client messaging, or client-ready release as Workbench-owned capabilities.
+18. Advisor suitability policy review queue reads are Workbench gateway-only operations backed by
+    Gateway advisory-policy evaluation contracts. Workbench may display Advise-owned evaluation
+    posture, sign-off posture, open approval/disclosure/consent requirements, source-evidence
+    completeness, and advisor next action, but it must not calculate suitability locally, mutate
+    policy sign-off, approve waivers, infer client-ready release, or expose raw policy payload
+    field names on advisor-facing screens.
 
 ### Visual Review Gate
 

--- a/src/features/proposals/api.ts
+++ b/src/features/proposals/api.ts
@@ -1,4 +1,6 @@
 import {
+  AdvisoryPolicyEnvelopeResponse,
+  AdvisoryPolicyReviewQueueData,
   ProposalApprovalActionRequest,
   ProposalApprovalsData,
   AdvisoryWorkspaceBodyRequest,
@@ -214,6 +216,23 @@ export async function listProposals(filters: ProposalListFilters = {}): Promise<
   }
   const envelope = (await response.json()) as ProposalEnvelopeResponse;
   return envelope.data as unknown as ProposalListData;
+}
+
+export async function getAdvisoryPolicyReviewQueue(
+  evaluationStatus = "PENDING_REVIEW"
+): Promise<AdvisoryPolicyReviewQueueData> {
+  const params = new URLSearchParams();
+  if (evaluationStatus) {
+    params.set("evaluation_status", evaluationStatus);
+  }
+  const query = params.toString() ? `?${params.toString()}` : "";
+  const response = await fetch(`${BFF_PROXY_BASE}/advisory-policy-evaluations/review-queue${query}`);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Advisory policy review queue failed (${response.status}): ${body}`);
+  }
+  const envelope = (await response.json()) as AdvisoryPolicyEnvelopeResponse;
+  return envelope.data as unknown as AdvisoryPolicyReviewQueueData;
 }
 
 export async function getProposal(

--- a/src/features/proposals/components/proposal-lifecycle-workspace.module.css
+++ b/src/features/proposals/components/proposal-lifecycle-workspace.module.css
@@ -14,6 +14,56 @@
   margin: 4px 0;
 }
 
+.policyReviewPanel {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  margin-bottom: 12px;
+  padding: 14px 16px;
+}
+
+.policyReviewHeader {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.policyReviewHeader h3 {
+  margin: 4px 0 0;
+}
+
+.policyReviewCounts {
+  border: 1px solid var(--border);
+  border-left: 4px solid #765a17;
+  border-radius: 8px;
+  background: #fffdf7;
+  min-width: 132px;
+  padding: 10px 12px;
+  text-align: right;
+}
+
+.policyReviewCounts span,
+.policyReviewCounts strong {
+  display: block;
+}
+
+.policyReviewCounts span {
+  color: var(--text);
+  font-size: 1.3rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.policyReviewCounts strong {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  margin-top: 6px;
+  text-transform: uppercase;
+}
+
 .countStrip {
   display: grid;
   grid-template-columns: repeat(2, minmax(96px, 1fr));
@@ -108,9 +158,25 @@
   margin-top: 3px;
 }
 
+.lifecycleTable td span {
+  color: var(--text-muted);
+  display: block;
+  font-size: 0.76rem;
+  margin-top: 5px;
+}
+
 @media (max-width: 760px) {
   .decisionPanel {
     flex-direction: column;
+  }
+
+  .policyReviewHeader {
+    flex-direction: column;
+  }
+
+  .policyReviewCounts {
+    text-align: left;
+    width: 100%;
   }
 
   .countStrip {

--- a/src/features/proposals/components/proposal-lifecycle-workspace.tsx
+++ b/src/features/proposals/components/proposal-lifecycle-workspace.tsx
@@ -8,11 +8,12 @@ import { Alert, CircularProgress, Stack } from "@mui/material";
 import { ScreenStatePanel, SectionBlock, SemanticBadge, Text } from "@/design-system";
 import { workbenchStrictQueryDefaults } from "@/features/platform-runtime/query-policy";
 
-import { listProposals } from "../api";
+import { getAdvisoryPolicyReviewQueue, listProposals } from "../api";
 import {
   buildProposalLifecycleWorkspaceModel,
   type ProposalLifecycleMode,
 } from "../proposal-lifecycle-workspace-view-model";
+import { buildPolicyReviewQueueModel } from "../proposal-policy-review-view-model";
 import styles from "./proposal-lifecycle-workspace.module.css";
 
 export default function ProposalLifecycleWorkspace({
@@ -27,11 +28,21 @@ export default function ProposalLifecycleWorkspace({
     queryFn: async () => await listProposals({ portfolioId }),
     ...workbenchStrictQueryDefaults,
   });
+  const policyQueueQuery = useQuery({
+    queryKey: ["advisory-policy-review-queue", portfolioId],
+    queryFn: async () => await getAdvisoryPolicyReviewQueue("PENDING_REVIEW"),
+    enabled: mode === "suitability",
+    ...workbenchStrictQueryDefaults,
+  });
 
   const proposals = useMemo(() => data?.items ?? [], [data?.items]);
   const model = useMemo(
     () => buildProposalLifecycleWorkspaceModel({ mode, proposals }),
     [mode, proposals]
+  );
+  const policyReviewModel = useMemo(
+    () => buildPolicyReviewQueueModel({ records: policyQueueQuery.data?.items ?? [] }),
+    [policyQueueQuery.data?.items]
   );
 
   if (isLoading) {
@@ -63,6 +74,11 @@ export default function ProposalLifecycleWorkspace({
           Proposal lifecycle is unavailable. No fallback proposal queue is shown.
         </Alert>
       ) : null}
+      {mode === "suitability" && policyQueueQuery.error ? (
+        <Alert severity="warning" sx={{ mb: 1 }}>
+          Policy review queue is unavailable. No fallback suitability policy queue is shown.
+        </Alert>
+      ) : null}
 
       <div className={styles.decisionPanel}>
         <div>
@@ -83,6 +99,15 @@ export default function ProposalLifecycleWorkspace({
           </div>
         </div>
       </div>
+
+      {mode === "suitability" ? (
+        <PolicyReviewQueueSection
+          portfolioId={portfolioId}
+          isLoading={policyQueueQuery.isLoading}
+          hasError={Boolean(policyQueueQuery.error)}
+          model={policyReviewModel}
+        />
+      ) : null}
 
       {error ? (
         <ScreenStatePanel
@@ -142,5 +167,101 @@ export default function ProposalLifecycleWorkspace({
         </div>
       )}
     </SectionBlock>
+  );
+}
+
+function PolicyReviewQueueSection({
+  portfolioId,
+  isLoading,
+  hasError,
+  model,
+}: {
+  portfolioId: string;
+  isLoading: boolean;
+  hasError: boolean;
+  model: ReturnType<typeof buildPolicyReviewQueueModel>;
+}) {
+  if (isLoading) {
+    return (
+      <div className={styles.policyReviewPanel}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <CircularProgress size={16} />
+          <Text variant="body">Loading policy review queue...</Text>
+        </Stack>
+      </div>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <ScreenStatePanel
+        kind="error"
+        title="Policy review queue unavailable"
+        body="Suitability policy evaluations could not be loaded from the approved advisory workflow."
+        surface="default"
+      />
+    );
+  }
+
+  if (model.rows.length === 0) {
+    return (
+      <ScreenStatePanel
+        kind="empty"
+        title="No policy evaluations need review"
+        body={`No suitability policy evaluations are waiting for ${portfolioId}.`}
+        surface="default"
+      />
+    );
+  }
+
+  return (
+    <div className={styles.policyReviewPanel}>
+      <div className={styles.policyReviewHeader}>
+        <div>
+          <Text variant="microLabel">Suitability Policy Queue</Text>
+          <Text variant="subsectionTitle" as="h3">
+            Policy evaluations needing review
+          </Text>
+        </div>
+        <div className={styles.policyReviewCounts} aria-label="Policy review counts">
+          <span>{model.totalCount}</span>
+          <strong>{model.actionCount} need action</strong>
+        </div>
+      </div>
+      <div className={styles.tableWrap}>
+        <table className={styles.lifecycleTable}>
+          <thead>
+            <tr>
+              <th>Proposal</th>
+              <th>Policy Review</th>
+              <th>Sign-Off</th>
+              <th>Open Requirements</th>
+              <th>Evidence</th>
+              <th>Next Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {model.rows.map((row) => (
+              <tr key={row.evaluationId}>
+                <td>
+                  <Link href={row.href}>{row.proposalId}</Link>
+                  <span>{row.proposalVersion}</span>
+                </td>
+                <td>
+                  <SemanticBadge tone={row.policyStatusTone}>{row.policyStatus}</SemanticBadge>
+                  <span>{row.policyPack}</span>
+                </td>
+                <td>
+                  <SemanticBadge tone={row.signOffTone}>{row.signOffStatus}</SemanticBadge>
+                </td>
+                <td>{row.openRequirements}</td>
+                <td>{row.evidencePosture}</td>
+                <td>{row.nextAction}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
   );
 }

--- a/src/features/proposals/proposal-policy-review-view-model.ts
+++ b/src/features/proposals/proposal-policy-review-view-model.ts
@@ -1,0 +1,206 @@
+import type { SemanticBadgeTone } from "@/design-system";
+
+import type { AdvisoryPolicyEvaluationRecord } from "./types";
+
+export type PolicyReviewQueueRow = {
+  evaluationId: string;
+  proposalId: string;
+  proposalVersion: string;
+  policyPack: string;
+  policyStatus: string;
+  policyStatusTone: SemanticBadgeTone;
+  signOffStatus: string;
+  signOffTone: SemanticBadgeTone;
+  openRequirements: string;
+  nextAction: string;
+  evidencePosture: string;
+  href: string;
+};
+
+export type PolicyReviewQueueModel = {
+  totalCount: number;
+  actionCount: number;
+  rows: PolicyReviewQueueRow[];
+};
+
+export function buildPolicyReviewQueueModel({
+  records,
+}: {
+  records: AdvisoryPolicyEvaluationRecord[];
+}): PolicyReviewQueueModel {
+  const rows = records.map((record) => {
+    const proposalId = stringValue(record.proposal_id, "Proposal not reported");
+    const policyStatus = policyStatusLabel(record.evaluation_status);
+    const approvalDependencies = stringArray(record.approval_dependencies);
+    const disclosureRequirements = stringArray(record.disclosure_requirements);
+    const consentRequirements = stringArray(record.consent_requirements);
+    const sourceGaps = stringArray(record.source_gaps);
+
+    return {
+      evaluationId: stringValue(record.evaluation_id, "Evaluation not reported"),
+      proposalId,
+      proposalVersion: stringValue(record.proposal_version_id, "Version not reported"),
+      policyPack: policyLabel(record.policy_pack_id, record.policy_version),
+      policyStatus,
+      policyStatusTone: policyStatusTone(record.evaluation_status),
+      signOffStatus: signOffStatus(record),
+      signOffTone: signOffTone(record),
+      openRequirements: requirementSummary({
+        approvalDependencies,
+        disclosureRequirements,
+        consentRequirements,
+      }),
+      nextAction: nextAction({
+        policyStatus: record.evaluation_status,
+        approvalDependencies,
+        disclosureRequirements,
+        consentRequirements,
+      }),
+      evidencePosture: evidencePosture(sourceGaps),
+      href: `/proposals/${encodeURIComponent(proposalId)}`,
+    };
+  });
+
+  return {
+    totalCount: rows.length,
+    actionCount: rows.filter((row) => row.policyStatus !== "Ready").length,
+    rows,
+  };
+}
+
+function stringValue(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function policyLabel(policyPackId: unknown, policyVersion: unknown): string {
+  const pack = friendlyPhrase(stringValue(policyPackId, "Policy pack not reported"));
+  const version = stringValue(policyVersion, "");
+  return version ? `${pack} / ${version}` : pack;
+}
+
+function policyStatusLabel(status: unknown): string {
+  switch (status) {
+    case "READY":
+      return "Ready";
+    case "PENDING_REVIEW":
+      return "Review required";
+    case "BLOCKED":
+      return "Blocked";
+    case "NOT_APPLICABLE":
+      return "Not applicable";
+    default:
+      return "Needs review";
+  }
+}
+
+function policyStatusTone(status: unknown): SemanticBadgeTone {
+  switch (status) {
+    case "READY":
+    case "NOT_APPLICABLE":
+      return "success";
+    case "BLOCKED":
+      return "danger";
+    case "PENDING_REVIEW":
+      return "warn";
+    default:
+      return "default";
+  }
+}
+
+function signOffStatus(record: AdvisoryPolicyEvaluationRecord): string {
+  if (Array.isArray(record.sign_off_events_json) && record.sign_off_events_json.length > 0) {
+    return "Sign-off recorded";
+  }
+  if (record.evaluation_status === "READY") {
+    return "Ready for sign-off";
+  }
+  return "Sign-off pending";
+}
+
+function signOffTone(record: AdvisoryPolicyEvaluationRecord): SemanticBadgeTone {
+  if (Array.isArray(record.sign_off_events_json) && record.sign_off_events_json.length > 0) {
+    return "success";
+  }
+  return record.evaluation_status === "READY" ? "success" : "warn";
+}
+
+function requirementSummary({
+  approvalDependencies,
+  disclosureRequirements,
+  consentRequirements,
+}: {
+  approvalDependencies: string[];
+  disclosureRequirements: string[];
+  consentRequirements: string[];
+}): string {
+  const parts = [
+    countPhrase(approvalDependencies.length, "approval dependency", "approval dependencies"),
+    countPhrase(disclosureRequirements.length, "disclosure review", "disclosure reviews"),
+    countPhrase(consentRequirements.length, "client consent", "client consents"),
+  ].filter(Boolean);
+
+  return parts.length > 0 ? parts.join(", ") : "No open requirements reported";
+}
+
+function countPhrase(count: number, singular: string, plural: string): string | null {
+  if (count === 0) {
+    return null;
+  }
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function nextAction({
+  policyStatus,
+  approvalDependencies,
+  disclosureRequirements,
+  consentRequirements,
+}: {
+  policyStatus: unknown;
+  approvalDependencies: string[];
+  disclosureRequirements: string[];
+  consentRequirements: string[];
+}): string {
+  if (policyStatus === "BLOCKED") {
+    return "Resolve blocking policy evidence before advisor sign-off.";
+  }
+  if (approvalDependencies.length > 0) {
+    return "Complete required approval review.";
+  }
+  if (disclosureRequirements.length > 0) {
+    return "Complete disclosure review.";
+  }
+  if (consentRequirements.length > 0) {
+    return "Confirm client consent evidence.";
+  }
+  if (policyStatus === "READY") {
+    return "Record sign-off when maker-checker review is complete.";
+  }
+  return "Review policy evidence before client discussion.";
+}
+
+function evidencePosture(sourceGaps: string[]): string {
+  if (sourceGaps.length === 0) {
+    return "Source evidence complete";
+  }
+  return `${sourceGaps.length} evidence ${sourceGaps.length === 1 ? "gap" : "gaps"}`;
+}
+
+function friendlyPhrase(value: string): string {
+  if (!value || value === "Policy pack not reported") {
+    return value;
+  }
+  return value
+    .split(/[_:\s-]+/)
+    .filter(Boolean)
+    .map((part) =>
+      part.length <= 3 ? part.toUpperCase() : part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+    )
+    .join(" ");
+}

--- a/src/features/proposals/types.ts
+++ b/src/features/proposals/types.ts
@@ -98,6 +98,38 @@ export type ProposalEnvelopeResponse = {
   data: Record<string, unknown>;
 };
 
+export type AdvisoryPolicyEnvelopeResponse = {
+  correlation_id: string;
+  contract_version: string;
+  data: Record<string, unknown>;
+};
+
+export type AdvisoryPolicyEvaluationRecord = {
+  evaluation_id?: string;
+  proposal_id?: string;
+  proposal_version_id?: string;
+  policy_pack_id?: string;
+  policy_version?: string;
+  evaluation_status?: string;
+  source_refs?: string[];
+  source_gaps?: string[];
+  approval_dependencies?: string[];
+  disclosure_requirements?: string[];
+  consent_requirements?: string[];
+  review_events_json?: Array<Record<string, unknown>>;
+  sign_off_events_json?: Array<Record<string, unknown>>;
+  report_archive_refs_json?: Array<Record<string, unknown>>;
+  replay_metadata_json?: Record<string, unknown>;
+  evaluation_json?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type AdvisoryPolicyReviewQueueData = {
+  items?: AdvisoryPolicyEvaluationRecord[];
+  queue_posture?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
 export type ProposalSummary = {
   proposal_id: string;
   portfolio_id?: string;

--- a/tests/integration/proposal-lifecycle-workspace.test.tsx
+++ b/tests/integration/proposal-lifecycle-workspace.test.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ProposalLifecycleWorkspace from "../../src/features/proposals/components/proposal-lifecycle-workspace";
 
-const listProposalsMock = vi.fn(async (_filters?: unknown) => ({
+const proposalListFixture = {
   items: [
     {
       proposal_id: "PRP-RISK",
@@ -20,9 +20,29 @@ const listProposalsMock = vi.fn(async (_filters?: unknown) => ({
       title: "Execution handoff",
     },
   ],
-}));
+};
+const policyReviewQueueFixture = {
+  items: [
+    {
+      evaluation_id: "pev_001",
+      proposal_id: "PRP-RISK",
+      proposal_version_id: "ppv_001",
+      policy_pack_id: "SG_PRIVATE_BANKING_REFERENCE",
+      policy_version: "2026.05",
+      evaluation_status: "PENDING_REVIEW",
+      approval_dependencies: ["COMPLIANCE_REVIEW:SG_STRUCTURED_NOTE"],
+      disclosure_requirements: ["advisor_reviewed_disclosure:SG_STRUCTURED_NOTE"],
+      source_gaps: ["client_consent:SG_STRUCTURED_NOTE"],
+    },
+  ],
+};
+const listProposalsMock = vi.fn(async (_filters?: unknown) => proposalListFixture);
+const getAdvisoryPolicyReviewQueueMock = vi.fn(
+  async (_status?: string) => policyReviewQueueFixture
+);
 
 vi.mock("../../src/features/proposals/api", () => ({
+  getAdvisoryPolicyReviewQueue: (status: string) => getAdvisoryPolicyReviewQueueMock(status),
   listProposals: (filters: unknown) => listProposalsMock(filters),
 }));
 
@@ -38,6 +58,15 @@ function renderWithQueryClient(ui: React.ReactElement) {
 }
 
 describe("ProposalLifecycleWorkspace", () => {
+  beforeEach(() => {
+    listProposalsMock.mockReset();
+    listProposalsMock.mockImplementation(async (_filters?: unknown) => proposalListFixture);
+    getAdvisoryPolicyReviewQueueMock.mockReset();
+    getAdvisoryPolicyReviewQueueMock.mockImplementation(
+      async (_status?: string) => policyReviewQueueFixture
+    );
+  });
+
   it("renders a focused risk and impact screen from proposal lifecycle data", async () => {
     renderWithQueryClient(
       <ProposalLifecycleWorkspace portfolioId="PB_SG_GLOBAL_BAL_001" mode="risk-impact" />
@@ -68,5 +97,36 @@ describe("ProposalLifecycleWorkspace", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Proposal lifecycle unavailable")).toBeInTheDocument();
     expect(screen.queryByText("Technology concentration trim")).not.toBeInTheDocument();
+  });
+
+  it("renders Gateway-backed suitability policy evaluations without raw policy payload language", async () => {
+    renderWithQueryClient(
+      <ProposalLifecycleWorkspace portfolioId="PB_SG_GLOBAL_BAL_001" mode="suitability" />
+    );
+
+    await waitFor(() => {
+      expect(getAdvisoryPolicyReviewQueueMock).toHaveBeenCalledWith("PENDING_REVIEW");
+    });
+
+    expect(await screen.findByRole("heading", { level: 3, name: "Policy evaluations needing review" })).toBeInTheDocument();
+    expect(screen.getByText("Review required")).toBeInTheDocument();
+    expect(screen.getByText("Sign-off pending")).toBeInTheDocument();
+    expect(screen.getByText("1 approval dependency, 1 disclosure review")).toBeInTheDocument();
+    expect(screen.getByText("Complete required approval review.")).toBeInTheDocument();
+    expect(screen.queryByText("PENDING_REVIEW")).not.toBeInTheDocument();
+    expect(screen.queryByText("advisor_reviewed_disclosure:SG_STRUCTURED_NOTE")).not.toBeInTheDocument();
+    expect(screen.queryByText("advisory-policy-evaluations")).not.toBeInTheDocument();
+  });
+
+  it("does not show fallback policy evaluations when the suitability queue is unavailable", async () => {
+    getAdvisoryPolicyReviewQueueMock.mockRejectedValueOnce(new Error("gateway unavailable"));
+
+    renderWithQueryClient(
+      <ProposalLifecycleWorkspace portfolioId="PB_SG_GLOBAL_BAL_001" mode="suitability" />
+    );
+
+    expect(await screen.findByText("Policy review queue is unavailable. No fallback suitability policy queue is shown.")).toBeInTheDocument();
+    expect(screen.getByText("Policy review queue unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("Review required")).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/proposal-policy-review-view-model.test.ts
+++ b/tests/unit/proposal-policy-review-view-model.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPolicyReviewQueueModel } from "../../src/features/proposals/proposal-policy-review-view-model";
+
+describe("proposal policy review view model", () => {
+  it("turns policy evaluation records into advisor-facing suitability review rows", () => {
+    const model = buildPolicyReviewQueueModel({
+      records: [
+        {
+          evaluation_id: "pev_001",
+          proposal_id: "PRP-SUITABILITY",
+          proposal_version_id: "ppv_001",
+          policy_pack_id: "SG_PRIVATE_BANKING_REFERENCE",
+          policy_version: "2026.05",
+          evaluation_status: "PENDING_REVIEW",
+          approval_dependencies: ["COMPLIANCE_REVIEW:SG_STRUCTURED_NOTE"],
+          disclosure_requirements: ["advisor_reviewed_disclosure:SG_STRUCTURED_NOTE"],
+          consent_requirements: [],
+          source_gaps: ["client_consent:SG_STRUCTURED_NOTE"],
+        },
+      ],
+    });
+
+    expect(model.totalCount).toBe(1);
+    expect(model.actionCount).toBe(1);
+    expect(model.rows[0]).toMatchObject({
+      evaluationId: "pev_001",
+      proposalId: "PRP-SUITABILITY",
+      proposalVersion: "ppv_001",
+      policyPack: "SG Private Banking Reference / 2026.05",
+      policyStatus: "Review required",
+      signOffStatus: "Sign-off pending",
+      openRequirements: "1 approval dependency, 1 disclosure review",
+      evidencePosture: "1 evidence gap",
+      nextAction: "Complete required approval review.",
+      href: "/proposals/PRP-SUITABILITY",
+    });
+    expect(JSON.stringify(model)).not.toContain("PENDING_REVIEW");
+    expect(JSON.stringify(model)).not.toContain("advisor_reviewed_disclosure");
+  });
+
+  it("keeps ready evaluations distinct from blocked reviews", () => {
+    const model = buildPolicyReviewQueueModel({
+      records: [
+        {
+          evaluation_id: "pev_ready",
+          proposal_id: "PRP-READY",
+          proposal_version_id: "ppv_ready",
+          policy_pack_id: "GLOBAL_PRIVATE_BANKING_BASELINE",
+          policy_version: "2026.05",
+          evaluation_status: "READY",
+          sign_off_events_json: [{ event_type: "POLICY_EVALUATION_SIGN_OFF_RECORDED" }],
+        },
+        {
+          evaluation_id: "pev_blocked",
+          proposal_id: "PRP-BLOCKED",
+          proposal_version_id: "ppv_blocked",
+          policy_pack_id: "GLOBAL_PRIVATE_BANKING_BASELINE",
+          policy_version: "2026.05",
+          evaluation_status: "BLOCKED",
+          source_gaps: ["missing_mandate_evidence"],
+        },
+      ],
+    });
+
+    expect(model.actionCount).toBe(1);
+    expect(model.rows[0].policyStatus).toBe("Ready");
+    expect(model.rows[0].signOffStatus).toBe("Sign-off recorded");
+    expect(model.rows[1].policyStatus).toBe("Blocked");
+    expect(model.rows[1].nextAction).toBe("Resolve blocking policy evidence before advisor sign-off.");
+  });
+});

--- a/tests/unit/proposals-api.test.ts
+++ b/tests/unit/proposals-api.test.ts
@@ -12,6 +12,7 @@ import {
   createProposalReportRequest,
   createProposalMemo,
   getAdvisoryWorkspaceSavedVersionReplayEvidence,
+  getAdvisoryPolicyReviewQueue,
   getProposalExecutionStatus,
   getProposalIdempotencyRecord,
   getProposalDeliveryEvents,
@@ -186,6 +187,33 @@ describe("proposal api", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       `${expectedBaseUrl}/proposals?portfolio_id=pf_1&state=DRAFT&created_by=advisor_1`
     );
+  });
+
+  it("loads the Gateway-backed advisory policy review queue", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            correlation_id: "c",
+            contract_version: "v1",
+            data: { items: [{ evaluation_id: "pev_1" }], queue_posture: {} },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+    );
+
+    const result = await getAdvisoryPolicyReviewQueue("PENDING_REVIEW");
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/advisory-policy-evaluations/review-queue?evaluation_status=PENDING_REVIEW`
+    );
+    expect(result.items?.[0]?.evaluation_id).toBe("pev_1");
   });
 
   it("calls proposal version endpoints", async () => {

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -12,6 +12,7 @@ It is intended for developers, business users, operations, sales/pre-sales, and 
 | Performance and risk review | `/performance` route modes | Gateway performance/risk APIs | Supported with bounded observability and canonical proof. |
 | Data-product discovery | `/data-products` | Gateway domain-product APIs | Supported for catalog, dependencies, and live trust posture. |
 | Advisor proposal narrative posture | `/proposals`, `/proposals/{proposalId}` | Gateway `/api/v1/proposals*` | Implemented for advisor proposal queue/detail, advisor-use narrative review, reviewed narrative report-package request, delivery-summary posture, delivery-event posture, and governed canonical proof through Gateway only. Canonical validation creates a seeded advisor-review narrative proposal, exercises the panel, and captures `proposal-narrative-posture-live.png`. The shell `Proposal` app entry remains disabled until broader product promotion is separately proven. |
+| Advisor suitability policy review queue | `/proposals?mode=suitability` | Gateway `/api/v1/advisory-policy-evaluations/review-queue` | Implemented for read-only review of Advise-owned suitability policy evaluations that need advisor, compliance, or supervisory attention. Workbench renders advisor-facing policy status, sign-off posture, open approval/disclosure/consent requirements, source-evidence completeness, and next action through Gateway only. Workbench does not calculate suitability, approve/waive policy findings, publish client-ready material, or call `lotus-advise` directly. |
 | DPM mandate command center | `/workbench/{portfolioId}`, `/workbench/{portfolioId}?mode=mandate` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit, PM-book-backed monitoring action, active exception queue, and governed exception-summary request through Gateway/Manage/lotus-ai. Workbench preserves Manage supportability posture: populated canonical `READY` is demo-ready, `PARTIAL`/`DEGRADED`/`BLOCKED` render as explicit partial states, and `EMPTY` stays an empty state rather than a false ready cockpit. |
 | DPM rebalance-wave command center | `/workbench/{portfolioId}?mode=waves` | Gateway `/api/v1/dpm/command-center/waves*` | Implemented for wave queue, preview, create, detail, items, source-check, simulation, approval, staging, handoff, proof posture, supportability, report-input, governed AI PM memo, governed operations-handoff summary, active Manage-owned campaign-definition list rendering, selected-campaign candidate-source review, read-only campaign lifecycle evidence, append-only launch history, preview-readiness review, launch-package readiness, and READY-gated campaign launch through Gateway only. |
 | DPM construction alternatives | `/workbench/{portfolioId}?mode=construction` | Gateway `/api/v1/dpm/command-center/construction/alternative-sets*` | Implemented for generation, comparison, and PM selection through Gateway only. Canonical panel proof is governed as `dpm.construction_alternatives` and does not claim Workbench-local construction methodology, order routing, trade execution, or OMS truth. |
@@ -27,6 +28,30 @@ It is intended for developers, business users, operations, sales/pre-sales, and 
 
 The RFC-0023 proposal detail panel gives advisors and supervisors a bounded way to review
 advisor-use narrative posture before downstream report packaging.
+
+## Advisor Suitability Policy Review Queue
+
+The RFC-0025 Suitability Review surface gives advisors and supervisors a read-only queue of
+source-owned policy evaluations that need review before client discussion.
+
+Implemented:
+
+1. loads the policy review queue through the Workbench BFF and Gateway only,
+2. requests the source review posture for evaluations requiring review,
+3. renders proposal identity, proposal version, policy pack/version, policy status, sign-off
+   posture, open approval/disclosure/consent requirements, source-evidence completeness, and
+   advisor next action,
+4. translates source statuses and requirement arrays into private-banking workflow language,
+5. shows explicit unavailable and empty states without fallback policy rows.
+
+Not supported in Workbench:
+
+1. local suitability calculation,
+2. policy approval, waiver, or sign-off mutation,
+3. client-ready publication,
+4. direct calls to `lotus-advise`,
+5. local interpretation of policy rule hashes, source refs, or technical payload fields as
+   advisor decisions.
 
 Implemented:
 

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -64,6 +64,10 @@
   Simulation, Suitability Review, Risk and Impact, Approval Queue, Client Discussion Pack, and
   Implementation Status. This is route evidence over existing Gateway-backed screens, not a new
   client-ready, communication, execution, or backend capability claim.
+- RFC-0025 Suitability Review policy-queue proof must use the Gateway-backed advisory policy
+  review queue and verify that Workbench renders source-owned policy posture in advisor language
+  without claiming local suitability calculation, policy approval, waiver authority, or
+  client-ready publication.
 - observability evidence capture writes local non-functional proof packs under
   `output/observability-live/<timestamp>/`
 - final visual review should use canonical validated captures, not pre-validation diagnostics


### PR DESCRIPTION
## Summary
- Adds a Gateway-backed advisory policy review queue to the Suitability Review screen.
- Maps Advise-owned policy evaluation posture into advisor-facing status, sign-off, evidence, and next-action language.
- Updates Workbench supported-feature/wiki/context documentation for the read-only support boundary.

## Validation
- npm test -- tests/unit/proposals-api.test.ts tests/unit/proposal-policy-review-view-model.test.ts tests/integration/proposal-lifecycle-workspace.test.tsx
- npm run typecheck
- npm run lint
- make check

## Wiki
- Updated repo-authored wiki source for Supported Features and Validation/CI.
- Pre-merge check-only drift is expected against the published wiki until this PR merges and the wiki is published.