### PR TITLE
RFC-0025: Add suitability policy evidence detail

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -278,11 +278,12 @@ Important validation expectations:
     posture, and latest delivery event, without presenting report rendering, archive publication,
     client messaging, or client-ready release as Workbench-owned capabilities.
 18. Advisor suitability policy review queue reads are Workbench gateway-only operations backed by
-    Gateway advisory-policy evaluation contracts. Workbench may display Advise-owned evaluation
-    posture, sign-off posture, open approval/disclosure/consent requirements, source-evidence
-    completeness, and advisor next action, but it must not calculate suitability locally, mutate
-    policy sign-off, approve waivers, infer client-ready release, or expose raw policy payload
-    field names on advisor-facing screens.
+    Gateway advisory-policy evaluation contracts. Workbench may display Advise-owned review
+    queue posture, selected evaluation detail, sign-off source-package posture,
+    client-publication block posture, open approval/disclosure/consent requirements,
+    source-evidence completeness, and advisor next action, but it must not calculate
+    suitability locally, mutate policy sign-off, approve waivers, infer client-ready release,
+    or expose raw policy payload field names on advisor-facing screens.
 
 ### Visual Review Gate
 

--- a/src/features/proposals/api.ts
+++ b/src/features/proposals/api.ts
@@ -1,6 +1,8 @@
 import {
   AdvisoryPolicyEnvelopeResponse,
+  AdvisoryPolicyEvaluationData,
   AdvisoryPolicyReviewQueueData,
+  AdvisoryPolicySignOffPackageData,
   ProposalApprovalActionRequest,
   ProposalApprovalsData,
   AdvisoryWorkspaceBodyRequest,
@@ -233,6 +235,36 @@ export async function getAdvisoryPolicyReviewQueue(
   }
   const envelope = (await response.json()) as AdvisoryPolicyEnvelopeResponse;
   return envelope.data as unknown as AdvisoryPolicyReviewQueueData;
+}
+
+export async function getAdvisoryPolicyEvaluation(
+  evaluationId: string
+): Promise<AdvisoryPolicyEvaluationData> {
+  const response = await fetch(
+    `${BFF_PROXY_BASE}/advisory-policy-evaluations/${encodeURIComponent(evaluationId)}`
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Advisory policy evaluation failed (${response.status}): ${body}`);
+  }
+  const envelope = (await response.json()) as AdvisoryPolicyEnvelopeResponse;
+  return envelope.data as unknown as AdvisoryPolicyEvaluationData;
+}
+
+export async function getAdvisoryPolicySignOffPackage(
+  evaluationId: string
+): Promise<AdvisoryPolicySignOffPackageData> {
+  const response = await fetch(
+    `${BFF_PROXY_BASE}/advisory-policy-evaluations/${encodeURIComponent(
+      evaluationId
+    )}/sign-off-package`
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Advisory policy sign-off package failed (${response.status}): ${body}`);
+  }
+  const envelope = (await response.json()) as AdvisoryPolicyEnvelopeResponse;
+  return envelope.data as unknown as AdvisoryPolicySignOffPackageData;
 }
 
 export async function getProposal(

--- a/src/features/proposals/components/proposal-lifecycle-workspace.module.css
+++ b/src/features/proposals/components/proposal-lifecycle-workspace.module.css
@@ -64,6 +64,48 @@
   text-transform: uppercase;
 }
 
+.policyEvidencePanel {
+  border-top: 1px solid var(--border);
+  margin-top: 14px;
+  padding-top: 14px;
+}
+
+.policyEvidencePanel h4 {
+  margin: 4px 0 0;
+}
+
+.policyEvidenceGrid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(6, minmax(120px, 1fr));
+  margin-top: 12px;
+}
+
+.policyEvidenceMetric,
+.policyEvidenceList {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-alt);
+  padding: 10px 12px;
+}
+
+.policyEvidenceColumns {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, minmax(180px, 1fr));
+  margin-top: 8px;
+}
+
+.policyEvidenceList ul {
+  color: var(--text);
+  margin: 6px 0 0;
+  padding-left: 18px;
+}
+
+.policyEvidenceList li {
+  margin: 3px 0;
+}
+
 .countStrip {
   display: grid;
   grid-template-columns: repeat(2, minmax(96px, 1fr));
@@ -181,6 +223,11 @@
 
   .countStrip {
     width: 100%;
+  }
+
+  .policyEvidenceGrid,
+  .policyEvidenceColumns {
+    grid-template-columns: 1fr;
   }
 
   .countStrip div {

--- a/src/features/proposals/components/proposal-lifecycle-workspace.tsx
+++ b/src/features/proposals/components/proposal-lifecycle-workspace.tsx
@@ -1,19 +1,27 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Alert, CircularProgress, Stack } from "@mui/material";
 
 import { ScreenStatePanel, SectionBlock, SemanticBadge, Text } from "@/design-system";
 import { workbenchStrictQueryDefaults } from "@/features/platform-runtime/query-policy";
 
-import { getAdvisoryPolicyReviewQueue, listProposals } from "../api";
+import {
+  getAdvisoryPolicyEvaluation,
+  getAdvisoryPolicyReviewQueue,
+  getAdvisoryPolicySignOffPackage,
+  listProposals,
+} from "../api";
 import {
   buildProposalLifecycleWorkspaceModel,
   type ProposalLifecycleMode,
 } from "../proposal-lifecycle-workspace-view-model";
-import { buildPolicyReviewQueueModel } from "../proposal-policy-review-view-model";
+import {
+  buildPolicyEvaluationEvidenceModel,
+  buildPolicyReviewQueueModel,
+} from "../proposal-policy-review-view-model";
 import styles from "./proposal-lifecycle-workspace.module.css";
 
 export default function ProposalLifecycleWorkspace({
@@ -43,6 +51,27 @@ export default function ProposalLifecycleWorkspace({
   const policyReviewModel = useMemo(
     () => buildPolicyReviewQueueModel({ records: policyQueueQuery.data?.items ?? [] }),
     [policyQueueQuery.data?.items]
+  );
+  const selectedPolicyEvaluationId = policyReviewModel.rows[0]?.evaluationId;
+  const policyEvaluationQuery = useQuery({
+    queryKey: ["advisory-policy-evaluation", selectedPolicyEvaluationId],
+    queryFn: async () => await getAdvisoryPolicyEvaluation(selectedPolicyEvaluationId),
+    enabled: mode === "suitability" && Boolean(selectedPolicyEvaluationId),
+    ...workbenchStrictQueryDefaults,
+  });
+  const policySignOffPackageQuery = useQuery({
+    queryKey: ["advisory-policy-sign-off-package", selectedPolicyEvaluationId],
+    queryFn: async () => await getAdvisoryPolicySignOffPackage(selectedPolicyEvaluationId),
+    enabled: mode === "suitability" && Boolean(selectedPolicyEvaluationId),
+    ...workbenchStrictQueryDefaults,
+  });
+  const policyEvidenceModel = useMemo(
+    () =>
+      buildPolicyEvaluationEvidenceModel({
+        evaluation: policyEvaluationQuery.data,
+        signOffPackage: policySignOffPackageQuery.data,
+      }),
+    [policyEvaluationQuery.data, policySignOffPackageQuery.data]
   );
 
   if (isLoading) {
@@ -106,6 +135,9 @@ export default function ProposalLifecycleWorkspace({
           isLoading={policyQueueQuery.isLoading}
           hasError={Boolean(policyQueueQuery.error)}
           model={policyReviewModel}
+          evidenceModel={policyEvidenceModel}
+          evidenceLoading={policyEvaluationQuery.isLoading || policySignOffPackageQuery.isLoading}
+          evidenceError={Boolean(policyEvaluationQuery.error || policySignOffPackageQuery.error)}
         />
       ) : null}
 
@@ -175,11 +207,17 @@ function PolicyReviewQueueSection({
   isLoading,
   hasError,
   model,
+  evidenceModel,
+  evidenceLoading,
+  evidenceError,
 }: {
   portfolioId: string;
   isLoading: boolean;
   hasError: boolean;
   model: ReturnType<typeof buildPolicyReviewQueueModel>;
+  evidenceModel: ReturnType<typeof buildPolicyEvaluationEvidenceModel>;
+  evidenceLoading: boolean;
+  evidenceError: boolean;
 }) {
   if (isLoading) {
     return (
@@ -262,6 +300,102 @@ function PolicyReviewQueueSection({
           </tbody>
         </table>
       </div>
+      <PolicyEvaluationEvidenceSection
+        isLoading={evidenceLoading}
+        hasError={evidenceError}
+        model={evidenceModel}
+      />
+    </div>
+  );
+}
+
+function PolicyEvaluationEvidenceSection({
+  isLoading,
+  hasError,
+  model,
+}: {
+  isLoading: boolean;
+  hasError: boolean;
+  model: ReturnType<typeof buildPolicyEvaluationEvidenceModel>;
+}) {
+  if (isLoading) {
+    return (
+      <div className={styles.policyEvidencePanel}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <CircularProgress size={16} />
+          <Text variant="body">Loading policy evidence...</Text>
+        </Stack>
+      </div>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <ScreenStatePanel
+        kind="error"
+        title="Policy evidence unavailable"
+        body="Policy detail and sign-off package posture could not be loaded from the approved advisory workflow."
+        surface="default"
+      />
+    );
+  }
+
+  if (!model) {
+    return null;
+  }
+
+  return (
+    <div className={styles.policyEvidencePanel}>
+      <div>
+        <Text variant="microLabel">Selected Policy Evidence</Text>
+        <Text variant="subsectionTitle" as="h4">
+          Sign-off source package and source evidence
+        </Text>
+      </div>
+      <div className={styles.policyEvidenceGrid}>
+        <EvidenceMetric label="Policy status">
+          <SemanticBadge tone={model.policyStatusTone}>{model.policyStatus}</SemanticBadge>
+        </EvidenceMetric>
+        <EvidenceMetric label="Source evidence">{model.sourcePosture}</EvidenceMetric>
+        <EvidenceMetric label="Rule results">{model.ruleCount} reviewed</EvidenceMetric>
+        <EvidenceMetric label="Blocking rules">{model.blockingRuleCount} blocking</EvidenceMetric>
+        <EvidenceMetric label="Sign-off package">{model.signOffPackagePosture}</EvidenceMetric>
+        <EvidenceMetric label="Client publication">{model.clientPublicationPosture}</EvidenceMetric>
+      </div>
+      <div className={styles.policyEvidenceColumns}>
+        <EvidenceList title="Approval dependencies" values={model.approvalDependencies} />
+        <EvidenceList title="Disclosure reviews" values={model.disclosureRequirements} />
+        <EvidenceList title="Client consent evidence" values={model.consentRequirements} />
+        <EvidenceList title="Source references" values={model.sourceRefs} />
+        <EvidenceList title="Source gaps" values={model.sourceGaps} />
+        <EvidenceMetric label="Next action">{model.nextAction}</EvidenceMetric>
+      </div>
+    </div>
+  );
+}
+
+function EvidenceMetric({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className={styles.policyEvidenceMetric}>
+      <Text variant="microLabel">{label}</Text>
+      <Text variant="body">{children}</Text>
+    </div>
+  );
+}
+
+function EvidenceList({ title, values }: { title: string; values: string[] }) {
+  return (
+    <div className={styles.policyEvidenceList}>
+      <Text variant="microLabel">{title}</Text>
+      {values.length === 0 ? (
+        <Text variant="secondary">None reported</Text>
+      ) : (
+        <ul>
+          {values.map((value) => (
+            <li key={value}>{value}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/src/features/proposals/proposal-policy-review-view-model.ts
+++ b/src/features/proposals/proposal-policy-review-view-model.ts
@@ -1,6 +1,9 @@
 import type { SemanticBadgeTone } from "@/design-system";
 
-import type { AdvisoryPolicyEvaluationRecord } from "./types";
+import type {
+  AdvisoryPolicyEvaluationRecord,
+  AdvisoryPolicySignOffPackageData,
+} from "./types";
 
 export type PolicyReviewQueueRow = {
   evaluationId: string;
@@ -21,6 +24,24 @@ export type PolicyReviewQueueModel = {
   totalCount: number;
   actionCount: number;
   rows: PolicyReviewQueueRow[];
+};
+
+export type PolicyEvaluationEvidenceModel = {
+  evaluationId: string;
+  policyStatus: string;
+  policyStatusTone: SemanticBadgeTone;
+  sourcePosture: string;
+  sourceRefs: string[];
+  sourceGaps: string[];
+  ruleCount: number;
+  blockingRuleCount: number;
+  approvalDependencies: string[];
+  disclosureRequirements: string[];
+  consentRequirements: string[];
+  auditEventCount: number;
+  signOffPackagePosture: string;
+  clientPublicationPosture: string;
+  nextAction: string;
 };
 
 export function buildPolicyReviewQueueModel({
@@ -68,8 +89,70 @@ export function buildPolicyReviewQueueModel({
   };
 }
 
+export function buildPolicyEvaluationEvidenceModel({
+  evaluation,
+  signOffPackage,
+}: {
+  evaluation?: AdvisoryPolicyEvaluationRecord | null;
+  signOffPackage?: AdvisoryPolicySignOffPackageData | null;
+}): PolicyEvaluationEvidenceModel | null {
+  if (!evaluation) {
+    return null;
+  }
+
+  const sourceRefs = stringArray(evaluation.source_refs);
+  const sourceGaps = stringArray(evaluation.source_gaps);
+  const ruleResults = recordArray(recordValue(evaluation.evaluation_json)?.rule_results);
+  const packagePosture = recordValue(signOffPackage?.package_posture);
+  const lineage = recordValue(signOffPackage?.lineage);
+  const lineagePosture = recordValue(lineage?.lineage_posture);
+  const auditEvents = recordArray(lineage?.audit_events);
+  const approvalDependencies = stringArray(evaluation.approval_dependencies);
+  const disclosureRequirements = stringArray(evaluation.disclosure_requirements);
+  const consentRequirements = stringArray(evaluation.consent_requirements);
+
+  return {
+    evaluationId: stringValue(evaluation.evaluation_id, "Evaluation not reported"),
+    policyStatus: policyStatusLabel(evaluation.evaluation_status),
+    policyStatusTone: policyStatusTone(evaluation.evaluation_status),
+    sourcePosture: evidencePosture(sourceGaps),
+    sourceRefs: sourceRefs.map(friendlySourceRef).slice(0, 4),
+    sourceGaps: sourceGaps.map(friendlyRequirement).slice(0, 4),
+    ruleCount: ruleResults.length,
+    blockingRuleCount: ruleResults.filter((rule) => policyStatusTone(rule.status) === "danger").length,
+    approvalDependencies: approvalDependencies.map(friendlyRequirement).slice(0, 4),
+    disclosureRequirements: disclosureRequirements.map(friendlyRequirement).slice(0, 4),
+    consentRequirements: consentRequirements.map(friendlyRequirement).slice(0, 4),
+    auditEventCount: auditEvents.length,
+    signOffPackagePosture: signOffPackagePosture(packagePosture),
+    clientPublicationPosture: clientPublicationPosture(packagePosture, lineagePosture),
+    nextAction: nextAction({
+      policyStatus: evaluation.evaluation_status,
+      approvalDependencies,
+      disclosureRequirements,
+      consentRequirements,
+    }),
+  };
+}
+
 function stringValue(value: unknown, fallback: string): string {
   return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function recordArray(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (item): item is Record<string, unknown> =>
+      Boolean(item) && typeof item === "object" && !Array.isArray(item)
+  );
 }
 
 function stringArray(value: unknown): string[] {
@@ -192,6 +275,32 @@ function evidencePosture(sourceGaps: string[]): string {
   return `${sourceGaps.length} evidence ${sourceGaps.length === 1 ? "gap" : "gaps"}`;
 }
 
+function signOffPackagePosture(posture: Record<string, unknown> | null): string {
+  const sourcePackage = stringValue(posture?.sign_off_source_package, "");
+  if (sourcePackage.includes("SUPPORTED")) {
+    return "Source package available";
+  }
+  return "Source package posture not reported";
+}
+
+function clientPublicationPosture(
+  packagePosture: Record<string, unknown> | null,
+  lineagePosture: Record<string, unknown> | null
+): string {
+  const value =
+    stringValue(packagePosture?.client_ready_publication, "") ||
+    stringValue(lineagePosture?.client_ready_publication, "");
+  return value === "BLOCKED" ? "Client publication blocked" : "Client publication not supported";
+}
+
+function friendlySourceRef(value: string): string {
+  return friendlyPhrase(value.replace(/^lotus-[^:]+:/, "").replace(/^lotus-/, ""));
+}
+
+function friendlyRequirement(value: string): string {
+  return friendlyPhrase(value.replace(/^[^:]+:/, ""));
+}
+
 function friendlyPhrase(value: string): string {
   if (!value || value === "Policy pack not reported") {
     return value;
@@ -200,7 +309,9 @@ function friendlyPhrase(value: string): string {
     .split(/[_:\s-]+/)
     .filter(Boolean)
     .map((part) =>
-      part.length <= 3 ? part.toUpperCase() : part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
+      part.length <= 3
+        ? part.toUpperCase()
+        : part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()
     )
     .join(" ");
 }

--- a/src/features/proposals/types.ts
+++ b/src/features/proposals/types.ts
@@ -130,6 +130,22 @@ export type AdvisoryPolicyReviewQueueData = {
   [key: string]: unknown;
 };
 
+export type AdvisoryPolicyEvaluationData = AdvisoryPolicyEvaluationRecord;
+
+export type AdvisoryPolicySignOffPackageData = {
+  evaluation?: AdvisoryPolicyEvaluationRecord;
+  lineage?: {
+    evaluation_id?: string;
+    source_refs?: string[];
+    source_gaps?: string[];
+    audit_events?: Array<Record<string, unknown>>;
+    lineage_posture?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  package_posture?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
 export type ProposalSummary = {
   proposal_id: string;
   portfolio_id?: string;

--- a/tests/integration/proposal-lifecycle-workspace.test.tsx
+++ b/tests/integration/proposal-lifecycle-workspace.test.tsx
@@ -40,9 +40,33 @@ const listProposalsMock = vi.fn(async (_filters?: unknown) => proposalListFixtur
 const getAdvisoryPolicyReviewQueueMock = vi.fn(
   async (_status?: string) => policyReviewQueueFixture
 );
+const getAdvisoryPolicyEvaluationMock = vi.fn(async (_evaluationId: string) => ({
+  ...policyReviewQueueFixture.items[0],
+  source_refs: ["lotus-core:core_product_eligibility_target_market_complexity"],
+  evaluation_json: {
+    rule_results: [
+      { rule_id: "SG_COMPLEX_PRODUCT_DISCLOSURE_REVIEW", status: "PENDING_REVIEW" },
+      { rule_id: "MANDATE_ALIGNMENT", status: "READY" },
+    ],
+  },
+}));
+const getAdvisoryPolicySignOffPackageMock = vi.fn(async (_evaluationId: string) => ({
+  package_posture: {
+    sign_off_source_package: "SUPPORTED_BY_RFC0025_SLICE8_ADVISE_API",
+    client_ready_publication: "BLOCKED",
+  },
+  lineage: {
+    audit_events: [{ event_type: "POLICY_EVALUATION_FINALIZED" }],
+    lineage_posture: { client_ready_publication: "BLOCKED" },
+  },
+}));
 
 vi.mock("../../src/features/proposals/api", () => ({
+  getAdvisoryPolicyEvaluation: (evaluationId: string) =>
+    getAdvisoryPolicyEvaluationMock(evaluationId),
   getAdvisoryPolicyReviewQueue: (status: string) => getAdvisoryPolicyReviewQueueMock(status),
+  getAdvisoryPolicySignOffPackage: (evaluationId: string) =>
+    getAdvisoryPolicySignOffPackageMock(evaluationId),
   listProposals: (filters: unknown) => listProposalsMock(filters),
 }));
 
@@ -65,6 +89,28 @@ describe("ProposalLifecycleWorkspace", () => {
     getAdvisoryPolicyReviewQueueMock.mockImplementation(
       async (_status?: string) => policyReviewQueueFixture
     );
+    getAdvisoryPolicyEvaluationMock.mockReset();
+    getAdvisoryPolicyEvaluationMock.mockImplementation(async (_evaluationId: string) => ({
+      ...policyReviewQueueFixture.items[0],
+      source_refs: ["lotus-core:core_product_eligibility_target_market_complexity"],
+      evaluation_json: {
+        rule_results: [
+          { rule_id: "SG_COMPLEX_PRODUCT_DISCLOSURE_REVIEW", status: "PENDING_REVIEW" },
+          { rule_id: "MANDATE_ALIGNMENT", status: "READY" },
+        ],
+      },
+    }));
+    getAdvisoryPolicySignOffPackageMock.mockReset();
+    getAdvisoryPolicySignOffPackageMock.mockImplementation(async (_evaluationId: string) => ({
+      package_posture: {
+        sign_off_source_package: "SUPPORTED_BY_RFC0025_SLICE8_ADVISE_API",
+        client_ready_publication: "BLOCKED",
+      },
+      lineage: {
+        audit_events: [{ event_type: "POLICY_EVALUATION_FINALIZED" }],
+        lineage_posture: { client_ready_publication: "BLOCKED" },
+      },
+    }));
   });
 
   it("renders a focused risk and impact screen from proposal lifecycle data", async () => {
@@ -106,16 +152,22 @@ describe("ProposalLifecycleWorkspace", () => {
 
     await waitFor(() => {
       expect(getAdvisoryPolicyReviewQueueMock).toHaveBeenCalledWith("PENDING_REVIEW");
+      expect(getAdvisoryPolicyEvaluationMock).toHaveBeenCalledWith("pev_001");
+      expect(getAdvisoryPolicySignOffPackageMock).toHaveBeenCalledWith("pev_001");
     });
 
     expect(await screen.findByRole("heading", { level: 3, name: "Policy evaluations needing review" })).toBeInTheDocument();
-    expect(screen.getByText("Review required")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 4, name: "Sign-off source package and source evidence" })).toBeInTheDocument();
+    expect(screen.getAllByText("Review required")).toHaveLength(2);
     expect(screen.getByText("Sign-off pending")).toBeInTheDocument();
     expect(screen.getByText("1 approval dependency, 1 disclosure review")).toBeInTheDocument();
-    expect(screen.getByText("Complete required approval review.")).toBeInTheDocument();
+    expect(screen.getAllByText("Complete required approval review.")).toHaveLength(2);
+    expect(screen.getByText("Source package available")).toBeInTheDocument();
+    expect(screen.getByText("Client publication blocked")).toBeInTheDocument();
     expect(screen.queryByText("PENDING_REVIEW")).not.toBeInTheDocument();
     expect(screen.queryByText("advisor_reviewed_disclosure:SG_STRUCTURED_NOTE")).not.toBeInTheDocument();
     expect(screen.queryByText("advisory-policy-evaluations")).not.toBeInTheDocument();
+    expect(screen.queryByText("SUPPORTED_BY_RFC0025_SLICE8_ADVISE_API")).not.toBeInTheDocument();
   });
 
   it("does not show fallback policy evaluations when the suitability queue is unavailable", async () => {

--- a/tests/unit/proposal-policy-review-view-model.test.ts
+++ b/tests/unit/proposal-policy-review-view-model.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildPolicyReviewQueueModel } from "../../src/features/proposals/proposal-policy-review-view-model";
+import {
+  buildPolicyEvaluationEvidenceModel,
+  buildPolicyReviewQueueModel,
+} from "../../src/features/proposals/proposal-policy-review-view-model";
 
 describe("proposal policy review view model", () => {
   it("turns policy evaluation records into advisor-facing suitability review rows", () => {
@@ -68,5 +71,52 @@ describe("proposal policy review view model", () => {
     expect(model.rows[0].signOffStatus).toBe("Sign-off recorded");
     expect(model.rows[1].policyStatus).toBe("Blocked");
     expect(model.rows[1].nextAction).toBe("Resolve blocking policy evidence before advisor sign-off.");
+  });
+
+  it("builds selected policy evidence without exposing source payload names", () => {
+    const model = buildPolicyEvaluationEvidenceModel({
+      evaluation: {
+        evaluation_id: "pev_001",
+        evaluation_status: "PENDING_REVIEW",
+        source_refs: ["lotus-core:core_product_eligibility_target_market_complexity"],
+        source_gaps: ["client_consent:SG_STRUCTURED_NOTE"],
+        approval_dependencies: ["COMPLIANCE_REVIEW:SG_STRUCTURED_NOTE"],
+        disclosure_requirements: ["advisor_reviewed_disclosure:SG_STRUCTURED_NOTE"],
+        consent_requirements: ["client_consent:SG_STRUCTURED_NOTE"],
+        evaluation_json: {
+          rule_results: [
+            { rule_id: "SG_COMPLEX_PRODUCT_DISCLOSURE_REVIEW", status: "PENDING_REVIEW" },
+            { rule_id: "MANDATE_ALIGNMENT", status: "READY" },
+          ],
+        },
+      },
+      signOffPackage: {
+        package_posture: {
+          sign_off_source_package: "SUPPORTED_BY_RFC0025_SLICE8_ADVISE_API",
+          client_ready_publication: "BLOCKED",
+        },
+        lineage: {
+          audit_events: [{ event_type: "POLICY_EVALUATION_FINALIZED" }],
+          lineage_posture: { client_ready_publication: "BLOCKED" },
+        },
+      },
+    });
+
+    expect(model).toMatchObject({
+      evaluationId: "pev_001",
+      policyStatus: "Review required",
+      sourcePosture: "1 evidence gap",
+      ruleCount: 2,
+      blockingRuleCount: 0,
+      signOffPackagePosture: "Source package available",
+      clientPublicationPosture: "Client publication blocked",
+      approvalDependencies: ["SG Structured Note"],
+      disclosureRequirements: ["SG Structured Note"],
+      consentRequirements: ["SG Structured Note"],
+      sourceRefs: ["Core Product Eligibility Target Market Complexity"],
+      sourceGaps: ["SG Structured Note"],
+    });
+    expect(JSON.stringify(model)).not.toContain("client_consent");
+    expect(JSON.stringify(model)).not.toContain("SUPPORTED_BY_RFC0025");
   });
 });

--- a/tests/unit/proposals-api.test.ts
+++ b/tests/unit/proposals-api.test.ts
@@ -12,7 +12,9 @@ import {
   createProposalReportRequest,
   createProposalMemo,
   getAdvisoryWorkspaceSavedVersionReplayEvidence,
+  getAdvisoryPolicyEvaluation,
   getAdvisoryPolicyReviewQueue,
+  getAdvisoryPolicySignOffPackage,
   getProposalExecutionStatus,
   getProposalIdempotencyRecord,
   getProposalDeliveryEvents,
@@ -214,6 +216,46 @@ describe("proposal api", () => {
       `${expectedBaseUrl}/advisory-policy-evaluations/review-queue?evaluation_status=PENDING_REVIEW`
     );
     expect(result.items?.[0]?.evaluation_id).toBe("pev_1");
+  });
+
+  it("loads Gateway-backed advisory policy detail and sign-off package", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        const data = url.endsWith("/sign-off-package")
+          ? {
+              package_posture: {
+                sign_off_source_package: "SUPPORTED_BY_RFC0025_SLICE8_ADVISE_API",
+              },
+            }
+          : { evaluation_id: "pev_1", evaluation_status: "PENDING_REVIEW" };
+        return new Response(
+          JSON.stringify({
+            correlation_id: "c",
+            contract_version: "v1",
+            data,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        );
+      })
+    );
+
+    const evaluation = await getAdvisoryPolicyEvaluation("pev_1");
+    const signOffPackage = await getAdvisoryPolicySignOffPackage("pev_1");
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/advisory-policy-evaluations/pev_1`
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/advisory-policy-evaluations/pev_1/sign-off-package`
+    );
+    expect(evaluation.evaluation_id).toBe("pev_1");
+    expect(signOffPackage.package_posture?.sign_off_source_package).toContain("SUPPORTED");
   });
 
   it("calls proposal version endpoints", async () => {

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -12,7 +12,7 @@ It is intended for developers, business users, operations, sales/pre-sales, and 
 | Performance and risk review | `/performance` route modes | Gateway performance/risk APIs | Supported with bounded observability and canonical proof. |
 | Data-product discovery | `/data-products` | Gateway domain-product APIs | Supported for catalog, dependencies, and live trust posture. |
 | Advisor proposal narrative posture | `/proposals`, `/proposals/{proposalId}` | Gateway `/api/v1/proposals*` | Implemented for advisor proposal queue/detail, advisor-use narrative review, reviewed narrative report-package request, delivery-summary posture, delivery-event posture, and governed canonical proof through Gateway only. Canonical validation creates a seeded advisor-review narrative proposal, exercises the panel, and captures `proposal-narrative-posture-live.png`. The shell `Proposal` app entry remains disabled until broader product promotion is separately proven. |
-| Advisor suitability policy review queue | `/proposals?mode=suitability` | Gateway `/api/v1/advisory-policy-evaluations/review-queue` | Implemented for read-only review of Advise-owned suitability policy evaluations that need advisor, compliance, or supervisory attention. Workbench renders advisor-facing policy status, sign-off posture, open approval/disclosure/consent requirements, source-evidence completeness, and next action through Gateway only. Workbench does not calculate suitability, approve/waive policy findings, publish client-ready material, or call `lotus-advise` directly. |
+| Advisor suitability policy review queue | `/proposals?mode=suitability` | Gateway `/api/v1/advisory-policy-evaluations/review-queue`, `/api/v1/advisory-policy-evaluations/{evaluation_id}`, and `/api/v1/advisory-policy-evaluations/{evaluation_id}/sign-off-package` | Implemented for read-only review of Advise-owned suitability policy evaluations that need advisor, compliance, or supervisory attention. Workbench renders advisor-facing policy status, sign-off posture, selected evaluation evidence, sign-off source-package posture, client-publication block posture, open approval/disclosure/consent requirements, source-evidence completeness, and next action through Gateway only. Workbench does not calculate suitability, approve/waive policy findings, publish client-ready material, or call `lotus-advise` directly. |
 | DPM mandate command center | `/workbench/{portfolioId}`, `/workbench/{portfolioId}?mode=mandate` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit, PM-book-backed monitoring action, active exception queue, and governed exception-summary request through Gateway/Manage/lotus-ai. Workbench preserves Manage supportability posture: populated canonical `READY` is demo-ready, `PARTIAL`/`DEGRADED`/`BLOCKED` render as explicit partial states, and `EMPTY` stays an empty state rather than a false ready cockpit. |
 | DPM rebalance-wave command center | `/workbench/{portfolioId}?mode=waves` | Gateway `/api/v1/dpm/command-center/waves*` | Implemented for wave queue, preview, create, detail, items, source-check, simulation, approval, staging, handoff, proof posture, supportability, report-input, governed AI PM memo, governed operations-handoff summary, active Manage-owned campaign-definition list rendering, selected-campaign candidate-source review, read-only campaign lifecycle evidence, append-only launch history, preview-readiness review, launch-package readiness, and READY-gated campaign launch through Gateway only. |
 | DPM construction alternatives | `/workbench/{portfolioId}?mode=construction` | Gateway `/api/v1/dpm/command-center/construction/alternative-sets*` | Implemented for generation, comparison, and PM selection through Gateway only. Canonical panel proof is governed as `dpm.construction_alternatives` and does not claim Workbench-local construction methodology, order routing, trade execution, or OMS truth. |
@@ -39,10 +39,13 @@ Implemented:
 1. loads the policy review queue through the Workbench BFF and Gateway only,
 2. requests the source review posture for evaluations requiring review,
 3. renders proposal identity, proposal version, policy pack/version, policy status, sign-off
-   posture, open approval/disclosure/consent requirements, source-evidence completeness, and
-   advisor next action,
+   posture, selected evaluation evidence, sign-off source-package posture, client-publication
+   block posture, open approval/disclosure/consent requirements, source-evidence completeness,
+   and advisor next action,
 4. translates source statuses and requirement arrays into private-banking workflow language,
-5. shows explicit unavailable and empty states without fallback policy rows.
+5. shows explicit unavailable and empty states without fallback policy rows,
+6. keeps source refs, source gaps, and sign-off package evidence in private-banking language
+   without exposing endpoint names, RFC posture constants, or raw source payload fields.
 
 Not supported in Workbench:
 


### PR DESCRIPTION
## Summary
- add Gateway-backed selected advisory policy evaluation and sign-off package reads
- render selected Suitability Review evidence in private-banking language without raw policy payload leakage
- update Workbench supported-feature wiki source and repository context for the read-only policy evidence boundary

## Validation
- npm test -- tests/unit/proposals-api.test.ts tests/unit/proposal-policy-review-view-model.test.ts tests/integration/proposal-lifecycle-workspace.test.tsx
- make lint
- make typecheck
- make check
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench reports expected drift for wiki/Supported-Features.md until post-merge publication