### PR TITLE
Add RFC-0025 policy workflow evidence request

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -277,13 +277,15 @@ Important validation expectations:
     explicit about advisor-use review, reviewed narrative package inclusion, report delivery
     posture, and latest delivery event, without presenting report rendering, archive publication,
     client messaging, or client-ready release as Workbench-owned capabilities.
-18. Advisor suitability policy review queue reads are Workbench gateway-only operations backed by
-    Gateway advisory-policy evaluation contracts. Workbench may display Advise-owned review
-    queue posture, selected evaluation detail, sign-off source-package posture,
-    client-publication block posture, open approval/disclosure/consent requirements,
-    source-evidence completeness, and advisor next action, but it must not calculate
-    suitability locally, mutate policy sign-off, approve waivers, infer client-ready release,
-    or expose raw policy payload field names on advisor-facing screens.
+18. Advisor suitability policy review queue reads and bounded evidence-review requests are
+    Workbench gateway-only operations backed by Gateway advisory-policy evaluation contracts.
+    Workbench may display Advise-owned review queue posture, selected evaluation detail,
+    sign-off source-package posture, policy workflow posture, client-publication block posture,
+    open approval/disclosure/consent requirements, source-evidence completeness, and advisor next
+    action. Workbench may record a request for more evidence against the source evaluation hash,
+    but it must not calculate suitability locally, approve or waive policy findings, record
+    policy sign-off approval, infer client-ready release, or expose raw policy payload field names
+    on advisor-facing screens.
 
 ### Visual Review Gate
 

--- a/src/features/proposals/api.ts
+++ b/src/features/proposals/api.ts
@@ -2,7 +2,10 @@ import {
   AdvisoryPolicyEnvelopeResponse,
   AdvisoryPolicyEvaluationData,
   AdvisoryPolicyReviewQueueData,
+  AdvisoryPolicySignOffDecisionData,
+  AdvisoryPolicySignOffDecisionRequest,
   AdvisoryPolicySignOffPackageData,
+  AdvisoryPolicyWorkflowData,
   ProposalApprovalActionRequest,
   ProposalApprovalsData,
   AdvisoryWorkspaceBodyRequest,
@@ -265,6 +268,49 @@ export async function getAdvisoryPolicySignOffPackage(
   }
   const envelope = (await response.json()) as AdvisoryPolicyEnvelopeResponse;
   return envelope.data as unknown as AdvisoryPolicySignOffPackageData;
+}
+
+export async function getAdvisoryPolicyWorkflow(
+  evaluationId: string
+): Promise<AdvisoryPolicyWorkflowData> {
+  const response = await fetch(
+    `${BFF_PROXY_BASE}/advisory-policy-evaluations/${encodeURIComponent(evaluationId)}/workflow`
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Advisory policy workflow failed (${response.status}): ${body}`);
+  }
+  const envelope = (await response.json()) as AdvisoryPolicyEnvelopeResponse;
+  return envelope.data as unknown as AdvisoryPolicyWorkflowData;
+}
+
+export async function recordAdvisoryPolicySignOffDecision(
+  evaluationId: string,
+  payload: AdvisoryPolicySignOffDecisionRequest,
+  idempotencyKey?: string
+): Promise<AdvisoryPolicySignOffDecisionData> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (idempotencyKey) {
+    headers["Idempotency-Key"] = idempotencyKey;
+  }
+  const response = await fetch(
+    `${BFF_PROXY_BASE}/advisory-policy-evaluations/${encodeURIComponent(
+      evaluationId
+    )}/sign-off-decisions`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    }
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Advisory policy sign-off decision failed (${response.status}): ${body}`);
+  }
+  const envelope = (await response.json()) as AdvisoryPolicyEnvelopeResponse;
+  return envelope.data as unknown as AdvisoryPolicySignOffDecisionData;
 }
 
 export async function getProposal(

--- a/src/features/proposals/components/proposal-lifecycle-workspace.module.css
+++ b/src/features/proposals/components/proposal-lifecycle-workspace.module.css
@@ -106,6 +106,18 @@
   margin: 3px 0;
 }
 
+.policyEvidenceActions {
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fbfcfd;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin-top: 8px;
+  padding: 10px 12px;
+}
+
 .countStrip {
   display: grid;
   grid-template-columns: repeat(2, minmax(96px, 1fr));
@@ -228,6 +240,11 @@
   .policyEvidenceGrid,
   .policyEvidenceColumns {
     grid-template-columns: 1fr;
+  }
+
+  .policyEvidenceActions {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .countStrip div {

--- a/src/features/proposals/components/proposal-lifecycle-workspace.tsx
+++ b/src/features/proposals/components/proposal-lifecycle-workspace.tsx
@@ -2,17 +2,19 @@
 
 import Link from "next/link";
 import { useMemo, type ReactNode } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Alert, CircularProgress, Stack } from "@mui/material";
 
-import { ScreenStatePanel, SectionBlock, SemanticBadge, Text } from "@/design-system";
+import { ActionButton, ScreenStatePanel, SectionBlock, SemanticBadge, Text } from "@/design-system";
 import { workbenchStrictQueryDefaults } from "@/features/platform-runtime/query-policy";
 
 import {
   getAdvisoryPolicyEvaluation,
   getAdvisoryPolicyReviewQueue,
   getAdvisoryPolicySignOffPackage,
+  getAdvisoryPolicyWorkflow,
   listProposals,
+  recordAdvisoryPolicySignOffDecision,
 } from "../api";
 import {
   buildProposalLifecycleWorkspaceModel,
@@ -31,6 +33,7 @@ export default function ProposalLifecycleWorkspace({
   portfolioId: string;
   mode: ProposalLifecycleMode;
 }) {
+  const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery({
     queryKey: ["proposal-lifecycle-workspace", portfolioId, mode],
     queryFn: async () => await listProposals({ portfolioId }),
@@ -65,14 +68,51 @@ export default function ProposalLifecycleWorkspace({
     enabled: mode === "suitability" && Boolean(selectedPolicyEvaluationId),
     ...workbenchStrictQueryDefaults,
   });
+  const policyWorkflowQuery = useQuery({
+    queryKey: ["advisory-policy-workflow", selectedPolicyEvaluationId],
+    queryFn: async () => await getAdvisoryPolicyWorkflow(selectedPolicyEvaluationId),
+    enabled: mode === "suitability" && Boolean(selectedPolicyEvaluationId),
+    ...workbenchStrictQueryDefaults,
+  });
   const policyEvidenceModel = useMemo(
     () =>
       buildPolicyEvaluationEvidenceModel({
         evaluation: policyEvaluationQuery.data,
         signOffPackage: policySignOffPackageQuery.data,
+        workflow: policyWorkflowQuery.data,
       }),
-    [policyEvaluationQuery.data, policySignOffPackageQuery.data]
+    [policyEvaluationQuery.data, policySignOffPackageQuery.data, policyWorkflowQuery.data]
   );
+  const requestMoreEvidenceMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedPolicyEvaluationId || !policyEvidenceModel?.sourceEvaluationHash) {
+        throw new Error("Policy evaluation evidence is not ready for review request.");
+      }
+      return await recordAdvisoryPolicySignOffDecision(
+        selectedPolicyEvaluationId,
+        {
+          body: {
+            actor_id: "advisor_1",
+            decision: "REQUEST_MORE_EVIDENCE",
+            source_evaluation_hash: policyEvidenceModel.sourceEvaluationHash,
+            reason: {
+              purpose: "advisor_policy_review",
+              source: "lotus-workbench",
+            },
+          },
+        },
+        `ui-policy-review-request-${selectedPolicyEvaluationId}-${Date.now()}`
+      );
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["advisory-policy-workflow"] }),
+        queryClient.invalidateQueries({ queryKey: ["advisory-policy-evaluation"] }),
+        queryClient.invalidateQueries({ queryKey: ["advisory-policy-sign-off-package"] }),
+        queryClient.invalidateQueries({ queryKey: ["advisory-policy-review-queue"] }),
+      ]);
+    },
+  });
 
   if (isLoading) {
     return (
@@ -136,8 +176,20 @@ export default function ProposalLifecycleWorkspace({
           hasError={Boolean(policyQueueQuery.error)}
           model={policyReviewModel}
           evidenceModel={policyEvidenceModel}
-          evidenceLoading={policyEvaluationQuery.isLoading || policySignOffPackageQuery.isLoading}
-          evidenceError={Boolean(policyEvaluationQuery.error || policySignOffPackageQuery.error)}
+          evidenceLoading={
+            policyEvaluationQuery.isLoading ||
+            policySignOffPackageQuery.isLoading ||
+            policyWorkflowQuery.isLoading
+          }
+          evidenceError={Boolean(
+            policyEvaluationQuery.error ||
+              policySignOffPackageQuery.error ||
+              policyWorkflowQuery.error
+          )}
+          reviewRequestPending={requestMoreEvidenceMutation.isPending}
+          reviewRequestSucceeded={requestMoreEvidenceMutation.isSuccess}
+          reviewRequestFailed={Boolean(requestMoreEvidenceMutation.error)}
+          onRequestMoreEvidence={() => requestMoreEvidenceMutation.mutate()}
         />
       ) : null}
 
@@ -210,6 +262,10 @@ function PolicyReviewQueueSection({
   evidenceModel,
   evidenceLoading,
   evidenceError,
+  reviewRequestPending,
+  reviewRequestSucceeded,
+  reviewRequestFailed,
+  onRequestMoreEvidence,
 }: {
   portfolioId: string;
   isLoading: boolean;
@@ -218,6 +274,10 @@ function PolicyReviewQueueSection({
   evidenceModel: ReturnType<typeof buildPolicyEvaluationEvidenceModel>;
   evidenceLoading: boolean;
   evidenceError: boolean;
+  reviewRequestPending: boolean;
+  reviewRequestSucceeded: boolean;
+  reviewRequestFailed: boolean;
+  onRequestMoreEvidence: () => void;
 }) {
   if (isLoading) {
     return (
@@ -304,6 +364,10 @@ function PolicyReviewQueueSection({
         isLoading={evidenceLoading}
         hasError={evidenceError}
         model={evidenceModel}
+        reviewRequestPending={reviewRequestPending}
+        reviewRequestSucceeded={reviewRequestSucceeded}
+        reviewRequestFailed={reviewRequestFailed}
+        onRequestMoreEvidence={onRequestMoreEvidence}
       />
     </div>
   );
@@ -313,10 +377,18 @@ function PolicyEvaluationEvidenceSection({
   isLoading,
   hasError,
   model,
+  reviewRequestPending,
+  reviewRequestSucceeded,
+  reviewRequestFailed,
+  onRequestMoreEvidence,
 }: {
   isLoading: boolean;
   hasError: boolean;
   model: ReturnType<typeof buildPolicyEvaluationEvidenceModel>;
+  reviewRequestPending: boolean;
+  reviewRequestSucceeded: boolean;
+  reviewRequestFailed: boolean;
+  onRequestMoreEvidence: () => void;
 }) {
   if (isLoading) {
     return (
@@ -360,15 +432,37 @@ function PolicyEvaluationEvidenceSection({
         <EvidenceMetric label="Rule results">{model.ruleCount} reviewed</EvidenceMetric>
         <EvidenceMetric label="Blocking rules">{model.blockingRuleCount} blocking</EvidenceMetric>
         <EvidenceMetric label="Sign-off package">{model.signOffPackagePosture}</EvidenceMetric>
+        <EvidenceMetric label="Workflow status">
+          <SemanticBadge tone={model.workflowTone}>{model.workflowStatus}</SemanticBadge>
+        </EvidenceMetric>
+        <EvidenceMetric label="Maker-checker">{model.makerCheckerPosture}</EvidenceMetric>
+        <EvidenceMetric label="Review SLA">{model.slaPosture}</EvidenceMetric>
         <EvidenceMetric label="Client publication">{model.clientPublicationPosture}</EvidenceMetric>
       </div>
       <div className={styles.policyEvidenceColumns}>
         <EvidenceList title="Approval dependencies" values={model.approvalDependencies} />
         <EvidenceList title="Disclosure reviews" values={model.disclosureRequirements} />
         <EvidenceList title="Client consent evidence" values={model.consentRequirements} />
+        <EvidenceList title="Sign-off blockers" values={model.workflowBlockers} />
         <EvidenceList title="Source references" values={model.sourceRefs} />
         <EvidenceList title="Source gaps" values={model.sourceGaps} />
         <EvidenceMetric label="Next action">{model.nextAction}</EvidenceMetric>
+      </div>
+      <div className={styles.policyEvidenceActions}>
+        <ActionButton
+          priority="secondary"
+          onClick={onRequestMoreEvidence}
+          disabled={reviewRequestPending || !model.sourceEvaluationHash}
+        >
+          {reviewRequestPending ? "Recording request..." : "Request more evidence"}
+        </ActionButton>
+        <Text variant="secondary">
+          {reviewRequestSucceeded
+            ? "Evidence review request recorded through the advisory policy workflow."
+            : reviewRequestFailed
+              ? "Evidence review request could not be recorded from the advisory policy workflow."
+              : "Records a review request only; it does not approve sign-off or client publication."}
+        </Text>
       </div>
     </div>
   );

--- a/src/features/proposals/proposal-policy-review-view-model.ts
+++ b/src/features/proposals/proposal-policy-review-view-model.ts
@@ -3,6 +3,7 @@ import type { SemanticBadgeTone } from "@/design-system";
 import type {
   AdvisoryPolicyEvaluationRecord,
   AdvisoryPolicySignOffPackageData,
+  AdvisoryPolicyWorkflowData,
 } from "./types";
 
 export type PolicyReviewQueueRow = {
@@ -28,6 +29,7 @@ export type PolicyReviewQueueModel = {
 
 export type PolicyEvaluationEvidenceModel = {
   evaluationId: string;
+  sourceEvaluationHash: string | null;
   policyStatus: string;
   policyStatusTone: SemanticBadgeTone;
   sourcePosture: string;
@@ -41,6 +43,11 @@ export type PolicyEvaluationEvidenceModel = {
   auditEventCount: number;
   signOffPackagePosture: string;
   clientPublicationPosture: string;
+  workflowStatus: string;
+  workflowTone: SemanticBadgeTone;
+  makerCheckerPosture: string;
+  slaPosture: string;
+  workflowBlockers: string[];
   nextAction: string;
 };
 
@@ -92,9 +99,11 @@ export function buildPolicyReviewQueueModel({
 export function buildPolicyEvaluationEvidenceModel({
   evaluation,
   signOffPackage,
+  workflow,
 }: {
   evaluation?: AdvisoryPolicyEvaluationRecord | null;
   signOffPackage?: AdvisoryPolicySignOffPackageData | null;
+  workflow?: AdvisoryPolicyWorkflowData | null;
 }): PolicyEvaluationEvidenceModel | null {
   if (!evaluation) {
     return null;
@@ -110,9 +119,12 @@ export function buildPolicyEvaluationEvidenceModel({
   const approvalDependencies = stringArray(evaluation.approval_dependencies);
   const disclosureRequirements = stringArray(evaluation.disclosure_requirements);
   const consentRequirements = stringArray(evaluation.consent_requirements);
+  const workflowBlockers = stringArray(workflow?.sign_off_blockers);
+  const sourceEvaluationHash = stringValue(evaluation.evaluation_hash, "");
 
   return {
     evaluationId: stringValue(evaluation.evaluation_id, "Evaluation not reported"),
+    sourceEvaluationHash: sourceEvaluationHash || null,
     policyStatus: policyStatusLabel(evaluation.evaluation_status),
     policyStatusTone: policyStatusTone(evaluation.evaluation_status),
     sourcePosture: evidencePosture(sourceGaps),
@@ -126,6 +138,14 @@ export function buildPolicyEvaluationEvidenceModel({
     auditEventCount: auditEvents.length,
     signOffPackagePosture: signOffPackagePosture(packagePosture),
     clientPublicationPosture: clientPublicationPosture(packagePosture, lineagePosture),
+    workflowStatus: workflowStatusLabel(workflow?.sign_off_status),
+    workflowTone: workflowStatusTone(workflow?.sign_off_status),
+    makerCheckerPosture:
+      workflow?.maker_checker_required === true
+        ? "Independent checker required"
+        : "Maker-checker requirement not reported",
+    slaPosture: slaPosture(recordValue(workflow?.sla_posture)),
+    workflowBlockers: workflowBlockers.map(friendlyRequirement).slice(0, 4),
     nextAction: nextAction({
       policyStatus: evaluation.evaluation_status,
       approvalDependencies,
@@ -214,6 +234,35 @@ function signOffTone(record: AdvisoryPolicyEvaluationRecord): SemanticBadgeTone 
   return record.evaluation_status === "READY" ? "success" : "warn";
 }
 
+function workflowStatusLabel(status: unknown): string {
+  switch (status) {
+    case "READY_FOR_SIGN_OFF":
+      return "Ready for sign-off";
+    case "SIGNED_OFF":
+      return "Signed off";
+    case "PENDING_REVIEW":
+      return "Review required";
+    case "BLOCKED":
+      return "Blocked";
+    default:
+      return "Workflow not reported";
+  }
+}
+
+function workflowStatusTone(status: unknown): SemanticBadgeTone {
+  switch (status) {
+    case "READY_FOR_SIGN_OFF":
+    case "SIGNED_OFF":
+      return "success";
+    case "PENDING_REVIEW":
+      return "warn";
+    case "BLOCKED":
+      return "danger";
+    default:
+      return "default";
+  }
+}
+
 function requirementSummary({
   approvalDependencies,
   disclosureRequirements,
@@ -293,12 +342,22 @@ function clientPublicationPosture(
   return value === "BLOCKED" ? "Client publication blocked" : "Client publication not supported";
 }
 
+function slaPosture(posture: Record<string, unknown> | null): string {
+  const status = stringValue(posture?.status, "");
+  const openCount = typeof posture?.open_requirement_count === "number"
+    ? posture.open_requirement_count
+    : null;
+  const label = status === "OVERDUE" ? "SLA overdue" : "Within review SLA";
+  return openCount === null ? label : `${label}, ${openCount} open`;
+}
+
 function friendlySourceRef(value: string): string {
   return friendlyPhrase(value.replace(/^lotus-[^:]+:/, "").replace(/^lotus-/, ""));
 }
 
 function friendlyRequirement(value: string): string {
-  return friendlyPhrase(value.replace(/^[^:]+:/, ""));
+  const parts = value.split(":").filter(Boolean);
+  return friendlyPhrase(parts.at(-1) ?? value);
 }
 
 function friendlyPhrase(value: string): string {

--- a/src/features/proposals/types.ts
+++ b/src/features/proposals/types.ts
@@ -132,6 +132,35 @@ export type AdvisoryPolicyReviewQueueData = {
 
 export type AdvisoryPolicyEvaluationData = AdvisoryPolicyEvaluationRecord;
 
+export type AdvisoryPolicyRequirementProjection = {
+  requirement_id?: string;
+  requirement_type?: string;
+  status?: string;
+  owner_role?: string;
+  review_sla?: string;
+  due_at?: string | null;
+  reason_codes?: string[];
+  [key: string]: unknown;
+};
+
+export type AdvisoryPolicyWorkflowData = {
+  evaluation_id?: string;
+  proposal_id?: string;
+  proposal_version_id?: string;
+  evaluation_status?: string;
+  approval_dependencies?: AdvisoryPolicyRequirementProjection[];
+  disclosure_requirements?: AdvisoryPolicyRequirementProjection[];
+  consent_requirements?: AdvisoryPolicyRequirementProjection[];
+  conflict_posture?: Record<string, unknown>;
+  sla_posture?: Record<string, unknown>;
+  sign_off_status?: string;
+  sign_off_blockers?: string[];
+  maker_checker_required?: boolean;
+  latest_sign_off_event?: Record<string, unknown> | null;
+  client_ready_publication?: string;
+  [key: string]: unknown;
+};
+
 export type AdvisoryPolicySignOffPackageData = {
   evaluation?: AdvisoryPolicyEvaluationRecord;
   lineage?: {
@@ -143,6 +172,26 @@ export type AdvisoryPolicySignOffPackageData = {
     [key: string]: unknown;
   };
   package_posture?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type AdvisoryPolicySignOffDecisionRequest = {
+  body: {
+    actor_id: string;
+    decision: "APPROVE_FOR_POLICY_SIGN_OFF" | "REQUEST_MORE_EVIDENCE" | "REJECT_POLICY_SIGN_OFF";
+    source_evaluation_hash: string;
+    resolved_approval_dependencies?: string[];
+    satisfied_disclosure_requirements?: string[];
+    satisfied_consent_requirements?: string[];
+    conflict_review_outcome?: string | null;
+    reason?: Record<string, unknown>;
+  };
+};
+
+export type AdvisoryPolicySignOffDecisionData = {
+  workflow?: AdvisoryPolicyWorkflowData;
+  sign_off_event?: Record<string, unknown>;
+  replay_metadata?: Record<string, unknown>;
   [key: string]: unknown;
 };
 

--- a/tests/integration/proposal-lifecycle-workspace.test.tsx
+++ b/tests/integration/proposal-lifecycle-workspace.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -42,6 +42,7 @@ const getAdvisoryPolicyReviewQueueMock = vi.fn(
 );
 const getAdvisoryPolicyEvaluationMock = vi.fn(async (_evaluationId: string) => ({
   ...policyReviewQueueFixture.items[0],
+  evaluation_hash: "sha256:policy-evaluation-1",
   source_refs: ["lotus-core:core_product_eligibility_target_market_complexity"],
   evaluation_json: {
     rule_results: [
@@ -60,6 +61,23 @@ const getAdvisoryPolicySignOffPackageMock = vi.fn(async (_evaluationId: string) 
     lineage_posture: { client_ready_publication: "BLOCKED" },
   },
 }));
+const getAdvisoryPolicyWorkflowMock = vi.fn(async (_evaluationId: string) => ({
+  sign_off_status: "PENDING_REVIEW",
+  sign_off_blockers: [
+    "DISCLOSURE_REQUIREMENT_OPEN:advisor_reviewed_disclosure:SG_STRUCTURED_NOTE",
+  ],
+  maker_checker_required: true,
+  sla_posture: { status: "WITHIN_SLA", open_requirement_count: 2 },
+  client_ready_publication: "BLOCKED",
+}));
+const recordAdvisoryPolicySignOffDecisionMock = vi.fn(
+  async (_evaluationId: string, _payload: unknown, _idempotencyKey?: string) => ({
+    workflow: {
+      sign_off_status: "PENDING_REVIEW",
+      client_ready_publication: "BLOCKED",
+    },
+  })
+);
 
 vi.mock("../../src/features/proposals/api", () => ({
   getAdvisoryPolicyEvaluation: (evaluationId: string) =>
@@ -67,7 +85,14 @@ vi.mock("../../src/features/proposals/api", () => ({
   getAdvisoryPolicyReviewQueue: (status: string) => getAdvisoryPolicyReviewQueueMock(status),
   getAdvisoryPolicySignOffPackage: (evaluationId: string) =>
     getAdvisoryPolicySignOffPackageMock(evaluationId),
+  getAdvisoryPolicyWorkflow: (evaluationId: string) =>
+    getAdvisoryPolicyWorkflowMock(evaluationId),
   listProposals: (filters: unknown) => listProposalsMock(filters),
+  recordAdvisoryPolicySignOffDecision: (
+    evaluationId: string,
+    payload: unknown,
+    idempotencyKey?: string
+  ) => recordAdvisoryPolicySignOffDecisionMock(evaluationId, payload, idempotencyKey),
 }));
 
 function renderWithQueryClient(ui: React.ReactElement) {
@@ -92,6 +117,7 @@ describe("ProposalLifecycleWorkspace", () => {
     getAdvisoryPolicyEvaluationMock.mockReset();
     getAdvisoryPolicyEvaluationMock.mockImplementation(async (_evaluationId: string) => ({
       ...policyReviewQueueFixture.items[0],
+      evaluation_hash: "sha256:policy-evaluation-1",
       source_refs: ["lotus-core:core_product_eligibility_target_market_complexity"],
       evaluation_json: {
         rule_results: [
@@ -111,6 +137,25 @@ describe("ProposalLifecycleWorkspace", () => {
         lineage_posture: { client_ready_publication: "BLOCKED" },
       },
     }));
+    getAdvisoryPolicyWorkflowMock.mockReset();
+    getAdvisoryPolicyWorkflowMock.mockImplementation(async (_evaluationId: string) => ({
+      sign_off_status: "PENDING_REVIEW",
+      sign_off_blockers: [
+        "DISCLOSURE_REQUIREMENT_OPEN:advisor_reviewed_disclosure:SG_STRUCTURED_NOTE",
+      ],
+      maker_checker_required: true,
+      sla_posture: { status: "WITHIN_SLA", open_requirement_count: 2 },
+      client_ready_publication: "BLOCKED",
+    }));
+    recordAdvisoryPolicySignOffDecisionMock.mockReset();
+    recordAdvisoryPolicySignOffDecisionMock.mockImplementation(
+      async (_evaluationId: string, _payload: unknown, _idempotencyKey?: string) => ({
+        workflow: {
+          sign_off_status: "PENDING_REVIEW",
+          client_ready_publication: "BLOCKED",
+        },
+      })
+    );
   });
 
   it("renders a focused risk and impact screen from proposal lifecycle data", async () => {
@@ -154,20 +199,54 @@ describe("ProposalLifecycleWorkspace", () => {
       expect(getAdvisoryPolicyReviewQueueMock).toHaveBeenCalledWith("PENDING_REVIEW");
       expect(getAdvisoryPolicyEvaluationMock).toHaveBeenCalledWith("pev_001");
       expect(getAdvisoryPolicySignOffPackageMock).toHaveBeenCalledWith("pev_001");
+      expect(getAdvisoryPolicyWorkflowMock).toHaveBeenCalledWith("pev_001");
     });
 
     expect(await screen.findByRole("heading", { level: 3, name: "Policy evaluations needing review" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 4, name: "Sign-off source package and source evidence" })).toBeInTheDocument();
-    expect(screen.getAllByText("Review required")).toHaveLength(2);
+    expect(screen.getAllByText("Review required")).toHaveLength(3);
     expect(screen.getByText("Sign-off pending")).toBeInTheDocument();
     expect(screen.getByText("1 approval dependency, 1 disclosure review")).toBeInTheDocument();
     expect(screen.getAllByText("Complete required approval review.")).toHaveLength(2);
     expect(screen.getByText("Source package available")).toBeInTheDocument();
     expect(screen.getByText("Client publication blocked")).toBeInTheDocument();
+    expect(screen.getByText("Independent checker required")).toBeInTheDocument();
+    expect(screen.getByText("Within review SLA, 2 open")).toBeInTheDocument();
+    expect(screen.getByText("Request more evidence")).toBeInTheDocument();
     expect(screen.queryByText("PENDING_REVIEW")).not.toBeInTheDocument();
     expect(screen.queryByText("advisor_reviewed_disclosure:SG_STRUCTURED_NOTE")).not.toBeInTheDocument();
     expect(screen.queryByText("advisory-policy-evaluations")).not.toBeInTheDocument();
     expect(screen.queryByText("SUPPORTED_BY_RFC0025_SLICE8_ADVISE_API")).not.toBeInTheDocument();
+    expect(screen.queryByText("DISCLOSURE_REQUIREMENT_OPEN")).not.toBeInTheDocument();
+  });
+
+  it("records bounded policy evidence review requests through Gateway only", async () => {
+    renderWithQueryClient(
+      <ProposalLifecycleWorkspace portfolioId="PB_SG_GLOBAL_BAL_001" mode="suitability" />
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Request more evidence" }));
+
+    await waitFor(() => {
+      expect(recordAdvisoryPolicySignOffDecisionMock).toHaveBeenCalledWith(
+        "pev_001",
+        expect.objectContaining({
+          body: expect.objectContaining({
+            actor_id: "advisor_1",
+            decision: "REQUEST_MORE_EVIDENCE",
+            source_evaluation_hash: "sha256:policy-evaluation-1",
+          }),
+        }),
+        expect.stringMatching(/^ui-policy-review-request-pev_001-\d+$/)
+      );
+    });
+
+    expect(
+      await screen.findByText(
+        "Evidence review request recorded through the advisory policy workflow."
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText("APPROVE_FOR_POLICY_SIGN_OFF")).not.toBeInTheDocument();
   });
 
   it("does not show fallback policy evaluations when the suitability queue is unavailable", async () => {

--- a/tests/unit/proposal-policy-review-view-model.test.ts
+++ b/tests/unit/proposal-policy-review-view-model.test.ts
@@ -78,6 +78,7 @@ describe("proposal policy review view model", () => {
       evaluation: {
         evaluation_id: "pev_001",
         evaluation_status: "PENDING_REVIEW",
+        evaluation_hash: "sha256:policy-evaluation-1",
         source_refs: ["lotus-core:core_product_eligibility_target_market_complexity"],
         source_gaps: ["client_consent:SG_STRUCTURED_NOTE"],
         approval_dependencies: ["COMPLIANCE_REVIEW:SG_STRUCTURED_NOTE"],
@@ -100,10 +101,20 @@ describe("proposal policy review view model", () => {
           lineage_posture: { client_ready_publication: "BLOCKED" },
         },
       },
+      workflow: {
+        sign_off_status: "PENDING_REVIEW",
+        sign_off_blockers: [
+          "DISCLOSURE_REQUIREMENT_OPEN:advisor_reviewed_disclosure:SG_STRUCTURED_NOTE",
+        ],
+        maker_checker_required: true,
+        sla_posture: { status: "WITHIN_SLA", open_requirement_count: 3 },
+        client_ready_publication: "BLOCKED",
+      },
     });
 
     expect(model).toMatchObject({
       evaluationId: "pev_001",
+      sourceEvaluationHash: "sha256:policy-evaluation-1",
       policyStatus: "Review required",
       sourcePosture: "1 evidence gap",
       ruleCount: 2,
@@ -115,8 +126,13 @@ describe("proposal policy review view model", () => {
       consentRequirements: ["SG Structured Note"],
       sourceRefs: ["Core Product Eligibility Target Market Complexity"],
       sourceGaps: ["SG Structured Note"],
+      workflowStatus: "Review required",
+      makerCheckerPosture: "Independent checker required",
+      slaPosture: "Within review SLA, 3 open",
+      workflowBlockers: ["SG Structured Note"],
     });
     expect(JSON.stringify(model)).not.toContain("client_consent");
     expect(JSON.stringify(model)).not.toContain("SUPPORTED_BY_RFC0025");
+    expect(JSON.stringify(model)).not.toContain("DISCLOSURE_REQUIREMENT_OPEN");
   });
 });

--- a/tests/unit/proposals-api.test.ts
+++ b/tests/unit/proposals-api.test.ts
@@ -15,6 +15,7 @@ import {
   getAdvisoryPolicyEvaluation,
   getAdvisoryPolicyReviewQueue,
   getAdvisoryPolicySignOffPackage,
+  getAdvisoryPolicyWorkflow,
   getProposalExecutionStatus,
   getProposalIdempotencyRecord,
   getProposalDeliveryEvents,
@@ -35,6 +36,7 @@ import {
   recordProposalExecutionUpdate,
   recordProposalMemoReportPackageEvent,
   listProposals,
+  recordAdvisoryPolicySignOffDecision,
   recordClientConsent,
   regenerateProposalNarrative,
   requestAdvisoryWorkspaceRationale,
@@ -256,6 +258,59 @@ describe("proposal api", () => {
     );
     expect(evaluation.evaluation_id).toBe("pev_1");
     expect(signOffPackage.package_posture?.sign_off_source_package).toContain("SUPPORTED");
+  });
+
+  it("loads advisory policy workflow and records review requests through Gateway", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const data = init?.method === "POST"
+          ? { workflow: { sign_off_status: "PENDING_REVIEW" } }
+          : { sign_off_status: "PENDING_REVIEW", maker_checker_required: true };
+        return new Response(
+          JSON.stringify({
+            correlation_id: "c",
+            contract_version: "v1",
+            data,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        );
+      })
+    );
+
+    const workflow = await getAdvisoryPolicyWorkflow("pev_1");
+    const decision = await recordAdvisoryPolicySignOffDecision(
+      "pev_1",
+      {
+        body: {
+          actor_id: "advisor_1",
+          decision: "REQUEST_MORE_EVIDENCE",
+          source_evaluation_hash: "sha256:policy-evaluation-1",
+          reason: { purpose: "advisor_policy_review" },
+        },
+      },
+      "idem-policy-review-request"
+    );
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/advisory-policy-evaluations/pev_1/workflow`
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${expectedBaseUrl}/advisory-policy-evaluations/pev_1/sign-off-decisions`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Idempotency-Key": "idem-policy-review-request",
+        }),
+      })
+    );
+    expect(workflow.sign_off_status).toBe("PENDING_REVIEW");
+    expect(decision.workflow?.sign_off_status).toBe("PENDING_REVIEW");
   });
 
   it("calls proposal version endpoints", async () => {

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -12,7 +12,7 @@ It is intended for developers, business users, operations, sales/pre-sales, and 
 | Performance and risk review | `/performance` route modes | Gateway performance/risk APIs | Supported with bounded observability and canonical proof. |
 | Data-product discovery | `/data-products` | Gateway domain-product APIs | Supported for catalog, dependencies, and live trust posture. |
 | Advisor proposal narrative posture | `/proposals`, `/proposals/{proposalId}` | Gateway `/api/v1/proposals*` | Implemented for advisor proposal queue/detail, advisor-use narrative review, reviewed narrative report-package request, delivery-summary posture, delivery-event posture, and governed canonical proof through Gateway only. Canonical validation creates a seeded advisor-review narrative proposal, exercises the panel, and captures `proposal-narrative-posture-live.png`. The shell `Proposal` app entry remains disabled until broader product promotion is separately proven. |
-| Advisor suitability policy review queue | `/proposals?mode=suitability` | Gateway `/api/v1/advisory-policy-evaluations/review-queue`, `/api/v1/advisory-policy-evaluations/{evaluation_id}`, and `/api/v1/advisory-policy-evaluations/{evaluation_id}/sign-off-package` | Implemented for read-only review of Advise-owned suitability policy evaluations that need advisor, compliance, or supervisory attention. Workbench renders advisor-facing policy status, sign-off posture, selected evaluation evidence, sign-off source-package posture, client-publication block posture, open approval/disclosure/consent requirements, source-evidence completeness, and next action through Gateway only. Workbench does not calculate suitability, approve/waive policy findings, publish client-ready material, or call `lotus-advise` directly. |
+| Advisor suitability policy review queue | `/proposals?mode=suitability` | Gateway `/api/v1/advisory-policy-evaluations/review-queue`, `/api/v1/advisory-policy-evaluations/{evaluation_id}`, `/api/v1/advisory-policy-evaluations/{evaluation_id}/sign-off-package`, `/api/v1/advisory-policy-evaluations/{evaluation_id}/workflow`, and `/api/v1/advisory-policy-evaluations/{evaluation_id}/sign-off-decisions` | Implemented for review of Advise-owned suitability policy evaluations that need advisor, compliance, or supervisory attention. Workbench renders advisor-facing policy status, sign-off posture, selected evaluation evidence, sign-off source-package posture, policy workflow posture, client-publication block posture, open approval/disclosure/consent requirements, source-evidence completeness, and next action through Gateway only. Workbench can record a bounded request for more evidence against the source evaluation hash; it does not calculate suitability, approve/waive policy findings, record sign-off approval, publish client-ready material, or call `lotus-advise` directly. |
 | DPM mandate command center | `/workbench/{portfolioId}`, `/workbench/{portfolioId}?mode=mandate` | Gateway `/api/v1/dpm/command-center*` | Supported for embedded canonical mandate cockpit, PM-book-backed monitoring action, active exception queue, and governed exception-summary request through Gateway/Manage/lotus-ai. Workbench preserves Manage supportability posture: populated canonical `READY` is demo-ready, `PARTIAL`/`DEGRADED`/`BLOCKED` render as explicit partial states, and `EMPTY` stays an empty state rather than a false ready cockpit. |
 | DPM rebalance-wave command center | `/workbench/{portfolioId}?mode=waves` | Gateway `/api/v1/dpm/command-center/waves*` | Implemented for wave queue, preview, create, detail, items, source-check, simulation, approval, staging, handoff, proof posture, supportability, report-input, governed AI PM memo, governed operations-handoff summary, active Manage-owned campaign-definition list rendering, selected-campaign candidate-source review, read-only campaign lifecycle evidence, append-only launch history, preview-readiness review, launch-package readiness, and READY-gated campaign launch through Gateway only. |
 | DPM construction alternatives | `/workbench/{portfolioId}?mode=construction` | Gateway `/api/v1/dpm/command-center/construction/alternative-sets*` | Implemented for generation, comparison, and PM selection through Gateway only. Canonical panel proof is governed as `dpm.construction_alternatives` and does not claim Workbench-local construction methodology, order routing, trade execution, or OMS truth. |
@@ -31,26 +31,29 @@ advisor-use narrative posture before downstream report packaging.
 
 ## Advisor Suitability Policy Review Queue
 
-The RFC-0025 Suitability Review surface gives advisors and supervisors a read-only queue of
+The RFC-0025 Suitability Review surface gives advisors and supervisors a governed queue of
 source-owned policy evaluations that need review before client discussion.
 
 Implemented:
 
 1. loads the policy review queue through the Workbench BFF and Gateway only,
-2. requests the source review posture for evaluations requiring review,
+2. requests the source review posture and policy workflow posture for evaluations requiring review,
 3. renders proposal identity, proposal version, policy pack/version, policy status, sign-off
-   posture, selected evaluation evidence, sign-off source-package posture, client-publication
-   block posture, open approval/disclosure/consent requirements, source-evidence completeness,
-   and advisor next action,
+   posture, selected evaluation evidence, sign-off source-package posture, policy workflow
+   posture, client-publication block posture, open approval/disclosure/consent requirements,
+   source-evidence completeness, and advisor next action,
 4. translates source statuses and requirement arrays into private-banking workflow language,
 5. shows explicit unavailable and empty states without fallback policy rows,
-6. keeps source refs, source gaps, and sign-off package evidence in private-banking language
-   without exposing endpoint names, RFC posture constants, or raw source payload fields.
+6. keeps source refs, source gaps, sign-off package evidence, workflow blockers, and review
+   request outcomes in private-banking language without exposing endpoint names, RFC posture
+   constants, or raw source payload fields,
+7. records a bounded request for more evidence through Gateway against the source evaluation hash
+   without claiming approval, waiver, sign-off completion, or client-ready publication.
 
 Not supported in Workbench:
 
 1. local suitability calculation,
-2. policy approval, waiver, or sign-off mutation,
+2. policy approval, waiver, or sign-off approval mutation,
 3. client-ready publication,
 4. direct calls to `lotus-advise`,
 5. local interpretation of policy rule hashes, source refs, or technical payload fields as

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -65,9 +65,10 @@
   Implementation Status. This is route evidence over existing Gateway-backed screens, not a new
   client-ready, communication, execution, or backend capability claim.
 - RFC-0025 Suitability Review policy-queue proof must use the Gateway-backed advisory policy
-  review queue and verify that Workbench renders source-owned policy posture in advisor language
-  without claiming local suitability calculation, policy approval, waiver authority, or
-  client-ready publication.
+  review queue, selected evaluation, sign-off package, workflow posture, and bounded
+  request-more-evidence decision route. It must verify that Workbench renders source-owned policy
+  posture in advisor language without claiming local suitability calculation, policy approval,
+  waiver authority, sign-off completion, or client-ready publication.
 - observability evidence capture writes local non-functional proof packs under
   `output/observability-live/<timestamp>/`
 - final visual review should use canonical validated captures, not pre-validation diagnostics


### PR DESCRIPTION
## Summary
- load advisory policy workflow posture for the Suitability Review surface through Gateway
- render maker-checker, SLA, and blocker posture in advisor-facing language
- add a bounded request-more-evidence action backed by the advisory policy sign-off decision route
- update Workbench context and wiki source for the implemented boundary

## Validation
- npm test -- tests/unit/proposals-api.test.ts tests/unit/proposal-policy-review-view-model.test.ts tests/integration/proposal-lifecycle-workspace.test.tsx
- npm run typecheck
- npm run lint
- git diff --check
- make check
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench (expected pre-publish drift: Supported-Features.md, Validation-and-CI.md)