### PR TITLE
Add canonical advisory policy live proof

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -311,6 +311,15 @@ visibility, and screenshot evidence for `proposal.narrative_posture`. Proposal m
 the RFC-0024 memo/evidence-pack surface can create or replay an advisor-use memo, record advisor-use
 review, request memo report-package posture, request non-authoritative commentary, preserve replay
 hash visibility, and capture governed screenshot evidence for `proposal.memo_evidence_pack`.
+RFC-0025 policy checks now use the governed
+`advisory_proposal_scenarios.policy_evaluation` block in
+`lotus-platform/context/contracts/canonical-front-office-demo-data-contract.json` to activate the
+Singapore private-banking policy pack, create a structured-note `PENDING_REVIEW` policy evaluation
+through Gateway, verify the review queue, workflow, sign-off package, blocked client-ready posture,
+and a bounded request-more-evidence decision, and then render the Suitability Review route from the
+same source-owned queue. The validator records this as
+`POLICY_EVALUATION_PENDING_REVIEW_CREATED` so reviewers can distinguish real policy evidence from a
+route-only screenshot.
 The validator also records `advisoryJourneyChecks` for the front-office advisory route sequence:
 Advisory Overview, Client Context, Opportunities and Ideas, Proposal Builder, Proposal Simulation,
 Suitability Review, Risk and Impact, Approval Queue, Client Discussion Pack, and Implementation

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -1,5 +1,4 @@
 import process from "node:process";
-import { createHash } from "node:crypto";
 import { chromium, expect } from "@playwright/test";
 import { resolveValidationConfig } from "./validation/args.mjs";
 import {
@@ -53,6 +52,12 @@ import {
   buildRfc3643FeatureCoverage,
 } from "./validation/rfc36-43-feature-coverage.mjs";
 import { validateAdvisorBriefWorkflowPackReviewChain } from "./validation/workflow-pack-proof.mjs";
+import { createCanonicalPolicyEvaluation } from "./validation/advisory-policy-proof.mjs";
+import {
+  buildPayloadScopedIdempotencyKey,
+  extractGatewayEnvelopeData,
+  readString,
+} from "./validation/payload-utils.mjs";
 
 const {
   portfolioId,
@@ -96,243 +101,6 @@ const summary = createValidationSummary({
 });
 const panelGovernance = createPanelGovernance(summary, panelRegistry);
 
-function buildPayloadScopedIdempotencyKey(prefix, payload) {
-  const digest = createHash("sha256").update(JSON.stringify(payload)).digest("hex").slice(0, 16);
-  return `${prefix}-${digest}`.slice(0, 64);
-}
-
-function extractPolicyPackContentHash(response) {
-  const payload = extractGatewayEnvelopeData(response);
-  return (
-    readString(payload?.policy_pack?.content_hash) ||
-    readString(payload?.policy_pack_version?.policy_pack?.content_hash) ||
-    readString(payload?.content_hash) ||
-    readString(payload?.policy_pack?.metadata?.content_hash) ||
-    null
-  );
-}
-
-function isAlreadyActivePolicyPackError(error) {
-  return (
-    error instanceof Error &&
-    error.message.includes("POLICY_PACK_VERSION_ALREADY_ACTIVE_IMMUTABLE")
-  );
-}
-
-async function ensureAdvisoryPolicyPackActive({ scenario, gatewayBaseUrl, timeoutMs }) {
-  const version = await fetchJson(
-    summary,
-    `${gatewayBaseUrl}/api/v1/advisory-policy-packs/${encodeURIComponent(
-      scenario.policyPackId
-    )}/versions/${encodeURIComponent(scenario.policyVersion)}`,
-    "Advisory policy pack version for canonical scenario",
-    timeoutMs
-  );
-  const contentHash = extractPolicyPackContentHash(version);
-  if (!contentHash) {
-    throw new Error("Canonical advisory policy pack version returned no content hash.");
-  }
-  const validateBody = {
-    body: {
-      requested_by: "workbench-canonical-validator",
-      reason: {
-        purpose: "canonical_rfc0025_policy_validation",
-        scenario_id: scenario.scenarioId,
-      },
-    },
-  };
-  await sendJson(
-    summary,
-    `${gatewayBaseUrl}/api/v1/advisory-policy-packs/${encodeURIComponent(
-      scenario.policyPackId
-    )}/versions/${encodeURIComponent(scenario.policyVersion)}/validate`,
-    "Validate advisory policy pack for canonical scenario",
-    timeoutMs,
-    {
-      method: "POST",
-      body: validateBody,
-      headers: {
-        "Idempotency-Key": buildPayloadScopedIdempotencyKey("wb-policy-pack-validate", validateBody),
-      },
-    }
-  );
-  const activateBody = {
-    body: {
-      activated_by: "workbench-canonical-validator",
-      source_content_hash: contentHash,
-      reason: {
-        purpose: "canonical_rfc0025_policy_validation",
-        scenario_id: scenario.scenarioId,
-      },
-    },
-  };
-  const activateUrl = `${gatewayBaseUrl}/api/v1/advisory-policy-packs/${encodeURIComponent(
-    scenario.policyPackId
-  )}/versions/${encodeURIComponent(scenario.policyVersion)}/activate`;
-  try {
-    await sendJson(
-      summary,
-      activateUrl,
-      "Activate advisory policy pack for canonical scenario",
-      timeoutMs,
-      {
-        method: "POST",
-        body: activateBody,
-        headers: {
-          "Idempotency-Key": buildPayloadScopedIdempotencyKey("wb-policy-pack-activate", activateBody),
-        },
-      }
-    );
-  } catch (error) {
-    if (!isAlreadyActivePolicyPackError(error)) {
-      throw error;
-    }
-    summary.apiChecks.push({
-      description: "Activate advisory policy pack for canonical scenario",
-      url: activateUrl,
-      status: "already_active",
-      kind: "json-idempotent-replay",
-      method: "POST",
-    });
-  }
-}
-
-async function createCanonicalPolicyEvaluation({
-  scenario,
-  gatewayBaseUrl,
-  proposalId,
-  proposalVersionId,
-  timeoutMs,
-}) {
-  await ensureAdvisoryPolicyPackActive({ scenario, gatewayBaseUrl, timeoutMs });
-  const createBody = {
-    body: {
-      policy_pack_id: scenario.policyPackId,
-      policy_version: scenario.policyVersion,
-      created_by: scenario.createdBy,
-      evidence_bundle: scenario.evidenceBundle,
-      reason: {
-        purpose: "canonical_suitability_policy_review",
-        scenario_id: scenario.scenarioId,
-      },
-    },
-  };
-  const created = await sendJson(
-    summary,
-    `${gatewayBaseUrl}/api/v1/proposals/${encodeURIComponent(
-      proposalId
-    )}/versions/${encodeURIComponent(proposalVersionId)}/policy-evaluations`,
-    "Create advisory policy evaluation canonical proof",
-    timeoutMs,
-    {
-      method: "POST",
-      body: createBody,
-      headers: {
-        "Idempotency-Key": buildPayloadScopedIdempotencyKey("wb-policy-evaluation", createBody),
-      },
-    }
-  );
-  const createdData = extractGatewayEnvelopeData(created);
-  const record = createdData?.record ?? createdData;
-  const evaluationId = readString(record?.evaluation_id);
-  const evaluationHash = readString(record?.evaluation_hash);
-  if (!evaluationId || !evaluationHash) {
-    throw new Error("Canonical policy evaluation proof did not return evaluation identity and hash.");
-  }
-  if (record.evaluation_status !== scenario.expectedEvaluationStatus) {
-    throw new Error(
-      `Canonical policy evaluation returned ${record.evaluation_status}, expected ${scenario.expectedEvaluationStatus}.`
-    );
-  }
-
-  const queue = await fetchJson(
-    summary,
-    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/review-queue?evaluation_status=${encodeURIComponent(
-      scenario.expectedEvaluationStatus
-    )}`,
-    "Advisory policy review queue canonical proof",
-    timeoutMs
-  );
-  const queueData = extractGatewayEnvelopeData(queue);
-  const queueItems = Array.isArray(queueData?.items) ? queueData.items : [];
-  if (!queueItems.some((item) => item?.evaluation_id === evaluationId)) {
-    throw new Error("Canonical policy review queue did not include the seeded evaluation.");
-  }
-  if (queueData?.queue_posture?.client_ready_publication !== scenario.expectedClientReadyPublication) {
-    throw new Error("Canonical policy review queue did not preserve blocked client-ready posture.");
-  }
-
-  const workflow = await fetchJson(
-    summary,
-    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/${encodeURIComponent(
-      evaluationId
-    )}/workflow`,
-    "Advisory policy workflow canonical proof",
-    timeoutMs
-  );
-  const workflowData = extractGatewayEnvelopeData(workflow);
-  if (workflowData?.client_ready_publication !== scenario.expectedClientReadyPublication) {
-    throw new Error("Canonical policy workflow did not preserve blocked client-ready posture.");
-  }
-
-  const signOffPackage = await fetchJson(
-    summary,
-    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/${encodeURIComponent(
-      evaluationId
-    )}/sign-off-package`,
-    "Advisory policy sign-off package canonical proof",
-    timeoutMs
-  );
-  const signOffPackageData = extractGatewayEnvelopeData(signOffPackage);
-  if (signOffPackageData?.package_posture?.client_ready_publication !== scenario.expectedClientReadyPublication) {
-    throw new Error("Canonical policy sign-off package did not preserve blocked client-ready posture.");
-  }
-
-  const reviewDecisionBody = {
-    body: {
-      actor_id: "policy_checker_1",
-      decision: "REQUEST_MORE_EVIDENCE",
-      source_evaluation_hash: evaluationHash,
-      reason: {
-        purpose: "canonical_policy_review_request",
-        scenario_id: scenario.scenarioId,
-      },
-    },
-  };
-  await sendJson(
-    summary,
-    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/${encodeURIComponent(
-      evaluationId
-    )}/sign-off-decisions`,
-    "Record advisory policy review request canonical proof",
-    timeoutMs,
-    {
-      method: "POST",
-      body: reviewDecisionBody,
-      headers: {
-        "Idempotency-Key": buildPayloadScopedIdempotencyKey(
-          "wb-policy-review-request",
-          reviewDecisionBody
-        ),
-      },
-    }
-  );
-
-  summary.workflowPackChecks.push({
-    actionType: "POLICY_EVALUATION_PENDING_REVIEW_CREATED",
-    route: "/api/v1/advisory-policy-evaluations/review-queue",
-    scenarioId: scenario.scenarioId,
-    proposalId,
-    proposalVersionId,
-    evaluationId,
-    resultReviewState: workflowData?.sign_off_status,
-    resultSupportabilityStatus: record.evaluation_status,
-    clientReadyPublication: workflowData?.client_ready_publication,
-  });
-
-  return { evaluationId, evaluationHash };
-}
-
 async function fetchOptionalJson(description, url) {
   try {
     return await fetchJson(summary, url, description, timeoutMs);
@@ -347,10 +115,6 @@ async function fetchOptionalJson(description, url) {
     });
     return null;
   }
-}
-
-function readString(value) {
-  return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
 function readSupportabilityState(supportability) {
@@ -511,10 +275,6 @@ function extractWorkflowPackRunId(payload) {
     readString(payload?.audit?.workflow_pack_run_id) ||
     null
   );
-}
-
-function extractGatewayEnvelopeData(payload) {
-  return payload?.data ?? payload;
 }
 
 function buildPmQualitySourceRef({
@@ -1053,6 +813,7 @@ async function run() {
   });
 
   await createCanonicalPolicyEvaluation({
+    summary,
     scenario: advisoryScenario.policyEvaluation,
     gatewayBaseUrl,
     proposalId,

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -101,6 +101,238 @@ function buildPayloadScopedIdempotencyKey(prefix, payload) {
   return `${prefix}-${digest}`.slice(0, 64);
 }
 
+function extractPolicyPackContentHash(response) {
+  const payload = extractGatewayEnvelopeData(response);
+  return (
+    readString(payload?.policy_pack?.content_hash) ||
+    readString(payload?.policy_pack_version?.policy_pack?.content_hash) ||
+    readString(payload?.content_hash) ||
+    readString(payload?.policy_pack?.metadata?.content_hash) ||
+    null
+  );
+}
+
+function isAlreadyActivePolicyPackError(error) {
+  return (
+    error instanceof Error &&
+    error.message.includes("POLICY_PACK_VERSION_ALREADY_ACTIVE_IMMUTABLE")
+  );
+}
+
+async function ensureAdvisoryPolicyPackActive({ scenario, gatewayBaseUrl, timeoutMs }) {
+  const version = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-packs/${encodeURIComponent(
+      scenario.policyPackId
+    )}/versions/${encodeURIComponent(scenario.policyVersion)}`,
+    "Advisory policy pack version for canonical scenario",
+    timeoutMs
+  );
+  const contentHash = extractPolicyPackContentHash(version);
+  if (!contentHash) {
+    throw new Error("Canonical advisory policy pack version returned no content hash.");
+  }
+  const validateBody = {
+    body: {
+      requested_by: "workbench-canonical-validator",
+      reason: {
+        purpose: "canonical_rfc0025_policy_validation",
+        scenario_id: scenario.scenarioId,
+      },
+    },
+  };
+  await sendJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-packs/${encodeURIComponent(
+      scenario.policyPackId
+    )}/versions/${encodeURIComponent(scenario.policyVersion)}/validate`,
+    "Validate advisory policy pack for canonical scenario",
+    timeoutMs,
+    {
+      method: "POST",
+      body: validateBody,
+      headers: {
+        "Idempotency-Key": buildPayloadScopedIdempotencyKey("wb-policy-pack-validate", validateBody),
+      },
+    }
+  );
+  const activateBody = {
+    body: {
+      activated_by: "workbench-canonical-validator",
+      source_content_hash: contentHash,
+      reason: {
+        purpose: "canonical_rfc0025_policy_validation",
+        scenario_id: scenario.scenarioId,
+      },
+    },
+  };
+  const activateUrl = `${gatewayBaseUrl}/api/v1/advisory-policy-packs/${encodeURIComponent(
+    scenario.policyPackId
+  )}/versions/${encodeURIComponent(scenario.policyVersion)}/activate`;
+  try {
+    await sendJson(
+      summary,
+      activateUrl,
+      "Activate advisory policy pack for canonical scenario",
+      timeoutMs,
+      {
+        method: "POST",
+        body: activateBody,
+        headers: {
+          "Idempotency-Key": buildPayloadScopedIdempotencyKey("wb-policy-pack-activate", activateBody),
+        },
+      }
+    );
+  } catch (error) {
+    if (!isAlreadyActivePolicyPackError(error)) {
+      throw error;
+    }
+    summary.apiChecks.push({
+      description: "Activate advisory policy pack for canonical scenario",
+      url: activateUrl,
+      status: "already_active",
+      kind: "json-idempotent-replay",
+      method: "POST",
+    });
+  }
+}
+
+async function createCanonicalPolicyEvaluation({
+  scenario,
+  gatewayBaseUrl,
+  proposalId,
+  proposalVersionId,
+  timeoutMs,
+}) {
+  await ensureAdvisoryPolicyPackActive({ scenario, gatewayBaseUrl, timeoutMs });
+  const createBody = {
+    body: {
+      policy_pack_id: scenario.policyPackId,
+      policy_version: scenario.policyVersion,
+      created_by: scenario.createdBy,
+      evidence_bundle: scenario.evidenceBundle,
+      reason: {
+        purpose: "canonical_suitability_policy_review",
+        scenario_id: scenario.scenarioId,
+      },
+    },
+  };
+  const created = await sendJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/proposals/${encodeURIComponent(
+      proposalId
+    )}/versions/${encodeURIComponent(proposalVersionId)}/policy-evaluations`,
+    "Create advisory policy evaluation canonical proof",
+    timeoutMs,
+    {
+      method: "POST",
+      body: createBody,
+      headers: {
+        "Idempotency-Key": buildPayloadScopedIdempotencyKey("wb-policy-evaluation", createBody),
+      },
+    }
+  );
+  const createdData = extractGatewayEnvelopeData(created);
+  const record = createdData?.record ?? createdData;
+  const evaluationId = readString(record?.evaluation_id);
+  const evaluationHash = readString(record?.evaluation_hash);
+  if (!evaluationId || !evaluationHash) {
+    throw new Error("Canonical policy evaluation proof did not return evaluation identity and hash.");
+  }
+  if (record.evaluation_status !== scenario.expectedEvaluationStatus) {
+    throw new Error(
+      `Canonical policy evaluation returned ${record.evaluation_status}, expected ${scenario.expectedEvaluationStatus}.`
+    );
+  }
+
+  const queue = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/review-queue?evaluation_status=${encodeURIComponent(
+      scenario.expectedEvaluationStatus
+    )}`,
+    "Advisory policy review queue canonical proof",
+    timeoutMs
+  );
+  const queueData = extractGatewayEnvelopeData(queue);
+  const queueItems = Array.isArray(queueData?.items) ? queueData.items : [];
+  if (!queueItems.some((item) => item?.evaluation_id === evaluationId)) {
+    throw new Error("Canonical policy review queue did not include the seeded evaluation.");
+  }
+  if (queueData?.queue_posture?.client_ready_publication !== scenario.expectedClientReadyPublication) {
+    throw new Error("Canonical policy review queue did not preserve blocked client-ready posture.");
+  }
+
+  const workflow = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/${encodeURIComponent(
+      evaluationId
+    )}/workflow`,
+    "Advisory policy workflow canonical proof",
+    timeoutMs
+  );
+  const workflowData = extractGatewayEnvelopeData(workflow);
+  if (workflowData?.client_ready_publication !== scenario.expectedClientReadyPublication) {
+    throw new Error("Canonical policy workflow did not preserve blocked client-ready posture.");
+  }
+
+  const signOffPackage = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/${encodeURIComponent(
+      evaluationId
+    )}/sign-off-package`,
+    "Advisory policy sign-off package canonical proof",
+    timeoutMs
+  );
+  const signOffPackageData = extractGatewayEnvelopeData(signOffPackage);
+  if (signOffPackageData?.package_posture?.client_ready_publication !== scenario.expectedClientReadyPublication) {
+    throw new Error("Canonical policy sign-off package did not preserve blocked client-ready posture.");
+  }
+
+  const reviewDecisionBody = {
+    body: {
+      actor_id: "policy_checker_1",
+      decision: "REQUEST_MORE_EVIDENCE",
+      source_evaluation_hash: evaluationHash,
+      reason: {
+        purpose: "canonical_policy_review_request",
+        scenario_id: scenario.scenarioId,
+      },
+    },
+  };
+  await sendJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/${encodeURIComponent(
+      evaluationId
+    )}/sign-off-decisions`,
+    "Record advisory policy review request canonical proof",
+    timeoutMs,
+    {
+      method: "POST",
+      body: reviewDecisionBody,
+      headers: {
+        "Idempotency-Key": buildPayloadScopedIdempotencyKey(
+          "wb-policy-review-request",
+          reviewDecisionBody
+        ),
+      },
+    }
+  );
+
+  summary.workflowPackChecks.push({
+    actionType: "POLICY_EVALUATION_PENDING_REVIEW_CREATED",
+    route: "/api/v1/advisory-policy-evaluations/review-queue",
+    scenarioId: scenario.scenarioId,
+    proposalId,
+    proposalVersionId,
+    evaluationId,
+    resultReviewState: workflowData?.sign_off_status,
+    resultSupportabilityStatus: record.evaluation_status,
+    clientReadyPublication: workflowData?.client_ready_publication,
+  });
+
+  return { evaluationId, evaluationHash };
+}
+
 async function fetchOptionalJson(description, url) {
   try {
     return await fetchJson(summary, url, description, timeoutMs);
@@ -764,25 +996,24 @@ async function run() {
     postJson,
   });
 
+  const advisoryScenario =
+    canonicalContract.advisoryProposalScenarios ??
+    DEFAULT_CANONICAL_CONTRACT.advisoryProposalScenarios;
+  const proposalScenario = advisoryScenario.proposal;
   const proposalCreateBody = {
     body: {
-      created_by: "workbench-canonical-validator",
+      created_by: proposalScenario.createdBy,
       input_mode: "stateful",
       stateful_input: {
         portfolio_id: portfolioId,
         as_of: canonicalAsOfDate,
-        narrative_request: {
-          audience: "ADVISOR_REVIEW",
-          jurisdiction: "SG",
-          client_audience: "ADVISOR_REVIEW",
-          sections: ["EXECUTIVE_SUMMARY", "RISK_AND_CONCENTRATION"],
-          requested_by: "workbench-canonical-validator",
-        },
+        narrative_request: proposalScenario.narrativeRequest,
       },
       metadata: {
-        title: "Canonical advisor narrative proof",
-        advisor_notes: "Workbench canonical validation proposal for RFC-0023 Slice 12.",
-        jurisdiction: "SG",
+        title: proposalScenario.title,
+        advisor_notes: proposalScenario.advisorNotes,
+        jurisdiction: proposalScenario.jurisdiction,
+        canonical_scenario_id: advisoryScenario.scenarioId,
       },
     },
   };
@@ -806,8 +1037,9 @@ async function run() {
   const proposalCreateData = extractGatewayEnvelopeData(proposalCreate);
   const proposalId = readString(proposalCreateData?.proposal?.proposal_id);
   const proposalVersionNo = proposalCreateData?.version?.version_no ?? null;
+  const proposalVersionId = readString(proposalCreateData?.version?.proposal_version_id);
   const proposalNarrative = proposalCreateData?.version?.artifact?.proposal_narrative;
-  if (!proposalId || !proposalNarrative?.narrative_id) {
+  if (!proposalId || !proposalVersionId || !proposalNarrative?.narrative_id) {
     throw new Error("Canonical proposal narrative proof did not create a narrative proposal.");
   }
   summary.workflowPackChecks.push({
@@ -818,6 +1050,14 @@ async function run() {
     resultSupportabilityStatus: proposalNarrative.generation_mode,
     proposalId,
     versionNo: proposalVersionNo,
+  });
+
+  await createCanonicalPolicyEvaluation({
+    scenario: advisoryScenario.policyEvaluation,
+    gatewayBaseUrl,
+    proposalId,
+    proposalVersionId,
+    timeoutMs,
   });
 
   const manageSupportabilitySummary = await fetchJson(

--- a/scripts/live/validation/advisory-policy-proof.mjs
+++ b/scripts/live/validation/advisory-policy-proof.mjs
@@ -1,0 +1,244 @@
+import { fetchJson, sendJson } from "./probes.mjs";
+import {
+  buildPayloadScopedIdempotencyKey,
+  extractGatewayEnvelopeData,
+  readString,
+} from "./payload-utils.mjs";
+
+function extractPolicyPackContentHash(response) {
+  const payload = extractGatewayEnvelopeData(response);
+  return (
+    readString(payload?.policy_pack?.content_hash) ||
+    readString(payload?.policy_pack_version?.policy_pack?.content_hash) ||
+    readString(payload?.content_hash) ||
+    readString(payload?.policy_pack?.metadata?.content_hash) ||
+    null
+  );
+}
+
+function isAlreadyActivePolicyPackError(error) {
+  return (
+    error instanceof Error &&
+    error.message.includes("POLICY_PACK_VERSION_ALREADY_ACTIVE_IMMUTABLE")
+  );
+}
+
+async function ensureAdvisoryPolicyPackActive({ summary, scenario, gatewayBaseUrl, timeoutMs }) {
+  const version = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-packs/${encodeURIComponent(
+      scenario.policyPackId
+    )}/versions/${encodeURIComponent(scenario.policyVersion)}`,
+    "Advisory policy pack version for canonical scenario",
+    timeoutMs
+  );
+  const contentHash = extractPolicyPackContentHash(version);
+  if (!contentHash) {
+    throw new Error("Canonical advisory policy pack version returned no content hash.");
+  }
+
+  const validateBody = {
+    body: {
+      requested_by: "workbench-canonical-validator",
+      reason: {
+        purpose: "canonical_rfc0025_policy_validation",
+        scenario_id: scenario.scenarioId,
+      },
+    },
+  };
+  await sendJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-packs/${encodeURIComponent(
+      scenario.policyPackId
+    )}/versions/${encodeURIComponent(scenario.policyVersion)}/validate`,
+    "Validate advisory policy pack for canonical scenario",
+    timeoutMs,
+    {
+      method: "POST",
+      body: validateBody,
+      headers: {
+        "Idempotency-Key": buildPayloadScopedIdempotencyKey("wb-policy-pack-validate", validateBody),
+      },
+    }
+  );
+
+  const activateBody = {
+    body: {
+      activated_by: "workbench-canonical-validator",
+      source_content_hash: contentHash,
+      reason: {
+        purpose: "canonical_rfc0025_policy_validation",
+        scenario_id: scenario.scenarioId,
+      },
+    },
+  };
+  const activateUrl = `${gatewayBaseUrl}/api/v1/advisory-policy-packs/${encodeURIComponent(
+    scenario.policyPackId
+  )}/versions/${encodeURIComponent(scenario.policyVersion)}/activate`;
+  try {
+    await sendJson(
+      summary,
+      activateUrl,
+      "Activate advisory policy pack for canonical scenario",
+      timeoutMs,
+      {
+        method: "POST",
+        body: activateBody,
+        headers: {
+          "Idempotency-Key": buildPayloadScopedIdempotencyKey("wb-policy-pack-activate", activateBody),
+        },
+      }
+    );
+  } catch (error) {
+    if (!isAlreadyActivePolicyPackError(error)) {
+      throw error;
+    }
+    summary.apiChecks.push({
+      description: "Activate advisory policy pack for canonical scenario",
+      url: activateUrl,
+      status: "already_active",
+      kind: "json-idempotent-replay",
+      method: "POST",
+    });
+  }
+}
+
+export async function createCanonicalPolicyEvaluation({
+  summary,
+  scenario,
+  gatewayBaseUrl,
+  proposalId,
+  proposalVersionId,
+  timeoutMs,
+}) {
+  await ensureAdvisoryPolicyPackActive({ summary, scenario, gatewayBaseUrl, timeoutMs });
+  const createBody = {
+    body: {
+      policy_pack_id: scenario.policyPackId,
+      policy_version: scenario.policyVersion,
+      created_by: scenario.createdBy,
+      evidence_bundle: scenario.evidenceBundle,
+      reason: {
+        purpose: "canonical_suitability_policy_review",
+        scenario_id: scenario.scenarioId,
+      },
+    },
+  };
+  const created = await sendJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/proposals/${encodeURIComponent(
+      proposalId
+    )}/versions/${encodeURIComponent(proposalVersionId)}/policy-evaluations`,
+    "Create advisory policy evaluation canonical proof",
+    timeoutMs,
+    {
+      method: "POST",
+      body: createBody,
+      headers: {
+        "Idempotency-Key": buildPayloadScopedIdempotencyKey("wb-policy-evaluation", createBody),
+      },
+    }
+  );
+  const createdData = extractGatewayEnvelopeData(created);
+  const record = createdData?.record ?? createdData;
+  const evaluationId = readString(record?.evaluation_id);
+  const evaluationHash = readString(record?.evaluation_hash);
+  if (!evaluationId || !evaluationHash) {
+    throw new Error("Canonical policy evaluation proof did not return evaluation identity and hash.");
+  }
+  if (record.evaluation_status !== scenario.expectedEvaluationStatus) {
+    throw new Error(
+      `Canonical policy evaluation returned ${record.evaluation_status}, expected ${scenario.expectedEvaluationStatus}.`
+    );
+  }
+
+  const queue = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/review-queue?evaluation_status=${encodeURIComponent(
+      scenario.expectedEvaluationStatus
+    )}`,
+    "Advisory policy review queue canonical proof",
+    timeoutMs
+  );
+  const queueData = extractGatewayEnvelopeData(queue);
+  const queueItems = Array.isArray(queueData?.items) ? queueData.items : [];
+  if (!queueItems.some((item) => item?.evaluation_id === evaluationId)) {
+    throw new Error("Canonical policy review queue did not include the seeded evaluation.");
+  }
+  if (queueData?.queue_posture?.client_ready_publication !== scenario.expectedClientReadyPublication) {
+    throw new Error("Canonical policy review queue did not preserve blocked client-ready posture.");
+  }
+
+  const workflow = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/${encodeURIComponent(
+      evaluationId
+    )}/workflow`,
+    "Advisory policy workflow canonical proof",
+    timeoutMs
+  );
+  const workflowData = extractGatewayEnvelopeData(workflow);
+  if (workflowData?.client_ready_publication !== scenario.expectedClientReadyPublication) {
+    throw new Error("Canonical policy workflow did not preserve blocked client-ready posture.");
+  }
+
+  const signOffPackage = await fetchJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/${encodeURIComponent(
+      evaluationId
+    )}/sign-off-package`,
+    "Advisory policy sign-off package canonical proof",
+    timeoutMs
+  );
+  const signOffPackageData = extractGatewayEnvelopeData(signOffPackage);
+  if (
+    signOffPackageData?.package_posture?.client_ready_publication !==
+    scenario.expectedClientReadyPublication
+  ) {
+    throw new Error("Canonical policy sign-off package did not preserve blocked client-ready posture.");
+  }
+
+  const reviewDecisionBody = {
+    body: {
+      actor_id: "policy_checker_1",
+      decision: "REQUEST_MORE_EVIDENCE",
+      source_evaluation_hash: evaluationHash,
+      reason: {
+        purpose: "canonical_policy_review_request",
+        scenario_id: scenario.scenarioId,
+      },
+    },
+  };
+  await sendJson(
+    summary,
+    `${gatewayBaseUrl}/api/v1/advisory-policy-evaluations/${encodeURIComponent(
+      evaluationId
+    )}/sign-off-decisions`,
+    "Record advisory policy review request canonical proof",
+    timeoutMs,
+    {
+      method: "POST",
+      body: reviewDecisionBody,
+      headers: {
+        "Idempotency-Key": buildPayloadScopedIdempotencyKey(
+          "wb-policy-review-request",
+          reviewDecisionBody
+        ),
+      },
+    }
+  );
+
+  summary.workflowPackChecks.push({
+    actionType: "POLICY_EVALUATION_PENDING_REVIEW_CREATED",
+    route: "/api/v1/advisory-policy-evaluations/review-queue",
+    scenarioId: scenario.scenarioId,
+    proposalId,
+    proposalVersionId,
+    evaluationId,
+    resultReviewState: workflowData?.sign_off_status,
+    resultSupportabilityStatus: record.evaluation_status,
+    clientReadyPublication: workflowData?.client_ready_publication,
+  });
+
+  return { evaluationId, evaluationHash };
+}

--- a/scripts/live/validation/contract-metadata.mjs
+++ b/scripts/live/validation/contract-metadata.mjs
@@ -67,6 +67,92 @@ export const DEFAULT_CANONICAL_CONTRACT = {
       ],
     },
   },
+  advisoryProposalScenarios: {
+    scenarioId: "RFC23_25_ADVISORY_PROPOSAL_POLICY_CANONICAL",
+    sourceScope: "workbench_live_validation_scenario_seed",
+    proposal: {
+      title: "Canonical advisor narrative and policy proof",
+      createdBy: "workbench-canonical-validator",
+      jurisdiction: "SG",
+      advisorNotes: "Workbench canonical validation proposal for RFC-0023, RFC-0024, and RFC-0025.",
+      narrativeRequest: {
+        audience: "ADVISOR_REVIEW",
+        jurisdiction: "SG",
+        client_audience: "ADVISOR_REVIEW",
+        sections: ["EXECUTIVE_SUMMARY", "RISK_AND_CONCENTRATION"],
+        requested_by: "workbench-canonical-validator",
+      },
+    },
+    policyEvaluation: {
+      scenarioId: "RFC25_SG_STRUCTURED_NOTE_PENDING_REVIEW",
+      policyPackId: "SG_PRIVATE_BANKING_REFERENCE",
+      policyVersion: "2026.05",
+      createdBy: "advisor_1",
+      expectedEvaluationStatus: "PENDING_REVIEW",
+      expectedClientReadyPublication: "BLOCKED",
+      expectedWorkbenchPanel: "advisory.suitability_review",
+      evidenceBundle: {
+        context_resolution: {
+          advisory_policy_context: {
+            household_id: "HH-PB-001",
+            jurisdiction: "SG",
+            client_classification: "ACCREDITED_INVESTOR",
+            booking_center_code: "SG",
+            account_id: "ACCT-PB-001",
+            time_horizon: "5Y",
+            liquidity_need: "MEDIUM",
+            mandate_id: "MANDATE-BALANCED-001",
+            objectives: ["capital_preservation", "balanced_growth"],
+            restrictions: ["no_single_name_above_10pct"],
+          },
+        },
+        inputs: {
+          portfolio_snapshot: {
+            portfolio_id: "PB_SG_GLOBAL_BAL_001",
+            positions: [{ instrument_id: "US_EQ_ETF", quantity: "100" }],
+            cash_balances: [{ currency: "USD", amount: "50000" }],
+          },
+          market_data_snapshot: {
+            prices: [{ instrument_id: "SG_STRUCTURED_NOTE", price: "100", currency: "USD" }],
+            fx_rates: [{ pair: "USD/SGD", rate: "1.35" }],
+          },
+          shelf_entries: [
+            {
+              instrument_id: "SG_STRUCTURED_NOTE",
+              eligibility: { jurisdictions: ["SG"] },
+              target_market: { client_segments: ["ACCREDITED_INVESTOR"] },
+              complexity: "COMPLEX",
+              private_asset: false,
+              structured_product: true,
+            },
+          ],
+          proposed_trades: [{ instrument_id: "SG_STRUCTURED_NOTE", side: "BUY" }],
+        },
+        risk_lens: {
+          source_service: "lotus-risk",
+          single_position_concentration: { top_position_weight_current: "0.10" },
+          issuer_concentration: { hhi_current: "1200" },
+          drawdown: { max_drawdown_1y: "0.08" },
+          var: { var_95_1m: "0.04" },
+          stress: { equity_down_20: "-0.09" },
+          liquidity_risk: { days_to_liquidate: "3" },
+          private_asset_risk: { private_asset_weight: "0.00" },
+          climate_geopolitical_risk: { status: "not_material" },
+        },
+        artifact: {
+          assumptions_and_limits: {
+            costs_and_fees: { included: true },
+            tax: { included: true },
+            execution: { included: true },
+          },
+          disclosures: {
+            product_docs: [{ instrument_id: "SG_STRUCTURED_NOTE", doc_ref: "Term sheet" }],
+          },
+        },
+        conflict_evidence: { material_conflict: false, review_ref: "conflict-review-001" },
+      },
+    },
+  },
 };
 
 export const DEFAULT_PANEL_REGISTRY = {
@@ -366,6 +452,9 @@ export async function loadCanonicalContractMetadata(cwd = process.cwd()) {
             payload.dpm_command_center?.multi_portfolio_wave_scenario
           ),
         },
+        advisoryProposalScenarios: normalizeAdvisoryProposalScenarios(
+          payload.advisory_proposal_scenarios
+        ),
         sourcePath: candidatePath,
       };
     } catch (error) {
@@ -400,6 +489,44 @@ function normalizeMultiPortfolioWaveScenario(rawScenario) {
       Number(rawScenario.minimum_portfolio_count ?? fallback.minimumPortfolioCount) ||
       fallback.minimumPortfolioCount,
     portfolios: Array.isArray(rawScenario.portfolios) ? rawScenario.portfolios : fallback.portfolios,
+  };
+}
+
+function normalizeAdvisoryProposalScenarios(rawScenario) {
+  const fallback = DEFAULT_CANONICAL_CONTRACT.advisoryProposalScenarios;
+  if (!rawScenario || typeof rawScenario !== "object") {
+    return fallback;
+  }
+  const rawProposal = rawScenario.proposal && typeof rawScenario.proposal === "object"
+    ? rawScenario.proposal
+    : {};
+  const rawPolicy = rawScenario.policy_evaluation && typeof rawScenario.policy_evaluation === "object"
+    ? rawScenario.policy_evaluation
+    : {};
+  return {
+    scenarioId: rawScenario.scenario_id ?? fallback.scenarioId,
+    sourceScope: rawScenario.source_scope ?? fallback.sourceScope,
+    proposal: {
+      title: rawProposal.title ?? fallback.proposal.title,
+      createdBy: rawProposal.created_by ?? fallback.proposal.createdBy,
+      jurisdiction: rawProposal.jurisdiction ?? fallback.proposal.jurisdiction,
+      advisorNotes: rawProposal.advisor_notes ?? fallback.proposal.advisorNotes,
+      narrativeRequest: rawProposal.narrative_request ?? fallback.proposal.narrativeRequest,
+    },
+    policyEvaluation: {
+      scenarioId: rawPolicy.scenario_id ?? fallback.policyEvaluation.scenarioId,
+      policyPackId: rawPolicy.policy_pack_id ?? fallback.policyEvaluation.policyPackId,
+      policyVersion: rawPolicy.policy_version ?? fallback.policyEvaluation.policyVersion,
+      createdBy: rawPolicy.created_by ?? fallback.policyEvaluation.createdBy,
+      expectedEvaluationStatus:
+        rawPolicy.expected_evaluation_status ?? fallback.policyEvaluation.expectedEvaluationStatus,
+      expectedClientReadyPublication:
+        rawPolicy.expected_client_ready_publication ??
+        fallback.policyEvaluation.expectedClientReadyPublication,
+      expectedWorkbenchPanel:
+        rawPolicy.expected_workbench_panel ?? fallback.policyEvaluation.expectedWorkbenchPanel,
+      evidenceBundle: rawPolicy.evidence_bundle ?? fallback.policyEvaluation.evidenceBundle,
+    },
   };
 }
 

--- a/scripts/live/validation/payload-utils.mjs
+++ b/scripts/live/validation/payload-utils.mjs
@@ -1,0 +1,17 @@
+import { createHash } from "node:crypto";
+
+export function buildPayloadScopedIdempotencyKey(prefix, payload) {
+  const digest = createHash("sha256").update(JSON.stringify(payload)).digest("hex").slice(0, 16);
+  return `${prefix}-${digest}`.slice(0, 64);
+}
+
+export function readString(value) {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+export function extractGatewayEnvelopeData(payload) {
+  if (payload?.data && typeof payload.data === "object") {
+    return payload.data;
+  }
+  return payload;
+}

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -216,9 +216,15 @@ describe("canonical live validation script", () => {
     expect(script).toContain("validateProposalNarrativePosturePanel");
     expect(script).toContain("validateProposalMemoEvidencePackPanel");
     expect(script).toContain("Create proposal narrative canonical proof");
+    expect(script).toContain("Create advisory policy evaluation canonical proof");
+    expect(script).toContain("Advisory policy review queue canonical proof");
+    expect(script).toContain("POLICY_EVALUATION_PENDING_REVIEW_CREATED");
+    expect(script).toContain("POLICY_PACK_VERSION_ALREADY_ACTIVE_IMMUTABLE");
+    expect(script).toContain('status: "already_active"');
     expect(script).toContain('import { createHash } from "node:crypto"');
     expect(script).toContain("buildPayloadScopedIdempotencyKey");
     expect(script).toContain("proposalCreateIdempotencyKey");
+    expect(script).toContain("wb-policy-evaluation");
     expect(script).toContain("proofPackIdempotencyKey");
     expect(script).toContain("proposal.narrative_posture");
     expect(script).toContain("proposal.memo_evidence_pack");
@@ -502,6 +508,8 @@ describe("canonical live validation script", () => {
     expect(contractModule).toContain('panelId: "performance.risk.snapshot"');
     expect(contractModule).toContain('panelId: "proposal.narrative_posture"');
     expect(contractModule).toContain('panelId: "proposal.memo_evidence_pack"');
+    expect(contractModule).toContain("advisoryProposalScenarios");
+    expect(contractModule).toContain("RFC25_SG_STRUCTURED_NOTE_PENDING_REVIEW");
     expect(contractModule).toContain('screenshotName: "performance-risk-live.png"');
     expect(contractModule).toContain('screenshotName: "proposal-narrative-posture-live.png"');
     expect(contractModule).toContain('screenshotName: "proposal-memo-evidence-pack-live.png"');

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -201,6 +201,14 @@ describe("canonical live validation script", () => {
       join(process.cwd(), "scripts", "live", "validation", "browser-workflows.mjs"),
       "utf8"
     );
+    const advisoryPolicyProof = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "advisory-policy-proof.mjs"),
+      "utf8"
+    );
+    const payloadUtils = readFileSync(
+      join(process.cwd(), "scripts", "live", "validation", "payload-utils.mjs"),
+      "utf8"
+    );
 
     expect(script).toContain("assertPerformanceCalculationSanity");
     expect(script).toContain("assertRiskCalculationSanity");
@@ -215,16 +223,18 @@ describe("canonical live validation script", () => {
     expect(script).toContain("validateAdvisoryJourneyScreens");
     expect(script).toContain("validateProposalNarrativePosturePanel");
     expect(script).toContain("validateProposalMemoEvidencePackPanel");
+    expect(script).toContain('from "./validation/advisory-policy-proof.mjs"');
     expect(script).toContain("Create proposal narrative canonical proof");
-    expect(script).toContain("Create advisory policy evaluation canonical proof");
-    expect(script).toContain("Advisory policy review queue canonical proof");
-    expect(script).toContain("POLICY_EVALUATION_PENDING_REVIEW_CREATED");
-    expect(script).toContain("POLICY_PACK_VERSION_ALREADY_ACTIVE_IMMUTABLE");
-    expect(script).toContain('status: "already_active"');
-    expect(script).toContain('import { createHash } from "node:crypto"');
+    expect(advisoryPolicyProof).toContain("Create advisory policy evaluation canonical proof");
+    expect(advisoryPolicyProof).toContain("Advisory policy review queue canonical proof");
+    expect(advisoryPolicyProof).toContain("POLICY_EVALUATION_PENDING_REVIEW_CREATED");
+    expect(advisoryPolicyProof).toContain("POLICY_PACK_VERSION_ALREADY_ACTIVE_IMMUTABLE");
+    expect(advisoryPolicyProof).toContain('status: "already_active"');
+    expect(payloadUtils).toContain('import { createHash } from "node:crypto"');
+    expect(payloadUtils).toContain("buildPayloadScopedIdempotencyKey");
     expect(script).toContain("buildPayloadScopedIdempotencyKey");
     expect(script).toContain("proposalCreateIdempotencyKey");
-    expect(script).toContain("wb-policy-evaluation");
+    expect(advisoryPolicyProof).toContain("wb-policy-evaluation");
     expect(script).toContain("proofPackIdempotencyKey");
     expect(script).toContain("proposal.narrative_posture");
     expect(script).toContain("proposal.memo_evidence_pack");

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -66,9 +66,12 @@
   client-ready, communication, execution, or backend capability claim.
 - RFC-0025 Suitability Review policy-queue proof must use the Gateway-backed advisory policy
   review queue, selected evaluation, sign-off package, workflow posture, and bounded
-  request-more-evidence decision route. It must verify that Workbench renders source-owned policy
-  posture in advisor language without claiming local suitability calculation, policy approval,
-  waiver authority, sign-off completion, or client-ready publication.
+  request-more-evidence decision route. The live validator seeds this from the governed
+  `RFC25_SG_STRUCTURED_NOTE_PENDING_REVIEW` scenario in the canonical front-office demo-data
+  contract, then records `POLICY_EVALUATION_PENDING_REVIEW_CREATED` in `workflowPackChecks`.
+  It must verify that Workbench renders source-owned policy posture in advisor language without
+  claiming local suitability calculation, policy approval, waiver authority, sign-off completion, or
+  client-ready publication.
 - observability evidence capture writes local non-functional proof packs under
   `output/observability-live/<timestamp>/`
 - final visual review should use canonical validated captures, not pre-validation diagnostics


### PR DESCRIPTION
## Summary
- extends canonical Workbench live validation to create real RFC-0025 advisory policy evidence through Gateway
- handles immutable already-active policy-pack activation as idempotent replay evidence
- refactors advisory policy proof and payload helpers into focused modules
- updates runbook/wiki validation guidance

## Validation
- npm test -- --run tests/unit/live-canonical-validation-script.test.ts
- node --check scripts/live/validate-canonical-workbench-live.mjs
- node --check scripts/live/validation/advisory-policy-proof.mjs
- node --check scripts/live/validation/payload-utils.mjs
- npm run live:validate passed after stack bring-up for PB_SG_GLOBAL_BAL_001