### PR TITLE
Align live bank demo claim posture rendering

### DIFF
--- a/scripts/live/validation/contract-metadata.mjs
+++ b/scripts/live/validation/contract-metadata.mjs
@@ -203,9 +203,8 @@ export const DEFAULT_CANONICAL_CONTRACT = {
       expectedClientReadyPublication: "BLOCKED",
       expectedClaimPostures: {
         backend_proof_capture_repeatable: "IMPLEMENTATION_BACKED",
-        advisor_journey_backend_evidence_available:
-          "BACKEND_BACKED_UI_PENDING",
-        advisor_use_document_proof_available: "BACKEND_BACKED_UI_PENDING",
+        advisor_journey_backend_evidence_available: "IMPLEMENTATION_BACKED",
+        advisor_use_document_proof_available: "IMPLEMENTATION_BACKED",
         client_ready_publication_blocked: "UNSUPPORTED",
       },
       unsupportedCapabilityBoundaries: [

--- a/tests/integration/bank-demo-proof-workspace.test.tsx
+++ b/tests/integration/bank-demo-proof-workspace.test.tsx
@@ -38,7 +38,7 @@ const getBankDemoSupportedClaimRegisterMock = vi.fn(async () => ({
     {
       claim_id: "advisor_journey_backend_evidence_available",
       title: "Advisor journey backend evidence available",
-      classification: "BACKEND_BACKED_UI_PENDING",
+      classification: "IMPLEMENTATION_BACKED",
       audiences: ["CLIENT_DEMO", "PRE_SALES"],
       allowed_materials: ["WIKI", "DEMO_SCRIPT"],
       claim_text:
@@ -110,7 +110,7 @@ describe("BankDemoProofWorkspace", () => {
     expect(
       screen.getByText("Advisor journey backend evidence available"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Backend Backed UI Pending")).toBeInTheDocument();
+    expect(screen.getByText("Implementation Backed")).toBeInTheDocument();
     expect(
       screen.getByText("Client-ready publication is blocked"),
     ).toBeInTheDocument();

--- a/tests/unit/bank-demo-proof-view-model.test.ts
+++ b/tests/unit/bank-demo-proof-view-model.test.ts
@@ -38,7 +38,7 @@ describe("bank demo proof view model", () => {
           {
             claim_id: "advisor_journey_backend_evidence_available",
             title: "Advisor journey backend evidence available",
-            classification: "BACKEND_BACKED_UI_PENDING",
+            classification: "IMPLEMENTATION_BACKED",
             audiences: ["CLIENT_DEMO"],
             allowed_materials: ["DEMO_SCRIPT"],
             claim_text:
@@ -82,8 +82,8 @@ describe("bank demo proof view model", () => {
       expect.arrayContaining([
         expect.objectContaining({
           title: "Advisor journey backend evidence available",
-          classification: "Backend Backed UI Pending",
-          classificationTone: "warn",
+          classification: "Implementation Backed",
+          classificationTone: "success",
           proofRequirements: "RFC0028 Backend Advisor Journey Review",
         }),
         expect.objectContaining({


### PR DESCRIPTION
## Summary
- align Workbench live validation metadata and proof rendering with implementation-backed RFC-0028 claim postures
- update focused view-model and integration expectations for claim posture state

## Evidence
- npm test -- --run tests/unit/bank-demo-proof-view-model.test.ts tests/integration/bank-demo-proof-workspace.test.tsx: 3 passed
- Remote Feature Lane: https://github.com/sgajbi/lotus-workbench/actions/runs/27687386499
- npm run live:validate passed for PB_SG_GLOBAL_BAL_001 after platform/workbench/gateway alignment

## Risk
- This changes proof posture text/state only where backend evidence is now available; unsupported client-ready publication remains blocked.