### PR TITLE
Accept empty priority attention in canonical validator

### DIFF
--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -551,11 +551,20 @@ export async function validatePortfolioPanels(
   await expect(page.getByText("YTD Return")).toBeVisible({
     timeout: timeoutMs,
   });
-  await expect(
-    page.getByRole("heading", { name: "Review priority attention" }),
-  ).toBeVisible({
-    timeout: timeoutMs,
+  const priorityAttentionHeading = page.getByRole("heading", {
+    name: "Review priority attention",
   });
+  if ((await priorityAttentionHeading.count()) > 0) {
+    await expect(priorityAttentionHeading).toBeVisible({
+      timeout: timeoutMs,
+    });
+  } else {
+    await expect(
+      page.getByText("No priority attention items for the selected view."),
+    ).toBeVisible({
+      timeout: timeoutMs,
+    });
+  }
   await expect(
     page.getByRole("heading", { name: "Review Evidence" }),
   ).toBeVisible({


### PR DESCRIPTION
## Summary
- updates canonical browser validation to accept the legitimate no-priority-attention UI state
- keeps failure behavior for broken attention panels while avoiding false negatives when the selected view has no priority items

## Evidence
- `node --check scripts\live\validation\browser-workflows.mjs`
- canonical Workbench validation passed for `PB_SG_GLOBAL_BAL_001`
- evidence path: `output\playwright\live-canonical\live-validation-summary.json`

## Risk
- validation-only change; no product runtime code changed