### PR TITLE
Make canonical copilot review validation repeatable

### DIFF
--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -371,13 +371,39 @@ export async function validateAdvisoryJourneyScreens(
       await expect(page.getByText("Run posture", { exact: true })).toBeVisible({
         timeout: timeoutMs,
       });
-      await expect(
-        page.getByRole("button", { name: "Record internal review" }),
-      ).toBeEnabled({
-        timeout: timeoutMs,
+      const internalReviewButton = page.getByRole("button", {
+        name: "Record internal review",
       });
-      await page.getByRole("button", { name: "Record internal review" }).click();
-      await expect(page.getByLabel("Status Approved For Internal Use")).toBeVisible({
+      const approvedPosture = page.getByText("Approved For Internal Use", {
+        exact: true,
+      });
+      const reviewReadyDeadline = Date.now() + timeoutMs;
+      let reviewState = "pending";
+      while (Date.now() < reviewReadyDeadline) {
+        if (
+          await approvedPosture
+            .first()
+            .isVisible()
+            .catch(() => false)
+        ) {
+          reviewState = "approved";
+          break;
+        }
+        if (await internalReviewButton.isEnabled().catch(() => false)) {
+          reviewState = "reviewable";
+          break;
+        }
+        await page.waitForTimeout(500);
+      }
+      if (reviewState === "pending") {
+        throw new Error(
+          "Advisory copilot review never became reviewable or approved.",
+        );
+      }
+      if (reviewState === "reviewable") {
+        await internalReviewButton.click();
+      }
+      await expect(approvedPosture.first()).toBeVisible({
         timeout: timeoutMs,
       });
       await expect(page.getByText("workflow_pack")).toHaveCount(0);

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -1003,11 +1003,10 @@ describe("canonical live validation script", () => {
     expect(browserWorkflowModule).toContain("Advisory copilot posture");
     expect(browserWorkflowModule).toContain("Record internal review");
     expect(browserWorkflowModule).toContain(
-      'getByLabel("Status Approved For Internal Use")',
+      'getByText("Approved For Internal Use",',
     );
-    expect(browserWorkflowModule).not.toContain(
-      'getByText("Approved For Internal Use")',
-    );
+    expect(browserWorkflowModule).toContain('reviewState = "approved"');
+    expect(browserWorkflowModule).toContain('reviewState = "reviewable"');
     expect(browserWorkflowModule).toContain(
       "advisory-proposal-builder-live.png",
     );


### PR DESCRIPTION
## Summary
- make the canonical advisory copilot browser validation tolerate an idempotently already-approved internal review state
- keep the existing path that clicks Record internal review when the run is still reviewable

## Evidence
- node --check scripts/live/validation/browser-workflows.mjs
- powershell -ExecutionPolicy Bypass -File scripts/live/Validate-LotusFrontOfficeCanonical.ps1 -PortfolioId PB_SG_GLOBAL_BAL_001 -BenchmarkCode BMK_PB_GLOBAL_BALANCED_60_40 -ScreenshotDirectory output/playwright/live-canonical-main
- live evidence: output/playwright/live-canonical-main/live-validation-summary.json generatedAt 2026-06-17T17:41:42.911Z
- screenshot index: output/playwright/live-canonical-main/SHOT-INDEX.md, 29 demo_ready captures

## Risk
- scoped to live validation automation; no product runtime behavior changed
- preserves failure when the run is neither reviewable nor already approved
