### PR TITLE
Fix proof pack preload demo posture

### DIFF
--- a/src/features/workbench/manage-workspace-data.ts
+++ b/src/features/workbench/manage-workspace-data.ts
@@ -13,6 +13,7 @@ import {
   getDpmPmOperatingQualitySummaryInvocation,
   getDpmPortfolioMemory,
   getDpmProofPack,
+  getWorkbenchApiErrorStatus,
   listDpmCampaignDefinitions,
   listDpmCampaignDiscovery,
   listDpmCampaignApprovalInbox,
@@ -159,12 +160,12 @@ export async function loadManageWorkspaceData(
 
   let proofPack: Awaited<ReturnType<typeof getDpmProofPack>> | null = null;
   let proofPackError: string | null = null;
-  const proofPackId = readDpmProofPackId(outcomeReviews?.data ?? null);
+  const proofPackId = readPreloadableDpmProofPackId(outcomeReviews?.data ?? null);
   if (proofPackId) {
     try {
-      proofPack = await getDpmProofPack(proofPackId);
+      proofPack = await getDpmProofPack(proofPackId, "server");
     } catch (error) {
-      proofPackError = error instanceof Error ? error.message : "Evidence pack endpoint unavailable.";
+      proofPackError = proofPackPreloadErrorMessage(error);
     }
   }
 
@@ -403,6 +404,24 @@ export function readDpmSummaryInvocationId(data: Record<string, unknown> | null)
     }
   }
   return null;
+}
+
+export function readPreloadableDpmProofPackId(data: Record<string, unknown> | null): string | null {
+  if (!data) {
+    return null;
+  }
+  if (typeof data.proof_pack_id === "string" && data.proof_pack_id.trim().length > 0) {
+    return data.proof_pack_id;
+  }
+  return null;
+}
+
+export function proofPackPreloadErrorMessage(error: unknown): string | null {
+  const status = getWorkbenchApiErrorStatus(error);
+  if (status === 404) {
+    return null;
+  }
+  return "Evidence pack preload is temporarily unavailable. Prepare evidence to generate the current review pack.";
 }
 
 export function readDpmReviewActionId(data: Record<string, unknown> | null): string | null {

--- a/src/features/workbench/use-proof-pack-actions.ts
+++ b/src/features/workbench/use-proof-pack-actions.ts
@@ -8,6 +8,7 @@ import {
   getDpmProofPackReportInput,
   requestDpmProofPackAiPmMemo,
 } from "@/features/workbench/proof-pack-api";
+import { getWorkbenchApiErrorStatus } from "@/features/workbench/api-client";
 import {
   buildProofPackPanelModel,
   type ProofPackPanelModel,
@@ -43,6 +44,7 @@ type UseProofPackActionsResult = {
 
 export function useProofPackActions({
   initialProofPack,
+  contextProofPackId,
   contextRebalanceRunId,
   contextMandateId,
   mandateId,
@@ -53,7 +55,8 @@ export function useProofPackActions({
   const [actionError, setActionError] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const model = buildProofPackPanelModel(proofPack);
-  const proofPackId = model.proofPackId !== "N/A" ? model.proofPackId : null;
+  const proofPackId =
+    model.proofPackId !== "N/A" ? model.proofPackId : contextProofPackId;
   const rebalanceRunId =
     contextRebalanceRunId ?? (model.rebalanceRunId !== "N/A" ? model.rebalanceRunId : null);
   const resolvedMandateId =
@@ -68,6 +71,12 @@ export function useProofPackActions({
     try {
       await action();
     } catch (error) {
+      if (getWorkbenchApiErrorStatus(error) === 404) {
+        setActionError(
+          "Evidence pack is not available from Gateway. Prepare evidence to generate the current review pack."
+        );
+        return;
+      }
       setActionError(error instanceof Error ? error.message : `${label} failed`);
     } finally {
       setPendingAction(null);

--- a/src/features/workbench/use-proof-pack-actions.ts
+++ b/src/features/workbench/use-proof-pack-actions.ts
@@ -43,7 +43,6 @@ type UseProofPackActionsResult = {
 
 export function useProofPackActions({
   initialProofPack,
-  contextProofPackId,
   contextRebalanceRunId,
   contextMandateId,
   mandateId,
@@ -54,7 +53,7 @@ export function useProofPackActions({
   const [actionError, setActionError] = useState<string | null>(null);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const model = buildProofPackPanelModel(proofPack);
-  const proofPackId = model.proofPackId !== "N/A" ? model.proofPackId : contextProofPackId;
+  const proofPackId = model.proofPackId !== "N/A" ? model.proofPackId : null;
   const rebalanceRunId =
     contextRebalanceRunId ?? (model.rebalanceRunId !== "N/A" ? model.rebalanceRunId : null);
   const resolvedMandateId =

--- a/tests/integration/workbench-page.test.tsx
+++ b/tests/integration/workbench-page.test.tsx
@@ -295,7 +295,7 @@ describe("WorkbenchPage", () => {
     ).toBe(true);
   });
 
-  it("renders the evidence pack from the linked Gateway proof pack", async () => {
+  it("renders the evidence pack without preloading context-only outcome review proof refs", async () => {
     const fetchMock = vi.fn(createManageFetch({ portfolioId: "PF_5001" }));
     vi.stubGlobal("fetch", fetchMock);
 
@@ -308,16 +308,16 @@ describe("WorkbenchPage", () => {
 
     expect(screen.getAllByRole("heading", { name: "Evidence Pack" }).length).toBeGreaterThan(0);
     expect(screen.getByText("Evidence Areas")).toBeInTheDocument();
-    expect(screen.getAllByText("Mandate Alignment").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Ready for advisor review").length).toBeGreaterThan(0);
-    expect(screen.getByText("Signature Pending")).toBeInTheDocument();
+    expect(screen.queryByText("Mandate Alignment")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ready for advisor review")).not.toBeInTheDocument();
+    expect(screen.queryByText("Signature Pending")).not.toBeInTheDocument();
     expect(screen.queryByText("ppack_1")).not.toBeInTheDocument();
     expect(screen.queryByText("sha256:proof-pack")).not.toBeInTheDocument();
     expect(
       fetchMock.mock.calls.some(([input]) =>
         input.toString().includes("/api/v1/dpm/command-center/proof-packs/ppack_1")
       )
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 

--- a/tests/unit/manage-workspace-data.test.ts
+++ b/tests/unit/manage-workspace-data.test.ts
@@ -1,13 +1,27 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import {
+  proofPackPreloadErrorMessage,
   readDpmFairnessAnalysisId,
   readDpmMandateId,
+  readPreloadableDpmProofPackId,
   readDpmProofPackId,
   readDpmReviewActionId,
 } from "../../src/features/workbench/manage-workspace-data";
+import { WorkbenchApiError } from "../../src/features/workbench/api-client";
 
 describe("manage workspace data selectors", () => {
+  it("preloads proof-pack detail through the server Gateway target", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../src/features/workbench/manage-workspace-data.ts"),
+      "utf8"
+    );
+
+    expect(source).toContain('getDpmProofPack(proofPackId, "server")');
+  });
+
   it("reads mandate identifiers from top-level and nested Gateway payloads", () => {
     expect(readDpmMandateId({ mandate_id: "mandate_direct" })).toBe("mandate_direct");
     expect(readDpmMandateId({ mandate: { mandate_id: "mandate_nested" } })).toBe(
@@ -24,6 +38,24 @@ describe("manage workspace data selectors", () => {
       })
     ).toBe("ppack_from_review");
     expect(readDpmProofPackId({ items: [{ proof_pack_id: " " }] })).toBeNull();
+  });
+
+  it("preloads only directly available proof-pack detail identifiers", () => {
+    expect(readPreloadableDpmProofPackId({ proof_pack_id: "ppack_direct" })).toBe(
+      "ppack_direct"
+    );
+    expect(
+      readPreloadableDpmProofPackId({
+        items: [{ proof_pack_id: "ppack_from_review" }],
+      })
+    ).toBeNull();
+  });
+
+  it("renders product-safe copy for optional proof-pack preload failures", () => {
+    expect(proofPackPreloadErrorMessage(new WorkbenchApiError("DPM proof pack", 404))).toBeNull();
+    expect(proofPackPreloadErrorMessage(new Error("Failed to parse URL from /api/bff"))).toBe(
+      "Evidence pack preload is temporarily unavailable. Prepare evidence to generate the current review pack."
+    );
   });
 
   it("reads fairness-analysis identifiers from every supported Gateway shape", () => {

--- a/tests/unit/use-proof-pack-actions.test.ts
+++ b/tests/unit/use-proof-pack-actions.test.ts
@@ -9,6 +9,7 @@ import {
   getDpmProofPackReportInput,
   requestDpmProofPackAiPmMemo,
 } from "../../src/features/workbench/proof-pack-api";
+import { WorkbenchApiError } from "../../src/features/workbench/api-client";
 import type { DpmProofPackGatewayResponse } from "../../src/features/workbench/types";
 
 vi.mock("../../src/features/workbench/proof-pack-api", () => ({
@@ -85,7 +86,7 @@ describe("useProofPackActions", () => {
     vi.mocked(generateDpmProofPackFromRun).mockResolvedValue(readyProofPack);
     const { result } = renderProofPackActions(null);
 
-    expect(result.current.proofPackId).toBeNull();
+    expect(result.current.proofPackId).toBe("context_ppack");
 
     act(() => {
       result.current.generateProofPack();
@@ -99,6 +100,34 @@ describe("useProofPackActions", () => {
     });
     await waitFor(() => expect(result.current.handoffStatus).toBe("Evidence pack prepared."));
     expect(result.current.model.proofPackId).toBe("ppack_1");
+  });
+
+  it("keeps context proof-pack ids available for intentional manual loading", async () => {
+    vi.mocked(getDpmProofPack).mockResolvedValue(readyProofPack);
+    const { result } = renderProofPackActions(null);
+
+    expect(result.current.model.proofPackId).toBe("N/A");
+    expect(result.current.proofPackId).toBe("context_ppack");
+
+    act(() => result.current.loadProofPack());
+
+    await waitFor(() => expect(getDpmProofPack).toHaveBeenCalledWith("context_ppack"));
+    await waitFor(() => expect(result.current.handoffStatus).toBe("Evidence pack loaded."));
+    expect(result.current.model.proofPackId).toBe("ppack_1");
+  });
+
+  it("reports missing context proof-pack detail as a product-safe unavailable state", async () => {
+    vi.mocked(getDpmProofPack).mockRejectedValue(new WorkbenchApiError("DPM proof pack", 404));
+    const { result } = renderProofPackActions(null);
+
+    act(() => result.current.loadProofPack());
+
+    await waitFor(() => expect(getDpmProofPack).toHaveBeenCalledWith("context_ppack"));
+    await waitFor(() =>
+      expect(result.current.actionError).toBe(
+        "Evidence pack is not available from Gateway. Prepare evidence to generate the current review pack."
+      )
+    );
   });
 
   it("loads proof-pack detail and handoff payload posture through Gateway only", async () => {

--- a/tests/unit/use-proof-pack-actions.test.ts
+++ b/tests/unit/use-proof-pack-actions.test.ts
@@ -85,6 +85,8 @@ describe("useProofPackActions", () => {
     vi.mocked(generateDpmProofPackFromRun).mockResolvedValue(readyProofPack);
     const { result } = renderProofPackActions(null);
 
+    expect(result.current.proofPackId).toBeNull();
+
     act(() => {
       result.current.generateProofPack();
     });


### PR DESCRIPTION
## Summary- fix Workbench proof-pack server preload so server-rendered Manage evidence pages do not use the client-relative BFF URL- treat outcome-review proof-pack references as context-only until a real proof-pack detail is loaded or generated- keep missing optional preload evidence out of the initial advisor-facing demo surface while preserving the Gateway-backed Prepare evidence path## Evidence- `npm test -- --run tests/unit/manage-workspace-data.test.ts tests/unit/use-proof-pack-actions.test.ts` PASS- `npm run lint` PASS- `npm run typecheck` PASS- `docker compose up -d --build lotus-workbench` PASS, existing AG Grid CSS autoprefixer warning only- Canonical validation PASS: `output/playwright/live-canonical-20260618-proof-pack-context-only-fix/live-validation-summary.json`  - 29 screenshots, 25/25 panels ready, 0 non-ready, 0 missing, 0 unexpected API failures- Observability evidence PASS: `output/observability-live/20260618-proof-pack-context-only-fix/observability-evidence-manifest.json`  - DNS 13/13, API 13/13, metrics 4/4, logs 14/14, Prometheus targets 14/14 up  - no proof-pack-detail or Workbench error-state metric counters in the clean pack## Risk- Scoped to Workbench Manage proof-pack preload/action enablement.- No API contract changes and no docs/wiki truth change required.Fix-forward evidence after commit `183053f`:- `npm run lint` - passed.- `npm run typecheck` - passed.- `npm test -- --run tests/integration/workbench-page.test.tsx tests/unit/manage-workspace-data.test.ts tests/unit/use-proof-pack-actions.test.ts` - passed, 20 tests.- `npm test -- --run` - passed, 276 files / 1175 tests.
Review fix-forward evidence after commit `819afb8`:
- Restored context proof-pack ids for intentional manual `Load evidence` actions without restoring unsafe server preloading.
- Missing linked proof-pack detail now reports a product-safe unavailable message instead of raw technical failure text.
- `npm run lint` - passed.
- `npm run typecheck` - passed.
- `npm test -- --run tests/unit/use-proof-pack-actions.test.ts tests/unit/manage-workspace-data.test.ts tests/integration/workbench-page.test.tsx` - passed, 22 tests.
- `npm test -- --run` - passed, 276 files / 1177 tests.