### PR TITLE
[codex] Harden canonical Workbench runtime

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -119,7 +119,10 @@ Current repository posture:
     prompt bodies, model responses, PM rankings, client-contact instructions, order claims, or
     OMS claims.
 15. current UX work emphasizes truthful data-backed modules, stronger density, reduced duplication, and cleaner system-wide visual consistency.
-16. `/recommendations`, `/proposals`, `/proposals/simulate`, and `/proposals/{proposalId}` are
+16. the governed canonical runtime starts `lotus-core` with `DEMO_DATA_PACK_ENABLED=false` so the
+    broad Core app-local demo pack cannot pollute `PB_SG_GLOBAL_BAL_001` evidence, and it starts
+    `lotus-idea` by default because the opportunity mode depends on Idea-owned runtime posture.
+17. `/recommendations`, `/proposals`, `/proposals/simulate`, and `/proposals/{proposalId}` are
     active Gateway-backed advisory lifecycle surfaces. The advisory shell uses a governed journey
     model across overview, RFC-0026 advisor cockpit, RFC-0027 advisory copilot, RFC-0028
     bank-demo proof, opportunities, proposal builder, suitability, risk impact, approval queue,

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -17,6 +17,7 @@ This flow covers the local experience for:
 - `lotus-report`
 - `lotus-archive`
 - `lotus-render`
+- `lotus-idea`
 - `lotus-gateway`
 - `lotus-workbench`
 - direct ingress via `*.dev.lotus`
@@ -40,6 +41,7 @@ Required canonical host mappings on the host:
 127.0.0.1 report.dev.lotus
 127.0.0.1 archive.dev.lotus
 127.0.0.1 render.dev.lotus
+127.0.0.1 idea.dev.lotus
 127.0.0.1 core-query.dev.lotus
 127.0.0.1 core-control.dev.lotus
 127.0.0.1 core-ingestion.dev.lotus
@@ -72,7 +74,7 @@ so the exact required block can still be reviewed and applied manually.
 Direct Administrator fallback:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -Command "Add-Content -Path 'C:\Windows\System32\drivers\etc\hosts' -Value \"`n127.0.0.1 workbench.dev.lotus`n127.0.0.1 gateway.dev.lotus`n127.0.0.1 performance.dev.lotus`n127.0.0.1 risk.dev.lotus`n127.0.0.1 advise.dev.lotus`n127.0.0.1 manage.dev.lotus`n127.0.0.1 report.dev.lotus`n127.0.0.1 archive.dev.lotus`n127.0.0.1 render.dev.lotus`n127.0.0.1 core-query.dev.lotus`n127.0.0.1 core-control.dev.lotus`n127.0.0.1 core-ingestion.dev.lotus`n127.0.0.1 ai.dev.lotus\""
+powershell -ExecutionPolicy Bypass -Command "Add-Content -Path 'C:\Windows\System32\drivers\etc\hosts' -Value \"`n127.0.0.1 workbench.dev.lotus`n127.0.0.1 gateway.dev.lotus`n127.0.0.1 performance.dev.lotus`n127.0.0.1 risk.dev.lotus`n127.0.0.1 advise.dev.lotus`n127.0.0.1 manage.dev.lotus`n127.0.0.1 report.dev.lotus`n127.0.0.1 archive.dev.lotus`n127.0.0.1 render.dev.lotus`n127.0.0.1 idea.dev.lotus`n127.0.0.1 core-query.dev.lotus`n127.0.0.1 core-control.dev.lotus`n127.0.0.1 core-ingestion.dev.lotus`n127.0.0.1 ai.dev.lotus\""
 ```
 
 Workbench local environment:
@@ -98,16 +100,22 @@ npm run live:stack:up
 That script performs:
 
 1. preview the canonical hosts block from `lotus-platform`
-2. `docker compose up -d` for `lotus-core`, `lotus-performance`, `lotus-risk`, `lotus-ai`, `lotus-advise`, `lotus-manage`, `lotus-report`, `lotus-archive`, and `lotus-render`
-3. `docker compose up -d` for `lotus-gateway`
-4. direct ingress restart on port `80` using `lotus-platform/platform-stack/dev-ingress/Caddyfile.direct-host`
-5. canonical `lotus-gateway` exposure on port `8100`
-6. governed `lotus-core` seed for `PB_SG_GLOBAL_BAL_001`
-7. `docker compose up -d` for `lotus-workbench` on port `3000`
+2. `docker compose up -d` for `lotus-core` with `DEMO_DATA_PACK_ENABLED=false`
+3. `docker compose up -d` for `lotus-performance`, `lotus-risk`, `lotus-ai`, `lotus-advise`, `lotus-manage`, `lotus-report`, and `lotus-idea`
+4. seed the governed Lotus Idea advisor queue through `lotus-idea` using a deterministic canonical high-cash candidate for `PB_SG_GLOBAL_BAL_001`
+5. start `lotus-archive` and `lotus-render`
+6. direct ingress restart on port `80` using `lotus-platform/platform-stack/dev-ingress/Caddyfile.direct-host`
+7. canonical `lotus-gateway` exposure on port `8100`
+8. governed `lotus-core` seed for `PB_SG_GLOBAL_BAL_001`
+9. governed DPM command-center seed through `lotus-platform`
+10. `docker compose up -d` for `lotus-workbench` on port `3000`
 
 Docker is the default for every canonical front-office app. The startup flow replaces stale local
 listeners on canonical app ports before Docker startup, while leaving Docker-owned listeners in
 place. This avoids stale local dev servers blocking Docker without terminating Docker port proxies.
+The governed `lotus-core` startup explicitly sets `DEMO_DATA_PACK_ENABLED=false`; the broad
+app-local demo pack remains available for diagnostics, but it is not part of canonical
+`PB_SG_GLOBAL_BAL_001` seeding or evidence collection.
 
 For active RFC or UI development, pass `-LocalApps` with a comma-separated app list. Local apps use
 the same canonical hostnames and public ports as Docker-backed apps, so live evidence remains
@@ -134,7 +142,7 @@ This mode still uses the canonical hosts block, starts Docker-backed `lotus-core
 `lotus-manage` on the canonical coexistence port `8001`, restarts direct ingress, and runs the
 governed `PB_SG_GLOBAL_BAL_001` core seed in ingest-only mode. It intentionally skips `lotus-performance`,
 `lotus-risk`, `lotus-ai`, `lotus-advise`, `lotus-report`, `lotus-archive`, `lotus-render`,
-`lotus-gateway`, and `lotus-workbench`. Use it only for API-level RFC proof where the evidence
+`lotus-idea`, `lotus-gateway`, and `lotus-workbench`. Use it only for API-level RFC proof where the evidence
 target is core source-data products plus manage APIs, not populated Workbench screenshots or
 gateway-mediated product flows.
 

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -24,6 +24,7 @@ $manageRepo = Join-Path $ProjectsRoot "lotus-manage"
 $reportRepo = Join-Path $ProjectsRoot "lotus-report"
 $archiveRepo = Join-Path $ProjectsRoot "lotus-archive"
 $renderRepo = Join-Path $ProjectsRoot "lotus-render"
+$ideaRepo = Join-Path $ProjectsRoot "lotus-idea"
 $gatewayRepo = Join-Path $ProjectsRoot "lotus-gateway"
 $workbenchRepo = Join-Path $ProjectsRoot "lotus-workbench"
 $platformRepo = Join-Path $ProjectsRoot "lotus-platform"
@@ -305,6 +306,86 @@ function Invoke-DpmCommandCenterSeed {
   Invoke-RepoCommand $platformRepo $dpmSeedCommand
 }
 
+function Invoke-CanonicalIdeaSeed {
+  $ideaBaseUrl = "http://127.0.0.1:8330"
+  $deadline = (Get-Date).AddSeconds(120)
+  while ((Get-Date) -lt $deadline) {
+    if (Test-HttpReady "$ideaBaseUrl/health/ready") {
+      break
+    }
+    Start-Sleep -Seconds 2
+  }
+  if (-not (Test-HttpReady "$ideaBaseUrl/health/ready")) {
+    throw "lotus-idea did not become ready before canonical advisor queue seed."
+  }
+
+  $sourceRef = {
+    param([string]$ProductId)
+    return @{
+      productId = $ProductId
+      sourceSystem = "lotus-core"
+      productVersion = "v1"
+      route = "/source/$ProductId"
+      asOfDate = "2026-06-21"
+      generatedAtUtc = "2026-06-21T10:00:00Z"
+      contentHash = "sha256:$($ProductId):canonical-workbench-seed"
+      dataQualityStatus = "complete"
+      freshness = "current"
+    }
+  }
+
+  $payload = @{
+    asOfDate = "2026-06-21"
+    evaluatedAtUtc = "2026-06-21T10:00:00Z"
+    sourceReportedCashWeight = "0.18"
+    sourceEvidence = @{
+      portfolioStateRef = & $sourceRef "lotus-core:PortfolioStateSnapshot:v1"
+      holdingsRef = & $sourceRef "lotus-core:HoldingsAsOf:v1"
+      cashMovementRef = & $sourceRef "lotus-core:PortfolioCashMovementSummary:v1"
+      cashflowProjectionRef = & $sourceRef "lotus-core:PortfolioCashflowProjection:v1"
+    }
+    accessScope = @{
+      tenantId = "tenant-private-bank-sg"
+      bookId = "book-advisor-001"
+      portfolioId = $PortfolioId
+      clientId = "client-001"
+    }
+    entitlementAllowed = $true
+  }
+  $headers = @{
+    "X-Caller-Subject" = "canonical-front-office-seed"
+    "X-Caller-Capabilities" = "idea.candidate.persist"
+    "X-Correlation-Id" = "corr-canonical-idea-seed"
+    "Idempotency-Key" = "canonical-idea-high-cash:$PortfolioId:2026-06-21T10:00:00Z"
+  }
+
+  Write-Host "Seeding governed Lotus Idea advisor queue candidate for $PortfolioId ..."
+  $response = Invoke-RestMethod `
+    -Method Post `
+    -Uri "$ideaBaseUrl/api/v1/idea-signals/high-cash/evaluate-and-persist" `
+    -Headers $headers `
+    -ContentType "application/json" `
+    -Body ($payload | ConvertTo-Json -Depth 12)
+
+  $decision = $response.persistence.decision
+  if ($decision -notin @("accepted", "replayed", "duplicate_candidate")) {
+    throw "Canonical Lotus Idea seed did not persist an advisor queue candidate. Decision: $decision"
+  }
+
+  $queueHeaders = @{
+    "X-Caller-Subject" = "canonical-front-office-validator"
+    "X-Caller-Roles" = "advisor"
+    "X-Caller-Capabilities" = "idea.review.queue.read"
+    "X-Caller-Portfolio-Ids" = $PortfolioId
+  }
+  $queue = Invoke-RestMethod `
+    -Uri "$ideaBaseUrl/api/v1/review-queues/advisor" `
+    -Headers $queueHeaders
+  if ($queue.page.returnedItemCount -lt 1) {
+    throw "Canonical Lotus Idea advisor queue seed completed but returned no reviewable items."
+  }
+}
+
 Write-Host "Previewing managed canonical hosts block from lotus-platform ..."
 Invoke-RepoCommand $platformRepo "powershell -ExecutionPolicy Bypass -File automation\\Sync-Dev-Ingress-Hosts.ps1"
 
@@ -320,7 +401,11 @@ if ($localAppSet.Count -gt 0) {
 Write-Host "Starting Docker-backed canonical services..."
 $resolvedLotusAiEnvFile = Resolve-LotusAiEnvFile -EnvFile $LotusAiEnvFile
 Write-Host "Using lotus-ai env file for canonical proof: $resolvedLotusAiEnvFile"
-Invoke-ComposeUp $coreRepo
+$canonicalCoreEnvironment = @{
+  DEMO_DATA_PACK_ENABLED = "false"
+}
+Write-Host "Starting lotus-core with auxiliary demo data pack disabled for canonical PB seed isolation."
+Invoke-ComposeUp $coreRepo $canonicalCoreEnvironment
 
 if ($CoreManageOnly) {
   Write-Host "Core/manage proof mode enabled; skipping non-essential front-office services."
@@ -345,6 +430,8 @@ Invoke-ComposeUp $adviseRepo
 Start-CanonicalManage
 
 Invoke-ComposeUp $reportRepo
+Invoke-ComposeUp $ideaRepo
+Invoke-CanonicalIdeaSeed
 
 if (Test-LocalApp "archive") {
   Invoke-RepoCommand $archiveRepo "docker compose down --remove-orphans"
@@ -399,6 +486,7 @@ if (-not $RunValidation) {
   Write-Host "  Workbench: http://workbench.dev.lotus"
   Write-Host "  Gateway:   http://gateway.dev.lotus"
   Write-Host "  Manage:    http://manage.dev.lotus"
+  Write-Host "  Idea:      http://idea.dev.lotus"
   Write-Host "  Archive:   http://archive.dev.lotus"
   Write-Host "  Render:    http://render.dev.lotus"
   Write-Host ""

--- a/scripts/live/Stop-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Stop-LotusFrontOfficeCanonical.ps1
@@ -15,6 +15,7 @@ $manageRepo = Join-Path $ProjectsRoot "lotus-manage"
 $reportRepo = Join-Path $ProjectsRoot "lotus-report"
 $archiveRepo = Join-Path $ProjectsRoot "lotus-archive"
 $renderRepo = Join-Path $ProjectsRoot "lotus-render"
+$ideaRepo = Join-Path $ProjectsRoot "lotus-idea"
 $gatewayRepo = Join-Path $ProjectsRoot "lotus-gateway"
 $workbenchRepo = Join-Path $ProjectsRoot "lotus-workbench"
 
@@ -65,7 +66,7 @@ function Remove-ContainerIfPresent {
 }
 
 Write-Host "Stopping canonical host processes..."
-Stop-ListenersOnPorts @(3000, 8001, 8100, 8111, 8150, 8310)
+Stop-ListenersOnPorts @(3000, 8001, 8100, 8111, 8150, 8310, 8330)
 
 Write-Host "Stopping direct ingress..."
 Remove-ContainerIfPresent "lotus-direct-dev-ingress"
@@ -87,6 +88,7 @@ Invoke-RepoCommand $manageRepo $downCommand
 Invoke-RepoCommand $reportRepo $downCommand
 Invoke-RepoCommand $archiveRepo $downCommand
 Invoke-RepoCommand $renderRepo $downCommand
+Invoke-RepoCommand $ideaRepo $downCommand
 Invoke-RepoCommand $gatewayRepo $downCommand
 Invoke-RepoCommand $workbenchRepo $downCommand
 

--- a/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
@@ -1,6 +1,7 @@
 param(
   [string]$PortfolioId = "PB_SG_GLOBAL_BAL_001",
   [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40",
+  [string]$StartDate = "2025-03-31",
   [string]$AsOfDate = "2026-04-10",
   [string]$WorkbenchBaseUrl = "http://workbench.dev.lotus",
   [string]$GatewayBaseUrl = "http://gateway.dev.lotus",
@@ -72,6 +73,21 @@ function Test-Endpoint {
   throw "$lastError after $Attempts attempts."
 }
 
+function Assert-IdeaQueueSeed {
+  $headers = @{
+    "X-Caller-Subject" = "canonical-front-office-validator"
+    "X-Caller-Roles" = "advisor"
+    "X-Caller-Capabilities" = "idea.review.queue.read,idea.candidate.detail.read"
+    "X-Caller-Portfolio-Ids" = $PortfolioId
+  }
+  $url = "$GatewayBaseUrl/api/v1/ideas/review-queues/advisor"
+  $queue = Invoke-RestMethod -Uri $url -Headers $headers -TimeoutSec 45
+  if ($queue.page.returnedItemCount -lt 1) {
+    throw "Gateway Idea review queue is empty for $PortfolioId. Run canonical stack startup to seed Lotus Idea before validation."
+  }
+  Write-Host "[ok] Gateway Idea review queue contains $($queue.page.returnedItemCount) item(s) -> $url"
+}
+
 Test-CanonicalHost "workbench.dev.lotus"
 Test-CanonicalHost "gateway.dev.lotus"
 Test-CanonicalHost "core-query.dev.lotus"
@@ -84,6 +100,7 @@ Test-CanonicalHost "manage.dev.lotus"
 Test-CanonicalHost "report.dev.lotus"
 Test-CanonicalHost "archive.dev.lotus"
 Test-CanonicalHost "render.dev.lotus"
+Test-CanonicalHost "idea.dev.lotus"
 Test-CanonicalHost "ai.dev.lotus" -Optional
 
 Test-Endpoint "$GatewayBaseUrl/health/ready" "Gateway readiness"
@@ -93,14 +110,16 @@ Test-Endpoint "http://manage.dev.lotus/health/ready" "lotus-manage readiness"
 Test-Endpoint "http://report.dev.lotus/health/ready" "lotus-report readiness"
 Test-Endpoint "http://archive.dev.lotus/health/ready" "lotus-archive readiness"
 Test-Endpoint "http://render.dev.lotus/health/ready" "lotus-render readiness"
+Test-Endpoint "http://idea.dev.lotus/health/ready" "lotus-idea readiness"
 Test-Endpoint "http://manage.dev.lotus/api/v1/rebalance/supportability/summary" "lotus-manage supportability summary"
 Test-Endpoint "http://report.dev.lotus/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default" "lotus-report integration capabilities"
 Test-Endpoint "$GatewayBaseUrl/api/v1/foundation/portfolios/$PortfolioId/workspace" "Gateway foundation workspace" -Headers $canonicalCallerContextHeaders
 Test-Endpoint "$GatewayBaseUrl/api/v1/platform/capabilities" "Gateway platform capabilities" -Headers $canonicalCallerContextHeaders
 Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/overview" "Gateway workbench overview" -Headers $canonicalCallerContextHeaders
-Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode&report_end_date=$AsOfDate" "Gateway performance summary" -Headers $canonicalCallerContextHeaders
-Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/risk/summary?period=YTD&detail_basis=NET&benchmark_code=$BenchmarkCode&as_of_date=$AsOfDate" "Gateway risk summary" -Headers $canonicalCallerContextHeaders
-Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode&report_end_date=$AsOfDate" "Gateway advisor brief" -Headers $canonicalCallerContextHeaders
+Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/summary?period=EXPLICIT&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode&report_start_date=$StartDate&report_end_date=$AsOfDate" "Gateway performance summary" -Headers $canonicalCallerContextHeaders
+Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/risk/summary?period=EXPLICIT&detail_basis=NET&benchmark_code=$BenchmarkCode&report_start_date=$StartDate&report_end_date=$AsOfDate&as_of_date=$AsOfDate" "Gateway risk summary" -Headers $canonicalCallerContextHeaders
+Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=EXPLICIT&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode&report_start_date=$StartDate&report_end_date=$AsOfDate" "Gateway advisor brief" -Headers $canonicalCallerContextHeaders
+Assert-IdeaQueueSeed
 
 Push-Location $repoRoot
 try {
@@ -110,6 +129,8 @@ try {
     $PortfolioId,
     "--benchmark-code",
     $BenchmarkCode,
+    "--start-date",
+    $StartDate,
     "--as-of-date",
     $AsOfDate,
     "--workbench-base-url",

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -69,6 +69,7 @@ const {
   gatewayBaseUrl,
   outputDir,
   timeoutMs,
+  canonicalStartDate,
   canonicalAsOfDate,
 } = resolveValidationConfig(process.argv.slice(2));
 const { summaryPath, shotIndexPath } = buildSummaryPaths(outputDir);
@@ -103,6 +104,35 @@ const summary = createValidationSummary({
   panelRegistry,
 });
 const panelGovernance = createPanelGovernance(summary, panelRegistry);
+
+function canonicalPerformanceQuery(extra = {}) {
+  const query = new URLSearchParams({
+    period: "EXPLICIT",
+    chart_frequency: extra.chartFrequency ?? "monthly",
+    detail_basis: extra.detailBasis ?? "NET",
+    contribution_dimension: extra.contributionDimension ?? "asset_class",
+    attribution_dimension: extra.attributionDimension ?? "asset_class",
+    benchmark_code: benchmarkCode,
+    report_start_date: extra.reportStartDate ?? canonicalStartDate,
+    report_end_date: extra.reportEndDate ?? canonicalAsOfDate,
+  });
+  return query.toString();
+}
+
+function canonicalRiskQuery(extra = {}) {
+  const query = new URLSearchParams({
+    period: "EXPLICIT",
+    detail_basis: extra.detailBasis ?? "NET",
+    benchmark_code: benchmarkCode,
+    report_start_date: extra.reportStartDate ?? canonicalStartDate,
+    report_end_date: extra.reportEndDate ?? canonicalAsOfDate,
+    as_of_date: extra.asOfDate ?? canonicalAsOfDate,
+  });
+  for (const [key, value] of Object.entries(extra.params ?? {})) {
+    query.set(key, value);
+  }
+  return query.toString();
+}
 
 async function fetchOptionalJson(description, url) {
   try {
@@ -681,7 +711,7 @@ async function run() {
     throw new Error(`Foundation workspace did not resolve ${portfolioId}.`);
   }
 
-  const performanceSummaryUrl = `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/summary?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}&report_end_date=${canonicalAsOfDate}`;
+  const performanceSummaryUrl = `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/summary?${canonicalPerformanceQuery()}`;
   const performanceSummary = await fetchJsonUntil(
     summary,
     performanceSummaryUrl,
@@ -696,11 +726,25 @@ async function run() {
     throw new Error("Performance summary returned no portfolio payload.");
   }
 
-  const performanceDetails = await fetchJson(
+  const performanceDetailsUrl = `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/details?${canonicalPerformanceQuery()}`;
+  const performanceDetails = await fetchJsonUntil(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/details?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}&report_end_date=${canonicalAsOfDate}`,
-    "Performance details",
+    performanceDetailsUrl,
+    "Performance details contribution readiness",
     timeoutMs,
+    (payload) => {
+      const rows = payload?.contribution?.levels?.[0]?.rows;
+      if (
+        payload?.capabilities?.contribution_detail?.state === "supported" &&
+        Array.isArray(rows) &&
+        rows.length >= 4
+      ) {
+        return true;
+      }
+      return `contribution_detail state is ${
+        payload?.capabilities?.contribution_detail?.state ?? "missing"
+      }; rows=${Array.isArray(rows) ? rows.length : "non-array"}`;
+    },
   );
   if (!performanceDetails?.portfolio_id) {
     throw new Error("Performance details returned no portfolio payload.");
@@ -708,7 +752,7 @@ async function run() {
 
   const riskSummary = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/summary?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&as_of_date=${canonicalAsOfDate}`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/summary?${canonicalRiskQuery()}`,
     "Risk summary",
     timeoutMs,
   );
@@ -718,25 +762,25 @@ async function run() {
 
   const riskConcentration = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/concentration?period=YTD&benchmark_code=${benchmarkCode}&as_of_date=${canonicalAsOfDate}`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/concentration?${canonicalRiskQuery({ detailBasis: "NET" })}`,
     "Risk concentration",
     timeoutMs,
   );
   const riskDrawdown = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/drawdown?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&as_of_date=${canonicalAsOfDate}&include_underwater_series=true`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/drawdown?${canonicalRiskQuery({ params: { include_underwater_series: "true" } })}`,
     "Risk drawdown",
     timeoutMs,
   );
   const riskRolling = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/rolling?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&as_of_date=${canonicalAsOfDate}&include_time_series=true`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/rolling?${canonicalRiskQuery({ params: { include_time_series: "true" } })}`,
     "Risk rolling",
     timeoutMs,
   );
   const riskAttribution = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/attribution?period=YTD&detail_basis=NET&benchmark_code=${benchmarkCode}&as_of_date=${canonicalAsOfDate}&attribution_type=total_risk&grouping_dimension=sector`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/risk/attribution?${canonicalRiskQuery({ params: { attribution_type: "total_risk", grouping_dimension: "sector" } })}`,
     "Risk attribution",
     timeoutMs,
   );
@@ -770,7 +814,7 @@ async function run() {
 
   const advisorBrief = await fetchJson(
     summary,
-    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}&report_end_date=${canonicalAsOfDate}`,
+    `${gatewayBaseUrl}/api/v1/workbench/${portfolioId}/performance/advisor-brief?${canonicalPerformanceQuery()}`,
     "Advisor brief",
     timeoutMs,
   );
@@ -782,7 +826,7 @@ async function run() {
   }
   summary.workflowPackChecks.push({
     actionType: "INITIAL_VISIBLE",
-    route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief?period=YTD&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=${benchmarkCode}&report_end_date=${canonicalAsOfDate}`,
+    route: `/api/v1/workbench/${portfolioId}/performance/advisor-brief?${canonicalPerformanceQuery()}`,
     sourceRunId: advisorBrief.workflow_pack_run.run_id,
     resultReviewState: advisorBrief.workflow_pack_run.review_state,
     resultSupportabilityStatus:
@@ -794,6 +838,7 @@ async function run() {
     gatewayBaseUrl,
     portfolioId,
     benchmarkCode,
+    canonicalStartDate,
     canonicalAsOfDate,
     timeoutMs,
     fetchJson,
@@ -1836,6 +1881,7 @@ async function run() {
       workbenchBaseUrl,
       portfolioId,
       benchmarkCode,
+      canonicalStartDate,
       canonicalAsOfDate,
       timeoutMs,
       assertTableHasRows: browserHelpers.assertTableHasRows,
@@ -1845,6 +1891,7 @@ async function run() {
       workbenchBaseUrl,
       portfolioId,
       benchmarkCode,
+      canonicalStartDate,
       canonicalAsOfDate,
       timeoutMs,
       assertTableHasRows: browserHelpers.assertTableHasRows,
@@ -1855,6 +1902,7 @@ async function run() {
       workbenchBaseUrl,
       portfolioId,
       benchmarkCode,
+      canonicalStartDate,
       canonicalAsOfDate,
       timeoutMs,
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,
@@ -1894,6 +1942,7 @@ async function run() {
       workbenchBaseUrl,
       portfolioId,
       benchmarkCode,
+      canonicalStartDate,
       canonicalAsOfDate,
       timeoutMs,
       assertTableHasRows: browserHelpers.assertTableHasRows,
@@ -1904,6 +1953,7 @@ async function run() {
       workbenchBaseUrl,
       portfolioId,
       benchmarkCode,
+      canonicalStartDate,
       canonicalAsOfDate,
       timeoutMs,
       screenshotRegisteredPanel: browserHelpers.screenshotRegisteredPanel,

--- a/scripts/live/validation/args.mjs
+++ b/scripts/live/validation/args.mjs
@@ -31,6 +31,7 @@ export function resolveValidationConfig(argv, cwd = process.cwd()) {
     gatewayBaseUrl: (args.get("gateway-base-url") ?? "http://gateway.dev.lotus").replace(/\/+$/, ""),
     outputDir: path.resolve(cwd, args.get("output-dir") ?? "output/playwright/live-canonical"),
     timeoutMs: Number(args.get("timeout-ms") ?? "60000"),
+    canonicalStartDate: args.get("start-date") ?? "2025-03-31",
     canonicalAsOfDate: args.get("as-of-date") ?? "2026-04-10",
   };
 }

--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -633,6 +633,7 @@ export async function validatePerformanceSummaryPanel(
     workbenchBaseUrl,
     portfolioId,
     benchmarkCode,
+    canonicalStartDate,
     canonicalAsOfDate,
     timeoutMs,
     assertTableHasRows,
@@ -640,7 +641,7 @@ export async function validatePerformanceSummaryPanel(
   },
 ) {
   await page.goto(
-    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}&reportEndDate=${canonicalAsOfDate}`,
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&period=EXPLICIT&detailBasis=NET&benchmark=${benchmarkCode}&reportStartDate=${canonicalStartDate}&reportEndDate=${canonicalAsOfDate}`,
     {
       waitUntil: "networkidle",
       timeout: timeoutMs,
@@ -683,6 +684,7 @@ export async function validatePerformanceAnalysisPanel(
     workbenchBaseUrl,
     portfolioId,
     benchmarkCode,
+    canonicalStartDate,
     canonicalAsOfDate,
     timeoutMs,
     assertTableHasRows,
@@ -690,7 +692,7 @@ export async function validatePerformanceAnalysisPanel(
   },
 ) {
   await page.goto(
-    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=analysis&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}&reportEndDate=${canonicalAsOfDate}`,
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=analysis&period=EXPLICIT&detailBasis=NET&contributionDimension=asset_class&attributionDimension=asset_class&benchmark=${benchmarkCode}&reportStartDate=${canonicalStartDate}&reportEndDate=${canonicalAsOfDate}`,
     { waitUntil: "networkidle", timeout: timeoutMs },
   );
   await assertRailModeActive(page, /^Performance Analysis/, timeoutMs);
@@ -714,10 +716,17 @@ export async function validatePerformanceAnalysisPanel(
     1,
     "Attribution detail table",
   );
+  await page.getByRole("tab", { name: /^Positions/i }).click();
+  await assertTableHasRows(
+    tableByExactLabel(page, "Position contribution table"),
+    1,
+    "Position contribution detail table",
+  );
+  await page.getByRole("tab", { name: /^Segment Summary/i }).click();
   await assertTableHasRows(
     tableByExactLabel(page, "Asset Class contribution table"),
     1,
-    "Contribution detail table",
+    "Segment contribution detail table",
   );
   await screenshotRegisteredPanel(page, "performance.analysis.contribution");
 }
@@ -729,6 +738,7 @@ export async function validateAdvisorBriefPanel(
     workbenchBaseUrl,
     portfolioId,
     benchmarkCode,
+    canonicalStartDate,
     canonicalAsOfDate,
     timeoutMs,
     screenshotRegisteredPanel,
@@ -736,7 +746,7 @@ export async function validateAdvisorBriefPanel(
   },
 ) {
   await page.goto(
-    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=advisor&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}&reportEndDate=${canonicalAsOfDate}`,
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=advisor&period=EXPLICIT&detailBasis=NET&benchmark=${benchmarkCode}&reportStartDate=${canonicalStartDate}&reportEndDate=${canonicalAsOfDate}`,
     { waitUntil: "networkidle", timeout: timeoutMs },
   );
   await assertRailModeActive(page, /^Advisor Brief/, timeoutMs);
@@ -1049,6 +1059,7 @@ export async function validateRiskPanel(
     workbenchBaseUrl,
     portfolioId,
     benchmarkCode,
+    canonicalStartDate,
     canonicalAsOfDate,
     timeoutMs,
     assertTableHasRows,
@@ -1056,7 +1067,7 @@ export async function validateRiskPanel(
   },
 ) {
   await page.goto(
-    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=risk&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}&reportEndDate=${canonicalAsOfDate}`,
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=risk&period=EXPLICIT&detailBasis=NET&benchmark=${benchmarkCode}&reportStartDate=${canonicalStartDate}&reportEndDate=${canonicalAsOfDate}`,
     { waitUntil: "networkidle", timeout: timeoutMs },
   );
   await assertRailModeActive(page, /^Risk Review/, timeoutMs);
@@ -1103,13 +1114,14 @@ export async function validateEvidencePanel(
     workbenchBaseUrl,
     portfolioId,
     benchmarkCode,
+    canonicalStartDate,
     canonicalAsOfDate,
     timeoutMs,
     screenshotRegisteredPanel,
   },
 ) {
   await page.goto(
-    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=evidence&period=YTD&detailBasis=NET&benchmark=${benchmarkCode}&reportEndDate=${canonicalAsOfDate}`,
+    `${workbenchBaseUrl}/performance?portfolioId=${portfolioId}&mode=evidence&period=EXPLICIT&detailBasis=NET&benchmark=${benchmarkCode}&reportStartDate=${canonicalStartDate}&reportEndDate=${canonicalAsOfDate}`,
     { waitUntil: "networkidle", timeout: timeoutMs },
   );
   await assertRailModeActive(page, /^Evidence/, timeoutMs);

--- a/scripts/live/validation/workflow-pack-proof.mjs
+++ b/scripts/live/validation/workflow-pack-proof.mjs
@@ -233,15 +233,18 @@ export async function validateAdvisorBriefWorkflowPackReviewChain({
   gatewayBaseUrl,
   portfolioId,
   benchmarkCode,
+  canonicalStartDate,
   canonicalAsOfDate,
   timeoutMs,
   fetchJson,
   postJson,
 }) {
   const acceptQuery = buildAdvisorBriefWorkspaceQuery({
-    period: "YTD",
+    period: "EXPLICIT",
     detailBasis: "NET",
     benchmarkCode,
+    reportStartDate: canonicalStartDate,
+    reportEndDate: canonicalAsOfDate,
   });
   const acceptRoute = `/api/v1/workbench/${portfolioId}/performance/advisor-brief/review-actions?${acceptQuery}`;
   const acceptSourceRoute = `/api/v1/workbench/${portfolioId}/performance/advisor-brief?${acceptQuery}`;
@@ -359,9 +362,11 @@ export async function validateAdvisorBriefWorkflowPackReviewChain({
   });
 
   const reviseOriginalQuery = buildAdvisorBriefWorkspaceQuery({
-    period: "YTD",
+    period: "EXPLICIT",
     detailBasis: "GROSS",
     benchmarkCode,
+    reportStartDate: canonicalStartDate,
+    reportEndDate: canonicalAsOfDate,
   });
   const reviseReplacementQuery = buildAdvisorBriefWorkspaceQuery({
     period: "EXPLICIT",

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -23,6 +23,10 @@ describe("canonical live validation script", () => {
     expect(script).toContain("if ($LASTEXITCODE -ne 0)");
     expect(script).toContain("Canonical Workbench browser validation failed");
     expect(script).toContain("[string]$ScreenshotDirectory");
+    expect(script).toContain('[string]$StartDate = "2025-03-31"');
+    expect(script).toContain("period=EXPLICIT");
+    expect(script).toContain("report_start_date=$StartDate");
+    expect(script).toContain('"--start-date"');
     expect(script).toContain('"--output-dir"');
     expect(script).toContain("[int]$Attempts = 8");
     expect(script).toContain("retrying ($attempt/$Attempts)");
@@ -173,6 +177,11 @@ describe("canonical live validation script", () => {
     expect(script).toContain("[switch]$CleanCoreState");
     expect(script).toContain("[switch]$CoreManageOnly");
     expect(script).toContain("Core/manage proof mode enabled");
+    expect(script).toContain("$canonicalCoreEnvironment = @{");
+    expect(script).toContain('DEMO_DATA_PACK_ENABLED = "false"');
+    expect(script).toContain(
+      "Starting lotus-core with auxiliary demo data pack disabled for canonical PB seed isolation.",
+    );
     expect(script).toContain("param([switch]$IngestOnly)");
     expect(script).toContain("--ingest-only");
     expect(script).toContain("$global:LASTEXITCODE = 0");
@@ -279,6 +288,7 @@ describe("canonical live validation script", () => {
     for (const service of [
       "lotus-archive",
       "lotus-render",
+      "lotus-idea",
       "lotus-gateway",
       "lotus-workbench",
     ]) {
@@ -286,7 +296,7 @@ describe("canonical live validation script", () => {
       expect(stopScript).toContain(service);
     }
     expect(stopScript).toContain(
-      "Stop-ListenersOnPorts @(3000, 8001, 8100, 8111, 8150, 8310)",
+      "Stop-ListenersOnPorts @(3000, 8001, 8100, 8111, 8150, 8310, 8330)",
     );
     expect(stopScript).toContain("Leaving Docker-owned listener");
     expect(validationScript).toContain(
@@ -299,6 +309,14 @@ describe("canonical live validation script", () => {
     expect(validationScript).toContain(
       'Test-Endpoint "http://render.dev.lotus/health/ready"',
     );
+    expect(validationScript).toContain('Test-CanonicalHost "idea.dev.lotus"');
+    expect(validationScript).toContain(
+      'Test-Endpoint "http://idea.dev.lotus/health/ready"',
+    );
+    expect(startScript).toContain("function Invoke-CanonicalIdeaSeed");
+    expect(startScript).toContain("canonical-idea-high-cash:$PortfolioId");
+    expect(validationScript).toContain("function Assert-IdeaQueueSeed");
+    expect(validationScript).toContain("Gateway Idea review queue contains");
     expect(browserValidator).toContain(
       'checkDns(summary, "archive.dev.lotus")',
     );
@@ -388,6 +406,9 @@ describe("canonical live validation script", () => {
     expect(script).toContain("assertPerformanceCalculationSanity");
     expect(script).toContain("assertRiskCalculationSanity");
     expect(script).toContain("/performance/details?");
+    expect(script).toContain("Performance details contribution readiness");
+    expect(script).toContain("contribution_detail state is");
+    expect(script).toContain('rows=${Array.isArray(rows) ? rows.length : "non-array"}');
     expect(script).toContain("/risk/concentration?");
     expect(script).toContain("/risk/drawdown?");
     expect(script).toContain("/risk/rolling?");
@@ -745,7 +766,10 @@ describe("canonical live validation script", () => {
       "utf8",
     );
 
+    expect(script).toContain("canonicalStartDate");
     expect(script).toContain("canonicalAsOfDate");
+    expect(script).toContain("report_start_date: extra.reportStartDate ?? canonicalStartDate");
+    expect(browserWorkflowModule).toContain("reportStartDate=${canonicalStartDate}");
     expect(script).toContain("createBrowserValidationHelpers");
     expect(script).toContain("validatePortfolioMemoryPanel");
     expect(script).toContain("validateConstructionAlternativesPanel");

--- a/tests/unit/live-validation-browser-workflows.test.ts
+++ b/tests/unit/live-validation-browser-workflows.test.ts
@@ -29,6 +29,17 @@ describe("live validation browser workflow helpers", () => {
     ).toBe(false);
   });
 
+  it("validates the canonical contribution analysis default and segment views", () => {
+    const source = browserWorkflowModule.validatePerformanceAnalysisPanel.toString();
+
+    expect(source).toContain("contributionDimension=asset_class");
+    expect(source).toContain("attributionDimension=asset_class");
+    expect(source).toContain("Positions");
+    expect(source).toContain("Position contribution table");
+    expect(source).toContain("Segment Summary");
+    expect(source).toContain("Asset Class contribution table");
+  });
+
   it("resolves governed routes and records screenshot evidence with absolute paths", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lotus-browser-workflow-"));
     const screenshotCalls: Array<{ path: string; fullPage: boolean }> = [];

--- a/tests/unit/live-validation-workflow-pack-proof.test.ts
+++ b/tests/unit/live-validation-workflow-pack-proof.test.ts
@@ -9,6 +9,7 @@ const {
     gatewayBaseUrl: string;
     portfolioId: string;
     benchmarkCode: string;
+    canonicalStartDate: string;
     canonicalAsOfDate: string;
     timeoutMs: number;
     fetchJson: (
@@ -134,15 +135,9 @@ function createFetchAdvisorBriefPayload() {
         taskFlowId: "taskflow-explicit-gross",
       });
     }
-    if (url.includes("detail_basis=GROSS") && url.includes("period=YTD")) {
-      return createAdvisorBriefPayload({
-        runId: "packrun-ytd-gross",
-        taskFlowId: "taskflow-ytd-gross",
-      });
-    }
     return createAdvisorBriefPayload({
-      runId: "packrun-ytd-net",
-      taskFlowId: "taskflow-ytd-net",
+      runId: "packrun-explicit-net",
+      taskFlowId: "taskflow-explicit-net",
     });
   };
 }
@@ -159,6 +154,7 @@ describe("live validation workflow-pack proof", () => {
       gatewayBaseUrl: "http://gateway.dev.lotus",
       portfolioId: "PB_SG_GLOBAL_BAL_001",
       benchmarkCode: "BMK_PB_GLOBAL_BALANCED_60_40",
+      canonicalStartDate: "2025-03-31",
       canonicalAsOfDate: "2026-04-10",
       timeoutMs: 1000,
       fetchJson: async (_summary: unknown, url: string) => {
@@ -175,10 +171,10 @@ describe("live validation workflow-pack proof", () => {
         postCalls.push({ url, body });
         if (body.action_type === "ACCEPT") {
           return createAdvisorBriefPayload({
-            runId: "packrun-ytd-net",
+            runId: "packrun-explicit-net",
             reviewState: "ACCEPTED",
             supportabilityStatus: "READY",
-            taskFlowId: "taskflow-ytd-net",
+            taskFlowId: "taskflow-explicit-net",
             taskFlowStatus: "COMPLETED",
             taskFlowSupportabilityStatus: "READY",
             handoffStatus: "READY_FOR_HANDOFF",
@@ -197,12 +193,12 @@ describe("live validation workflow-pack proof", () => {
           });
         }
         return createAdvisorBriefPayload({
-          runId: "packrun-ytd-gross",
+          runId: "packrun-explicit-gross",
           reviewState: "REVISED",
           supportabilityStatus: "HISTORICAL",
           superseded: true,
           replacementRunId: body.replacement_run_id,
-          taskFlowId: "taskflow-ytd-gross",
+          taskFlowId: "taskflow-explicit-gross",
           taskFlowStatus: "SUPERSEDED",
           taskFlowSupportabilityStatus: "HISTORICAL",
         });
@@ -212,7 +208,7 @@ describe("live validation workflow-pack proof", () => {
     expect(getCalls).toHaveLength(5);
     expect(postCalls).toEqual([
       expect.objectContaining({
-        url: expect.stringContaining("/performance/advisor-brief/review-actions?period=YTD"),
+        url: expect.stringContaining("/performance/advisor-brief/review-actions?period=EXPLICIT"),
         body: expect.objectContaining({ action_type: "ACCEPT" }),
       }),
       expect.objectContaining({
@@ -231,8 +227,8 @@ describe("live validation workflow-pack proof", () => {
     expect(summary.workflowPackChecks).toEqual([
       expect.objectContaining({
         actionType: "ACCEPT",
-        sourceRunId: "packrun-ytd-net",
-        taskFlowId: "taskflow-ytd-net",
+        sourceRunId: "packrun-explicit-net",
+        taskFlowId: "taskflow-explicit-net",
         taskFlowStatus: "COMPLETED",
         taskFlowSupportabilityStatus: "READY",
         resultReviewState: "ACCEPTED",
@@ -250,9 +246,9 @@ describe("live validation workflow-pack proof", () => {
       }),
       expect.objectContaining({
         actionType: "REVISE",
-        sourceRunId: "packrun-ytd-gross",
+        sourceRunId: "packrun-explicit-gross",
         replacementRunId: "packrun-revise-replacement",
-        taskFlowId: "taskflow-ytd-gross",
+        taskFlowId: "taskflow-explicit-gross",
         taskFlowStatus: "SUPERSEDED",
         taskFlowSupportabilityStatus: "HISTORICAL",
         resultReviewState: "REVISED",
@@ -270,6 +266,7 @@ describe("live validation workflow-pack proof", () => {
       gatewayBaseUrl: "http://gateway.dev.lotus",
       portfolioId: "PB_SG_GLOBAL_BAL_001",
       benchmarkCode: "BMK_PB_GLOBAL_BALANCED_60_40",
+      canonicalStartDate: "2025-03-31",
       canonicalAsOfDate: "2026-04-10",
       timeoutMs: 1000,
       fetchJson: async (_summary: unknown, url: string) => {
@@ -284,11 +281,11 @@ describe("live validation workflow-pack proof", () => {
       ) => {
         if (body.action_type === "ACCEPT") {
           return createAdvisorBriefPayload({
-            runId: "packrun-ytd-net",
+            runId: "packrun-explicit-net",
             reviewState: "ACCEPTED",
             supportabilityStatus: "ACTION_REQUIRED",
             superseded: false,
-            taskFlowId: "taskflow-ytd-net",
+            taskFlowId: "taskflow-explicit-net",
             taskFlowStatus: "COMPLETED",
             taskFlowSupportabilityStatus: "READY",
             handoffStatus: "READY_FOR_HANDOFF",
@@ -307,12 +304,12 @@ describe("live validation workflow-pack proof", () => {
           });
         }
         return createAdvisorBriefPayload({
-          runId: "packrun-ytd-gross",
+          runId: "packrun-explicit-gross",
           reviewState: "REVISED",
           supportabilityStatus: "HISTORICAL",
           superseded: true,
           replacementRunId: body.replacement_run_id,
-          taskFlowId: "taskflow-ytd-gross",
+          taskFlowId: "taskflow-explicit-gross",
           taskFlowStatus: "SUPERSEDED",
           taskFlowSupportabilityStatus: "HISTORICAL",
         });
@@ -323,8 +320,8 @@ describe("live validation workflow-pack proof", () => {
       expect.arrayContaining([
         expect.objectContaining({
           actionType: "ACCEPT",
-          sourceRunId: "packrun-ytd-net",
-          taskFlowId: "taskflow-ytd-net",
+          sourceRunId: "packrun-explicit-net",
+          taskFlowId: "taskflow-explicit-net",
           taskFlowStatus: "COMPLETED",
           taskFlowSupportabilityStatus: "READY",
           resultReviewState: "ACCEPTED",
@@ -344,17 +341,18 @@ describe("live validation workflow-pack proof", () => {
       gatewayBaseUrl: "http://gateway.dev.lotus",
       portfolioId: "PB_SG_GLOBAL_BAL_001",
       benchmarkCode: "BMK_PB_GLOBAL_BALANCED_60_40",
+      canonicalStartDate: "2025-03-31",
       canonicalAsOfDate: "2026-04-10",
       timeoutMs: 1000,
       fetchJson: async (_summary: unknown, url: string) => {
         getCalls.push(url);
         return createAdvisorBriefPayload({
-          runId: "packrun-ytd-net-failed",
+          runId: "packrun-explicit-net-failed",
           runtimeState: "FAILED",
           reviewState: "AWAITING_REVIEW",
           allowedReviewActions: [],
           supportabilityStatus: "ACTION_REQUIRED",
-          taskFlowId: "taskflow-ytd-net-failed",
+          taskFlowId: "taskflow-explicit-net-failed",
           taskFlowStatus: "FAILED",
           taskFlowSupportabilityStatus: "ACTION_REQUIRED",
         });
@@ -376,8 +374,8 @@ describe("live validation workflow-pack proof", () => {
     expect(summary.workflowPackChecks).toEqual([
       expect.objectContaining({
         actionType: "ACCEPT",
-        sourceRunId: "packrun-ytd-net-failed",
-        taskFlowId: "taskflow-ytd-net-failed",
+        sourceRunId: "packrun-explicit-net-failed",
+        taskFlowId: "taskflow-explicit-net-failed",
         taskFlowStatus: "FAILED",
         taskFlowSupportabilityStatus: "ACTION_REQUIRED",
         resultReviewState: "AWAITING_REVIEW",


### PR DESCRIPTION
## Summary
- bring Lotus Idea into the canonical Workbench stack by default
- seed a deterministic canonical Idea advisor-queue candidate during stack startup
- disable Core auxiliary demo data during canonical PB seed startup
- run canonical performance/risk/advisor validation against the explicit RFC-0076 window
- make live browser proof deterministic across contribution detail tabs and Idea queue data
- document the updated canonical runtime order and seed responsibilities

## Validation
- `npm test -- tests/unit/live-canonical-validation-script.test.ts tests/unit/live-validation-browser-workflows.test.ts`
- PowerShell parser check for `Start-LotusFrontOfficeCanonical.ps1` and `Validate-LotusFrontOfficeCanonical.ps1`
- `npm run live:validate` passed for `PB_SG_GLOBAL_BAL_001`
- screenshot evidence: `output/playwright/live-canonical`

## Notes
- Stranded-truth reconciliation found no unmerged remote branches against `origin/main`.
- The Idea seed is app-specific queue data and is separate from the canonical PB Core seed; the Core demo pack remains disabled for canonical PB seed isolation.