### PR TITLE
fix: harden canonical performance browser validation

### DIFF
--- a/scripts/live/validation/browser-workflows.mjs
+++ b/scripts/live/validation/browser-workflows.mjs
@@ -716,15 +716,28 @@ export async function validatePerformanceAnalysisPanel(
     1,
     "Attribution detail table",
   );
-  await page.getByRole("tab", { name: /^Positions/i }).click();
+  const performanceDriversPanel = page.locator("#performance-drivers").first();
+  await expect(performanceDriversPanel).toBeVisible({ timeout: timeoutMs });
+  await performanceDriversPanel.scrollIntoViewIfNeeded();
+  const positionsTab = performanceDriversPanel.getByRole("tab", {
+    name: /^Positions/i,
+  });
+  await expect(positionsTab).toBeVisible({ timeout: timeoutMs });
+  await positionsTab.scrollIntoViewIfNeeded();
+  await positionsTab.click({ timeout: timeoutMs });
   await assertTableHasRows(
-    tableByExactLabel(page, "Position contribution table"),
+    performanceDriversPanel.locator('table[aria-label="Position contribution table"]'),
     1,
     "Position contribution detail table",
   );
-  await page.getByRole("tab", { name: /^Segment Summary/i }).click();
+  const segmentSummaryTab = performanceDriversPanel.getByRole("tab", {
+    name: /^Segment Summary/i,
+  });
+  await expect(segmentSummaryTab).toBeVisible({ timeout: timeoutMs });
+  await segmentSummaryTab.scrollIntoViewIfNeeded();
+  await segmentSummaryTab.click({ timeout: timeoutMs });
   await assertTableHasRows(
-    tableByExactLabel(page, "Asset Class contribution table"),
+    performanceDriversPanel.locator('table[aria-label="Asset Class contribution table"]'),
     1,
     "Segment contribution detail table",
   );

--- a/tests/unit/live-validation-browser-workflows.test.ts
+++ b/tests/unit/live-validation-browser-workflows.test.ts
@@ -34,10 +34,16 @@ describe("live validation browser workflow helpers", () => {
 
     expect(source).toContain("contributionDimension=asset_class");
     expect(source).toContain("attributionDimension=asset_class");
+    expect(source).toContain('page.locator("#performance-drivers").first()');
+    expect(source).toContain("performanceDriversPanel.scrollIntoViewIfNeeded()");
+    expect(source).toContain("const positionsTab = performanceDriversPanel.getByRole");
+    expect(source).toContain("positionsTab.scrollIntoViewIfNeeded()");
     expect(source).toContain("Positions");
-    expect(source).toContain("Position contribution table");
+    expect(source).toContain('performanceDriversPanel.locator(\'table[aria-label="Position contribution table"]\')');
     expect(source).toContain("Segment Summary");
-    expect(source).toContain("Asset Class contribution table");
+    expect(source).toContain("const segmentSummaryTab = performanceDriversPanel.getByRole");
+    expect(source).toContain("segmentSummaryTab.scrollIntoViewIfNeeded()");
+    expect(source).toContain('performanceDriversPanel.locator(\'table[aria-label="Asset Class contribution table"]\')');
   });
 
   it("resolves governed routes and records screenshot evidence with absolute paths", async () => {


### PR DESCRIPTION
## Summary
- Scope the canonical performance contribution browser validation to `#performance-drivers`.
- Add explicit visibility and scroll guards before clicking Positions and Segment Summary tabs to remove a timing/actionability race in live validation.

## Evidence
- Unit: `npm test -- tests/unit/live-validation-browser-workflows.test.ts` -> 3 passed.
- Typecheck: `npm run typecheck` -> passed.
- Runtime: `node scripts/live/validate-canonical-workbench-live.mjs --portfolio-id PB_SG_GLOBAL_BAL_001 --benchmark-code BMK_PB_GLOBAL_BALANCED_60_40 --start-date 2025-03-31 --as-of-date 2026-04-10 --workbench-base-url http://workbench.dev.lotus --gateway-base-url http://gateway.dev.lotus` -> passed.
- Platform runtime: platform canonical QA wrapper subsequently passed and wrote `output/front-office-qa/canonical-front-office-qa-20260703-140914.json`.
- Wiki/docs: no durable user-facing docs or repo-local wiki source changed; no wiki publish required.
- Non-degradation: preserves strict populated-table checks while making the browser workflow deterministic against the implemented panel scope.