### PR TITLE
Align canonical Idea seed with platform date contract

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -116,6 +116,10 @@ place. This avoids stale local dev servers blocking Docker without terminating D
 The governed `lotus-core` startup explicitly sets `DEMO_DATA_PACK_ENABLED=false`; the broad
 app-local demo pack remains available for diagnostics, but it is not part of canonical
 `PB_SG_GLOBAL_BAL_001` seeding or evidence collection.
+The Lotus Idea advisor-queue seed reads the governed canonical as-of date from
+`lotus-platform/context/contracts/canonical-front-office-demo-data-contract.json` instead of
+duplicating date literals in Workbench automation. If the platform contract is missing the date
+policy, canonical startup fails closed before seeding Idea evidence.
 
 For active RFC or UI development, pass `-LocalApps` with a comma-separated app list. Local apps use
 the same canonical hostnames and public ports as Docker-backed apps, so live evidence remains

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -29,6 +29,7 @@ $gatewayRepo = Join-Path $ProjectsRoot "lotus-gateway"
 $workbenchRepo = Join-Path $ProjectsRoot "lotus-workbench"
 $platformRepo = Join-Path $ProjectsRoot "lotus-platform"
 $ingressCaddyfile = Join-Path $platformRepo "platform-stack\\dev-ingress\\Caddyfile.direct-host"
+$canonicalContractPath = Join-Path $platformRepo "context\\contracts\\canonical-front-office-demo-data-contract.json"
 $composeUpCommand = "docker compose up -d"
 if ($BuildImages) {
   $composeUpCommand = "$composeUpCommand --build"
@@ -119,6 +120,23 @@ function Test-LocalApp {
   param([string]$AppName)
 
   return $localAppSet.Contains($AppName)
+}
+
+function Get-CanonicalFrontOfficeDatePolicy {
+  if (-not (Test-Path $canonicalContractPath)) {
+    throw "Canonical front-office demo data contract not found: $canonicalContractPath"
+  }
+
+  $contract = Get-Content -Raw $canonicalContractPath | ConvertFrom-Json
+  $asOfDate = [string]$contract.date_policy.canonical_as_of_date
+  if ([string]::IsNullOrWhiteSpace($asOfDate)) {
+    throw "Canonical front-office demo data contract is missing date_policy.canonical_as_of_date."
+  }
+
+  return [ordered]@{
+    AsOfDate = $asOfDate
+    GeneratedAtUtc = "$($asOfDate)T10:00:00Z"
+  }
 }
 
 function Invoke-ComposeUp {
@@ -308,6 +326,9 @@ function Invoke-DpmCommandCenterSeed {
 
 function Invoke-CanonicalIdeaSeed {
   $ideaBaseUrl = "http://127.0.0.1:8330"
+  $datePolicy = Get-CanonicalFrontOfficeDatePolicy
+  $asOfDate = $datePolicy.AsOfDate
+  $generatedAtUtc = $datePolicy.GeneratedAtUtc
   $deadline = (Get-Date).AddSeconds(120)
   while ((Get-Date) -lt $deadline) {
     if (Test-HttpReady "$ideaBaseUrl/health/ready") {
@@ -326,8 +347,8 @@ function Invoke-CanonicalIdeaSeed {
       sourceSystem = "lotus-core"
       productVersion = "v1"
       route = "/source/$ProductId"
-      asOfDate = "2026-06-21"
-      generatedAtUtc = "2026-06-21T10:00:00Z"
+      asOfDate = $asOfDate
+      generatedAtUtc = $generatedAtUtc
       contentHash = "sha256:$($ProductId):canonical-workbench-seed"
       dataQualityStatus = "complete"
       freshness = "current"
@@ -335,8 +356,8 @@ function Invoke-CanonicalIdeaSeed {
   }
 
   $payload = @{
-    asOfDate = "2026-06-21"
-    evaluatedAtUtc = "2026-06-21T10:00:00Z"
+    asOfDate = $asOfDate
+    evaluatedAtUtc = $generatedAtUtc
     sourceReportedCashWeight = "0.18"
     sourceEvidence = @{
       portfolioStateRef = & $sourceRef "lotus-core:PortfolioStateSnapshot:v1"
@@ -356,7 +377,7 @@ function Invoke-CanonicalIdeaSeed {
     "X-Caller-Subject" = "canonical-front-office-seed"
     "X-Caller-Capabilities" = "idea.candidate.persist"
     "X-Correlation-Id" = "corr-canonical-idea-seed"
-    "Idempotency-Key" = "canonical-idea-high-cash:$PortfolioId:2026-06-21T10:00:00Z"
+    "Idempotency-Key" = "canonical-idea-high-cash:$($PortfolioId):$generatedAtUtc"
   }
 
   Write-Host "Seeding governed Lotus Idea advisor queue candidate for $PortfolioId ..."

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -314,7 +314,10 @@ describe("canonical live validation script", () => {
       'Test-Endpoint "http://idea.dev.lotus/health/ready"',
     );
     expect(startScript).toContain("function Invoke-CanonicalIdeaSeed");
-    expect(startScript).toContain("canonical-idea-high-cash:$PortfolioId");
+    expect(startScript).toContain("Get-CanonicalFrontOfficeDatePolicy");
+    expect(startScript).toContain(
+      '"Idempotency-Key" = "canonical-idea-high-cash:$($PortfolioId):$generatedAtUtc"',
+    );
     expect(validationScript).toContain("function Assert-IdeaQueueSeed");
     expect(validationScript).toContain("Gateway Idea review queue contains");
     expect(browserValidator).toContain(

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -80,6 +80,8 @@
   canonical browser validation proves populated Workbench rendering, source-safe candidate detail
   access, and no reranking, no auto-proposal creation, no suitability authority, no execution
   authority, and no client-publication claims.
+  The canonical Lotus Idea seed takes its as-of date from the platform demo-data contract instead of
+  duplicating date literals in Workbench startup automation.
 - RFC-0028 bank-demo proof validation must read the Gateway-backed scenario contract and
   supported-claim register, verify the governed scenario id, proof marker, and claim postures, and
   render `/recommendations?mode=proof` as `advisory.bank_demo_proof`. The screenshot is accepted


### PR DESCRIPTION
## Summary

Aligns canonical Workbench Lotus Idea seeding with the platform demo-data contract:

- reads `date_policy.canonical_as_of_date` from `lotus-platform/context/contracts/canonical-front-office-demo-data-contract.json`
- fails canonical startup closed if the platform contract or canonical date policy is missing
- uses the contract-derived date for Idea source refs, evaluated timestamp, and idempotency key
- updates the canonical runtime runbook, wiki source, and focused unit test

This folds the canonical runtime fix into the image-provenance workstream because the validated front-office stack now includes `lotus-idea` by default and should seed Idea evidence from canonical platform truth, not duplicated date literals.

Related cross-repo work:

- `lotus-idea` PR #323 implements image provenance metadata and `/version`.
- `lotus-platform` PR #491 strengthens reusable image provenance skill/lens guidance.

## Validation

- `npm run test -- tests/unit/live-canonical-validation-script.test.ts` -> 11 passed
- `npm run typecheck` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `npm run live:stack:up` -> passed earlier in this workstream
- `npm run live:validate` -> passed earlier for `PB_SG_GLOBAL_BAL_001`
  - screenshots: `C:\Users\Sandeep\projects\lotus-workbench\output\playwright\live-canonical`
  - generated at: `2026-07-05T02:43:39.442Z`
  - 29 screenshots, 102 API checks, 17 UI checks, 10 workflow pack checks, 12 advisory journey checks
  - included `advisory.opportunities` with owner `lotus-idea` and source posture `idea-review-queue-through-gateway`
- `npm run live:stack:down` -> canonical runtime stopped cleanly after validation

## Wiki

Repo-authored wiki source changed (`Validation-and-CI.md`). `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench` reports expected source-to-published drift before merge. Publish after merge to `main`.

## Stranded Truth

Ran stranded-truth reconciliation before opening this PR. `origin/fix/canonical-idea-seed-as-of` is this active branch; `origin/codex/sync-agent-operating-contract-20260704` remains separate agent-contract sync work and was not folded into this runtime seed slice.

## Non-Degradation

This keeps canonical runtime truth contract-backed and does not add product claims, screenshots without machine-readable validation, or unsupported Workbench feature promotion.