### PR TITLE
[codex] Honor canonical portfolio selection in Workbench validation

### DIFF
--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -270,6 +270,7 @@ function Start-CanonicalManage {
     LOTUS_MANAGE_HOST_PORT = "8001"
     DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED = "true"
     DPM_STATEFUL_CORE_SOURCING_ENABLED = "true"
+    DPM_WORKFLOW_ENABLED = "true"
     DPM_CORE_BASE_URL = "http://core-control.dev.lotus"
     DPM_CORE_QUERY_BASE_URL = "http://core-query.dev.lotus"
   }

--- a/src/apps/portfolio/api.ts
+++ b/src/apps/portfolio/api.ts
@@ -751,6 +751,7 @@ async function fetchPortfolioJson<T>(
   }
 
   const request = (async () => {
+    let shouldCacheResponse = true;
     const payload = await observeWorkbenchAnalyticsRequest(
       observedPortfolioSurface(path),
       async () => {
@@ -761,13 +762,14 @@ async function fetchPortfolioJson<T>(
             : {}),
         });
         if (!response.ok) {
+          shouldCacheResponse = false;
           return null;
         }
 
         return (await response.json()) as T;
       }
     );
-    if (useCache) {
+    if (useCache && shouldCacheResponse) {
       portfolioApiResponseCache.set(url, payload);
     }
     return payload;

--- a/src/apps/portfolio/portfolio-experience-page.tsx
+++ b/src/apps/portfolio/portfolio-experience-page.tsx
@@ -1,6 +1,6 @@
-import { resolvePreferredPortfolioId } from "@/features/canonical-portfolio-selection";
 import { getPortfolioCatalog, getPortfolioWorkspaceShell } from "./api";
 import PortfolioWorkspaceClient from "./components/portfolio-workspace-client";
+import { resolveSelectedPortfolioId } from "./portfolio-selection";
 
 export default async function PortfolioExperiencePage({
   searchParams,
@@ -9,9 +9,7 @@ export default async function PortfolioExperiencePage({
 }) {
   const portfolios = await getPortfolioCatalog();
   const resolvedSearch = await searchParams;
-  const selectedPortfolioId =
-    portfolios.find((item) => item.portfolio_id === resolvedSearch.portfolioId)?.portfolio_id ??
-    resolvePreferredPortfolioId(portfolios, (item) => item.portfolio_id);
+  const selectedPortfolioId = resolveSelectedPortfolioId(portfolios, resolvedSearch.portfolioId);
   const workspace = selectedPortfolioId
     ? await getPortfolioWorkspaceShell(selectedPortfolioId)
     : null;

--- a/src/apps/portfolio/portfolio-record-screen.tsx
+++ b/src/apps/portfolio/portfolio-record-screen.tsx
@@ -1,5 +1,3 @@
-import { resolvePreferredPortfolioId } from "@/features/canonical-portfolio-selection";
-
 import {
   getPortfolioCatalog,
   getPortfolioWorkspaceDetailedDetails,
@@ -8,6 +6,7 @@ import {
   mergePortfolioWorkspace,
 } from "./api";
 import PortfolioRecordScreenClient from "./components/portfolio-record-screen-client";
+import { resolveSelectedPortfolioId } from "./portfolio-selection";
 import {
   type PortfolioRecordScreenKind,
   resolvePortfolioRecordScreenWindow,
@@ -24,9 +23,7 @@ export default async function PortfolioRecordScreen({
 }) {
   const portfolios = await getPortfolioCatalog();
   const resolvedSearch = await searchParams;
-  const selectedPortfolioId =
-    portfolios.find((item) => item.portfolio_id === resolvedSearch.portfolioId)?.portfolio_id ??
-    resolvePreferredPortfolioId(portfolios, (item) => item.portfolio_id);
+  const selectedPortfolioId = resolveSelectedPortfolioId(portfolios, resolvedSearch.portfolioId);
   const shell = selectedPortfolioId ? await getPortfolioWorkspaceShell(selectedPortfolioId) : null;
 
   if (!selectedPortfolioId || !shell) {

--- a/src/apps/portfolio/portfolio-selection.ts
+++ b/src/apps/portfolio/portfolio-selection.ts
@@ -1,0 +1,17 @@
+import { resolvePreferredPortfolioId } from "@/features/canonical-portfolio-selection";
+
+type PortfolioCatalogIdentity = {
+  portfolio_id: string;
+};
+
+export function resolveSelectedPortfolioId(
+  portfolios: PortfolioCatalogIdentity[],
+  requestedPortfolioId: string | null | undefined
+): string | null {
+  const normalizedRequestedPortfolioId = requestedPortfolioId?.trim();
+  if (normalizedRequestedPortfolioId) {
+    return normalizedRequestedPortfolioId;
+  }
+
+  return resolvePreferredPortfolioId(portfolios, (item) => item.portfolio_id);
+}

--- a/tests/unit/portfolio-api.test.ts
+++ b/tests/unit/portfolio-api.test.ts
@@ -1222,6 +1222,32 @@ describe("portfolio api", () => {
     }
   });
 
+  it("does not cache failed portfolio responses", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("gateway unavailable", { status: 503 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              portfolio_id: "PB_SG_GLOBAL_BAL_001",
+              display_name: "PB_SG_GLOBAL_BAL_001",
+              base_currency: "USD",
+              client_id: "CIF_001",
+              booking_center_code: "Singapore",
+            },
+          ],
+        })
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(getPortfolioCatalog()).resolves.toEqual([]);
+    await expect(getPortfolioCatalog()).resolves.toEqual([
+      expect.objectContaining({ portfolio_id: "PB_SG_GLOBAL_BAL_001" }),
+    ]);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("preserves gateway portfolio catalog picker metadata", async () => {
     vi.stubGlobal(
       "fetch",

--- a/tests/unit/portfolio-selection.test.ts
+++ b/tests/unit/portfolio-selection.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSelectedPortfolioId } from "../../src/apps/portfolio/portfolio-selection";
+
+describe("portfolio selection", () => {
+  it("honors an explicitly requested portfolio even when catalog data is unavailable", () => {
+    expect(resolveSelectedPortfolioId([], "PB_SG_GLOBAL_BAL_001")).toBe("PB_SG_GLOBAL_BAL_001");
+  });
+
+  it("falls back to the preferred catalog portfolio when no explicit portfolio is requested", () => {
+    expect(
+      resolveSelectedPortfolioId(
+        [
+          { portfolio_id: "MANUAL_PB_USD_001" },
+          { portfolio_id: "PB_SG_GLOBAL_BAL_001" },
+        ],
+        undefined
+      )
+    ).toBe("PB_SG_GLOBAL_BAL_001");
+  });
+});


### PR DESCRIPTION
## Summary
- honors canonical portfolio selection during Workbench live validation
- adds a shared portfolio-selection helper for Workbench portfolio APIs and screens
- enables the Manage workflow in the canonical front-office stack path used by lotus-idea proof validation

## Validation
- `npm run typecheck` -> passed
- `npm test -- --run tests/unit/portfolio-api.test.ts tests/unit/portfolio-selection.test.ts` -> 18 passed

## Governance
- Runtime boundary: Workbench remains a UI/front-office validation surface; backend truth remains in source services.
- Non-degradation: canonical selection logic is factored into a small helper with focused tests instead of duplicating route selection logic.
- Stranded truth: no Workbench docs/wiki/context durable truth changed in this slice.

## Known External Dependency
- lotus-core source proof blockers are tracked separately in sgajbi/lotus-core#704.
