### PR TITLE
feat(workbench): govern Idea capacity seed evidence

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -122,6 +122,12 @@ Current repository posture:
 16. the governed canonical runtime starts `lotus-core` with `DEMO_DATA_PACK_ENABLED=false` so the
     broad Core app-local demo pack cannot pollute `PB_SG_GLOBAL_BAL_001` evidence, and it starts
     `lotus-idea` by default because the opportunity mode depends on Idea-owned runtime posture.
+    It also delegates isolated downstream-capacity resource construction and a single report-only
+    submission probe to Idea-owned automation after Idea and Advise are ready. Workbench validates
+    exact `/version` provenance and stores only source artifact paths, hashes, and non-certifying
+    posture. It must not construct the resource directly, reuse the canonical client portfolio,
+    expose resource identifiers or credentials, or interpret this integration proof as load, soak,
+    capacity-certification, or supported-feature evidence.
 17. `/recommendations`, `/proposals`, `/proposals/simulate`, and `/proposals/{proposalId}` are
     active Gateway-backed advisory lifecycle surfaces. The advisory shell uses a governed journey
     model across overview, RFC-0026 advisor cockpit, RFC-0027 advisory copilot, RFC-0028

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -108,7 +108,8 @@ That script performs:
 7. canonical `lotus-gateway` exposure on port `8100`
 8. governed `lotus-core` seed for `PB_SG_GLOBAL_BAL_001`
 9. governed DPM command-center seed through `lotus-platform`
-10. `docker compose up -d` for `lotus-workbench` on port `3000`
+10. create an isolated Lotus Idea downstream-capacity resource and run one report-only downstream-submission probe
+11. `docker compose up -d` for `lotus-workbench` on port `3000`
 
 Docker is the default for every canonical front-office app. The startup flow replaces stale local
 listeners on canonical app ports before Docker startup, while leaving Docker-owned listeners in
@@ -120,6 +121,23 @@ The Lotus Idea advisor-queue seed reads the governed canonical as-of date from
 `lotus-platform/context/contracts/canonical-front-office-demo-data-contract.json` instead of
 duplicating date literals in Workbench automation. If the platform contract is missing the date
 policy, canonical startup fails closed before seeding Idea evidence.
+
+### Lotus Idea capacity evidence
+
+Canonical startup delegates capacity-resource construction and workload execution to
+`lotus-idea`. Workbench only coordinates readiness and verifies the returned evidence. The flow:
+
+1. waits for the exact Idea source revision and the Advise realization dependency,
+2. verifies Idea `/version` commit and branch metadata against the checked-out repository,
+3. invokes the Idea-owned synthetic seed and service-capacity workload runners,
+4. accepts exactly one successful `downstream_submission` probe in the `test` profile, and
+5. records source artifact paths, SHA-256 digests, and provenance in
+   `output/canonical-front-office/idea-capacity-seed-evidence.json`.
+
+Capacity evidence uses the isolated `CAPACITY_SYNTHETIC_PORTFOLIO_001` namespace. It must not reuse
+`PB_SG_GLOBAL_BAL_001`, expose the generated conversion-intent identifier or downstream path, or
+persist credentials in evidence. This is deterministic seed and integration-readiness proof only;
+it is not load or soak evidence, capacity certification, or supported-feature promotion.
 
 For active RFC or UI development, pass `-LocalApps` with a comma-separated app list. Local apps use
 the same canonical hostnames and public ports as Docker-backed apps, so live evidence remains

--- a/scripts/live/Invoke-IdeaCapacitySeed.ps1
+++ b/scripts/live/Invoke-IdeaCapacitySeed.ps1
@@ -15,9 +15,10 @@ $workbenchRepo = Join-Path $ProjectsRoot "lotus-workbench"
 $python = Join-Path $ideaRepo ".venv\Scripts\python.exe"
 $seedScript = Join-Path $ideaRepo "scripts\seed_downstream_capacity_resource.py"
 $workloadScript = Join-Path $ideaRepo "scripts\run_service_capacity_workload.py"
-$manifestPath = Join-Path $EvidenceDirectory "idea-capacity-seed-manifest.json"
-$workloadPath = Join-Path $EvidenceDirectory "idea-capacity-seed-workload.json"
 $evidencePath = Join-Path $EvidenceDirectory "idea-capacity-seed-evidence.json"
+$rawArtifactDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ("lotus-workbench-idea-capacity-" + [guid]::NewGuid().ToString("N"))
+$manifestPath = Join-Path $rawArtifactDirectory "idea-capacity-seed-manifest.json"
+$workloadPath = Join-Path $rawArtifactDirectory "idea-capacity-seed-workload.json"
 
 if (-not (Test-Path $python)) {
   throw "Lotus Idea repository Python was not found: $python"
@@ -40,6 +41,8 @@ if ($commitSha -ne $ExpectedCommitSha -or $branch -ne $ExpectedBranch) {
 }
 
 New-Item -ItemType Directory -Path $EvidenceDirectory -Force | Out-Null
+New-Item -ItemType Directory -Path $rawArtifactDirectory -Force | Out-Null
+try {
 $seedArguments = @(
   $seedScript,
   "--base-url", $IdeaBaseUrl,
@@ -85,6 +88,10 @@ $validator = Join-Path $workbenchRepo "scripts\live\Validate-IdeaCapacitySeedEvi
   --run-id $RunId
 if ($LASTEXITCODE -ne 0) {
   throw "Workbench Idea capacity seed evidence validation failed with exit code $LASTEXITCODE."
+}
+}
+finally {
+  Remove-Item -LiteralPath $rawArtifactDirectory -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 Write-Host "Validated isolated Lotus Idea capacity seed evidence: $evidencePath"

--- a/scripts/live/Invoke-IdeaCapacitySeed.ps1
+++ b/scripts/live/Invoke-IdeaCapacitySeed.ps1
@@ -1,0 +1,60 @@
+param(
+  [string]$ProjectsRoot = "C:\Users\Sandeep\projects",
+  [string]$IdeaBaseUrl = "http://127.0.0.1:8330",
+  [Parameter(Mandatory = $true)][string]$AsOfDate,
+  [Parameter(Mandatory = $true)][string]$SeededAtUtc,
+  [Parameter(Mandatory = $true)][string]$RunId,
+  [Parameter(Mandatory = $true)][string]$EvidenceDirectory
+)
+
+$ErrorActionPreference = "Stop"
+$ideaRepo = Join-Path $ProjectsRoot "lotus-idea"
+$workbenchRepo = Join-Path $ProjectsRoot "lotus-workbench"
+$python = Join-Path $ideaRepo ".venv\Scripts\python.exe"
+$seedScript = Join-Path $ideaRepo "scripts\seed_downstream_capacity_resource.py"
+$manifestPath = Join-Path $EvidenceDirectory "idea-capacity-seed-manifest.json"
+$evidencePath = Join-Path $EvidenceDirectory "idea-capacity-seed-evidence.json"
+
+if (-not (Test-Path $python)) {
+  throw "Lotus Idea repository Python was not found: $python"
+}
+if (-not (Test-Path $seedScript)) {
+  throw "Lotus Idea capacity seed producer was not found: $seedScript"
+}
+
+$version = Invoke-RestMethod -Uri "$IdeaBaseUrl/version" -TimeoutSec 30
+$commitSha = [string]$version.build.gitCommitSha
+$branch = [string]$version.build.gitBranch
+if ([string]::IsNullOrWhiteSpace($commitSha) -or [string]::IsNullOrWhiteSpace($branch)) {
+  throw "Lotus Idea /version did not expose commit and branch provenance."
+}
+
+New-Item -ItemType Directory -Path $EvidenceDirectory -Force | Out-Null
+$seedArguments = @(
+  $seedScript,
+  "--base-url", $IdeaBaseUrl,
+  "--as-of-date", $AsOfDate,
+  "--seeded-at-utc", $SeededAtUtc,
+  "--commit-sha", $commitSha,
+  "--branch", $branch,
+  "--run-id", $RunId,
+  "--confirmation", "SEED_SYNTHETIC_LOTUS_IDEA_CAPACITY_RESOURCE",
+  "--output", $manifestPath
+)
+& $python @seedArguments
+if ($LASTEXITCODE -ne 0) {
+  throw "Lotus Idea capacity seed producer failed with exit code $LASTEXITCODE."
+}
+
+$validator = Join-Path $workbenchRepo "scripts\live\Validate-IdeaCapacitySeedEvidence.mjs"
+& node $validator `
+  --manifest $manifestPath `
+  --output $evidencePath `
+  --commit-sha $commitSha `
+  --branch $branch `
+  --run-id $RunId
+if ($LASTEXITCODE -ne 0) {
+  throw "Workbench Idea capacity seed evidence validation failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Validated isolated Lotus Idea capacity seed evidence: $evidencePath"

--- a/scripts/live/Invoke-IdeaCapacitySeed.ps1
+++ b/scripts/live/Invoke-IdeaCapacitySeed.ps1
@@ -4,6 +4,8 @@ param(
   [Parameter(Mandatory = $true)][string]$AsOfDate,
   [Parameter(Mandatory = $true)][string]$SeededAtUtc,
   [Parameter(Mandatory = $true)][string]$RunId,
+  [Parameter(Mandatory = $true)][string]$ExpectedCommitSha,
+  [Parameter(Mandatory = $true)][string]$ExpectedBranch,
   [Parameter(Mandatory = $true)][string]$EvidenceDirectory
 )
 
@@ -12,7 +14,9 @@ $ideaRepo = Join-Path $ProjectsRoot "lotus-idea"
 $workbenchRepo = Join-Path $ProjectsRoot "lotus-workbench"
 $python = Join-Path $ideaRepo ".venv\Scripts\python.exe"
 $seedScript = Join-Path $ideaRepo "scripts\seed_downstream_capacity_resource.py"
+$workloadScript = Join-Path $ideaRepo "scripts\run_service_capacity_workload.py"
 $manifestPath = Join-Path $EvidenceDirectory "idea-capacity-seed-manifest.json"
+$workloadPath = Join-Path $EvidenceDirectory "idea-capacity-seed-workload.json"
 $evidencePath = Join-Path $EvidenceDirectory "idea-capacity-seed-evidence.json"
 
 if (-not (Test-Path $python)) {
@@ -21,12 +25,18 @@ if (-not (Test-Path $python)) {
 if (-not (Test-Path $seedScript)) {
   throw "Lotus Idea capacity seed producer was not found: $seedScript"
 }
+if (-not (Test-Path $workloadScript)) {
+  throw "Lotus Idea capacity workload runner was not found: $workloadScript"
+}
 
 $version = Invoke-RestMethod -Uri "$IdeaBaseUrl/version" -TimeoutSec 30
 $commitSha = [string]$version.build.gitCommitSha
 $branch = [string]$version.build.gitBranch
 if ([string]::IsNullOrWhiteSpace($commitSha) -or [string]::IsNullOrWhiteSpace($branch)) {
   throw "Lotus Idea /version did not expose commit and branch provenance."
+}
+if ($commitSha -ne $ExpectedCommitSha -or $branch -ne $ExpectedBranch) {
+  throw "Lotus Idea runtime provenance does not match the expected source commit and branch. Rebuild the Idea image."
 }
 
 New-Item -ItemType Directory -Path $EvidenceDirectory -Force | Out-Null
@@ -46,9 +56,29 @@ if ($LASTEXITCODE -ne 0) {
   throw "Lotus Idea capacity seed producer failed with exit code $LASTEXITCODE."
 }
 
+$workloadArguments = @(
+  $workloadScript,
+  "--base-url", $IdeaBaseUrl,
+  "--environment-profile", "test",
+  "--scenario", "downstream_submission",
+  "--request-count", "1",
+  "--concurrency", "1",
+  "--allow-mutating-workflows",
+  "--commit-sha", $commitSha,
+  "--branch", $branch,
+  "--run-id", $RunId,
+  "--downstream-capacity-seed", $manifestPath,
+  "--output", $workloadPath
+)
+& $python @workloadArguments
+if ($LASTEXITCODE -ne 0) {
+  throw "Lotus Idea capacity workload acceptance failed with exit code $LASTEXITCODE."
+}
+
 $validator = Join-Path $workbenchRepo "scripts\live\Validate-IdeaCapacitySeedEvidence.mjs"
 & node $validator `
   --manifest $manifestPath `
+  --workload $workloadPath `
   --output $evidencePath `
   --commit-sha $commitSha `
   --branch $branch `

--- a/scripts/live/Invoke-IdeaCapacitySeed.ps1
+++ b/scripts/live/Invoke-IdeaCapacitySeed.ps1
@@ -33,11 +33,12 @@ if (-not (Test-Path $workloadScript)) {
 $version = Invoke-RestMethod -Uri "$IdeaBaseUrl/version" -TimeoutSec 30
 $commitSha = [string]$version.build.gitCommitSha
 $branch = [string]$version.build.gitBranch
-if ([string]::IsNullOrWhiteSpace($commitSha) -or [string]::IsNullOrWhiteSpace($branch)) {
-  throw "Lotus Idea /version did not expose commit and branch provenance."
+$runtimeRunId = [string]$version.build.ciRunId
+if ([string]::IsNullOrWhiteSpace($commitSha) -or [string]::IsNullOrWhiteSpace($branch) -or [string]::IsNullOrWhiteSpace($runtimeRunId)) {
+  throw "Lotus Idea /version did not expose commit, branch, and run provenance."
 }
-if ($commitSha -ne $ExpectedCommitSha -or $branch -ne $ExpectedBranch) {
-  throw "Lotus Idea runtime provenance does not match the expected source commit and branch. Rebuild the Idea image."
+if ($commitSha -ne $ExpectedCommitSha -or $branch -ne $ExpectedBranch -or $runtimeRunId -ne $RunId) {
+  throw "Lotus Idea runtime provenance does not match the expected source commit, branch, and startup run. Rebuild the Idea image."
 }
 
 New-Item -ItemType Directory -Path $EvidenceDirectory -Force | Out-Null

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -3,6 +3,7 @@ param(
   [string]$PortfolioId = "PB_SG_GLOBAL_BAL_001",
   [string]$BenchmarkCode = "BMK_PB_GLOBAL_BALANCED_60_40",
   [string]$ScreenshotDirectory = "",
+  [string]$CanonicalEvidenceDirectory = "",
   [string]$LotusAiEnvFile = ".env.example",
   [int]$SeedWaitSeconds = 900,
   [string[]]$LocalApps = @(),
@@ -30,6 +31,13 @@ $workbenchRepo = Join-Path $ProjectsRoot "lotus-workbench"
 $platformRepo = Join-Path $ProjectsRoot "lotus-platform"
 $ingressCaddyfile = Join-Path $platformRepo "platform-stack\\dev-ingress\\Caddyfile.direct-host"
 $canonicalContractPath = Join-Path $platformRepo "context\\contracts\\canonical-front-office-demo-data-contract.json"
+$canonicalEvidenceRoot = if ([string]::IsNullOrWhiteSpace($CanonicalEvidenceDirectory)) {
+  Join-Path $workbenchRepo "output\\canonical-front-office"
+} elseif ([System.IO.Path]::IsPathRooted($CanonicalEvidenceDirectory)) {
+  $CanonicalEvidenceDirectory
+} else {
+  Join-Path $workbenchRepo $CanonicalEvidenceDirectory
+}
 $composeUpCommand = "docker compose up -d"
 if ($BuildImages) {
   $composeUpCommand = "$composeUpCommand --build"
@@ -71,6 +79,37 @@ function Test-HttpReady {
   } catch {
     return $false
   }
+}
+
+function Get-GitRepositoryIdentity {
+  param([string]$RepoPath)
+
+  $commitSha = (& git -C $RepoPath rev-parse HEAD).Trim()
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($commitSha)) {
+    throw "Unable to resolve Git commit for $RepoPath."
+  }
+  $branch = (& git -C $RepoPath branch --show-current).Trim()
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($branch)) {
+    throw "Unable to resolve Git branch for $RepoPath."
+  }
+  return [ordered]@{ CommitSha = $commitSha; Branch = $branch }
+}
+
+function Wait-HttpReady {
+  param(
+    [string]$Url,
+    [string]$Description,
+    [int]$TimeoutSeconds = 120
+  )
+
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  while ((Get-Date) -lt $deadline) {
+    if (Test-HttpReady $Url) {
+      return
+    }
+    Start-Sleep -Seconds 2
+  }
+  throw "$Description did not become ready at $Url within $TimeoutSeconds seconds."
 }
 
 function Remove-ContainerIfPresent {
@@ -408,6 +447,27 @@ function Invoke-CanonicalIdeaSeed {
   }
 }
 
+function Invoke-CanonicalIdeaCapacitySeed {
+  $datePolicy = Get-CanonicalFrontOfficeDatePolicy
+  Wait-HttpReady -Url "http://127.0.0.1:8330/health/ready" -Description "lotus-idea"
+  Wait-HttpReady -Url "http://127.0.0.1:8000/health/ready" -Description "lotus-advise"
+  $runId = "canonical-front-office-$($datePolicy.AsOfDate)"
+
+  Write-Host "Seeding isolated Lotus Idea downstream-capacity evidence ..."
+  & (Join-Path $workbenchRepo "scripts\\live\\Invoke-IdeaCapacitySeed.ps1") `
+    -ProjectsRoot $ProjectsRoot `
+    -IdeaBaseUrl "http://127.0.0.1:8330" `
+    -AsOfDate $datePolicy.AsOfDate `
+    -SeededAtUtc $datePolicy.GeneratedAtUtc `
+    -RunId $runId `
+    -ExpectedCommitSha $ideaSourceIdentity.CommitSha `
+    -ExpectedBranch $ideaSourceIdentity.Branch `
+    -EvidenceDirectory $canonicalEvidenceRoot
+  if ($LASTEXITCODE -ne 0) {
+    throw "Canonical Lotus Idea capacity seed failed with exit code $LASTEXITCODE."
+  }
+}
+
 Write-Host "Previewing managed canonical hosts block from lotus-platform ..."
 Invoke-RepoCommand $platformRepo "powershell -ExecutionPolicy Bypass -File automation\\Sync-Dev-Ingress-Hosts.ps1"
 
@@ -421,6 +481,19 @@ if ($localAppSet.Count -gt 0) {
 }
 
 Write-Host "Starting Docker-backed canonical services..."
+$ideaSourceIdentity = Get-GitRepositoryIdentity -RepoPath $ideaRepo
+$ideaDatePolicy = Get-CanonicalFrontOfficeDatePolicy
+$ideaCanonicalRunId = "canonical-front-office-$($ideaDatePolicy.AsOfDate)"
+$ideaBuildTimestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+$ideaBuildEnvironment = @{
+  LOTUS_IDEA_BUILD_GIT_COMMIT_SHA = $ideaSourceIdentity.CommitSha
+  LOTUS_IDEA_BUILD_GIT_BRANCH = $ideaSourceIdentity.Branch
+  LOTUS_IDEA_BUILD_TIMESTAMP = $ideaBuildTimestamp
+  LOTUS_IDEA_BUILD_REPO_URL = "https://github.com/sgajbi/lotus-idea.git"
+  LOTUS_IDEA_BUILD_RUN_ID = $ideaCanonicalRunId
+  LOTUS_IDEA_BUILD_IMAGE_ID = "$($ideaSourceIdentity.CommitSha).$ideaCanonicalRunId"
+  LOTUS_IDEA_BUILD_SERVICE_VERSION = "0.1.0"
+}
 $resolvedLotusAiEnvFile = Resolve-LotusAiEnvFile -EnvFile $LotusAiEnvFile
 Write-Host "Using lotus-ai env file for canonical proof: $resolvedLotusAiEnvFile"
 $canonicalCoreEnvironment = @{
@@ -452,7 +525,7 @@ Invoke-ComposeUp $adviseRepo
 Start-CanonicalManage
 
 Invoke-ComposeUp $reportRepo
-Invoke-ComposeUp $ideaRepo
+Invoke-ComposeUp $ideaRepo $ideaBuildEnvironment
 Invoke-CanonicalIdeaSeed
 
 if (Test-LocalApp "archive") {
@@ -489,6 +562,7 @@ if (Test-LocalApp "gateway") {
 
 Invoke-CanonicalCoreSeed
 Invoke-DpmCommandCenterSeed
+Invoke-CanonicalIdeaCapacitySeed
 
 if (Test-LocalApp "workbench") {
   Invoke-RepoCommand $workbenchRepo "docker compose down --remove-orphans"
@@ -520,6 +594,7 @@ Write-Host "Running canonical live validation ..."
 $validationArguments = @{
   PortfolioId = $PortfolioId
   BenchmarkCode = $BenchmarkCode
+  CanonicalEvidenceDirectory = $canonicalEvidenceRoot
 }
 if (-not [string]::IsNullOrWhiteSpace($ScreenshotDirectory)) {
   $validationArguments.ScreenshotDirectory = $ScreenshotDirectory

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -451,7 +451,6 @@ function Invoke-CanonicalIdeaCapacitySeed {
   $datePolicy = Get-CanonicalFrontOfficeDatePolicy
   Wait-HttpReady -Url "http://127.0.0.1:8330/health/ready" -Description "lotus-idea"
   Wait-HttpReady -Url "http://127.0.0.1:8000/health/ready" -Description "lotus-advise"
-  $runId = "canonical-front-office-$($datePolicy.AsOfDate)"
 
   Write-Host "Seeding isolated Lotus Idea downstream-capacity evidence ..."
   & (Join-Path $workbenchRepo "scripts\\live\\Invoke-IdeaCapacitySeed.ps1") `
@@ -459,7 +458,7 @@ function Invoke-CanonicalIdeaCapacitySeed {
     -IdeaBaseUrl "http://127.0.0.1:8330" `
     -AsOfDate $datePolicy.AsOfDate `
     -SeededAtUtc $datePolicy.GeneratedAtUtc `
-    -RunId $runId `
+    -RunId $ideaCanonicalRunId `
     -ExpectedCommitSha $ideaSourceIdentity.CommitSha `
     -ExpectedBranch $ideaSourceIdentity.Branch `
     -EvidenceDirectory $canonicalEvidenceRoot
@@ -504,7 +503,7 @@ if ($CoreManageOnly) {
 
 $ideaSourceIdentity = Get-GitRepositoryIdentity -RepoPath $ideaRepo
 $ideaDatePolicy = Get-CanonicalFrontOfficeDatePolicy
-$ideaCanonicalRunId = "canonical-front-office-$($ideaDatePolicy.AsOfDate)"
+$ideaCanonicalRunId = "canonical-front-office-$($ideaDatePolicy.AsOfDate)-$([guid]::NewGuid().ToString('N'))"
 $ideaBuildTimestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 $ideaBuildEnvironment = @{
   LOTUS_IDEA_BUILD_GIT_COMMIT_SHA = $ideaSourceIdentity.CommitSha

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -481,21 +481,6 @@ if ($localAppSet.Count -gt 0) {
 }
 
 Write-Host "Starting Docker-backed canonical services..."
-$ideaSourceIdentity = Get-GitRepositoryIdentity -RepoPath $ideaRepo
-$ideaDatePolicy = Get-CanonicalFrontOfficeDatePolicy
-$ideaCanonicalRunId = "canonical-front-office-$($ideaDatePolicy.AsOfDate)"
-$ideaBuildTimestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-$ideaBuildEnvironment = @{
-  LOTUS_IDEA_BUILD_GIT_COMMIT_SHA = $ideaSourceIdentity.CommitSha
-  LOTUS_IDEA_BUILD_GIT_BRANCH = $ideaSourceIdentity.Branch
-  LOTUS_IDEA_BUILD_TIMESTAMP = $ideaBuildTimestamp
-  LOTUS_IDEA_BUILD_REPO_URL = "https://github.com/sgajbi/lotus-idea.git"
-  LOTUS_IDEA_BUILD_RUN_ID = $ideaCanonicalRunId
-  LOTUS_IDEA_BUILD_IMAGE_ID = "$($ideaSourceIdentity.CommitSha).$ideaCanonicalRunId"
-  LOTUS_IDEA_BUILD_SERVICE_VERSION = "0.1.0"
-}
-$resolvedLotusAiEnvFile = Resolve-LotusAiEnvFile -EnvFile $LotusAiEnvFile
-Write-Host "Using lotus-ai env file for canonical proof: $resolvedLotusAiEnvFile"
 $canonicalCoreEnvironment = @{
   DEMO_DATA_PACK_ENABLED = "false"
 }
@@ -516,6 +501,22 @@ if ($CoreManageOnly) {
   Write-Host "Run the core and manage API validators for RFC-087/RFC-0036 proof."
   return
 }
+
+$ideaSourceIdentity = Get-GitRepositoryIdentity -RepoPath $ideaRepo
+$ideaDatePolicy = Get-CanonicalFrontOfficeDatePolicy
+$ideaCanonicalRunId = "canonical-front-office-$($ideaDatePolicy.AsOfDate)"
+$ideaBuildTimestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+$ideaBuildEnvironment = @{
+  LOTUS_IDEA_BUILD_GIT_COMMIT_SHA = $ideaSourceIdentity.CommitSha
+  LOTUS_IDEA_BUILD_GIT_BRANCH = $ideaSourceIdentity.Branch
+  LOTUS_IDEA_BUILD_TIMESTAMP = $ideaBuildTimestamp
+  LOTUS_IDEA_BUILD_REPO_URL = "https://github.com/sgajbi/lotus-idea.git"
+  LOTUS_IDEA_BUILD_RUN_ID = $ideaCanonicalRunId
+  LOTUS_IDEA_BUILD_IMAGE_ID = "$($ideaSourceIdentity.CommitSha).$ideaCanonicalRunId"
+  LOTUS_IDEA_BUILD_SERVICE_VERSION = "0.1.0"
+}
+$resolvedLotusAiEnvFile = Resolve-LotusAiEnvFile -EnvFile $LotusAiEnvFile
+Write-Host "Using lotus-ai env file for canonical proof: $resolvedLotusAiEnvFile"
 
 Invoke-ComposeUp $performanceRepo
 Invoke-ComposeUp $riskRepo

--- a/scripts/live/Validate-IdeaCapacitySeedEvidence.mjs
+++ b/scripts/live/Validate-IdeaCapacitySeedEvidence.mjs
@@ -1,0 +1,29 @@
+import { parseArgs } from "node:util";
+
+import { validateAndWriteIdeaCapacitySeedEvidence } from "./validation/idea-capacity-seed-evidence.mjs";
+
+const { values } = parseArgs({
+  options: {
+    manifest: { type: "string" },
+    output: { type: "string" },
+    "commit-sha": { type: "string" },
+    branch: { type: "string" },
+    "run-id": { type: "string" },
+  },
+});
+
+for (const name of ["manifest", "output", "commit-sha", "branch", "run-id"]) {
+  if (!values[name]) {
+    throw new Error(`Missing required --${name}`);
+  }
+}
+
+await validateAndWriteIdeaCapacitySeedEvidence({
+  manifestPath: values.manifest,
+  evidencePath: values.output,
+  commitSha: values["commit-sha"],
+  branch: values.branch,
+  runId: values["run-id"],
+});
+
+console.log("Idea capacity seed evidence validated");

--- a/scripts/live/Validate-IdeaCapacitySeedEvidence.mjs
+++ b/scripts/live/Validate-IdeaCapacitySeedEvidence.mjs
@@ -5,6 +5,7 @@ import { validateAndWriteIdeaCapacitySeedEvidence } from "./validation/idea-capa
 const { values } = parseArgs({
   options: {
     manifest: { type: "string" },
+    workload: { type: "string" },
     output: { type: "string" },
     "commit-sha": { type: "string" },
     branch: { type: "string" },
@@ -12,7 +13,7 @@ const { values } = parseArgs({
   },
 });
 
-for (const name of ["manifest", "output", "commit-sha", "branch", "run-id"]) {
+for (const name of ["manifest", "workload", "output", "commit-sha", "branch", "run-id"]) {
   if (!values[name]) {
     throw new Error(`Missing required --${name}`);
   }
@@ -20,6 +21,7 @@ for (const name of ["manifest", "output", "commit-sha", "branch", "run-id"]) {
 
 await validateAndWriteIdeaCapacitySeedEvidence({
   manifestPath: values.manifest,
+  workloadPath: values.workload,
   evidencePath: values.output,
   commitSha: values["commit-sha"],
   branch: values.branch,

--- a/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
@@ -5,11 +5,20 @@ param(
   [string]$AsOfDate = "2026-04-10",
   [string]$WorkbenchBaseUrl = "http://workbench.dev.lotus",
   [string]$GatewayBaseUrl = "http://gateway.dev.lotus",
-  [string]$ScreenshotDirectory = ""
+  [string]$ScreenshotDirectory = "",
+  [string]$CanonicalEvidenceDirectory = ""
 )
 
 $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$canonicalEvidenceRoot = if ([string]::IsNullOrWhiteSpace($CanonicalEvidenceDirectory)) {
+  Join-Path $repoRoot "output\\canonical-front-office"
+} elseif ([System.IO.Path]::IsPathRooted($CanonicalEvidenceDirectory)) {
+  $CanonicalEvidenceDirectory
+} else {
+  Join-Path $repoRoot $CanonicalEvidenceDirectory
+}
+$ideaCapacitySeedEvidencePath = Join-Path $canonicalEvidenceRoot "idea-capacity-seed-evidence.json"
 $canonicalCallerContextHeaders = @{
   "X-Actor-Id" = "workbench-system"
   "X-Tenant-Id" = "tenant-sg"
@@ -120,6 +129,9 @@ Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/summary
 Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/risk/summary?period=EXPLICIT&detail_basis=NET&benchmark_code=$BenchmarkCode&report_start_date=$StartDate&report_end_date=$AsOfDate&as_of_date=$AsOfDate" "Gateway risk summary" -Headers $canonicalCallerContextHeaders
 Test-Endpoint "$GatewayBaseUrl/api/v1/workbench/$PortfolioId/performance/advisor-brief?period=EXPLICIT&chart_frequency=monthly&detail_basis=NET&contribution_dimension=asset_class&attribution_dimension=asset_class&benchmark_code=$BenchmarkCode&report_start_date=$StartDate&report_end_date=$AsOfDate" "Gateway advisor brief" -Headers $canonicalCallerContextHeaders
 Assert-IdeaQueueSeed
+if (-not (Test-Path $ideaCapacitySeedEvidencePath)) {
+  throw "Canonical Lotus Idea capacity seed evidence is missing: $ideaCapacitySeedEvidencePath"
+}
 
 Push-Location $repoRoot
 try {
@@ -136,7 +148,9 @@ try {
     "--workbench-base-url",
     $WorkbenchBaseUrl,
     "--gateway-base-url",
-    $GatewayBaseUrl
+    $GatewayBaseUrl,
+    "--idea-capacity-seed-evidence",
+    $ideaCapacitySeedEvidencePath
   )
   if (-not [string]::IsNullOrWhiteSpace($ScreenshotDirectory)) {
     $validatorArguments += @("--output-dir", $ScreenshotDirectory)

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -68,6 +68,7 @@ const {
   benchmarkCode,
   workbenchBaseUrl,
   gatewayBaseUrl,
+  ideaBaseUrl,
   outputDir,
   timeoutMs,
   canonicalStartDate,
@@ -105,8 +106,19 @@ const summary = createValidationSummary({
   gatewayBaseUrl,
   panelRegistry,
 });
+const ideaVersion = await fetchJson(
+  summary,
+  `${ideaBaseUrl}/version`,
+  "Lotus Idea runtime version",
+  timeoutMs,
+);
 summary.ideaCapacitySeed = await loadIdeaCapacitySeedEvidence(
   ideaCapacitySeedEvidencePath,
+  {
+    commitSha: ideaVersion?.build?.gitCommitSha,
+    branch: ideaVersion?.build?.gitBranch,
+    runId: `canonical-front-office-${canonicalAsOfDate}`,
+  },
 );
 const panelGovernance = createPanelGovernance(summary, panelRegistry);
 

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -117,7 +117,7 @@ summary.ideaCapacitySeed = await loadIdeaCapacitySeedEvidence(
   {
     commitSha: ideaVersion?.build?.gitCommitSha,
     branch: ideaVersion?.build?.gitBranch,
-    runId: `canonical-front-office-${canonicalAsOfDate}`,
+    runId: ideaVersion?.build?.ciRunId,
   },
 );
 const panelGovernance = createPanelGovernance(summary, panelRegistry);

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -61,6 +61,7 @@ import {
   extractGatewayEnvelopeData,
   readString,
 } from "./validation/payload-utils.mjs";
+import { loadIdeaCapacitySeedEvidence } from "./validation/idea-capacity-seed-evidence.mjs";
 
 const {
   portfolioId,
@@ -71,6 +72,7 @@ const {
   timeoutMs,
   canonicalStartDate,
   canonicalAsOfDate,
+  ideaCapacitySeedEvidencePath,
 } = resolveValidationConfig(process.argv.slice(2));
 const { summaryPath, shotIndexPath } = buildSummaryPaths(outputDir);
 const canonicalContract = await loadCanonicalContractMetadata();
@@ -103,6 +105,9 @@ const summary = createValidationSummary({
   gatewayBaseUrl,
   panelRegistry,
 });
+summary.ideaCapacitySeed = await loadIdeaCapacitySeedEvidence(
+  ideaCapacitySeedEvidencePath,
+);
 const panelGovernance = createPanelGovernance(summary, panelRegistry);
 
 function canonicalPerformanceQuery(extra = {}) {

--- a/scripts/live/validation/args.mjs
+++ b/scripts/live/validation/args.mjs
@@ -29,6 +29,7 @@ export function resolveValidationConfig(argv, cwd = process.cwd()) {
       ""
     ),
     gatewayBaseUrl: (args.get("gateway-base-url") ?? "http://gateway.dev.lotus").replace(/\/+$/, ""),
+    ideaBaseUrl: (args.get("idea-base-url") ?? "http://127.0.0.1:8330").replace(/\/+$/, ""),
     outputDir: path.resolve(cwd, args.get("output-dir") ?? "output/playwright/live-canonical"),
     timeoutMs: Number(args.get("timeout-ms") ?? "60000"),
     canonicalStartDate: args.get("start-date") ?? "2025-03-31",

--- a/scripts/live/validation/args.mjs
+++ b/scripts/live/validation/args.mjs
@@ -33,5 +33,10 @@ export function resolveValidationConfig(argv, cwd = process.cwd()) {
     timeoutMs: Number(args.get("timeout-ms") ?? "60000"),
     canonicalStartDate: args.get("start-date") ?? "2025-03-31",
     canonicalAsOfDate: args.get("as-of-date") ?? "2026-04-10",
+    ideaCapacitySeedEvidencePath: path.resolve(
+      cwd,
+      args.get("idea-capacity-seed-evidence") ??
+        "output/canonical-front-office/idea-capacity-seed-evidence.json"
+    ),
   };
 }

--- a/scripts/live/validation/evidence-summary-writer.mjs
+++ b/scripts/live/validation/evidence-summary-writer.mjs
@@ -34,6 +34,7 @@ export function createValidationSummary({
     supportabilityMatrix: null,
     supportabilityChecks: [],
     screenshots: [],
+    ideaCapacitySeed: null,
   };
 }
 

--- a/scripts/live/validation/idea-capacity-seed-evidence.d.mts
+++ b/scripts/live/validation/idea-capacity-seed-evidence.d.mts
@@ -63,8 +63,14 @@ export function validateIdeaCapacitySeedEvidence(
   payload: unknown,
 ): asserts payload is IdeaCapacitySeedEvidence;
 
+export function validateIdeaCapacitySeedEvidenceProvenance(
+  payload: IdeaCapacitySeedEvidence | IdeaCapacitySeedManifest,
+  expected: IdeaCapacitySeedExpectedProvenance,
+): void;
+
 export function loadIdeaCapacitySeedEvidence(
   evidencePath: string,
+  expectedProvenance?: IdeaCapacitySeedExpectedProvenance,
 ): Promise<IdeaCapacitySeedEvidence>;
 
 export function validateAndWriteIdeaCapacitySeedEvidence(

--- a/scripts/live/validation/idea-capacity-seed-evidence.d.mts
+++ b/scripts/live/validation/idea-capacity-seed-evidence.d.mts
@@ -8,6 +8,7 @@ export interface IdeaCapacitySeedManifest {
   branch: string;
   runId: string;
   syntheticResource: boolean;
+  syntheticNamespace: "CAPACITY_SYNTHETIC_PORTFOLIO_001";
   conversionIntentId: string;
   downstreamSubmissionPath: string;
   productionCapacityCertified: boolean;

--- a/scripts/live/validation/idea-capacity-seed-evidence.d.mts
+++ b/scripts/live/validation/idea-capacity-seed-evidence.d.mts
@@ -1,0 +1,57 @@
+export interface IdeaCapacitySeedManifest {
+  schemaVersion: string;
+  repository: string;
+  proofScope: string;
+  claimPosture: string;
+  generatedAtUtc: string;
+  commitSha: string;
+  branch: string;
+  runId: string;
+  syntheticResource: boolean;
+  conversionIntentId: string;
+  downstreamSubmissionPath: string;
+  productionCapacityCertified: boolean;
+  supportedFeaturePromoted: boolean;
+}
+
+export interface IdeaCapacitySeedExpectedProvenance {
+  commitSha: string;
+  branch: string;
+  runId: string;
+}
+
+export interface IdeaCapacitySeedEvidence {
+  schemaVersion: "lotus-workbench.idea-capacity-seed-evidence.v1";
+  posture: "accepted_non_certifying";
+  manifestFileName: string;
+  manifestSha256: string;
+  repository: "lotus-idea";
+  commitSha: string;
+  branch: string;
+  runId: string;
+  proofScope: "synthetic_downstream_capacity_resource_seed";
+  claimPosture: "seed_only_not_capacity_evidence";
+  syntheticResource: true;
+  capacityWorkloadAccepted: false;
+  productionCapacityCertified: false;
+  supportedFeaturePromoted: false;
+  canonicalPortfolioUnaffected: true;
+}
+
+export function validateIdeaCapacitySeedManifest(
+  payload: unknown,
+  expected: IdeaCapacitySeedExpectedProvenance,
+): asserts payload is IdeaCapacitySeedManifest;
+
+export function buildIdeaCapacitySeedEvidence(input: {
+  manifestBytes: Uint8Array;
+  manifestFileName: string;
+  payload: IdeaCapacitySeedManifest;
+}): IdeaCapacitySeedEvidence;
+
+export function validateAndWriteIdeaCapacitySeedEvidence(
+  input: {
+    manifestPath: string;
+    evidencePath: string;
+  } & IdeaCapacitySeedExpectedProvenance,
+): Promise<IdeaCapacitySeedEvidence>;

--- a/scripts/live/validation/idea-capacity-seed-evidence.d.mts
+++ b/scripts/live/validation/idea-capacity-seed-evidence.d.mts
@@ -25,6 +25,8 @@ export interface IdeaCapacitySeedEvidence {
   posture: "accepted_non_certifying";
   manifestFileName: string;
   manifestSha256: string;
+  workloadFileName: string;
+  workloadSha256: string;
   repository: "lotus-idea";
   commitSha: string;
   branch: string;
@@ -32,7 +34,7 @@ export interface IdeaCapacitySeedEvidence {
   proofScope: "synthetic_downstream_capacity_resource_seed";
   claimPosture: "seed_only_not_capacity_evidence";
   syntheticResource: true;
-  capacityWorkloadAccepted: false;
+  capacityWorkloadAccepted: true;
   productionCapacityCertified: false;
   supportedFeaturePromoted: false;
   canonicalPortfolioUnaffected: true;
@@ -47,11 +49,27 @@ export function buildIdeaCapacitySeedEvidence(input: {
   manifestBytes: Uint8Array;
   manifestFileName: string;
   payload: IdeaCapacitySeedManifest;
+  workloadBytes: Uint8Array;
+  workloadFileName: string;
 }): IdeaCapacitySeedEvidence;
+
+export function validateIdeaCapacityWorkload(
+  payload: unknown,
+  expected: IdeaCapacitySeedExpectedProvenance,
+): void;
+
+export function validateIdeaCapacitySeedEvidence(
+  payload: unknown,
+): asserts payload is IdeaCapacitySeedEvidence;
+
+export function loadIdeaCapacitySeedEvidence(
+  evidencePath: string,
+): Promise<IdeaCapacitySeedEvidence>;
 
 export function validateAndWriteIdeaCapacitySeedEvidence(
   input: {
     manifestPath: string;
+    workloadPath: string;
     evidencePath: string;
   } & IdeaCapacitySeedExpectedProvenance,
 ): Promise<IdeaCapacitySeedEvidence>;

--- a/scripts/live/validation/idea-capacity-seed-evidence.mjs
+++ b/scripts/live/validation/idea-capacity-seed-evidence.mjs
@@ -57,12 +57,16 @@ export function buildIdeaCapacitySeedEvidence({
   manifestBytes,
   manifestFileName,
   payload,
+  workloadBytes,
+  workloadFileName,
 }) {
   return {
     schemaVersion: "lotus-workbench.idea-capacity-seed-evidence.v1",
     posture: "accepted_non_certifying",
     manifestFileName,
     manifestSha256: crypto.createHash("sha256").update(manifestBytes).digest("hex"),
+    workloadFileName,
+    workloadSha256: crypto.createHash("sha256").update(workloadBytes).digest("hex"),
     repository: payload.repository,
     commitSha: payload.commitSha,
     branch: payload.branch,
@@ -70,15 +74,102 @@ export function buildIdeaCapacitySeedEvidence({
     proofScope: payload.proofScope,
     claimPosture: payload.claimPosture,
     syntheticResource: true,
-    capacityWorkloadAccepted: false,
+    capacityWorkloadAccepted: true,
     productionCapacityCertified: false,
     supportedFeaturePromoted: false,
     canonicalPortfolioUnaffected: true,
   };
 }
 
+export function validateIdeaCapacityWorkload(payload, { commitSha, branch, runId }) {
+  const required = {
+    schemaVersion: "lotus-idea.service-capacity-baseline.v1",
+    repository: "lotus-idea",
+    proofScope: "source_safe_service_capacity_baseline",
+    claimPosture: "report_only_baseline",
+    environmentProfile: "test",
+    commitSha,
+    branch,
+    runId,
+    certificationReady: false,
+    supportedFeaturePromoted: false,
+  };
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Idea capacity workload evidence must be a JSON object");
+  }
+  for (const [field, expected] of Object.entries(required)) {
+    if (payload[field] !== expected) {
+      throw new Error(`Idea capacity workload evidence has invalid ${field}`);
+    }
+  }
+  const scenarios = Array.isArray(payload.scenarios) ? payload.scenarios : [];
+  const downstream = scenarios.find((item) => item?.scenario === "downstream_submission");
+  if (
+    !downstream ||
+    downstream.sampleCount !== 1 ||
+    downstream.acceptedCount !== 1 ||
+    downstream.errorCount !== 0 ||
+    downstream.conflictCount !== 0
+  ) {
+    throw new Error("Idea capacity workload did not accept exactly one downstream probe");
+  }
+}
+
+export function validateIdeaCapacitySeedEvidence(payload) {
+  const required = {
+    schemaVersion: "lotus-workbench.idea-capacity-seed-evidence.v1",
+    posture: "accepted_non_certifying",
+    repository: "lotus-idea",
+    proofScope: "synthetic_downstream_capacity_resource_seed",
+    claimPosture: "seed_only_not_capacity_evidence",
+    syntheticResource: true,
+    capacityWorkloadAccepted: true,
+    productionCapacityCertified: false,
+    supportedFeaturePromoted: false,
+    canonicalPortfolioUnaffected: true,
+  };
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Idea capacity seed evidence must be a JSON object");
+  }
+  for (const [field, expected] of Object.entries(required)) {
+    if (payload[field] !== expected) {
+      throw new Error(`Idea capacity seed evidence has invalid ${field}`);
+    }
+  }
+  for (const field of [
+    "manifestFileName",
+    "workloadFileName",
+    "commitSha",
+    "branch",
+    "runId",
+  ]) {
+    if (typeof payload[field] !== "string" || payload[field].length === 0) {
+      throw new Error(`Idea capacity seed evidence is missing ${field}`);
+    }
+  }
+  if (!/^[a-f0-9]{64}$/.test(payload.manifestSha256)) {
+    throw new Error("Idea capacity seed evidence has invalid manifestSha256");
+  }
+  if (!/^[a-f0-9]{64}$/.test(payload.workloadSha256)) {
+    throw new Error("Idea capacity seed evidence has invalid workloadSha256");
+  }
+  const serialized = JSON.stringify(payload);
+  for (const forbidden of ["conversionIntentId", "downstreamSubmissionPath", "Authorization"]) {
+    if (serialized.includes(forbidden)) {
+      throw new Error("Idea capacity seed evidence contains forbidden resource or credential data");
+    }
+  }
+}
+
+export async function loadIdeaCapacitySeedEvidence(evidencePath) {
+  const payload = JSON.parse(await fs.readFile(evidencePath, "utf8"));
+  validateIdeaCapacitySeedEvidence(payload);
+  return payload;
+}
+
 export async function validateAndWriteIdeaCapacitySeedEvidence({
   manifestPath,
+  workloadPath,
   evidencePath,
   commitSha,
   branch,
@@ -87,10 +178,15 @@ export async function validateAndWriteIdeaCapacitySeedEvidence({
   const manifestBytes = await fs.readFile(manifestPath);
   const payload = JSON.parse(manifestBytes.toString("utf8"));
   validateIdeaCapacitySeedManifest(payload, { commitSha, branch, runId });
+  const workloadBytes = await fs.readFile(workloadPath);
+  const workload = JSON.parse(workloadBytes.toString("utf8"));
+  validateIdeaCapacityWorkload(workload, { commitSha, branch, runId });
   const evidence = buildIdeaCapacitySeedEvidence({
     manifestBytes,
     manifestFileName: path.basename(manifestPath),
     payload,
+    workloadBytes,
+    workloadFileName: path.basename(workloadPath),
   });
   await fs.mkdir(path.dirname(evidencePath), { recursive: true });
   const temporaryPath = `${evidencePath}.tmp`;

--- a/scripts/live/validation/idea-capacity-seed-evidence.mjs
+++ b/scripts/live/validation/idea-capacity-seed-evidence.mjs
@@ -1,0 +1,100 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const EXPECTED = Object.freeze({
+  schemaVersion: "lotus-idea.downstream-capacity-seed.v1",
+  repository: "lotus-idea",
+  proofScope: "synthetic_downstream_capacity_resource_seed",
+  claimPosture: "seed_only_not_capacity_evidence",
+  syntheticResource: true,
+  productionCapacityCertified: false,
+  supportedFeaturePromoted: false,
+});
+
+const DOWNSTREAM_PATH = /^\/api\/v1\/conversion-intents\/capacity-conversion-[a-f0-9]{16}\/downstream-submissions$/;
+
+export function validateIdeaCapacitySeedManifest(
+  payload,
+  { commitSha, branch, runId },
+) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Idea capacity seed manifest must be a JSON object");
+  }
+  for (const [field, expected] of Object.entries(EXPECTED)) {
+    if (payload[field] !== expected) {
+      throw new Error(`Idea capacity seed manifest has invalid ${field}`);
+    }
+  }
+  for (const [field, expected] of Object.entries({ commitSha, branch, runId })) {
+    if (typeof expected !== "string" || expected.length === 0 || payload[field] !== expected) {
+      throw new Error(`Idea capacity seed manifest does not match expected ${field}`);
+    }
+  }
+  if (!DOWNSTREAM_PATH.test(payload.downstreamSubmissionPath)) {
+    throw new Error("Idea capacity seed manifest has an invalid downstream path");
+  }
+  if (
+    typeof payload.conversionIntentId !== "string" ||
+    !payload.downstreamSubmissionPath.includes(`/${payload.conversionIntentId}/`)
+  ) {
+    throw new Error("Idea capacity seed manifest resource identity is inconsistent");
+  }
+  const serialized = JSON.stringify(payload);
+  for (const forbidden of [
+    "PB_SG_GLOBAL_BAL_001",
+    "client-001",
+    "tenant-private-bank-sg",
+    "book-advisor-001",
+  ]) {
+    if (serialized.includes(forbidden)) {
+      throw new Error("Idea capacity seed manifest contains canonical or client-scoped identity");
+    }
+  }
+}
+
+export function buildIdeaCapacitySeedEvidence({
+  manifestBytes,
+  manifestFileName,
+  payload,
+}) {
+  return {
+    schemaVersion: "lotus-workbench.idea-capacity-seed-evidence.v1",
+    posture: "accepted_non_certifying",
+    manifestFileName,
+    manifestSha256: crypto.createHash("sha256").update(manifestBytes).digest("hex"),
+    repository: payload.repository,
+    commitSha: payload.commitSha,
+    branch: payload.branch,
+    runId: payload.runId,
+    proofScope: payload.proofScope,
+    claimPosture: payload.claimPosture,
+    syntheticResource: true,
+    capacityWorkloadAccepted: false,
+    productionCapacityCertified: false,
+    supportedFeaturePromoted: false,
+    canonicalPortfolioUnaffected: true,
+  };
+}
+
+export async function validateAndWriteIdeaCapacitySeedEvidence({
+  manifestPath,
+  evidencePath,
+  commitSha,
+  branch,
+  runId,
+}) {
+  const manifestBytes = await fs.readFile(manifestPath);
+  const payload = JSON.parse(manifestBytes.toString("utf8"));
+  validateIdeaCapacitySeedManifest(payload, { commitSha, branch, runId });
+  const evidence = buildIdeaCapacitySeedEvidence({
+    manifestBytes,
+    manifestFileName: path.basename(manifestPath),
+    payload,
+  });
+  await fs.mkdir(path.dirname(evidencePath), { recursive: true });
+  const temporaryPath = `${evidencePath}.tmp`;
+  await fs.writeFile(temporaryPath, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+  await fs.rename(temporaryPath, evidencePath);
+  return evidence;
+}

--- a/scripts/live/validation/idea-capacity-seed-evidence.mjs
+++ b/scripts/live/validation/idea-capacity-seed-evidence.mjs
@@ -13,6 +13,7 @@ const EXPECTED = Object.freeze({
 });
 
 const DOWNSTREAM_PATH = /^\/api\/v1\/conversion-intents\/capacity-conversion-[a-f0-9]{16}\/downstream-submissions$/;
+const SYNTHETIC_NAMESPACE = "CAPACITY_SYNTHETIC_PORTFOLIO_001";
 
 export function validateIdeaCapacitySeedManifest(
   payload,
@@ -39,6 +40,9 @@ export function validateIdeaCapacitySeedManifest(
     !payload.downstreamSubmissionPath.includes(`/${payload.conversionIntentId}/`)
   ) {
     throw new Error("Idea capacity seed manifest resource identity is inconsistent");
+  }
+  if (payload.syntheticNamespace !== SYNTHETIC_NAMESPACE) {
+    throw new Error("Idea capacity seed manifest does not use the isolated synthetic namespace");
   }
   const serialized = JSON.stringify(payload);
   for (const forbidden of [

--- a/scripts/live/validation/idea-capacity-seed-evidence.mjs
+++ b/scripts/live/validation/idea-capacity-seed-evidence.mjs
@@ -107,9 +107,11 @@ export function validateIdeaCapacityWorkload(payload, { commitSha, branch, runId
     }
   }
   const scenarios = Array.isArray(payload.scenarios) ? payload.scenarios : [];
-  const downstream = scenarios.find((item) => item?.scenario === "downstream_submission");
+  const downstream = scenarios[0];
   if (
+    scenarios.length !== 1 ||
     !downstream ||
+    downstream.scenario !== "downstream_submission" ||
     downstream.sampleCount !== 1 ||
     downstream.acceptedCount !== 1 ||
     downstream.errorCount !== 0 ||

--- a/scripts/live/validation/idea-capacity-seed-evidence.mjs
+++ b/scripts/live/validation/idea-capacity-seed-evidence.mjs
@@ -167,9 +167,23 @@ export function validateIdeaCapacitySeedEvidence(payload) {
   }
 }
 
-export async function loadIdeaCapacitySeedEvidence(evidencePath) {
+export function validateIdeaCapacitySeedEvidenceProvenance(
+  payload,
+  { commitSha, branch, runId },
+) {
+  for (const [field, expected] of Object.entries({ commitSha, branch, runId })) {
+    if (typeof expected !== "string" || expected.length === 0 || payload[field] !== expected) {
+      throw new Error(`Idea capacity seed evidence does not match current ${field}`);
+    }
+  }
+}
+
+export async function loadIdeaCapacitySeedEvidence(evidencePath, expectedProvenance) {
   const payload = JSON.parse(await fs.readFile(evidencePath, "utf8"));
   validateIdeaCapacitySeedEvidence(payload);
+  if (expectedProvenance) {
+    validateIdeaCapacitySeedEvidenceProvenance(payload, expectedProvenance);
+  }
   return payload;
 }
 

--- a/scripts/live/validation/shared-types.d.ts
+++ b/scripts/live/validation/shared-types.d.ts
@@ -16,6 +16,7 @@ export interface ValidationConfig {
   outputDir: string;
   timeoutMs: number;
   canonicalAsOfDate: string;
+  ideaCapacitySeedEvidencePath: string;
 }
 
 export interface CanonicalContractMetadata {
@@ -74,6 +75,7 @@ export interface ValidationSummary {
   supportabilityMatrix?: Record<string, unknown> | null;
   supportabilityChecks?: Array<Record<string, unknown>>;
   screenshots?: Array<Record<string, unknown>>;
+  ideaCapacitySeed?: Record<string, unknown> | null;
 }
 
 export interface BrowserValidationPage {

--- a/scripts/live/validation/shared-types.d.ts
+++ b/scripts/live/validation/shared-types.d.ts
@@ -13,6 +13,7 @@ export interface ValidationConfig {
   benchmarkCode: string;
   workbenchBaseUrl: string;
   gatewayBaseUrl: string;
+  ideaBaseUrl: string;
   outputDir: string;
   timeoutMs: number;
   canonicalAsOfDate: string;

--- a/tests/unit/idea-capacity-seed-evidence.test.ts
+++ b/tests/unit/idea-capacity-seed-evidence.test.ts
@@ -21,12 +21,13 @@ const manifest = {
   branch: "main",
   runId: "canonical-front-office-2026-04-10",
   syntheticResource: true,
+  syntheticNamespace: "CAPACITY_SYNTHETIC_PORTFOLIO_001",
   conversionIntentId: "capacity-conversion-0123456789abcdef",
   downstreamSubmissionPath:
     "/api/v1/conversion-intents/capacity-conversion-0123456789abcdef/downstream-submissions",
   productionCapacityCertified: false,
   supportedFeaturePromoted: false,
-};
+} as const;
 
 const expected = {
   commitSha: manifest.commitSha,
@@ -101,6 +102,7 @@ describe("Idea capacity seed evidence", () => {
     ["feature inflation", { supportedFeaturePromoted: true }],
     ["canonical portfolio leakage", { runId: "PB_SG_GLOBAL_BAL_001" }],
     ["unapproved path", { downstreamSubmissionPath: "/api/v1/clients/1" }],
+    ["unapproved synthetic namespace", { syntheticNamespace: "OTHER_SYNTHETIC_001" }],
   ])("rejects %s", (_name, mutation) => {
     expect(() =>
       validateIdeaCapacitySeedManifest({ ...manifest, ...mutation }, expected),

--- a/tests/unit/idea-capacity-seed-evidence.test.ts
+++ b/tests/unit/idea-capacity-seed-evidence.test.ts
@@ -7,6 +7,7 @@ import {
   loadIdeaCapacitySeedEvidence,
   validateAndWriteIdeaCapacitySeedEvidence,
   validateIdeaCapacitySeedEvidence,
+  validateIdeaCapacitySeedEvidenceProvenance,
   validateIdeaCapacitySeedManifest,
   validateIdeaCapacityWorkload,
 } from "../../scripts/live/validation/idea-capacity-seed-evidence.mjs";
@@ -106,6 +107,22 @@ describe("Idea capacity seed evidence", () => {
         expected,
       ),
     ).toThrow(/exactly one downstream probe/);
+  });
+
+  it("rejects evidence from a different runtime or canonical run", () => {
+    expect(() => validateIdeaCapacitySeedEvidenceProvenance(manifest, expected)).not.toThrow();
+    expect(() =>
+      validateIdeaCapacitySeedEvidenceProvenance(manifest, {
+        ...expected,
+        commitSha: "b".repeat(40),
+      }),
+    ).toThrow(/current commitSha/);
+    expect(() =>
+      validateIdeaCapacitySeedEvidenceProvenance(manifest, {
+        ...expected,
+        runId: "canonical-front-office-2026-04-11",
+      }),
+    ).toThrow(/current runId/);
   });
 
   it.each([

--- a/tests/unit/idea-capacity-seed-evidence.test.ts
+++ b/tests/unit/idea-capacity-seed-evidence.test.ts
@@ -94,6 +94,18 @@ describe("Idea capacity seed evidence", () => {
         expected,
       ),
     ).toThrow(/exactly one downstream probe/);
+    expect(() =>
+      validateIdeaCapacityWorkload(
+        {
+          ...workload,
+          scenarios: [
+            workload.scenarios[0],
+            { ...workload.scenarios[0], acceptedCount: 0, errorCount: 1 },
+          ],
+        },
+        expected,
+      ),
+    ).toThrow(/exactly one downstream probe/);
   });
 
   it.each([

--- a/tests/unit/idea-capacity-seed-evidence.test.ts
+++ b/tests/unit/idea-capacity-seed-evidence.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  buildIdeaCapacitySeedEvidence,
+  validateAndWriteIdeaCapacitySeedEvidence,
+  validateIdeaCapacitySeedManifest,
+} from "../../scripts/live/validation/idea-capacity-seed-evidence.mjs";
+
+const manifest = {
+  schemaVersion: "lotus-idea.downstream-capacity-seed.v1",
+  repository: "lotus-idea",
+  proofScope: "synthetic_downstream_capacity_resource_seed",
+  claimPosture: "seed_only_not_capacity_evidence",
+  generatedAtUtc: "2026-07-11T08:00:00Z",
+  commitSha: "a".repeat(40),
+  branch: "main",
+  runId: "canonical-front-office-2026-04-10",
+  syntheticResource: true,
+  conversionIntentId: "capacity-conversion-0123456789abcdef",
+  downstreamSubmissionPath:
+    "/api/v1/conversion-intents/capacity-conversion-0123456789abcdef/downstream-submissions",
+  productionCapacityCertified: false,
+  supportedFeaturePromoted: false,
+};
+
+const expected = {
+  commitSha: manifest.commitSha,
+  branch: manifest.branch,
+  runId: manifest.runId,
+};
+
+describe("Idea capacity seed evidence", () => {
+  it("retains provenance and hash without copying resource identity", () => {
+    validateIdeaCapacitySeedManifest(manifest, expected);
+    const evidence = buildIdeaCapacitySeedEvidence({
+      manifestBytes: Buffer.from(JSON.stringify(manifest)),
+      manifestFileName: "idea-capacity-seed-manifest.json",
+      payload: manifest,
+    });
+
+    expect(evidence).toMatchObject({
+      posture: "accepted_non_certifying",
+      commitSha: manifest.commitSha,
+      branch: "main",
+      syntheticResource: true,
+      capacityWorkloadAccepted: false,
+      productionCapacityCertified: false,
+      supportedFeaturePromoted: false,
+      canonicalPortfolioUnaffected: true,
+    });
+    expect(JSON.stringify(evidence)).not.toContain("conversionIntentId");
+    expect(JSON.stringify(evidence)).not.toContain("downstreamSubmissionPath");
+  });
+
+  it.each([
+    ["wrong commit", { commitSha: "b".repeat(40) }],
+    ["certification inflation", { productionCapacityCertified: true }],
+    ["feature inflation", { supportedFeaturePromoted: true }],
+    ["canonical portfolio leakage", { runId: "PB_SG_GLOBAL_BAL_001" }],
+    ["unapproved path", { downstreamSubmissionPath: "/api/v1/clients/1" }],
+  ])("rejects %s", (_name, mutation) => {
+    expect(() =>
+      validateIdeaCapacitySeedManifest({ ...manifest, ...mutation }, expected),
+    ).toThrow();
+  });
+
+  it("writes deterministic source-safe evidence atomically", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "idea-capacity-seed-"));
+    const manifestPath = path.join(directory, "manifest.json");
+    const evidencePath = path.join(directory, "evidence.json");
+    await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`, "utf8");
+
+    await validateAndWriteIdeaCapacitySeedEvidence({
+      manifestPath,
+      evidencePath,
+      ...expected,
+    });
+
+    const evidence = JSON.parse(await readFile(evidencePath, "utf8"));
+    expect(evidence.manifestSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(evidence.manifestFileName).toBe("manifest.json");
+  });
+});

--- a/tests/unit/idea-capacity-seed-evidence.test.ts
+++ b/tests/unit/idea-capacity-seed-evidence.test.ts
@@ -4,8 +4,11 @@ import path from "node:path";
 
 import {
   buildIdeaCapacitySeedEvidence,
+  loadIdeaCapacitySeedEvidence,
   validateAndWriteIdeaCapacitySeedEvidence,
+  validateIdeaCapacitySeedEvidence,
   validateIdeaCapacitySeedManifest,
+  validateIdeaCapacityWorkload,
 } from "../../scripts/live/validation/idea-capacity-seed-evidence.mjs";
 
 const manifest = {
@@ -30,6 +33,28 @@ const expected = {
   branch: manifest.branch,
   runId: manifest.runId,
 };
+const workload = {
+  schemaVersion: "lotus-idea.service-capacity-baseline.v1",
+  repository: "lotus-idea",
+  proofScope: "source_safe_service_capacity_baseline",
+  claimPosture: "report_only_baseline",
+  environmentProfile: "test",
+  commitSha: manifest.commitSha,
+  branch: manifest.branch,
+  runId: manifest.runId,
+  scenarios: [
+    {
+      scenario: "downstream_submission",
+      sampleCount: 1,
+      acceptedCount: 1,
+      errorCount: 0,
+      conflictCount: 0,
+    },
+  ],
+  certificationReady: false,
+  certificationBlockers: ["load_soak_attestation_missing"],
+  supportedFeaturePromoted: false,
+};
 
 describe("Idea capacity seed evidence", () => {
   it("retains provenance and hash without copying resource identity", () => {
@@ -38,6 +63,8 @@ describe("Idea capacity seed evidence", () => {
       manifestBytes: Buffer.from(JSON.stringify(manifest)),
       manifestFileName: "idea-capacity-seed-manifest.json",
       payload: manifest,
+      workloadBytes: Buffer.from(JSON.stringify(workload)),
+      workloadFileName: "idea-capacity-seed-workload.json",
     });
 
     expect(evidence).toMatchObject({
@@ -45,13 +72,27 @@ describe("Idea capacity seed evidence", () => {
       commitSha: manifest.commitSha,
       branch: "main",
       syntheticResource: true,
-      capacityWorkloadAccepted: false,
+      capacityWorkloadAccepted: true,
       productionCapacityCertified: false,
       supportedFeaturePromoted: false,
       canonicalPortfolioUnaffected: true,
     });
     expect(JSON.stringify(evidence)).not.toContain("conversionIntentId");
     expect(JSON.stringify(evidence)).not.toContain("downstreamSubmissionPath");
+    expect(() => validateIdeaCapacitySeedEvidence(evidence)).not.toThrow();
+  });
+
+  it("requires one accepted source-safe Idea downstream workload", () => {
+    expect(() => validateIdeaCapacityWorkload(workload, expected)).not.toThrow();
+    expect(() =>
+      validateIdeaCapacityWorkload(
+        {
+          ...workload,
+          scenarios: [{ ...workload.scenarios[0], acceptedCount: 0, errorCount: 1 }],
+        },
+        expected,
+      ),
+    ).toThrow(/exactly one downstream probe/);
   });
 
   it.each([
@@ -70,10 +111,13 @@ describe("Idea capacity seed evidence", () => {
     const directory = await mkdtemp(path.join(tmpdir(), "idea-capacity-seed-"));
     const manifestPath = path.join(directory, "manifest.json");
     const evidencePath = path.join(directory, "evidence.json");
+    const workloadPath = path.join(directory, "workload.json");
     await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`, "utf8");
+    await writeFile(workloadPath, `${JSON.stringify(workload)}\n`, "utf8");
 
     await validateAndWriteIdeaCapacitySeedEvidence({
       manifestPath,
+      workloadPath,
       evidencePath,
       ...expected,
     });
@@ -81,5 +125,28 @@ describe("Idea capacity seed evidence", () => {
     const evidence = JSON.parse(await readFile(evidencePath, "utf8"));
     expect(evidence.manifestSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(evidence.manifestFileName).toBe("manifest.json");
+    await expect(loadIdeaCapacitySeedEvidence(evidencePath)).resolves.toEqual(evidence);
+  });
+
+  it("rejects downgraded or resource-bearing Workbench evidence", () => {
+    const evidence = buildIdeaCapacitySeedEvidence({
+      manifestBytes: Buffer.from(JSON.stringify(manifest)),
+      manifestFileName: "manifest.json",
+      payload: manifest,
+      workloadBytes: Buffer.from(JSON.stringify(workload)),
+      workloadFileName: "workload.json",
+    });
+    expect(() =>
+      validateIdeaCapacitySeedEvidence({
+        ...evidence,
+        capacityWorkloadAccepted: false,
+      }),
+    ).toThrow(/capacityWorkloadAccepted/);
+    expect(() =>
+      validateIdeaCapacitySeedEvidence({
+        ...evidence,
+        conversionIntentId: manifest.conversionIntentId,
+      }),
+    ).toThrow(/forbidden/);
   });
 });

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -358,6 +358,8 @@ describe("canonical live validation script", () => {
     expect(script).toContain('Invoke-RestMethod -Uri "$IdeaBaseUrl/version"');
     expect(script).toContain("ExpectedCommitSha");
     expect(script).toContain("ExpectedBranch");
+    expect(script).toContain("$version.build.ciRunId");
+    expect(script).toContain("$runtimeRunId -ne $RunId");
     expect(script).toContain("runtime provenance does not match");
     expect(script).toContain("seed_downstream_capacity_resource.py");
     expect(script).toContain("run_service_capacity_workload.py");

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -251,6 +251,8 @@ describe("canonical live validation script", () => {
     expect(script).toContain("function Get-GitRepositoryIdentity");
     expect(script).toContain("LOTUS_IDEA_BUILD_GIT_COMMIT_SHA");
     expect(script).toContain("LOTUS_IDEA_BUILD_GIT_BRANCH");
+    expect(script).toContain("[guid]::NewGuid().ToString('N')");
+    expect(script).toContain("-RunId $ideaCanonicalRunId");
     expect(script).toContain("Invoke-ComposeUp $ideaRepo $ideaBuildEnvironment");
     expect(script.indexOf("if ($CoreManageOnly)")).toBeLessThan(
       script.indexOf("$ideaSourceIdentity = Get-GitRepositoryIdentity -RepoPath $ideaRepo"),
@@ -382,6 +384,8 @@ describe("canonical live validation script", () => {
       ),
       "utf8",
     );
+    expect(script).toContain("`${ideaBaseUrl}/version`");
+    expect(script).toContain("runId: ideaVersion?.build?.ciRunId");
     const calculationModule = readFileSync(
       join(
         process.cwd(),

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -241,6 +241,17 @@ describe("canonical live validation script", () => {
     );
     expect(script).toContain("[string]$ScreenshotDirectory");
     expect(script).toContain("ScreenshotDirectory = $ScreenshotDirectory");
+    expect(script).toContain("function Invoke-CanonicalIdeaCapacitySeed");
+    expect(script).toContain("Invoke-CanonicalIdeaCapacitySeed");
+    expect(script).toContain("function Wait-HttpReady");
+    expect(script).toContain(
+      'Wait-HttpReady -Url "http://127.0.0.1:8000/health/ready" -Description "lotus-advise"',
+    );
+    expect(script).toContain("output\\\\canonical-front-office");
+    expect(script).toContain("function Get-GitRepositoryIdentity");
+    expect(script).toContain("LOTUS_IDEA_BUILD_GIT_COMMIT_SHA");
+    expect(script).toContain("LOTUS_IDEA_BUILD_GIT_BRANCH");
+    expect(script).toContain("Invoke-ComposeUp $ideaRepo $ideaBuildEnvironment");
   });
 
   it("covers the complete front-office Docker app set in canonical automation", () => {
@@ -313,6 +324,8 @@ describe("canonical live validation script", () => {
     expect(validationScript).toContain(
       'Test-Endpoint "http://idea.dev.lotus/health/ready"',
     );
+    expect(validationScript).toContain("idea-capacity-seed-evidence.json");
+    expect(validationScript).toContain('"--idea-capacity-seed-evidence"');
     expect(startScript).toContain("function Invoke-CanonicalIdeaSeed");
     expect(startScript).toContain("Get-CanonicalFrontOfficeDatePolicy");
     expect(startScript).toContain(
@@ -329,6 +342,29 @@ describe("canonical live validation script", () => {
     expect(packageJson).toContain(
       '"live:stack:up:validate": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -RunValidation -BuildImages"',
     );
+  });
+
+  it("delegates isolated Idea capacity seeding without exposing credentials or client state", () => {
+    const script = readFileSync(
+      join(process.cwd(), "scripts", "live", "Invoke-IdeaCapacitySeed.ps1"),
+      "utf8",
+    );
+
+    expect(script).toContain('Invoke-RestMethod -Uri "$IdeaBaseUrl/version"');
+    expect(script).toContain("ExpectedCommitSha");
+    expect(script).toContain("ExpectedBranch");
+    expect(script).toContain("runtime provenance does not match");
+    expect(script).toContain("seed_downstream_capacity_resource.py");
+    expect(script).toContain("run_service_capacity_workload.py");
+    expect(script).toContain('"--scenario", "downstream_submission"');
+    expect(script).toContain('"--request-count", "1"');
+    expect(script).toContain('"--allow-mutating-workflows"');
+    expect(script).toContain("SEED_SYNTHETIC_LOTUS_IDEA_CAPACITY_RESOURCE");
+    expect(script).toContain("Validate-IdeaCapacitySeedEvidence.mjs");
+    expect(script).not.toContain("PB_SG_GLOBAL_BAL_001");
+    expect(script).not.toContain("client-001");
+    expect(script).not.toContain("LOTUS_IDEA_CAPACITY_AUTHORIZATION");
+    expect(script).not.toContain("LOTUS_IDEA_CAPACITY_TRUSTED_CALLER_CONTEXT");
   });
 
   it("asserts canonical performance and risk calculation sanity", () => {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -252,6 +252,9 @@ describe("canonical live validation script", () => {
     expect(script).toContain("LOTUS_IDEA_BUILD_GIT_COMMIT_SHA");
     expect(script).toContain("LOTUS_IDEA_BUILD_GIT_BRANCH");
     expect(script).toContain("Invoke-ComposeUp $ideaRepo $ideaBuildEnvironment");
+    expect(script.indexOf("if ($CoreManageOnly)")).toBeLessThan(
+      script.indexOf("$ideaSourceIdentity = Get-GitRepositoryIdentity -RepoPath $ideaRepo"),
+    );
   });
 
   it("covers the complete front-office Docker app set in canonical automation", () => {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -364,6 +364,8 @@ describe("canonical live validation script", () => {
     expect(script).toContain('"--allow-mutating-workflows"');
     expect(script).toContain("SEED_SYNTHETIC_LOTUS_IDEA_CAPACITY_RESOURCE");
     expect(script).toContain("Validate-IdeaCapacitySeedEvidence.mjs");
+    expect(script).toContain("[System.IO.Path]::GetTempPath()");
+    expect(script).toContain("Remove-Item -LiteralPath $rawArtifactDirectory");
     expect(script).not.toContain("PB_SG_GLOBAL_BAL_001");
     expect(script).not.toContain("client-001");
     expect(script).not.toContain("LOTUS_IDEA_CAPACITY_AUTHORIZATION");

--- a/tests/unit/live-validation-contract-modules.test.ts
+++ b/tests/unit/live-validation-contract-modules.test.ts
@@ -36,6 +36,9 @@ describe("live validation contract modules", () => {
     expect(config.timeoutMs).toBe(45000);
     expect(config.outputDir).toContain("output");
     expect(config.outputDir).toContain("live-canonical");
+    expect(config.ideaCapacitySeedEvidencePath).toContain(
+      "idea-capacity-seed-evidence.json",
+    );
   });
 
   it("builds governed summary evidence with registry metadata and writable artifacts", async () => {
@@ -91,6 +94,7 @@ describe("live validation contract modules", () => {
       expect(shotIndex).toContain(summaryPath);
       expect(shotIndex).toContain("2026-04-10");
       expect(persistedSummary.workflowPackChecks).toEqual([]);
+      expect(persistedSummary.ideaCapacitySeed).toBeNull();
       expect(
         DEFAULT_PANEL_REGISTRY.panels.some(
           (panel) =>

--- a/tests/unit/live-validation-contract-modules.test.ts
+++ b/tests/unit/live-validation-contract-modules.test.ts
@@ -33,6 +33,7 @@ describe("live validation contract modules", () => {
     expect(config.benchmarkCode).toBe("BMK_PB_GLOBAL_BALANCED_60_40");
     expect(config.workbenchBaseUrl).toBe("http://workbench.dev.lotus");
     expect(config.gatewayBaseUrl).toBe("http://gateway.dev.lotus");
+    expect(config.ideaBaseUrl).toBe("http://127.0.0.1:8330");
     expect(config.timeoutMs).toBe(45000);
     expect(config.outputDir).toContain("output");
     expect(config.outputDir).toContain("live-canonical");

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -82,6 +82,12 @@
   authority, and no client-publication claims.
   The canonical Lotus Idea seed takes its as-of date from the platform demo-data contract instead of
   duplicating date literals in Workbench startup automation.
+- Lotus Idea capacity integration proof must use Idea-owned seed and workload automation after Idea
+  and Advise readiness. The validator matches Idea `/version` to the checked-out commit and branch,
+  requires the isolated `CAPACITY_SYNTHETIC_PORTFOLIO_001` namespace, and accepts exactly one
+  report-only downstream-submission probe. Workbench evidence retains artifact paths, SHA-256
+  digests, and provenance but excludes conversion-intent identifiers, downstream paths, and
+  credentials. This proof does not certify load, soak, production capacity, or feature support.
 - RFC-0028 bank-demo proof validation must read the Gateway-backed scenario contract and
   supported-claim register, verify the governed scenario id, proof marker, and claim postures, and
   render `/recommendations?mode=proof` as `advisory.bank_demo_proof`. The screenshot is accepted


### PR DESCRIPTION
## Summary
- orchestrate lotus-idea capacity seeding in the canonical front-office runtime
- validate source-safe capacity evidence and carry it into canonical validation summaries
- document operator flow and supportability boundaries

## Validation
- npm run typecheck: passed
- full Vitest run: 1,199 passed; one unrelated entry-page test exceeded its 5-second timeout under full-suite load
- isolated rerun of tests/unit/workbench-entry-page.test.tsx: 5 passed
- Idea capacity evidence tests: 9 passed within the full run

## Boundaries
- capacity evidence does not promote unsupported Idea features or grant advisory/execution authority
- canonical runtime certification remains gated by backend readiness and complete live validation

Merge only after required CI is green.