### PR TITLE
test(api): bind metrics responses to authored examples

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -209,6 +209,19 @@ Boundary rules:
 5. domain-product discovery UI must consume gateway domain-product APIs only and must render
    unavailable, stale, partial, blocked, and error trust states truthfully.
 
+## Local API Contract Evidence
+
+The same-origin `POST /api/metrics/events` route has authored accepted and rejected response
+examples in `docs/operations/metrics-event-response-examples.v1.json`.
+`tests/unit/metrics-route.test.ts` invokes the real route with each documented request and compares
+the HTTP status plus complete JSON response using exact structural equality. This prevents stale,
+missing, additional, renamed, or mistyped response fields from remaining hidden behind a
+parseable documentation example.
+
+This is a bounded TypeScript adoption of the platform endpoint-example parity contract. It does
+not certify every Workbench BFF route, promote a product feature, or make Workbench the authority
+for Gateway or domain-service contracts.
+
 ## Repo-Native Commands
 
 Use these commands as the primary local contract:

--- a/docs/operations/metrics-event-response-examples.v1.json
+++ b/docs/operations/metrics-event-response-examples.v1.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": "lotus-workbench.metrics-event-response-examples.v1",
+  "endpoint": {
+    "method": "POST",
+    "path": "/api/metrics/events"
+  },
+  "cases": [
+    {
+      "id": "accepted_bounded_event",
+      "request": {
+        "event_name": "workbench.analytics.panel_state",
+        "metric_name": "lotus_workbench_panel_state_total",
+        "value": 1,
+        "labels": {
+          "route": "workbench.performance",
+          "panel": "performance-advisor-brief-review-action",
+          "operation": "performance.workspace.advisor-brief.review-action",
+          "service": "lotus-gateway",
+          "state": "ready",
+          "freshness_bucket": "unknown",
+          "supportability_state": "unknown"
+        },
+        "recorded_at": "2026-05-01T00:00:00.000Z"
+      },
+      "expectedStatus": 202,
+      "response": {
+        "status": "accepted"
+      }
+    },
+    {
+      "id": "rejected_forbidden_label",
+      "request": {
+        "event_name": "workbench.analytics.panel_state",
+        "metric_name": "lotus_workbench_panel_state_total",
+        "value": 1,
+        "labels": {
+          "route": "workbench.performance",
+          "panel": "performance-advisor-brief-review-action",
+          "operation": "performance.workspace.advisor-brief.review-action",
+          "portfolio_id": "must-not-be-recorded"
+        }
+      },
+      "expectedStatus": 400,
+      "response": {
+        "status": "rejected"
+      }
+    }
+  ]
+}

--- a/tests/unit/metrics-route.test.ts
+++ b/tests/unit/metrics-route.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { POST as POST_METRIC_EVENT } from "@/app/api/metrics/events/route";
@@ -6,6 +9,48 @@ import {
   recordAnalyticsUiPanelState,
   resetAnalyticsUiMetricEvents,
 } from "@/features/analytics-observability/metrics";
+
+type MetricsEventResponseExample = {
+  id: string;
+  request: Record<string, unknown>;
+  expectedStatus: number;
+  response: Record<string, unknown>;
+};
+
+type MetricsEventResponseExamples = {
+  schemaVersion: string;
+  endpoint: { method: string; path: string };
+  cases: MetricsEventResponseExample[];
+};
+
+const metricsEventResponseExamples = JSON.parse(
+  readFileSync(
+    join(
+      process.cwd(),
+      "docs",
+      "operations",
+      "metrics-event-response-examples.v1.json"
+    ),
+    "utf8"
+  )
+) as MetricsEventResponseExamples;
+
+function responseExample(id: string): MetricsEventResponseExample {
+  const example = metricsEventResponseExamples.cases.find((item) => item.id === id);
+  if (!example) {
+    throw new Error(`Missing metrics response example: ${id}`);
+  }
+  return example;
+}
+
+async function invokeResponseExample(example: MetricsEventResponseExample) {
+  return POST_METRIC_EVENT(
+    new Request(`http://workbench.dev.lotus${metricsEventResponseExamples.endpoint.path}`, {
+      method: metricsEventResponseExamples.endpoint.method,
+      body: JSON.stringify(example.request),
+    })
+  );
+}
 
 describe("metrics route", () => {
   it("returns product-safe Prometheus text for implemented analytics UI metrics", async () => {
@@ -37,31 +82,14 @@ describe("metrics route", () => {
 
   it("accepts bounded client-side metric events for Prometheus export", async () => {
     resetAnalyticsUiMetricEvents();
-    const response = await POST_METRIC_EVENT(
-      new Request("http://workbench.dev.lotus/api/metrics/events", {
-        method: "POST",
-        body: JSON.stringify({
-          event_name: "workbench.analytics.panel_state",
-          metric_name: "lotus_workbench_panel_state_total",
-          value: 1,
-          labels: {
-            route: "workbench.performance",
-            panel: "performance-advisor-brief-review-action",
-            operation: "performance.workspace.advisor-brief.review-action",
-            service: "lotus-gateway",
-            state: "ready",
-            freshness_bucket: "unknown",
-            supportability_state: "unknown",
-          },
-          recorded_at: "2026-05-01T00:00:00.000Z",
-        }),
-      })
-    );
+    const example = responseExample("accepted_bounded_event");
+    const response = await invokeResponseExample(example);
 
     const metricsResponse = await GET();
     const body = await metricsResponse.text();
 
-    expect(response.status).toBe(202);
+    expect(response.status).toBe(example.expectedStatus);
+    await expect(response.json()).resolves.toStrictEqual(example.response);
     expect(body).toContain("performance-advisor-brief-review-action");
     expect(body).toContain("performance.workspace.advisor-brief.review-action");
     expect(body).not.toContain("PB_SG_GLOBAL_BAL_001");
@@ -71,28 +99,29 @@ describe("metrics route", () => {
 
   it("rejects client-side metric events with forbidden labels", async () => {
     resetAnalyticsUiMetricEvents();
-    const response = await POST_METRIC_EVENT(
-      new Request("http://workbench.dev.lotus/api/metrics/events", {
-        method: "POST",
-        body: JSON.stringify({
-          event_name: "workbench.analytics.panel_state",
-          metric_name: "lotus_workbench_panel_state_total",
-          value: 1,
-          labels: {
-            route: "workbench.performance",
-            panel: "performance-advisor-brief-review-action",
-            operation: "performance.workspace.advisor-brief.review-action",
-            portfolio_id: "PB_SG_GLOBAL_BAL_001",
-          },
-        }),
-      })
-    );
+    const example = responseExample("rejected_forbidden_label");
+    const response = await invokeResponseExample(example);
 
     const metricsResponse = await GET();
     const body = await metricsResponse.text();
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(example.expectedStatus);
+    await expect(response.json()).resolves.toStrictEqual(example.response);
     expect(body).not.toContain("performance-advisor-brief-review-action");
-    expect(body).not.toContain("PB_SG_GLOBAL_BAL_001");
+    expect(body).not.toContain("must-not-be-recorded");
+  });
+
+  it("keeps the authored response evidence bound to the intended route", () => {
+    expect(metricsEventResponseExamples.schemaVersion).toBe(
+      "lotus-workbench.metrics-event-response-examples.v1"
+    );
+    expect(metricsEventResponseExamples.endpoint).toStrictEqual({
+      method: "POST",
+      path: "/api/metrics/events",
+    });
+    expect(metricsEventResponseExamples.cases.map((example) => example.id)).toStrictEqual([
+      "accepted_bounded_event",
+      "rejected_forbidden_label",
+    ]);
   });
 });

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -1,5 +1,18 @@
 # API Surface
 
+## Current Scope
+
+This page inventories Workbench-owned browser routes and local server routes. Route existence is
+not sufficient evidence of supported product capability; shell posture, Gateway backing, tests,
+and canonical validation remain authoritative.
+
+| Surface Class | Authority | Evidence Decision |
+| --- | --- | --- |
+| Active product navigation | Workbench shell plus Gateway capability posture | May be described as active only when capability and canonical route proof agree |
+| Direct workflow route | Workbench presentation over Gateway contracts | Must not imply Workbench owns upstream domain decisions |
+| Compatibility route | Redirect or bounded legacy entry | Must remain visibly separate from the primary topology |
+| `/api/bff/*` | Internal Workbench bridge | Is not a second public or domain-authoritative API |
+
 ## Product routes
 
 - `/portfolio`

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,5 +1,18 @@
 # Architecture
 
+## Current Scope
+
+This page describes the implemented Workbench presentation architecture and its Gateway-first
+runtime boundary. Target-state service capabilities and domain authority remain in their owning
+repositories and must not be inferred from a route or component shown here.
+
+| Concern | Workbench Responsibility | Upstream Authority |
+| --- | --- | --- |
+| Product composition | Navigation, interaction, rendering, and bounded local UI state | Gateway capability and domain-service contracts |
+| Domain decisions | Display source-owned outcomes and limitations | Core, Performance, Risk, Advise, Manage, Idea, Report, Archive, Render, or AI as applicable |
+| Integration | Same-origin BFF mediation and caller-context propagation | Gateway is the product backend boundary |
+| Operational proof | Browser, metrics, logs, and canonical validation evidence | Platform governance plus source-service readiness |
+
 ## Runtime model
 
 - Next.js App Router application

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -24,11 +24,11 @@ rest of the canonical app set remains Docker-backed.
 
 Canonical identities:
 
-- workbench: `http://workbench.dev.lotus`
-- gateway: `http://gateway.dev.lotus`
-- manage: `http://manage.dev.lotus`
-- archive: `http://archive.dev.lotus`
-- render: `http://render.dev.lotus`
+- [Workbench](http://workbench.dev.lotus)
+- [Gateway](http://gateway.dev.lotus)
+- [Manage](http://manage.dev.lotus)
+- [Archive](http://archive.dev.lotus)
+- [Render](http://render.dev.lotus)
 
 Required environment posture:
 

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -1,5 +1,17 @@
 # Integrations
 
+## Current Scope
+
+This page records implemented Workbench integration boundaries. It distinguishes product traffic
+from operational probes and does not promote direct domain-service calls as supported UI paths.
+
+| Integration Path | Supported Use | Evidence |
+| --- | --- | --- |
+| Browser to Workbench | Product navigation and interaction | Route, component, and browser tests |
+| Workbench BFF to Gateway | Product data and workflow contracts | BFF tests, Gateway contract evidence, and canonical validation |
+| Runtime readiness probes | Bounded supportability diagnostics only | Canonical validation artifacts |
+| Workbench to domain service | Not a product path | Any exception must remain operational, source-safe, and explicitly governed |
+
 ## Primary backend posture
 
 - `lotus-gateway`
@@ -24,10 +36,8 @@ must travel through Gateway-shaped contracts.
 
 ## Canonical local identities
 
-- workbench:
-  `http://workbench.dev.lotus`
-- gateway:
-  `http://gateway.dev.lotus`
+- [Workbench](http://workbench.dev.lotus)
+- [Gateway](http://gateway.dev.lotus)
 
 ## Contract notes
 

--- a/wiki/Observability-Evidence.md
+++ b/wiki/Observability-Evidence.md
@@ -101,6 +101,18 @@ Use the non-functional artifacts to explain how teams operate the stack:
 - bounded log tails show where operators start when investigating Gateway, Workbench, Core,
   Performance, Risk, Manage, Report, Archive, Render, and AI behavior
 
+### Metrics Ingest Response Contract
+
+Workbench authors the accepted and rejected JSON response examples for
+`POST /api/metrics/events` in
+`docs/operations/metrics-event-response-examples.v1.json`. The route test executes the actual
+Next.js handler for every authored case and requires exact status and response-object equality.
+Changing a field name, type, value, or presence in either documentation or runtime therefore fails
+the test instead of leaving a stale but parseable example.
+
+This evidence covers the local metrics-ingest route only. It is not whole-Workbench endpoint
+certification and does not replace live Prometheus, canonical stack, or Gateway contract proof.
+
 ## Evidence Quality Checks
 
 Before using a pack in client or operator material, review it for obvious degradation:

--- a/wiki/Observability-Evidence.md
+++ b/wiki/Observability-Evidence.md
@@ -4,6 +4,19 @@ This page defines the repeatable evidence pack for showing functional and non-fu
 runtime capabilities from the live canonical stack. It is intended for offline client-demo preparation,
 operator onboarding, and future incident-investigation walkthroughs.
 
+## Current Scope
+
+This page governs evidence collection and review for the canonical Workbench runtime. It does not
+promote a feature, replace source-service certification, or make screenshots authoritative when
+runtime validation fails.
+
+| Reader | Decision | Required Evidence |
+| --- | --- | --- |
+| Demo and product teams | Is a capture suitable for a supported demonstration? | Passing canonical validation for `PB_SG_GLOBAL_BAL_001` plus a same-run evidence manifest |
+| Operations and support | Where should first-response investigation begin? | Readiness, bounded logs, metrics, target posture, and failed API checks from one evidence pack |
+| Contract reviewers | Does documented local API behavior match runtime? | Exact route-test parity for metrics ingest and source-owned contracts for Gateway-backed behavior |
+| Engineers | Can a change be claimed as implementation-backed? | Repository tests, canonical runtime proof when applicable, and explicit unsupported boundaries |
+
 ## Evidence Rule
 
 Run validation first:

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -1,5 +1,17 @@
 # Operations Runbook
 
+## Current Scope
+
+This runbook covers first-response operation of the canonical local Workbench stack. It does not
+replace source-service recovery procedures or turn diagnostic screenshots into release evidence.
+
+| Situation | First Action | Evidence Before Escalation |
+| --- | --- | --- |
+| Product surface unavailable | Run canonical validation and inspect the failed API/panel check | Validation summary, readiness response, and bounded logs |
+| Data appears partial or stale | Inspect Gateway source-supportability and owning-service posture | Correlation-safe API evidence and source freshness state |
+| Metrics or dashboards missing | Check Workbench metrics, Prometheus targets, and Grafana health | Same-run evidence pack with target and query results |
+| Demo preparation | Validate `PB_SG_GLOBAL_BAL_001` before capture | Passing validation and same-run screenshots/manifest |
+
 ## Important operational checks
 
 - use `workbench.dev.lotus` and `gateway.dev.lotus` for canonical product proof
@@ -86,8 +98,8 @@ http://workbench.dev.lotus/performance?portfolioId=PB_SG_GLOBAL_BAL_001&mode=ris
   preserves binary PDF payloads plus checksum/content-disposition headers.
 - Canonical live validation checks `lotus-manage` supportability through
   `GET /api/v1/rebalance/supportability/summary`. The deprecated
-  `http://manage.dev.lotus/integration/capabilities` probe is not valid evidence for the current
-  Manage boundary.
+  [Manage integration-capabilities probe](http://manage.dev.lotus/integration/capabilities) is not
+  valid evidence for the current Manage boundary.
 
 ```mermaid
 sequenceDiagram

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -9,8 +9,9 @@
 - if a screen looks populated but canonical validation fails, treat it as diagnostic evidence only
 - if product data looks wrong, inspect gateway responses before adjusting frontend presentation
 - if Workbench BFF calls fail with `ECONNREFUSED` to `127.0.0.1:8111` or `localhost:8111`, ensure
-  local Workbench is running with `BFF_BASE_URL=http://gateway.dev.lotus`; canonical proof must use
-  the governed Gateway hostname, not a stale local port override
+  local Workbench sets `BFF_BASE_URL` to the
+  [canonical Gateway](http://gateway.dev.lotus); canonical proof must use the governed Gateway
+  hostname, not a stale local port override
 - if performance evidence is partial, review Gateway and performance logs for `correlation_id`,
   `request_id`, `trace_id`, lineage lookup status, and `PERFORMANCE_EVIDENCE_PARTIAL` before
   classifying the evidence as a runtime defect

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -1,5 +1,18 @@
 # Validation and CI
 
+## Evidence Map
+
+Validation depth must match the claim being made. A narrow unit test can prove a local contract,
+while integrated product support requires canonical runtime evidence and green repository lanes.
+
+| Change or Claim | Minimum Evidence | Promotion Boundary |
+| --- | --- | --- |
+| Local route or serializer | Focused behavioral test plus lint/typecheck | Does not certify an upstream or whole-product contract |
+| Product UI behavior | Unit/integration coverage, build, and relevant browser smoke | Must remain Gateway-backed and capability-truthful |
+| Canonical front-office support | `live:validate` evidence for the governed seed and affected panels | Screenshots alone cannot promote support |
+| Merge readiness | Feature Lane and PR Merge Gate | Mainline is not proven until Main Releasability passes |
+| Demo evidence | Passing canonical validation plus same-run evidence pack | Diagnostic captures stay separate |
+
 ## Lane model
 
 `lotus-workbench` uses:

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,3 +1,5 @@
+# Navigation
+
 [Home](Home)
 
 ### Orientation


### PR DESCRIPTION
## Summary

- add authored accepted/rejected response cases for same-origin `POST /api/metrics/events`
- execute the real Next.js route for every case and require exact status plus structural response equality
- document the bounded TypeScript adoption without claiming whole-Workbench or upstream API certification
- restructure the Workbench wiki first screens with current scope, decision/evidence maps, named runtime links, and professional navigation

## Dependency

Implements the TypeScript application adoption required by [lotus-platform#516](https://github.com/sgajbi/lotus-platform/issues/516).

The governing contract and reusable comparator are merged and green on `lotus-platform` main at `8b07884`. This Workbench implementation uses native TypeScript strict equality over a real route invocation because the route owns deterministic, dependency-free JSON responses.

## Contract Behavior

- accepted bounded event returns HTTP 202 and `{ "status": "accepted" }`
- forbidden metric label returns HTTP 400 and `{ "status": "rejected" }`
- missing, additional, renamed, mistyped, or changed fields fail `toStrictEqual`
- the artifact pins schema version, method, path, case identity, request, status, and response
- no dynamic-field normalizer is needed for these deterministic responses

## Validation

- focused real-route test: 4 passed
- branch `make check` completed previously with lint, typecheck, 1,203 tests, coverage thresholds, and production build green
- coverage: 90.66% statements/lines, 79.06% branches, 88.64% functions
- full professional wiki audit now passes across the complete repo-authored wiki
- pre-merge wiki check reports only the nine intentionally changed authored pages

The existing third-party AG Grid autoprefixer warning remains unchanged and non-blocking.

## Wiki

Changed pages:

- `Observability-Evidence.md`: bounded route parity evidence and first-screen reader map
- `API-Surface.md`, `Architecture.md`, `Integrations.md`: current scope and authority/evidence maps
- `Operations-Runbook.md`, `Validation-and-CI.md`: first-response and validation decision tables
- `Getting-Started.md`, `Troubleshooting.md`: named canonical runtime links
- `_Sidebar.md`: explicit professional navigation title

Publish these pages from repo source after merge, then require check-only synchronization.

## Non-Degradation

No product UI, Gateway contract, metric vocabulary, domain authority, supported-feature status, or runtime topology changes. No screenshots or live canonical run are required because this slice changes a local API contract test plus documentation presentation only. The quality scorecard is intentionally unchanged because no feature or supportability control is promoted.