### PR TITLE
Align Workbench auto-merge releasability proof

### DIFF
--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -1,0 +1,23 @@
+name: Merged PR Main Releasability Dispatch
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch-main-releasability:
+    name: Dispatch Main Releasability
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Dispatch main releasability gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref main

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -5,8 +5,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   queue-auto-merge:
@@ -17,12 +16,17 @@ jobs:
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Enable auto-merge queue (rebase)
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.LOTUS_AUTOMERGE_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::LOTUS_AUTOMERGE_TOKEN is required for automatic rebase merge so post-merge releasability dispatch is triggered by a non-GITHUB_TOKEN actor. Skipping auto-merge; use an authorized human or release actor to rebase merge this PR."
+            exit 0
+          fi
           set +e
           output=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --rebase --delete-branch 2>&1)
           code=$?
@@ -34,16 +38,6 @@ jobs:
           if echo "$output" | grep -qi "already"; then
             echo "$output"
             exit 0
-          fi
-          if echo "$output" | grep -qi "required status checks are expected"; then
-            echo "$output"
-            queued=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json autoMergeRequest --jq '.autoMergeRequest != null')
-            if [ "$queued" = "true" ]; then
-              echo "Auto-merge is already queued."
-              exit 0
-            fi
-            echo "Auto-merge was not queued; leaving this check red instead of reporting false readiness."
-            exit "$code"
           fi
           echo "$output"
           exit "$code"

--- a/README.md
+++ b/README.md
@@ -253,6 +253,13 @@ http://workbench.dev.lotus/data-products
 2. `Pull Request Merge Gate`
 3. `Main Releasability Gate`
 
+PR auto-merge is queued by rebase through the repository `LOTUS_AUTOMERGE_TOKEN` secret rather
+than the suppressed default `GITHUB_TOKEN`. If the secret is unavailable, the queue helper exits
+without claiming readiness and an authorized human or release actor must merge. Merged PRs also
+dispatch `main-releasability.yml` for exact-main proof; the main releasability workflow uses a
+single main-branch concurrency group so push and dispatcher events cannot leave ambiguous active
+evidence.
+
 Repo-native gate mapping:
 
 - `make check`

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -253,6 +253,11 @@ Use these commands as the primary local contract:
 2. `Pull Request Merge Gate`
 3. `Main Releasability Gate`
 
+Auto-merge is queued by rebase through `LOTUS_AUTOMERGE_TOKEN`, not the default `GITHUB_TOKEN`, so
+the resulting main update is not suppressed from downstream releasability automation. Merged PRs
+dispatch `main-releasability.yml` for exact-main evidence, with main-branch concurrency preventing
+ambiguous duplicate push/dispatch runs.
+
 Important validation expectations:
 
 1. unit and integration behavior is validated through Vitest coverage,

--- a/docs/documentation/git-branch-protection-workflow.md
+++ b/docs/documentation/git-branch-protection-workflow.md
@@ -25,3 +25,14 @@ gh pr merge <PR_NUMBER> --rebase --auto --delete-branch
 git checkout main
 git pull origin main
 ```
+
+## Auto-Merge Actor And Mainline Proof
+
+The repository auto-merge helper queues rebase auto-merge with `LOTUS_AUTOMERGE_TOKEN`, not the
+default `GITHUB_TOKEN`. This keeps the merged main update eligible for downstream workflow
+dispatch. If `LOTUS_AUTOMERGE_TOKEN` is not configured, the helper emits a warning and leaves merge
+ownership to an authorized human or release actor.
+
+After a PR merges to `main`, `.github/workflows/merged-pr-main-releasability.yml` dispatches
+`main-releasability.yml` for exact-main evidence. The main releasability workflow uses the
+repository-wide main-branch concurrency group to avoid ambiguous duplicate push/dispatch evidence.

--- a/tests/unit/pr-auto-merge-workflow.test.ts
+++ b/tests/unit/pr-auto-merge-workflow.test.ts
@@ -13,10 +13,46 @@ describe("PR auto-merge workflow", () => {
 
     expect(workflow).toContain("gh pr merge");
     expect(workflow).toContain("--auto --rebase --delete-branch");
-    expect(workflow).toContain("required status checks are expected");
-    expect(workflow).toContain("gh pr view");
-    expect(workflow).toContain(".autoMergeRequest != null");
-    expect(workflow).toContain("Auto-merge was not queued");
     expect(workflow).not.toContain("--auto --merge --delete-branch");
+  });
+
+  it("uses a non-suppressed auto-merge actor with read-only workflow permissions", () => {
+    const workflow = readFileSync(
+      join(repositoryRoot, ".github", "workflows", "pr-auto-merge.yml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain("contents: read");
+    expect(workflow).not.toContain("contents: write");
+    expect(workflow).not.toContain("pull-requests: write");
+    expect(workflow).toContain("GH_TOKEN: ${{ secrets.LOTUS_AUTOMERGE_TOKEN }}");
+    expect(workflow).toContain("LOTUS_AUTOMERGE_TOKEN is required");
+    expect(workflow).toContain("Skipping auto-merge");
+    expect(workflow).not.toContain("GH_TOKEN: ${{ github.token }}");
+  });
+
+  it("dispatches main releasability after merged pull requests", () => {
+    const dispatchWorkflow = readFileSync(
+      join(repositoryRoot, ".github", "workflows", "merged-pr-main-releasability.yml"),
+      "utf8",
+    );
+    const mainReleasabilityWorkflow = readFileSync(
+      join(repositoryRoot, ".github", "workflows", "main-releasability.yml"),
+      "utf8",
+    );
+
+    expect(dispatchWorkflow).toContain("name: Merged PR Main Releasability Dispatch");
+    expect(dispatchWorkflow).toContain("types: [closed]");
+    expect(dispatchWorkflow).toContain("github.event.pull_request.merged == true");
+    expect(dispatchWorkflow).toContain("github.event.pull_request.base.ref == 'main'");
+    expect(dispatchWorkflow).toContain("permissions:");
+    expect(dispatchWorkflow).toContain("actions: write");
+    expect(dispatchWorkflow).toContain("contents: read");
+    expect(dispatchWorkflow).toContain("gh workflow run main-releasability.yml");
+    expect(dispatchWorkflow).toContain("--ref main");
+
+    expect(mainReleasabilityWorkflow).toContain("concurrency:");
+    expect(mainReleasabilityWorkflow).toContain("group: ${{ github.workflow }}-${{ github.ref }}");
+    expect(mainReleasabilityWorkflow).toContain("cancel-in-progress: true");
   });
 });

--- a/tests/unit/workbench-entry-page.test.tsx
+++ b/tests/unit/workbench-entry-page.test.tsx
@@ -10,6 +10,8 @@ vi.mock("next/navigation", () => ({
   redirect: (target: string) => redirectMock(target),
 }));
 
+const asyncRouteImportTimeoutMs = 10_000;
+
 describe("WorkbenchEntryPage", () => {
   const originalFallback = process.env.WORKBENCH_FALLBACK_PORTFOLIO_IDS;
 
@@ -26,24 +28,28 @@ describe("WorkbenchEntryPage", () => {
     }
   });
 
-  it("redirects to the canonical portfolio when the lookup catalog contains it", async () => {
-    vi.resetModules();
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        items: [
-          { id: "DEMO_ADV_USD_001", label: "Legacy demo" },
-          { id: "PB_SG_GLOBAL_BAL_001", label: "Private Banking Global Balanced" },
-        ],
-      }),
-    } as Response);
+  it(
+    "redirects to the canonical portfolio when the lookup catalog contains it",
+    async () => {
+      vi.resetModules();
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          items: [
+            { id: "DEMO_ADV_USD_001", label: "Legacy demo" },
+            { id: "PB_SG_GLOBAL_BAL_001", label: "Private Banking Global Balanced" },
+          ],
+        }),
+      } as Response);
 
-    const { default: WorkbenchEntryPage } = await import("@/app/workbench/page");
-    await expect(WorkbenchEntryPage()).rejects.toThrowError(
-      "REDIRECT:/workbench/PB_SG_GLOBAL_BAL_001"
-    );
-    expect(redirectMock).toHaveBeenCalledWith("/workbench/PB_SG_GLOBAL_BAL_001");
-  });
+      const { default: WorkbenchEntryPage } = await import("@/app/workbench/page");
+      await expect(WorkbenchEntryPage()).rejects.toThrowError(
+        "REDIRECT:/workbench/PB_SG_GLOBAL_BAL_001"
+      );
+      expect(redirectMock).toHaveBeenCalledWith("/workbench/PB_SG_GLOBAL_BAL_001");
+    },
+    asyncRouteImportTimeoutMs
+  );
 
   it("redirects to the first lookup portfolio when no preferred portfolio is available", async () => {
     vi.resetModules();

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -21,6 +21,13 @@ while integrated product support requires canonical runtime evidence and green r
 2. `Pull Request Merge Gate`
 3. `Main Releasability Gate`
 
+PR auto-merge uses the repository `LOTUS_AUTOMERGE_TOKEN` secret for rebase auto-merge so the
+resulting main update is not suppressed as a default `GITHUB_TOKEN` push. When the secret is absent,
+the workflow records a warning and skips queueing auto-merge instead of making a false readiness
+claim. A merged-PR dispatcher triggers `main-releasability.yml` for exact-main evidence, and the
+main releasability workflow deduplicates main-branch push and dispatch events through its
+concurrency group.
+
 ## Local command mapping
 
 - `make check`


### PR DESCRIPTION
## Summary
- Closes #401 by aligning Workbench PR auto-merge with the platform-governed non-suppressed rebase merge posture.
- Switches `pr-auto-merge.yml` to read-only workflow permissions and `secrets.LOTUS_AUTOMERGE_TOKEN`, with a fail-safe warning/skip when the secret is absent.
- Adds the merged-PR main releasability dispatcher and pins workflow contracts with Vitest coverage.
- Updates README, repo engineering context, branch-protection workflow docs, and wiki CI source to reflect the new operating truth.
- Stabilizes the load-sensitive Workbench entry-page async import test that timed out during the full coverage gate.

## Evidence
- `npm test -- tests/unit/pr-auto-merge-workflow.test.ts`: 3 passed
- `npm test -- tests/unit/pr-auto-merge-workflow.test.ts tests/unit/workbench-entry-page.test.tsx`: 8 passed
- `npm run typecheck`: passed
- `make check`: lint passed, typecheck passed, coverage gate passed with 280 files / 1205 tests, build stage reached; standalone build rerun below records final build proof
- `npm run build`: passed
- `git diff --check`: passed
- `powershell -ExecutionPolicy Bypass -File ../lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench -AllowUnpublishedSourceChanges`: passed with expected DiffCount 1 for this branch's wiki source change

## Governance Notes
- Wiki source changed; publish `lotus-workbench` wiki after merge, then run strict wiki parity check.
- `origin/sync/agents-wiki-check-contract` was classified before implementation as superseded/no unique durable truth: no diff versus `origin/main`, and `git cherry` reports the commit as patch-equivalent.
- No product behavior, branch protection, or required PR check set was intentionally changed.
- The repository currently lacks governed `status/*` issue labels, so issue-loop lifecycle was recorded with structured comments instead of label mutation.