### PR TITLE
Gate canonical certification on mainline source provenance

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -270,7 +270,9 @@ Important validation expectations:
 2. browser smoke is validated through Playwright,
 3. Docker and build validation remain part of the merge gate,
 4. canonical live validation matters when a change affects integrated product flows,
-5. README and wiki updates should keep active product-surface truth explicit, especially when
+5. `-RequireMainlineSources` is required for mainline/RFC certification: ordinary canonical and
+   `-LocalApps` runs are useful branch-local development evidence, not certification evidence,
+6. README and wiki updates should keep active product-surface truth explicit, especially when
    legacy compatibility routes still exist beside the supported Portfolio and Performance paths,
 6. product docs should distinguish active shell navigation from disabled or compatibility-only
    routes when the shell bootstrap contract does not treat every historical route as supported,

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -99,9 +99,12 @@ npm run live:stack:up
 
 For RFC/mainline certification, add `-RequireMainlineSources`. It fetches each canonical sibling
 without changing its worktree and fails before Docker, seeding, or screenshots unless every
-participant is clean and exactly at `origin/main`. It writes the source-safe
-`mainline-source-provenance.json` artifact beside canonical evidence. Normal and `-LocalApps`
-runs remain development evidence and must never be presented as mainline certification.
+participant is clean and exactly at `origin/main`. Certification startup forces Docker image builds
+and container recreation, then regenerates source provenance after startup and fails if it changed.
+The live validator also binds Lotus Idea's `/version` commit and branch to that manifest before it
+records mainline-source certification posture. It writes source-safe preflight and runtime
+provenance artifacts beside canonical evidence. Normal and `-LocalApps` runs remain development
+evidence and must never be presented as mainline certification.
 
 That script performs:
 

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -103,8 +103,8 @@ participant is clean and exactly at `origin/main`. Certification startup forces 
 and container recreation, then regenerates source provenance after startup and fails if it changed.
 The live validator also binds Lotus Idea's `/version` commit and branch to that manifest before it
 records mainline-source certification posture. It writes source-safe preflight and runtime
-provenance artifacts to a per-run Local AppData directory outside every checked source worktree, so
-the second preflight cannot reject its own generated files. Normal and `-LocalApps` runs remain
+provenance and Idea capacity-seed artifacts to a per-run Local AppData directory outside every
+checked source worktree, so the second preflight cannot reject its own generated files. Normal and `-LocalApps` runs remain
 development evidence and must never be presented as mainline certification.
 
 That script performs:

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -97,6 +97,12 @@ From `lotus-workbench`:
 npm run live:stack:up
 ```
 
+For RFC/mainline certification, add `-RequireMainlineSources`. It fetches each canonical sibling
+without changing its worktree and fails before Docker, seeding, or screenshots unless every
+participant is clean and exactly at `origin/main`. It writes the source-safe
+`mainline-source-provenance.json` artifact beside canonical evidence. Normal and `-LocalApps`
+runs remain development evidence and must never be presented as mainline certification.
+
 That script performs:
 
 1. preview the canonical hosts block from `lotus-platform`

--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -103,8 +103,9 @@ participant is clean and exactly at `origin/main`. Certification startup forces 
 and container recreation, then regenerates source provenance after startup and fails if it changed.
 The live validator also binds Lotus Idea's `/version` commit and branch to that manifest before it
 records mainline-source certification posture. It writes source-safe preflight and runtime
-provenance artifacts beside canonical evidence. Normal and `-LocalApps` runs remain development
-evidence and must never be presented as mainline certification.
+provenance artifacts to a per-run Local AppData directory outside every checked source worktree, so
+the second preflight cannot reject its own generated files. Normal and `-LocalApps` runs remain
+development evidence and must never be presented as mainline certification.
 
 That script performs:
 

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -39,9 +39,14 @@ $canonicalEvidenceRoot = if ([string]::IsNullOrWhiteSpace($CanonicalEvidenceDire
 } else {
   Join-Path $workbenchRepo $CanonicalEvidenceDirectory
 }
-$composeUpCommand = "docker compose up -d"
-if ($BuildImages) {
-  $composeUpCommand = "$composeUpCommand --build"
+$mainlineSourcePreflightPath = $null
+$mainlineSourceRuntimePath = $null
+if ($RequireMainlineSources) {
+  $composeUpCommand = "docker compose up -d --build --force-recreate"
+} elseif ($BuildImages) {
+  $composeUpCommand = "docker compose up -d --build"
+} else {
+  $composeUpCommand = "docker compose up -d"
 }
 $localAppSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 foreach ($item in $LocalApps) {
@@ -62,7 +67,9 @@ if ($RequireMainlineSources) {
   }
   New-Item -ItemType Directory -Path $canonicalEvidenceRoot -Force | Out-Null
   $provenanceScript = Join-Path $workbenchRepo "scripts\\live\\validation\\mainline-source-provenance.mjs"
-  & node $provenanceScript --projects-root $ProjectsRoot --output (Join-Path $canonicalEvidenceRoot "mainline-source-provenance.json")
+  $mainlineSourcePreflightPath = Join-Path $canonicalEvidenceRoot "mainline-source-provenance.json"
+  $mainlineSourceRuntimePath = Join-Path $canonicalEvidenceRoot "mainline-source-provenance-runtime.json"
+  & node $provenanceScript --projects-root $ProjectsRoot --output $mainlineSourcePreflightPath
   if ($LASTEXITCODE -ne 0) {
     throw "Canonical mainline source provenance preflight failed. No Docker build, seed, or validation was started."
   }
@@ -613,6 +620,18 @@ if (-not $RunValidation) {
   return
 }
 
+if ($RequireMainlineSources) {
+  & node $provenanceScript --projects-root $ProjectsRoot --output $mainlineSourceRuntimePath
+  if ($LASTEXITCODE -ne 0) {
+    throw "Canonical mainline source provenance changed during Docker startup. Validation was not started."
+  }
+  $preflightHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $mainlineSourcePreflightPath).Hash
+  $runtimeHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $mainlineSourceRuntimePath).Hash
+  if ($preflightHash -ne $runtimeHash) {
+    throw "Canonical mainline sources changed during Docker startup. Validation was not started."
+  }
+}
+
 Write-Host "Running canonical live validation ..."
 $validationArguments = @{
   PortfolioId = $PortfolioId
@@ -623,6 +642,6 @@ if (-not [string]::IsNullOrWhiteSpace($ScreenshotDirectory)) {
   $validationArguments.ScreenshotDirectory = $ScreenshotDirectory
 }
 if ($RequireMainlineSources) {
-  $validationArguments.MainlineSourceProvenancePath = (Join-Path $canonicalEvidenceRoot "mainline-source-provenance.json")
+  $validationArguments.MainlineSourceProvenancePath = $mainlineSourceRuntimePath
 }
 & (Join-Path $workbenchRepo "scripts\\live\\Validate-LotusFrontOfficeCanonical.ps1") @validationArguments

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -41,6 +41,7 @@ $canonicalEvidenceRoot = if ([string]::IsNullOrWhiteSpace($CanonicalEvidenceDire
 }
 $mainlineSourcePreflightPath = $null
 $mainlineSourceRuntimePath = $null
+$ideaCapacityEvidenceRoot = $canonicalEvidenceRoot
 if ($RequireMainlineSources) {
   $composeUpCommand = "docker compose up -d --build --force-recreate"
 } elseif ($BuildImages) {
@@ -70,6 +71,7 @@ if ($RequireMainlineSources) {
     ([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::LocalApplicationData)) `
     "Lotus\\canonical-front-office\\mainline-source-provenance\\$mainlineProvenanceRunId"
   New-Item -ItemType Directory -Path $mainlineProvenanceRoot -Force | Out-Null
+  $ideaCapacityEvidenceRoot = $mainlineProvenanceRoot
   $provenanceScript = Join-Path $workbenchRepo "scripts\\live\\validation\\mainline-source-provenance.mjs"
   $mainlineSourcePreflightPath = Join-Path $mainlineProvenanceRoot "mainline-source-provenance.json"
   $mainlineSourceRuntimePath = Join-Path $mainlineProvenanceRoot "mainline-source-provenance-runtime.json"
@@ -495,7 +497,7 @@ function Invoke-CanonicalIdeaCapacitySeed {
     -RunId $ideaCanonicalRunId `
     -ExpectedCommitSha $ideaSourceIdentity.CommitSha `
     -ExpectedBranch $ideaSourceIdentity.Branch `
-    -EvidenceDirectory $canonicalEvidenceRoot
+    -EvidenceDirectory $ideaCapacityEvidenceRoot
   if ($LASTEXITCODE -ne 0) {
     throw "Canonical Lotus Idea capacity seed failed with exit code $LASTEXITCODE."
   }
@@ -647,5 +649,6 @@ if (-not [string]::IsNullOrWhiteSpace($ScreenshotDirectory)) {
 }
 if ($RequireMainlineSources) {
   $validationArguments.MainlineSourceProvenancePath = $mainlineSourceRuntimePath
+  $validationArguments.IdeaCapacitySeedEvidencePath = Join-Path $ideaCapacityEvidenceRoot "idea-capacity-seed-evidence.json"
 }
 & (Join-Path $workbenchRepo "scripts\\live\\Validate-LotusFrontOfficeCanonical.ps1") @validationArguments

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -65,10 +65,14 @@ if ($RequireMainlineSources) {
   if ($localAppSet.Count -gt 0) {
     throw "RequireMainlineSources cannot be combined with LocalApps; local-app evidence is branch-local by design."
   }
-  New-Item -ItemType Directory -Path $canonicalEvidenceRoot -Force | Out-Null
+  $mainlineProvenanceRunId = [guid]::NewGuid().ToString("N")
+  $mainlineProvenanceRoot = Join-Path `
+    ([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::LocalApplicationData)) `
+    "Lotus\\canonical-front-office\\mainline-source-provenance\\$mainlineProvenanceRunId"
+  New-Item -ItemType Directory -Path $mainlineProvenanceRoot -Force | Out-Null
   $provenanceScript = Join-Path $workbenchRepo "scripts\\live\\validation\\mainline-source-provenance.mjs"
-  $mainlineSourcePreflightPath = Join-Path $canonicalEvidenceRoot "mainline-source-provenance.json"
-  $mainlineSourceRuntimePath = Join-Path $canonicalEvidenceRoot "mainline-source-provenance-runtime.json"
+  $mainlineSourcePreflightPath = Join-Path $mainlineProvenanceRoot "mainline-source-provenance.json"
+  $mainlineSourceRuntimePath = Join-Path $mainlineProvenanceRoot "mainline-source-provenance-runtime.json"
   & node $provenanceScript --projects-root $ProjectsRoot --output $mainlineSourcePreflightPath
   if ($LASTEXITCODE -ne 0) {
     throw "Canonical mainline source provenance preflight failed. No Docker build, seed, or validation was started."

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -11,6 +11,7 @@ param(
   [switch]$SkipSeedCleanup,
   [switch]$BuildImages,
   [switch]$CoreManageOnly,
+  [switch]$RequireMainlineSources,
   [switch]$RunValidation
 )
 
@@ -52,6 +53,21 @@ foreach ($item in $LocalApps) {
   }
 }
 
+if ($RequireMainlineSources) {
+  if ($CoreManageOnly) {
+    throw "RequireMainlineSources requires the complete canonical front-office service set."
+  }
+  if ($localAppSet.Count -gt 0) {
+    throw "RequireMainlineSources cannot be combined with LocalApps; local-app evidence is branch-local by design."
+  }
+  New-Item -ItemType Directory -Path $canonicalEvidenceRoot -Force | Out-Null
+  $provenanceScript = Join-Path $workbenchRepo "scripts\\live\\validation\\mainline-source-provenance.mjs"
+  & node $provenanceScript --projects-root $ProjectsRoot --output (Join-Path $canonicalEvidenceRoot "mainline-source-provenance.json")
+  if ($LASTEXITCODE -ne 0) {
+    throw "Canonical mainline source provenance preflight failed. No Docker build, seed, or validation was started."
+  }
+}
+
 function Invoke-RepoCommand {
   param(
     [string]$RepoPath,
@@ -89,8 +105,15 @@ function Get-GitRepositoryIdentity {
     throw "Unable to resolve Git commit for $RepoPath."
   }
   $branch = (& git -C $RepoPath branch --show-current).Trim()
-  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($branch)) {
+  if ($LASTEXITCODE -ne 0) {
     throw "Unable to resolve Git branch for $RepoPath."
+  }
+  if ([string]::IsNullOrWhiteSpace($branch)) {
+    $originMainCommitSha = (& git -C $RepoPath rev-parse refs/remotes/origin/main).Trim()
+    if ($LASTEXITCODE -ne 0 -or $commitSha -ne $originMainCommitSha) {
+      throw "Detached Git checkout for $RepoPath is not exactly at origin/main."
+    }
+    $branch = "main"
   }
   return [ordered]@{ CommitSha = $commitSha; Branch = $branch }
 }
@@ -598,5 +621,8 @@ $validationArguments = @{
 }
 if (-not [string]::IsNullOrWhiteSpace($ScreenshotDirectory)) {
   $validationArguments.ScreenshotDirectory = $ScreenshotDirectory
+}
+if ($RequireMainlineSources) {
+  $validationArguments.MainlineSourceProvenancePath = (Join-Path $canonicalEvidenceRoot "mainline-source-provenance.json")
 }
 & (Join-Path $workbenchRepo "scripts\\live\\Validate-LotusFrontOfficeCanonical.ps1") @validationArguments

--- a/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
@@ -6,7 +6,8 @@ param(
   [string]$WorkbenchBaseUrl = "http://workbench.dev.lotus",
   [string]$GatewayBaseUrl = "http://gateway.dev.lotus",
   [string]$ScreenshotDirectory = "",
-  [string]$CanonicalEvidenceDirectory = ""
+  [string]$CanonicalEvidenceDirectory = "",
+  [string]$MainlineSourceProvenancePath = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -154,6 +155,9 @@ try {
   )
   if (-not [string]::IsNullOrWhiteSpace($ScreenshotDirectory)) {
     $validatorArguments += @("--output-dir", $ScreenshotDirectory)
+  }
+  if (-not [string]::IsNullOrWhiteSpace($MainlineSourceProvenancePath)) {
+    $validatorArguments += @("--mainline-source-provenance", $MainlineSourceProvenancePath)
   }
 
   & node @validatorArguments

--- a/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Validate-LotusFrontOfficeCanonical.ps1
@@ -7,6 +7,7 @@ param(
   [string]$GatewayBaseUrl = "http://gateway.dev.lotus",
   [string]$ScreenshotDirectory = "",
   [string]$CanonicalEvidenceDirectory = "",
+  [string]$IdeaCapacitySeedEvidencePath = "",
   [string]$MainlineSourceProvenancePath = ""
 )
 
@@ -19,7 +20,11 @@ $canonicalEvidenceRoot = if ([string]::IsNullOrWhiteSpace($CanonicalEvidenceDire
 } else {
   Join-Path $repoRoot $CanonicalEvidenceDirectory
 }
-$ideaCapacitySeedEvidencePath = Join-Path $canonicalEvidenceRoot "idea-capacity-seed-evidence.json"
+$ideaCapacitySeedEvidencePath = if ([string]::IsNullOrWhiteSpace($IdeaCapacitySeedEvidencePath)) {
+  Join-Path $canonicalEvidenceRoot "idea-capacity-seed-evidence.json"
+} else {
+  $IdeaCapacitySeedEvidencePath
+}
 $canonicalCallerContextHeaders = @{
   "X-Actor-Id" = "workbench-system"
   "X-Tenant-Id" = "tenant-sg"

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -62,6 +62,7 @@ import {
   readString,
 } from "./validation/payload-utils.mjs";
 import { loadIdeaCapacitySeedEvidence } from "./validation/idea-capacity-seed-evidence.mjs";
+import { loadValidatedMainlineSourceManifest } from "./validation/mainline-source-provenance.mjs";
 
 const {
   portfolioId,
@@ -74,6 +75,7 @@ const {
   canonicalStartDate,
   canonicalAsOfDate,
   ideaCapacitySeedEvidencePath,
+  mainlineSourceProvenancePath,
 } = resolveValidationConfig(process.argv.slice(2));
 const { summaryPath, shotIndexPath } = buildSummaryPaths(outputDir);
 const canonicalContract = await loadCanonicalContractMetadata();
@@ -106,6 +108,20 @@ const summary = createValidationSummary({
   gatewayBaseUrl,
   panelRegistry,
 });
+if (mainlineSourceProvenancePath) {
+  const mainlineSourceProvenance = loadValidatedMainlineSourceManifest(
+    mainlineSourceProvenancePath,
+  );
+  summary.mainlineSourceProvenance = {
+    path: mainlineSourceProvenancePath,
+    certificationClassification: mainlineSourceProvenance.certificationClassification,
+    repositories: mainlineSourceProvenance.repositories.map((repository) => ({
+      repository: repository.repository,
+      headSha: repository.headSha,
+      expectedMainSha: repository.expectedMainSha,
+    })),
+  };
+}
 const ideaVersion = await fetchJson(
   summary,
   `${ideaBaseUrl}/version`,

--- a/scripts/live/validate-canonical-workbench-live.mjs
+++ b/scripts/live/validate-canonical-workbench-live.mjs
@@ -62,7 +62,10 @@ import {
   readString,
 } from "./validation/payload-utils.mjs";
 import { loadIdeaCapacitySeedEvidence } from "./validation/idea-capacity-seed-evidence.mjs";
-import { loadValidatedMainlineSourceManifest } from "./validation/mainline-source-provenance.mjs";
+import {
+  bindMainlineSourceManifestToRuntime,
+  loadValidatedMainlineSourceManifest,
+} from "./validation/mainline-source-provenance.mjs";
 
 const {
   portfolioId,
@@ -108,9 +111,23 @@ const summary = createValidationSummary({
   gatewayBaseUrl,
   panelRegistry,
 });
-if (mainlineSourceProvenancePath) {
-  const mainlineSourceProvenance = loadValidatedMainlineSourceManifest(
-    mainlineSourceProvenancePath,
+const mainlineSourceProvenance = mainlineSourceProvenancePath
+  ? loadValidatedMainlineSourceManifest(mainlineSourceProvenancePath)
+  : null;
+const ideaVersion = await fetchJson(
+  summary,
+  `${ideaBaseUrl}/version`,
+  "Lotus Idea runtime version",
+  timeoutMs,
+);
+if (mainlineSourceProvenance) {
+  const ideaRuntimeBinding = bindMainlineSourceManifestToRuntime(
+    mainlineSourceProvenance,
+    {
+      repository: "lotus-idea",
+      commitSha: ideaVersion?.build?.gitCommitSha,
+      branch: ideaVersion?.build?.gitBranch,
+    },
   );
   summary.mainlineSourceProvenance = {
     path: mainlineSourceProvenancePath,
@@ -120,14 +137,9 @@ if (mainlineSourceProvenancePath) {
       headSha: repository.headSha,
       expectedMainSha: repository.expectedMainSha,
     })),
+    runtimeBindings: [ideaRuntimeBinding],
   };
 }
-const ideaVersion = await fetchJson(
-  summary,
-  `${ideaBaseUrl}/version`,
-  "Lotus Idea runtime version",
-  timeoutMs,
-);
 summary.ideaCapacitySeed = await loadIdeaCapacitySeedEvidence(
   ideaCapacitySeedEvidencePath,
   {

--- a/scripts/live/validation/args.mjs
+++ b/scripts/live/validation/args.mjs
@@ -39,5 +39,8 @@ export function resolveValidationConfig(argv, cwd = process.cwd()) {
       args.get("idea-capacity-seed-evidence") ??
         "output/canonical-front-office/idea-capacity-seed-evidence.json"
     ),
+    mainlineSourceProvenancePath: args.has("mainline-source-provenance")
+      ? path.resolve(cwd, args.get("mainline-source-provenance"))
+      : null,
   };
 }

--- a/scripts/live/validation/evidence-summary-writer.mjs
+++ b/scripts/live/validation/evidence-summary-writer.mjs
@@ -35,6 +35,7 @@ export function createValidationSummary({
     supportabilityChecks: [],
     screenshots: [],
     ideaCapacitySeed: null,
+    mainlineSourceProvenance: null,
   };
 }
 

--- a/scripts/live/validation/mainline-source-provenance.d.mts
+++ b/scripts/live/validation/mainline-source-provenance.d.mts
@@ -34,6 +34,16 @@ export function validateMainlineSourceManifest(manifest: unknown): {
   passed: true;
 };
 
+export function bindMainlineSourceManifestToRuntime(
+  manifest: unknown,
+  runtime: { repository: string; commitSha: string | null | undefined; branch: string | null | undefined },
+): {
+  repository: string;
+  commitSha: string;
+  branch: "main";
+  expectedMainSha: string;
+};
+
 export function loadValidatedMainlineSourceManifest(manifestPath: string): {
   schemaVersion: string;
   proofScope: string;

--- a/scripts/live/validation/mainline-source-provenance.d.mts
+++ b/scripts/live/validation/mainline-source-provenance.d.mts
@@ -1,0 +1,43 @@
+export type SourceRepositoryProvenance = {
+  repository: string;
+  branch: string | null;
+  headSha: string | null;
+  expectedMainSha: string | null;
+  passed: boolean;
+  reason: string;
+};
+
+export const CANONICAL_REPOSITORIES: readonly string[];
+
+export function evaluateRepository(input: {
+  name: string;
+  path: string;
+  runGit: (path: string, args: string[]) => string;
+}): SourceRepositoryProvenance;
+
+export function buildMainlineSourceManifest(
+  projectsRoot: string,
+  runGit: (path: string, args: string[]) => string,
+): {
+  schemaVersion: string;
+  proofScope: string;
+  certificationClassification: string;
+  repositories: SourceRepositoryProvenance[];
+  passed: boolean;
+};
+
+export function validateMainlineSourceManifest(manifest: unknown): {
+  schemaVersion: string;
+  proofScope: string;
+  certificationClassification: string;
+  repositories: SourceRepositoryProvenance[];
+  passed: true;
+};
+
+export function loadValidatedMainlineSourceManifest(manifestPath: string): {
+  schemaVersion: string;
+  proofScope: string;
+  certificationClassification: string;
+  repositories: SourceRepositoryProvenance[];
+  passed: true;
+};

--- a/scripts/live/validation/mainline-source-provenance.mjs
+++ b/scripts/live/validation/mainline-source-provenance.mjs
@@ -1,0 +1,101 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export const CANONICAL_REPOSITORIES = [
+  "lotus-core", "lotus-performance", "lotus-risk", "lotus-ai", "lotus-advise",
+  "lotus-manage", "lotus-report", "lotus-archive", "lotus-render", "lotus-idea",
+  "lotus-gateway", "lotus-workbench", "lotus-platform",
+];
+
+function git(repoPath, args, runGit) {
+  return runGit(repoPath, args).trim();
+}
+
+export function evaluateRepository({ name, path, runGit }) {
+  try {
+    git(path, ["fetch", "origin", "--prune"], runGit);
+    const dirty = git(path, ["status", "--porcelain"], runGit).length > 0;
+    const headSha = git(path, ["rev-parse", "HEAD"], runGit);
+    const expectedMainSha = git(path, ["rev-parse", "refs/remotes/origin/main"], runGit);
+    const branch = git(path, ["branch", "--show-current"], runGit);
+    const reason = dirty
+      ? "dirty_worktree"
+      : headSha !== expectedMainSha
+        ? "head_not_origin_main"
+        : branch !== "" && branch !== "main"
+          ? "non_main_branch"
+          : "aligned_with_origin_main";
+    return { repository: name, branch: branch || null, headSha, expectedMainSha, passed: reason === "aligned_with_origin_main", reason };
+  } catch {
+    return { repository: name, branch: null, headSha: null, expectedMainSha: null, passed: false, reason: "repository_unavailable_or_invalid" };
+  }
+}
+
+export function buildMainlineSourceManifest(projectsRoot, runGit) {
+  const repositories = CANONICAL_REPOSITORIES.map((name) =>
+    evaluateRepository({ name, path: join(projectsRoot, name), runGit }),
+  );
+  return {
+    schemaVersion: "lotus.canonical-front-office.mainline-source-provenance.v1",
+    proofScope: "canonical_front_office_mainline_source_preflight",
+    certificationClassification: "mainline_certification_preflight",
+    repositories,
+    passed: repositories.every((repository) => repository.passed),
+  };
+}
+
+export function validateMainlineSourceManifest(manifest) {
+  if (
+    !manifest ||
+    manifest.schemaVersion !== "lotus.canonical-front-office.mainline-source-provenance.v1" ||
+    manifest.proofScope !== "canonical_front_office_mainline_source_preflight" ||
+    manifest.certificationClassification !== "mainline_certification_preflight" ||
+    manifest.passed !== true ||
+    !Array.isArray(manifest.repositories)
+  ) {
+    throw new Error("Mainline source provenance manifest is not a passing canonical certification preflight.");
+  }
+  const names = manifest.repositories.map((repository) => repository?.repository);
+  if (names.length !== CANONICAL_REPOSITORIES.length || new Set(names).size !== names.length || CANONICAL_REPOSITORIES.some((name) => !names.includes(name))) {
+    throw new Error("Mainline source provenance manifest does not cover the complete canonical participant set.");
+  }
+  for (const repository of manifest.repositories) {
+    if (
+      repository.passed !== true ||
+      repository.reason !== "aligned_with_origin_main" ||
+      !repository.headSha ||
+      repository.headSha !== repository.expectedMainSha ||
+      (repository.branch !== null && repository.branch !== "main")
+    ) {
+      throw new Error(`Mainline source provenance manifest contains an invalid participant: ${repository.repository}.`);
+    }
+  }
+  return manifest;
+}
+
+export function loadValidatedMainlineSourceManifest(manifestPath) {
+  return validateMainlineSourceManifest(JSON.parse(readFileSync(manifestPath, "utf8")));
+}
+
+function defaultRunGit(repoPath, args) {
+  return execFileSync("git", ["-C", repoPath, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+}
+
+function readArgument(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+if (process.argv[1] && process.argv[1].endsWith("mainline-source-provenance.mjs")) {
+  const projectsRoot = readArgument("--projects-root");
+  const output = readArgument("--output");
+  if (!projectsRoot || !output) throw new Error("Usage: mainline-source-provenance.mjs --projects-root <path> --output <path>");
+  const manifest = buildMainlineSourceManifest(projectsRoot, defaultRunGit);
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, `${JSON.stringify(manifest, null, 2)}\n`);
+  if (!manifest.passed) {
+    const failed = manifest.repositories.filter((repository) => !repository.passed).map((repository) => `${repository.repository}:${repository.reason}`).join(", ");
+    throw new Error(`Canonical mainline source provenance failed: ${failed}`);
+  }
+}

--- a/scripts/live/validation/mainline-source-provenance.mjs
+++ b/scripts/live/validation/mainline-source-provenance.mjs
@@ -74,6 +74,30 @@ export function validateMainlineSourceManifest(manifest) {
   return manifest;
 }
 
+export function bindMainlineSourceManifestToRuntime(manifest, { repository, commitSha, branch }) {
+  const validatedManifest = validateMainlineSourceManifest(manifest);
+  const sourceRepository = validatedManifest.repositories.find(
+    (candidate) => candidate.repository === repository,
+  );
+  if (
+    !sourceRepository ||
+    !commitSha ||
+    sourceRepository.headSha !== commitSha ||
+    sourceRepository.expectedMainSha !== commitSha ||
+    branch !== "main"
+  ) {
+    throw new Error(
+      `Runtime provenance does not match the passing mainline source manifest for ${repository}.`,
+    );
+  }
+  return {
+    repository,
+    commitSha,
+    branch,
+    expectedMainSha: sourceRepository.expectedMainSha,
+  };
+}
+
 export function loadValidatedMainlineSourceManifest(manifestPath) {
   return validateMainlineSourceManifest(JSON.parse(readFileSync(manifestPath, "utf8")));
 }

--- a/scripts/live/validation/shared-types.d.ts
+++ b/scripts/live/validation/shared-types.d.ts
@@ -18,6 +18,7 @@ export interface ValidationConfig {
   timeoutMs: number;
   canonicalAsOfDate: string;
   ideaCapacitySeedEvidencePath: string;
+  mainlineSourceProvenancePath: string | null;
 }
 
 export interface CanonicalContractMetadata {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -352,6 +352,8 @@ describe("canonical live validation script", () => {
     expect(startScript).toContain("No Docker build, seed, or validation was started");
     expect(startScript).toContain("docker compose up -d --build --force-recreate");
     expect(startScript).toContain("mainline-source-provenance-runtime.json");
+    expect(startScript).toContain("SpecialFolder]::LocalApplicationData");
+    expect(startScript).toContain("mainlineProvenanceRoot");
     expect(startScript).toContain("Get-FileHash -Algorithm SHA256");
     expect(startScript).toContain("MainlineSourceProvenancePath");
     expect(validationScript).toContain("--mainline-source-provenance");

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -350,9 +350,14 @@ describe("canonical live validation script", () => {
     expect(startScript).toContain("[switch]$RequireMainlineSources");
     expect(startScript).toContain("mainline-source-provenance.mjs");
     expect(startScript).toContain("No Docker build, seed, or validation was started");
+    expect(startScript).toContain("docker compose up -d --build --force-recreate");
+    expect(startScript).toContain("mainline-source-provenance-runtime.json");
+    expect(startScript).toContain("Get-FileHash -Algorithm SHA256");
     expect(startScript).toContain("MainlineSourceProvenancePath");
     expect(validationScript).toContain("--mainline-source-provenance");
     expect(browserValidator).toContain("mainlineSourceProvenance");
+    expect(browserValidator).toContain("bindMainlineSourceManifestToRuntime");
+    expect(browserValidator).toContain("repository: \"lotus-idea\"");
   });
 
   it("delegates isolated Idea capacity seeding without exposing credentials or client state", () => {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -347,6 +347,12 @@ describe("canonical live validation script", () => {
     expect(packageJson).toContain(
       '"live:stack:up:validate": "powershell -ExecutionPolicy Bypass -File scripts/live/Start-LotusFrontOfficeCanonical.ps1 -RunValidation -BuildImages"',
     );
+    expect(startScript).toContain("[switch]$RequireMainlineSources");
+    expect(startScript).toContain("mainline-source-provenance.mjs");
+    expect(startScript).toContain("No Docker build, seed, or validation was started");
+    expect(startScript).toContain("MainlineSourceProvenancePath");
+    expect(validationScript).toContain("--mainline-source-provenance");
+    expect(browserValidator).toContain("mainlineSourceProvenance");
   });
 
   it("delegates isolated Idea capacity seeding without exposing credentials or client state", () => {

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -354,8 +354,11 @@ describe("canonical live validation script", () => {
     expect(startScript).toContain("mainline-source-provenance-runtime.json");
     expect(startScript).toContain("SpecialFolder]::LocalApplicationData");
     expect(startScript).toContain("mainlineProvenanceRoot");
+    expect(startScript).toContain("$ideaCapacityEvidenceRoot = $mainlineProvenanceRoot");
+    expect(startScript).toContain("IdeaCapacitySeedEvidencePath");
     expect(startScript).toContain("Get-FileHash -Algorithm SHA256");
     expect(startScript).toContain("MainlineSourceProvenancePath");
+    expect(validationScript).toContain("IdeaCapacitySeedEvidencePath");
     expect(validationScript).toContain("--mainline-source-provenance");
     expect(browserValidator).toContain("mainlineSourceProvenance");
     expect(browserValidator).toContain("bindMainlineSourceManifestToRuntime");

--- a/tests/unit/live-validation-contract-modules.test.ts
+++ b/tests/unit/live-validation-contract-modules.test.ts
@@ -40,6 +40,7 @@ describe("live validation contract modules", () => {
     expect(config.ideaCapacitySeedEvidencePath).toContain(
       "idea-capacity-seed-evidence.json",
     );
+    expect(config.mainlineSourceProvenancePath).toBeNull();
   });
 
   it("builds governed summary evidence with registry metadata and writable artifacts", async () => {

--- a/tests/unit/mainline-source-provenance.test.ts
+++ b/tests/unit/mainline-source-provenance.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { CANONICAL_REPOSITORIES, buildMainlineSourceManifest, evaluateRepository, validateMainlineSourceManifest } from "../../scripts/live/validation/mainline-source-provenance.mjs";
+
+function gitFixture(values: Record<string, string>) {
+  return (_path: string, args: string[]) => values[args.join(" ")] ?? "";
+}
+
+describe("canonical mainline source provenance", () => {
+  it("accepts a clean main checkout and an exact detached main SHA", () => {
+    const runGit = gitFixture({ "fetch origin --prune": "", "status --porcelain": "", "rev-parse HEAD": "abc", "rev-parse refs/remotes/origin/main": "abc", "branch --show-current": "" });
+    expect(evaluateRepository({ name: "lotus-idea", path: "unused", runGit })).toMatchObject({ passed: true, reason: "aligned_with_origin_main", branch: null });
+  });
+
+  it("fails closed for dirty, diverged, and non-main source checkouts", () => {
+    const base = { "fetch origin --prune": "", "rev-parse HEAD": "abc", "rev-parse refs/remotes/origin/main": "abc", "branch --show-current": "feature/proof" };
+    expect(evaluateRepository({ name: "lotus-idea", path: "unused", runGit: gitFixture({ ...base, "status --porcelain": " M docs/runbook.md" }) }).reason).toBe("dirty_worktree");
+    expect(evaluateRepository({ name: "lotus-idea", path: "unused", runGit: gitFixture({ ...base, "status --porcelain": "", "rev-parse HEAD": "old" }) }).reason).toBe("head_not_origin_main");
+    expect(evaluateRepository({ name: "lotus-idea", path: "unused", runGit: gitFixture({ ...base, "status --porcelain": "" }) }).reason).toBe("non_main_branch");
+  });
+
+  it("records every canonical participant without source paths or dirty filenames", () => {
+    const manifest = buildMainlineSourceManifest("C:/projects", gitFixture({ "fetch origin --prune": "", "status --porcelain": "", "rev-parse HEAD": "abc", "rev-parse refs/remotes/origin/main": "abc", "branch --show-current": "main" }));
+    expect(manifest).toMatchObject({ schemaVersion: "lotus.canonical-front-office.mainline-source-provenance.v1", passed: true });
+    expect(manifest.repositories.map((repository) => repository.repository)).toContain("lotus-idea");
+    expect(manifest.repositories.map((repository) => repository.repository)).toContain("lotus-platform");
+    expect(JSON.stringify(manifest)).not.toContain("C:/projects");
+  });
+
+  it("rejects incomplete, failed, or arbitrary manifests before certification is asserted", () => {
+    const validManifest = buildMainlineSourceManifest("C:/projects", gitFixture({ "fetch origin --prune": "", "status --porcelain": "", "rev-parse HEAD": "abc", "rev-parse refs/remotes/origin/main": "abc", "branch --show-current": "main" }));
+    expect(validateMainlineSourceManifest(validManifest)).toBe(validManifest);
+    expect(() => validateMainlineSourceManifest({ ...validManifest, repositories: validManifest.repositories.slice(1) })).toThrow("complete canonical participant set");
+    expect(() => validateMainlineSourceManifest({ ...validManifest, passed: false })).toThrow("passing canonical certification preflight");
+    expect(CANONICAL_REPOSITORIES).toContain("lotus-platform");
+  });
+});

--- a/tests/unit/mainline-source-provenance.test.ts
+++ b/tests/unit/mainline-source-provenance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { CANONICAL_REPOSITORIES, buildMainlineSourceManifest, evaluateRepository, validateMainlineSourceManifest } from "../../scripts/live/validation/mainline-source-provenance.mjs";
+import { CANONICAL_REPOSITORIES, bindMainlineSourceManifestToRuntime, buildMainlineSourceManifest, evaluateRepository, validateMainlineSourceManifest } from "../../scripts/live/validation/mainline-source-provenance.mjs";
 
 function gitFixture(values: Record<string, string>) {
   return (_path: string, args: string[]) => values[args.join(" ")] ?? "";
@@ -33,5 +33,12 @@ describe("canonical mainline source provenance", () => {
     expect(() => validateMainlineSourceManifest({ ...validManifest, repositories: validManifest.repositories.slice(1) })).toThrow("complete canonical participant set");
     expect(() => validateMainlineSourceManifest({ ...validManifest, passed: false })).toThrow("passing canonical certification preflight");
     expect(CANONICAL_REPOSITORIES).toContain("lotus-platform");
+  });
+
+  it("binds the Idea runtime version to the passing source manifest", () => {
+    const manifest = buildMainlineSourceManifest("C:/projects", gitFixture({ "fetch origin --prune": "", "status --porcelain": "", "rev-parse HEAD": "abc", "rev-parse refs/remotes/origin/main": "abc", "branch --show-current": "main" }));
+    expect(bindMainlineSourceManifestToRuntime(manifest, { repository: "lotus-idea", commitSha: "abc", branch: "main" })).toMatchObject({ repository: "lotus-idea", expectedMainSha: "abc" });
+    expect(() => bindMainlineSourceManifestToRuntime(manifest, { repository: "lotus-idea", commitSha: "branch-built", branch: "main" })).toThrow("Runtime provenance does not match");
+    expect(() => bindMainlineSourceManifestToRuntime(manifest, { repository: "lotus-idea", commitSha: "abc", branch: "feature/proof" })).toThrow("Runtime provenance does not match");
   });
 });

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -107,8 +107,9 @@ concurrency group.
   before Docker, seeding, or screenshots when any canonical participant is dirty or not exactly at
   `origin/main`. Certification startup forces image builds and container recreation, compares
   preflight and post-start source manifests, and binds Lotus Idea runtime `/version` provenance
-  before recording the mainline-source posture. Standard and `-LocalApps` runtime runs remain
-  branch-local development evidence.
+  before recording the mainline-source posture. Its manifests are written to a per-run Local AppData
+  directory outside checked source worktrees, so generated evidence cannot make the source preflight
+  appear dirty. Standard and `-LocalApps` runtime runs remain branch-local development evidence.
 - Lotus Idea capacity integration proof must use Idea-owned seed and workload automation after Idea
   and Advise readiness. The validator matches Idea `/version` to the checked-out commit and branch,
   requires the isolated `CAPACITY_SYNTHETIC_PORTFOLIO_001` namespace, and accepts exactly one

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -105,7 +105,10 @@ concurrency group.
 - RFC or mainline certification runs must invoke the canonical startup script with
   `-RequireMainlineSources`. The preflight writes a source-safe provenance manifest and fails
   before Docker, seeding, or screenshots when any canonical participant is dirty or not exactly at
-  `origin/main`. Standard and `-LocalApps` runtime runs remain branch-local development evidence.
+  `origin/main`. Certification startup forces image builds and container recreation, compares
+  preflight and post-start source manifests, and binds Lotus Idea runtime `/version` provenance
+  before recording the mainline-source posture. Standard and `-LocalApps` runtime runs remain
+  branch-local development evidence.
 - Lotus Idea capacity integration proof must use Idea-owned seed and workload automation after Idea
   and Advise readiness. The validator matches Idea `/version` to the checked-out commit and branch,
   requires the isolated `CAPACITY_SYNTHETIC_PORTFOLIO_001` namespace, and accepts exactly one

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -107,7 +107,7 @@ concurrency group.
   before Docker, seeding, or screenshots when any canonical participant is dirty or not exactly at
   `origin/main`. Certification startup forces image builds and container recreation, compares
   preflight and post-start source manifests, and binds Lotus Idea runtime `/version` provenance
-  before recording the mainline-source posture. Its manifests are written to a per-run Local AppData
+  before recording the mainline-source posture. Its manifests and Idea capacity-seed evidence are written to a per-run Local AppData
   directory outside checked source worktrees, so generated evidence cannot make the source preflight
   appear dirty. Standard and `-LocalApps` runtime runs remain branch-local development evidence.
 - Lotus Idea capacity integration proof must use Idea-owned seed and workload automation after Idea

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -102,6 +102,10 @@ concurrency group.
   authority, and no client-publication claims.
   The canonical Lotus Idea seed takes its as-of date from the platform demo-data contract instead of
   duplicating date literals in Workbench startup automation.
+- RFC or mainline certification runs must invoke the canonical startup script with
+  `-RequireMainlineSources`. The preflight writes a source-safe provenance manifest and fails
+  before Docker, seeding, or screenshots when any canonical participant is dirty or not exactly at
+  `origin/main`. Standard and `-LocalApps` runtime runs remain branch-local development evidence.
 - Lotus Idea capacity integration proof must use Idea-owned seed and workload automation after Idea
   and Advise readiness. The validator matches Idea `/version` to the checked-out commit and branch,
   requires the isolated `CAPACITY_SYNTHETIC_PORTFOLIO_001` namespace, and accepts exactly one


### PR DESCRIPTION
## Summary

Closes #421.

Adds a fail-closed mainline-provenance gate for canonical front-office certification:

- checks all canonical source participants, including `lotus-platform`, are clean and exactly at `origin/main`;
- rejects `-LocalApps` and Core/manage-only paths for certification;
- forces `docker compose up -d --build --force-recreate` whenever `-RequireMainlineSources` is selected;
- regenerates source provenance after startup and rejects a changed participant set or SHA;
- binds the running Lotus Idea `/version` commit and branch to the passing manifest before recording mainline-source certification posture;
- supports detached checkouts exactly at `origin/main` by normalizing their downstream branch identity to `main`.

## Local evidence

- `npm run lint` — passed
- `npm run test -- --run tests/unit/mainline-source-provenance.test.ts tests/unit/live-canonical-validation-script.test.ts tests/unit/live-validation-contract-modules.test.ts` — passed (19 tests)
- `npm run typecheck` — passed
- `git diff --check` — passed
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench -AllowUnpublishedSourceChanges` — passed (`DiffCount 0`)

## Governance

- Rebased on `origin/main` at `a99a00e` before this push.
- Stranded-truth reconciliation: `git fetch origin --prune` and `git branch -r --no-merged origin/main`; the only relevant branch is this tracked, active PR branch.
- Wiki: repo-authored source was updated and currently matches published wiki (`DiffCount 0`); post-merge strict parity will be run.
- The `mainline_certification_preflight` label is runtime-bound evidence only after forced build/recreate, stable source manifests, and matching Lotus Idea runtime provenance. Normal and `-LocalApps` runs remain development evidence.