### PR TITLE
RFC-0002: harden Idea Workbench BFF authority

### DIFF
--- a/src/features/workbench/caller-context.ts
+++ b/src/features/workbench/caller-context.ts
@@ -44,13 +44,6 @@ const DEFAULT_IDEA_CALLER_CONTEXT = {
   portfolioIds: "PB_SG_GLOBAL_BAL_001",
 } as const;
 
-const IDEA_AUTHORITY_HEADERS = [
-  "X-Caller-Subject",
-  "X-Caller-Roles",
-  "X-Caller-Capabilities",
-  "X-Caller-Portfolio-Ids",
-] as const;
-
 export const SERVER_DERIVED_CALLER_AUTHORITY_HEADERS = [
   "X-Actor-Id",
   "X-Caller-Application",
@@ -173,7 +166,7 @@ export function applyIdeaRouteCallerContextHeaders(
     return { status: "not_applicable" };
   }
 
-  for (const headerName of IDEA_AUTHORITY_HEADERS) {
+  for (const headerName of SERVER_DERIVED_CALLER_AUTHORITY_HEADERS) {
     headers.delete(headerName);
   }
 
@@ -189,11 +182,14 @@ export function applyIdeaRouteCallerContextHeaders(
       : { status: "rejected", reason: authorityMode };
   }
 
-  headers.set(
-    "X-Caller-Subject",
-    process.env[IDEA_CALLER_CONTEXT_ENV_OVERRIDES.subject]?.trim() ||
-      DEFAULT_IDEA_CALLER_CONTEXT.subject,
-  );
+  const defaultContext = resolveDefaultCallerContext();
+  headers.set("X-Actor-Id", defaultContext.actorId);
+  headers.set("X-Caller-Application", defaultContext.callerApplication);
+  headers.set("X-Tenant-Id", defaultContext.tenantId);
+  headers.set("X-Region", defaultContext.region);
+  headers.set("X-Booking-Center-Code", defaultContext.bookingCenterCode);
+  headers.set("X-Role", defaultContext.role);
+  headers.set("X-Caller-Subject", configuredIdeaCallerSubject());
   headers.set(
     "X-Caller-Roles",
     process.env[IDEA_CALLER_CONTEXT_ENV_OVERRIDES.roles]?.trim() ||
@@ -207,6 +203,13 @@ export function applyIdeaRouteCallerContextHeaders(
   );
 
   return { status: "applied", mode: authorityMode };
+}
+
+function configuredIdeaCallerSubject(): string {
+  return (
+    process.env[IDEA_CALLER_CONTEXT_ENV_OVERRIDES.subject]?.trim() ||
+    DEFAULT_IDEA_CALLER_CONTEXT.subject
+  );
 }
 
 export function applyReportOrderingRouteCallerContextHeaders(

--- a/tests/unit/bff-route.test.ts
+++ b/tests/unit/bff-route.test.ts
@@ -157,10 +157,18 @@ describe("BFF proxy route", () => {
         method: "POST",
         headers: {
           "content-type": "application/json",
+          "X-Actor-Id": "spoofed-actor",
+          "X-Caller-Application": "spoofed-application",
+          "X-Tenant-Id": "spoofed-tenant",
+          "X-Region": "spoofed-region",
+          "X-Booking-Center-Code": "spoofed-centre",
+          "X-Role": "administrator",
           "X-Caller-Subject": "spoofed-subject",
           "X-Caller-Roles": "compliance",
           "X-Caller-Capabilities": "idea.conversion.intent.record",
           "X-Caller-Portfolio-Ids": "UNENTITLED_PORTFOLIO",
+          "X-Caller-Client-Ids": "UNENTITLED_CLIENT",
+          "X-Principal-Status": "SUSPENDED",
         },
         body: JSON.stringify({ action: "approve_for_conversion" }),
       },
@@ -180,6 +188,14 @@ describe("BFF proxy route", () => {
     });
 
     const upstreamHeaders = fetchMock.mock.calls[0][1]?.headers as Headers;
+    expect(upstreamHeaders.get("X-Actor-Id")).toBe("workbench-system");
+    expect(upstreamHeaders.get("X-Caller-Application")).toBe(
+      "lotus-workbench",
+    );
+    expect(upstreamHeaders.get("X-Tenant-Id")).toBe("tenant-sg");
+    expect(upstreamHeaders.get("X-Region")).toBe("APAC");
+    expect(upstreamHeaders.get("X-Booking-Center-Code")).toBe("SG");
+    expect(upstreamHeaders.get("X-Role")).toBe("advisor");
     expect(upstreamHeaders.get("X-Caller-Subject")).toBe("workbench-advisor");
     expect(upstreamHeaders.get("X-Caller-Roles")).toBe("advisor");
     expect(upstreamHeaders.get("X-Caller-Capabilities")).toBe(
@@ -188,7 +204,55 @@ describe("BFF proxy route", () => {
     expect(upstreamHeaders.get("X-Caller-Portfolio-Ids")).toBe(
       "PB_SG_GLOBAL_BAL_001",
     );
+    expect(upstreamHeaders.get("X-Caller-Client-Ids")).toBeNull();
+    expect(upstreamHeaders.get("X-Principal-Status")).toBeNull();
   });
+
+  it.each([
+    ["review-actions", "idea.review.record"],
+    ["feedback", "idea.feedback.record"],
+    ["conversion-intents", "idea.conversion.intent.record"],
+  ])(
+    "derives Idea %s capability from the allowlisted BFF route",
+    async (routeSuffix, expectedCapability) => {
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+      const request = new NextRequest(
+        `http://localhost:3000/api/bff/api/v1/ideas/candidates/idea_high_cash_001/${routeSuffix}`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "Idempotency-Key": `idem-${routeSuffix}`,
+            "X-Caller-Capabilities": "idea.admin",
+          },
+          body: JSON.stringify({ reasonCodes: ["advisor_review"] }),
+        },
+      );
+
+      const response = await POST(request, {
+        params: Promise.resolve({
+          path: [
+            "api",
+            "v1",
+            "ideas",
+            "candidates",
+            "idea_high_cash_001",
+            routeSuffix,
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const upstreamHeaders = fetchMock.mock.calls[0][1]?.headers as Headers;
+      expect(upstreamHeaders.get("X-Caller-Capabilities")).toBe(
+        expectedCapability,
+      );
+      expect(upstreamHeaders.get("Idempotency-Key")).toBe(
+        `idem-${routeSuffix}`,
+      );
+    },
+  );
 
   it("requires an authenticated Idea principal outside development before proxying", async () => {
     process.env.LOTUS_ENVIRONMENT = "uat";


### PR DESCRIPTION
## Summary

Implements the Workbench side of RFC-0002 Slice 11 Idea opportunity certification for issue #484 by hardening the Idea BFF authority boundary:

- strips every browser-supplied server-derived authority header before proxying `/api/v1/ideas/*` routes
- derives actor/application/tenant/region/booking-center/role from server-side Workbench development configuration
- derives exact least-privilege Idea mutation capabilities per allowlisted route
- preserves `Idempotency-Key` forwarding for review-action, feedback, and conversion-intent writes

## Traceability

- Refs #484
- RFC: RFC-0002
- Slices: Slice 11, Slice 16, Slice 17
- Related Gateway issue/PR: sgajbi/lotus-gateway#505 / sgajbi/lotus-gateway#508
- Related Idea PR: sgajbi/lotus-idea#703

## Validation

- `npm run test -- tests/unit/bff-route.test.ts tests/unit/proposals-api.test.ts tests/unit/advisory-opportunities-view-model.test.ts` — passed, 3 files / 55 tests
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run test` — passed, 310 files / 1445 tests
- `git diff --check` — passed; only Windows CRLF normalization warnings were reported

## Non-functional posture

- No production authentication or authorization is implemented in this slice; non-development Idea routes remain fail-closed until authenticated-principal resolution is delivered by Workbench #436 / platform #563.
- No local ranking, conversion lifecycle synthesis, proposal creation, execution authority, or client communication is added.
- No supported-feature promotion is claimed.
- No wiki change: this PR aligns implementation with existing repo context that browser-supplied authority must not grant Idea access.