### PR TITLE
fix: harden BFF principal authority boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ environments. An unset environment, `uat`, production, or any other environment 
 available. Browser headers never grant Idea authority. The eventual session and token-claims
 contract remains tracked in [lotus-platform#563](https://github.com/sgajbi/lotus-platform/issues/563)
 and Workbench BFF resolution in [lotus-workbench#436](https://github.com/sgajbi/lotus-workbench/issues/436).
+Workbench consumes the platform contract identifiers from
+`lotus-platform.bff-principal-session.v1` and currently records the contract posture as
+`not_certified`, `productionIdentityCertified=false`, and `supportedFeaturePromoted=false`.
+For governed authority routes, the BFF strips browser-supplied Lotus authority headers plus
+`Authorization`, `Cookie`, proxy authorization, and common upstream-auth identity aliases before
+projecting server-derived Gateway headers. General non-authority BFF proxy routes are unchanged.
 Only the explicit Idea queue, candidate-detail, review-action, feedback, and conversion-intent
 routes are allowlisted through the BFF; any other `/api/v1/ideas/*` route returns `404` before
 Gateway is contacted.

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -159,7 +159,8 @@ Current repository posture:
     `/recommendations?mode=cockpit` renders Advise-owned cockpit action items, source evidence,
     supportability, meeting-preparation packets, and bounded advisor acknowledgements through
     Gateway advisor-cockpit endpoints only. Its BFF authority adapter strips browser-supplied
-    identity, role, capability, tenant, legal-entity, principal-status, and entitlement headers;
+    identity, role, capability, tenant, legal-entity, principal-status, entitlement, browser
+    authorization, browser cookie, proxy authorization, session id, and upstream-auth identity headers;
     rejects query/body authority; derives the development advisor from the server-side actor;
     verifies the selected portfolio against configured entitlement; and emits only the exact read
     or acknowledgement capability required by the allowlisted route. Non-development requests
@@ -181,10 +182,13 @@ Current repository posture:
     client-ready release, render reports, archive artifacts, contact clients, route orders, or call
     advisory/report/archive/render services directly. `/recommendations?mode=opportunities`
     renders the Gateway-backed Lotus Idea advisor review queue. The Workbench BFF strips browser
-    Idea authority headers and applies configured subject, role, route capability, and portfolio
-    entitlement only in explicitly development-scoped `dev`/`development`/`local`/`test` runtime.
+    Idea authority, authorization, cookie, proxy-authorization, session, and upstream-auth identity
+    headers and applies configured subject, role, route capability, and portfolio entitlement only
+    in explicitly development-scoped `dev`/`development`/`local`/`test` runtime.
     It fails closed before Gateway for an unset environment and every other environment until authenticated session principal
-    resolution is available (platform #563, Workbench #436), and it rejects unallowlisted
+    resolution is available (platform #563, Workbench #436), consumes the
+    `lotus-platform.bff-principal-session.v1` contract posture as non-certifying source-contract
+    evidence, and rejects unallowlisted
     `/api/v1/ideas/*` paths before Gateway in every environment. The surface is limited to canonical `PB_SG_GLOBAL_BAL_001` until authenticated
     portfolio entitlement is available; it renders score, review posture, source-signal ids, reason codes,
     durable-storage posture, policy version, and

--- a/src/features/advisor-book/caller-context.ts
+++ b/src/features/advisor-book/caller-context.ts
@@ -1,7 +1,7 @@
 import { resolveConfiguredAuthorityMode } from "@/features/workbench/authority-mode";
 import {
   resolveDefaultCallerContext,
-  SERVER_DERIVED_CALLER_AUTHORITY_HEADERS,
+  stripBrowserSuppliedAuthorityHeaders,
 } from "@/features/workbench/caller-context";
 
 const ADVISOR_BOOK_ROUTE = "api/v1/advisor-book/portfolios";
@@ -33,9 +33,7 @@ export function applyAdvisorBookCallerContextHeaders(
     return { status: "not_applicable" };
   }
 
-  for (const headerName of SERVER_DERIVED_CALLER_AUTHORITY_HEADERS) {
-    headers.delete(headerName);
-  }
+  stripBrowserSuppliedAuthorityHeaders(headers);
 
   const authorityMode = resolveConfiguredAuthorityMode(ADVISOR_BOOK_AUTH_MODE_ENV);
   if (authorityMode !== "development_configured") {

--- a/src/features/advisor-cockpit/caller-context.ts
+++ b/src/features/advisor-cockpit/caller-context.ts
@@ -1,7 +1,7 @@
 import { resolveConfiguredAuthorityMode } from "@/features/workbench/authority-mode";
 import {
   resolveDefaultCallerContext,
-  SERVER_DERIVED_CALLER_AUTHORITY_HEADERS,
+  stripBrowserSuppliedAuthorityHeaders,
 } from "@/features/workbench/caller-context";
 
 const ADVISOR_COCKPIT_ROUTE_PREFIX = "api/v1/advisor-cockpit";
@@ -62,9 +62,7 @@ export function applyAdvisorCockpitCallerContextHeaders(
     return { status: "not_applicable" };
   }
 
-  for (const headerName of SERVER_DERIVED_CALLER_AUTHORITY_HEADERS) {
-    headers.delete(headerName);
-  }
+  stripBrowserSuppliedAuthorityHeaders(headers);
 
   const capability = resolveAdvisorCockpitCapability(request);
   if (!capability) {

--- a/src/features/workbench/caller-context.ts
+++ b/src/features/workbench/caller-context.ts
@@ -63,6 +63,41 @@ export const SERVER_DERIVED_CALLER_AUTHORITY_HEADERS = [
   "X-Authorized-Portfolio-Id",
 ] as const;
 
+export const BFF_PRINCIPAL_SESSION_CONTRACT_POSTURE = {
+  schemaVersion: "lotus-platform.bff-principal-session.v1",
+  certificationSchemaVersion:
+    "lotus-platform.bff-principal-session-certification.v1",
+  contractId: "lotus-platform-authenticated-bff-principal-session",
+  contractVersion: "1.0.0",
+  consumer: "lotus-workbench",
+  upstreamService: "lotus-gateway",
+  productSafeDenialCode: "AUTHENTICATED_PRINCIPAL_REQUIRED",
+  certificationStatus: "not_certified",
+  productionIdentityCertified: false,
+  supportedFeaturePromoted: false,
+  localDevFixtureNonCertifying: true,
+} as const;
+
+export const FORBIDDEN_BROWSER_AUTHORITY_HEADERS = [
+  ...SERVER_DERIVED_CALLER_AUTHORITY_HEADERS,
+  "Authorization",
+  "Cookie",
+  "Proxy-Authorization",
+  "X-Forwarded-User",
+  "X-Forwarded-Email",
+  "X-Auth-Request-User",
+  "X-Auth-Request-Email",
+  "X-Authenticated-User",
+  "X-Authenticated-Email",
+  "X-Session-Id",
+] as const;
+
+export function stripBrowserSuppliedAuthorityHeaders(headers: Headers) {
+  for (const headerName of FORBIDDEN_BROWSER_AUTHORITY_HEADERS) {
+    headers.delete(headerName);
+  }
+}
+
 const REPORTING_CALLER_CONTEXT_ENV_OVERRIDES = {
   role: "WORKBENCH_REPORTING_CALLER_ROLE",
   portfolioIds: "WORKBENCH_REPORTING_CALLER_PORTFOLIO_IDS",
@@ -166,9 +201,7 @@ export function applyIdeaRouteCallerContextHeaders(
     return { status: "not_applicable" };
   }
 
-  for (const headerName of SERVER_DERIVED_CALLER_AUTHORITY_HEADERS) {
-    headers.delete(headerName);
-  }
+  stripBrowserSuppliedAuthorityHeaders(headers);
 
   const capability = resolveIdeaRouteCapability(request);
   if (!capability) {
@@ -225,9 +258,7 @@ export function applyReportOrderingRouteCallerContextHeaders(
     return { status: "not_applicable" };
   }
 
-  for (const headerName of SERVER_DERIVED_CALLER_AUTHORITY_HEADERS) {
-    headers.delete(headerName);
-  }
+  stripBrowserSuppliedAuthorityHeaders(headers);
 
   const authorityMode = resolveConfiguredAuthorityMode(REPORTING_AUTH_MODE_ENV);
   if (authorityMode !== "development_configured") {

--- a/tests/unit/bff-route.test.ts
+++ b/tests/unit/bff-route.test.ts
@@ -2,6 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 import { GET, POST } from "@/app/api/bff/[...path]/route";
+import {
+  BFF_PRINCIPAL_SESSION_CONTRACT_POSTURE,
+  FORBIDDEN_BROWSER_AUTHORITY_HEADERS,
+} from "@/features/workbench/caller-context";
 
 describe("BFF proxy route", () => {
   const originalBffBaseUrl = process.env.BFF_BASE_URL;
@@ -58,6 +62,33 @@ describe("BFF proxy route", () => {
         process.env[key] = original;
       }
     }
+  });
+
+  it("records the platform BFF principal-session contract posture consumed by Workbench", () => {
+    expect(BFF_PRINCIPAL_SESSION_CONTRACT_POSTURE).toEqual({
+      schemaVersion: "lotus-platform.bff-principal-session.v1",
+      certificationSchemaVersion:
+        "lotus-platform.bff-principal-session-certification.v1",
+      contractId: "lotus-platform-authenticated-bff-principal-session",
+      contractVersion: "1.0.0",
+      consumer: "lotus-workbench",
+      upstreamService: "lotus-gateway",
+      productSafeDenialCode: "AUTHENTICATED_PRINCIPAL_REQUIRED",
+      certificationStatus: "not_certified",
+      productionIdentityCertified: false,
+      supportedFeaturePromoted: false,
+      localDevFixtureNonCertifying: true,
+    });
+    expect(FORBIDDEN_BROWSER_AUTHORITY_HEADERS).toEqual(
+      expect.arrayContaining([
+        "X-Actor-Id",
+        "X-Caller-Capabilities",
+        "Authorization",
+        "Cookie",
+        "Proxy-Authorization",
+        "X-Session-Id",
+      ]),
+    );
   });
 
   it("forwards GET requests to the configured upstream without the host header", async () => {
@@ -169,6 +200,10 @@ describe("BFF proxy route", () => {
           "X-Caller-Portfolio-Ids": "UNENTITLED_PORTFOLIO",
           "X-Caller-Client-Ids": "UNENTITLED_CLIENT",
           "X-Principal-Status": "SUSPENDED",
+          Authorization: "Bearer browser-asserted-authority",
+          Cookie: "lotus_session=browser-asserted-cookie",
+          "Proxy-Authorization": "Basic browser-proxy-authority",
+          "X-Session-Id": "browser-session-id",
         },
         body: JSON.stringify({ action: "approve_for_conversion" }),
       },
@@ -206,6 +241,10 @@ describe("BFF proxy route", () => {
     );
     expect(upstreamHeaders.get("X-Caller-Client-Ids")).toBeNull();
     expect(upstreamHeaders.get("X-Principal-Status")).toBeNull();
+    expect(upstreamHeaders.get("Authorization")).toBeNull();
+    expect(upstreamHeaders.get("Cookie")).toBeNull();
+    expect(upstreamHeaders.get("Proxy-Authorization")).toBeNull();
+    expect(upstreamHeaders.get("X-Session-Id")).toBeNull();
   });
 
   it.each([
@@ -412,6 +451,8 @@ describe("BFF proxy route", () => {
           "X-Caller-Portfolio-Ids": "UNENTITLED_PORTFOLIO",
           "X-Caller-Client-Ids": "UNENTITLED_CLIENT",
           "X-Caller-Book-Ids": "UNENTITLED_BOOK",
+          Authorization: "Bearer browser-asserted-authority",
+          Cookie: "lotus_session=browser-asserted-cookie",
         },
       },
     );
@@ -433,6 +474,8 @@ describe("BFF proxy route", () => {
     expect(upstreamHeaders.get("X-Caller-Portfolio-Ids")).toBeNull();
     expect(upstreamHeaders.get("X-Caller-Client-Ids")).toBeNull();
     expect(upstreamHeaders.get("X-Caller-Book-Ids")).toBeNull();
+    expect(upstreamHeaders.get("Authorization")).toBeNull();
+    expect(upstreamHeaders.get("Cookie")).toBeNull();
   });
 
   it("uses explicitly configured development advisor-book identity", async () => {
@@ -519,6 +562,8 @@ describe("BFF proxy route", () => {
           "X-Principal-Status": "SUSPENDED",
           "X-Authorized-Advisor-Id": "another-advisor",
           "X-Authorized-Portfolio-Id": "UNENTITLED_PORTFOLIO",
+          Authorization: "Bearer browser-asserted-authority",
+          Cookie: "lotus_session=browser-asserted-cookie",
         },
       },
     );
@@ -548,6 +593,8 @@ describe("BFF proxy route", () => {
     expect(upstreamHeaders.get("X-Authorized-Portfolio-Id")).toBe(
       "PB_SG_GLOBAL_BAL_001",
     );
+    expect(upstreamHeaders.get("Authorization")).toBeNull();
+    expect(upstreamHeaders.get("Cookie")).toBeNull();
   });
 
   it("applies the read capability to Advisor Cockpit object lookup", async () => {
@@ -737,6 +784,8 @@ describe("BFF proxy route", () => {
           "X-Caller-Roles": "reporting-admin",
           "X-Caller-Capabilities": "reporting.approve,reporting.distribute",
           "X-Caller-Portfolio-Ids": "UNENTITLED_PORTFOLIO",
+          Authorization: "Bearer browser-asserted-authority",
+          Cookie: "lotus_session=browser-asserted-cookie",
         },
       },
     );
@@ -757,6 +806,8 @@ describe("BFF proxy route", () => {
     expect(upstreamHeaders.get("X-Caller-Portfolio-Ids")).toBe(
       "PB_SG_GLOBAL_BAL_001",
     );
+    expect(upstreamHeaders.get("Authorization")).toBeNull();
+    expect(upstreamHeaders.get("Cookie")).toBeNull();
   });
 
   it("rejects a report-ordering portfolio outside the server-configured entitlement", async () => {

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -74,8 +74,9 @@ promote dormant labels into product ownership just because historical route file
 - internal browser-to-gateway traffic can flow through `/api/bff/*`
 - `/book` consumes `GET /api/v1/advisor-book/portfolios` through the Workbench BFF. The BFF
   replaces browser-supplied actor, tenant, region, booking-centre, role, and capability headers;
-  only development-configured authority is currently supported, while non-development runtime
-  fails closed pending authenticated principal resolution in Workbench #436.
+  strips browser `Authorization`, browser `Cookie`, proxy authorization, session id, and upstream
+  auth identity aliases; and supports only development-configured authority. Non-development
+  runtime fails closed pending authenticated principal resolution in Workbench #436.
 - `/intake` submits portfolio bundle writes through `/api/bff/api/v1/intake/portfolio-bundle`
   and forwards a bounded `X-Idempotency-Key` so Gateway/Core own safe duplicate-submit replay
   semantics

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -34,7 +34,9 @@
 Advisor Cockpit browser requests carry business scope, not caller authority. The Workbench BFF:
 
 1. discards caller identity, tenant, region, booking centre, legal entity, role, capability,
-   principal status, advisor scope, and portfolio entitlement supplied by the browser,
+   principal status, advisor scope, portfolio entitlement, browser `Authorization`, browser
+   `Cookie`, proxy authorization, session id, and common upstream-auth identity aliases supplied
+   by the browser,
 2. rejects advisor, role, or other authority claims in query parameters or acknowledgement bodies,
 3. derives the development advisor from a server-configured actor and verifies the selected
    portfolio against a server-configured entitlement list,
@@ -45,3 +47,10 @@ Advisor Cockpit browser requests carry business scope, not caller authority. The
 
 This is a local and test fixture, not production authentication. UAT and production remain closed
 until Workbench #436 and platform #563 supply the governed authenticated-session principal.
+
+Workbench now consumes the `lotus-platform.bff-principal-session.v1` source-contract identifiers
+for the governed BFF principal boundary and keeps the certification posture explicit:
+`not_certified`, `productionIdentityCertified=false`, `supportedFeaturePromoted=false`, and
+`localDevFixtureNonCertifying=true`. This clears only the source-contract consumer boundary. It
+does not install an IdP, validate token claims, certify revocation/logout, or promote Lotus Idea or
+advisor workflows as production-authenticated features.


### PR DESCRIPTION
## Summary

Keep #436 open.

This PR consumes the source-contract portion of `sgajbi/lotus-platform#563` in Workbench's governed BFF principal boundary without claiming production authentication.

Changes:
- records the `lotus-platform.bff-principal-session.v1` / certification posture identifiers in Workbench BFF caller-context code;
- centralizes forbidden browser authority-header stripping for governed BFF route families;
- strips browser `Authorization`, `Cookie`, proxy authorization, session id, and common upstream-auth identity aliases before server-derived Gateway authority is projected for Idea, Advisor Book, Advisor Cockpit, and Reporting routes;
- preserves general non-authority BFF proxy behavior;
- updates README, repo context, and repo-authored wiki source with the non-certifying posture and remaining #436/#563 production-auth boundary.

## Evidence

Static:
- `npm run lint` — passed
- `npm run typecheck` — passed
- `git diff --check` — passed

Unit / coverage:
- `npm run test -- --run tests/unit/bff-route.test.ts` — 30 passed
- `make check` — passed: dependency audit, lint, typecheck, 311 files / 1,459 tests, 90.97% statement coverage, 25-route production build

Governance / wiki:
- `powershell -NoProfile -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench -AllowUnpublishedSourceChanges` — passed with expected branch-local DiffCount 2 because `wiki/` changed and must be published after merge

Tiering:
- UI Product profile. PR Merge Gate checks are required by branch protection; Main Releasability is post-merge evidence.

Stranded truth:
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` — no unmerged remote branches reported for `lotus-workbench` at slice start.

Non-degradation:
- Does not implement IdP, token claims, session cookie verification, revocation/logout, or supported-feature promotion.
- General BFF proxy route behavior remains unchanged, including non-governed `Authorization` forwarding.
- Governed authority route families now fail safer by removing browser authority/session transport headers before least-privilege server-derived Gateway headers are applied.

## Remaining work on #436

- production IdP/session authority selection and approval;
- issuer/audience/token-claim verification;
- managed key discovery/rotation;
- revocation/logout/expiry verification;
- entitlement-denied browser proof;
- exact-main consumer certification and wiki publication after merge.