### PR TITLE
chore(lint): add React Compiler hook inventory gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,10 @@ http://workbench.dev.lotus/data-products
 - `make install`
   install dependencies
 - `make lint`
-  lint the Next.js app
+  run the flat ESLint gate across the repository, including Next/Core Web Vitals and stable React
+  Hooks correctness rules for production app source
+- `npm run lint:react-compiler`
+  report-only React Compiler compatibility lint inventory for production app source
 - `make typecheck`
   TypeScript typecheck
 - `make test-coverage`

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -401,7 +401,12 @@ Important validation expectations:
 1. unit and integration behavior is validated through Vitest coverage,
 2. dependency security rejects high/critical findings across the complete graph and
    moderate-or-higher findings in browser-delivered production dependencies,
-3. browser smoke is validated through Playwright,
+3. `npm run lint` uses the flat ESLint CLI gate with stable React Hooks correctness rules
+   (`rules-of-hooks` and `exhaustive-deps`) for source files. `npm run lint:react-compiler` is a
+   separate report-only evaluator for the broader `eslint-plugin-react-hooks` recommended rule set,
+   including React Compiler compatibility rules; do not promote it to blocking until the current
+   finding families are refactored and the governance test/context are updated,
+4. browser smoke is validated through Playwright,
 4. Docker and build validation remain part of the merge gate,
 4. canonical live validation matters when a change affects integrated product flows,
 5. `-RequireMainlineSources` is required for mainline/RFC certification: ordinary canonical and

--- a/eslint.react-compiler.config.mjs
+++ b/eslint.react-compiler.config.mjs
@@ -1,0 +1,15 @@
+import baseConfig from "./eslint.config.mjs";
+import reactHooks from "eslint-plugin-react-hooks";
+
+export default [
+  ...baseConfig,
+  {
+    files: ["src/**/*.{js,jsx,mjs,cjs,ts,tsx}"],
+    plugins: {
+      "react-hooks": reactHooks,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
+    "lint:react-compiler": "eslint src --config eslint.react-compiler.config.mjs --max-warnings=0",
     "security:audit": "npm audit --audit-level=high && npm audit --omit=dev --audit-level=moderate",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/tests/unit/dependency-security-governance.test.ts
+++ b/tests/unit/dependency-security-governance.test.ts
@@ -13,7 +13,7 @@ function hasExactLine(source: string, expectedLine: string): boolean {
 }
 
 describe("dependency security governance", () => {
-  it("preserves React Hooks linting under the flat ESLint CLI gate", () => {
+  it("preserves stable React Hooks linting under the flat ESLint CLI gate", () => {
     const packageJson = JSON.parse(readRepositoryFile("package.json")) as {
       devDependencies?: Record<string, string>;
       scripts?: Record<string, string>;
@@ -33,6 +33,24 @@ describe("dependency security governance", () => {
     expect(eslintConfig).toContain("...stableReactHooksRules");
     expect(eslintConfig).toContain('files: ["src/**/*.{js,jsx,mjs,cjs,ts,tsx}"]');
     expect(eslintConfig).toContain("intentionalUnusedValuePattern");
+  });
+
+  it("keeps React Compiler linting as an explicit report-only evaluator", () => {
+    const packageJson = JSON.parse(readRepositoryFile("package.json")) as {
+      scripts?: Record<string, string>;
+    };
+    const eslintConfig = readRepositoryFile("eslint.config.mjs");
+    const compilerConfig = readRepositoryFile("eslint.react-compiler.config.mjs");
+
+    expect(packageJson.scripts?.["lint:react-compiler"]).toBe(
+      "eslint src --config eslint.react-compiler.config.mjs --max-warnings=0",
+    );
+    expect(packageJson.scripts?.lint).not.toContain("react-compiler");
+    expect(eslintConfig).not.toContain("reactHooks.configs.recommended.rules,");
+    expect(compilerConfig).toContain('import baseConfig from "./eslint.config.mjs";');
+    expect(compilerConfig).toContain('import reactHooks from "eslint-plugin-react-hooks";');
+    expect(compilerConfig).toContain("...reactHooks.configs.recommended.rules");
+    expect(compilerConfig).toContain('files: ["src/**/*.{js,jsx,mjs,cjs,ts,tsx}"]');
   });
 
   it("keeps lint scope broad enough for source, tests, scripts, and configuration", () => {

--- a/wiki/Development-Workflow.md
+++ b/wiki/Development-Workflow.md
@@ -12,6 +12,10 @@
   Runs `eslint . --max-warnings=0` through the repository flat ESLint configuration. The gate scans
   application source, tests, live validators, scripts, and configuration files while keeping
   Next/Core Web Vitals and stable React Hooks correctness rules scoped to production app source.
+- `npm run lint:react-compiler`
+  Runs the broader `eslint-plugin-react-hooks` recommended rule set against `src/` as an explicit
+  report-only evaluator for React Compiler compatibility. It is not part of `make check` until the
+  current finding families are refactored and promoted through a focused issue.
 - `make typecheck`
 - `make test-coverage`
 - `make test-e2e`

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -47,8 +47,12 @@ concurrency group.
   app source keeps the direct Next, Core Web Vitals, TypeScript, and stable React Hooks correctness
   rules; tests, live validators, scripts, and configuration files are scanned by the shared
   TypeScript/JavaScript policy. Deprecated `next lint` and `eslint-config-next` are not part of the
-  governed gate. React Compiler lint-rule adoption remains separate under the dedicated follow-up
-  issue.
+  governed gate.
+- `npm run lint:react-compiler`
+  runs the broader `eslint-plugin-react-hooks` recommended rule set against `src/` as an explicit
+  report-only React Compiler compatibility evaluator. It is not part of `make check`, Feature Lane,
+  PR Merge Gate, or Main Releasability until its finding families are refactored and promoted by a
+  focused governance change. Running the evaluator does not enable the React Compiler runtime.
 - `make build`
   runs `next build` after the repository-owned lint and typecheck gates in `make check`. Workbench
   does not rely on Next's duplicate build-time ESLint integration as the lint authority.


### PR DESCRIPTION
## Summary

Closes #503.

This PR turns the React Compiler hook-rule review into durable Workbench tooling instead of a chat-only evaluation:

- adds `eslint.react-compiler.config.mjs` and `npm run lint:react-compiler` as an explicit report-only evaluator over `src/`;
- preserves the existing blocking `npm run lint` lane with stable React Hooks correctness rules (`rules-of-hooks` and `exhaustive-deps`);
- adds governance tests proving the blocking lint lane and report-only compiler evaluator stay distinct;
- updates README, repository context, and repo-authored wiki source with the developer-workflow truth.

## Evaluation result

Current report-only React Compiler lint inventory:

- 504 source files scanned
- 28 findings total
- 25 `react-hooks/set-state-in-effect`
- 1 `react-hooks/immutability`
- 1 `react-hooks/refs`
- 1 `react-hooks/incompatible-library`

Follow-up refactor issues:

- #506 — set-state-in-effect refactor family
- #507 — render-purity/ref-access family
- #508 — React Hook Form watch compatibility

Keep #506, #507, and #508 open. This PR does not enable the React Compiler runtime and does not promote the compiler lint evaluator into `make check`.

## Validation

- [x] `npm run test -- --run tests/unit/dependency-security-governance.test.ts`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `make check`
- [x] `git diff --check`
- [x] `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench -AllowUnpublishedSourceChanges` returned expected branch-local DiffCount 2 because this PR changes repo-authored wiki source.