### PR TITLE
Fix React Compiler hook findings

### DIFF
--- a/src/apps/performance/components/performance-analysis-control-bar.tsx
+++ b/src/apps/performance/components/performance-analysis-control-bar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { FormEvent, ReactNode } from "react";
-import { useEffect, useState } from "react";
 import { TextField } from "@mui/material";
 
 import {
@@ -10,6 +9,7 @@ import {
   Text,
   WorkbenchSegmentedControl,
 } from "@/design-system";
+import { useClientMounted } from "@/design-system/hooks/use-client-mounted";
 import { lotusThemeTokens } from "@/design-system/theme/tokens";
 import type { PerformanceBenchmarkOptionView } from "@/features/workbench/types";
 
@@ -65,11 +65,7 @@ export default function PerformanceAnalysisControlBar({
   onToDateChange,
   onChartViewModeChange,
 }: PerformanceAnalysisControlBarProps) {
-  const [isHydrated, setIsHydrated] = useState(false);
-
-  useEffect(() => {
-    setIsHydrated(true);
-  }, []);
+  const isHydrated = useClientMounted();
 
   if (!isHydrated) {
     return (

--- a/src/apps/performance/components/performance-chart-panel.tsx
+++ b/src/apps/performance/components/performance-chart-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, useMemo, useState } from "react";
 
 import {
   WorkbenchChartShell,
@@ -42,6 +42,13 @@ import {
   type PerformanceChartViewMode,
   type PerformanceControlPatch,
 } from "./performance-chart-panel-helpers";
+
+type ExplicitDateDraft = {
+  sourceStartDate: string;
+  sourceEndDate: string;
+  fromDate: string;
+  toDate: string;
+};
 
 export default function PerformanceChartPanel({
   title,
@@ -90,32 +97,37 @@ export default function PerformanceChartPanel({
     () => resolveReportDates(points, reportStartDate, reportEndDate),
     [points, reportEndDate, reportStartDate]
   );
-  const [fromDate, setFromDate] = useState(resolvedReportDates.startDate);
-  const [toDate, setToDate] = useState(resolvedReportDates.endDate);
+  const [dateDraft, setDateDraft] = useState<ExplicitDateDraft>({
+    sourceStartDate: resolvedReportDates.startDate,
+    sourceEndDate: resolvedReportDates.endDate,
+    fromDate: resolvedReportDates.startDate,
+    toDate: resolvedReportDates.endDate,
+  });
+  const activeDateDraft =
+    dateDraft.sourceStartDate === resolvedReportDates.startDate &&
+    dateDraft.sourceEndDate === resolvedReportDates.endDate
+      ? dateDraft
+      : {
+          sourceStartDate: resolvedReportDates.startDate,
+          sourceEndDate: resolvedReportDates.endDate,
+          fromDate: resolvedReportDates.startDate,
+          toDate: resolvedReportDates.endDate,
+        };
+  const fromDate = activeDateDraft.fromDate;
+  const toDate = activeDateDraft.toDate;
   const hasBenchmarkSeries = hasBenchmarkReturnSeries(points);
   const hasActiveSeries = hasActiveReturnSeries(points);
-  const [chartViewMode, setChartViewMode] = useState<PerformanceChartViewMode>(
+  const [preferredChartViewMode, setPreferredChartViewMode] = useState<PerformanceChartViewMode>(
     resolveChartViewMode({
       hasBenchmarkSeries,
       hasActiveSeries,
     })
   );
-
-  useEffect(() => {
-    setFromDate(resolvedReportDates.startDate);
-    setToDate(resolvedReportDates.endDate);
-  }, [resolvedReportDates.endDate, resolvedReportDates.startDate]);
-
-  useEffect(() => {
-    const resolvedMode = resolveChartViewMode({
-      preferredMode: chartViewMode,
-      hasBenchmarkSeries,
-      hasActiveSeries,
-    });
-    if (resolvedMode !== chartViewMode) {
-      setChartViewMode(resolvedMode);
-    }
-  }, [chartViewMode, hasActiveSeries, hasBenchmarkSeries]);
+  const chartViewMode = resolveChartViewMode({
+    preferredMode: preferredChartViewMode,
+    hasBenchmarkSeries,
+    hasActiveSeries,
+  });
   const resolvedBenchmarkOptions = useMemo(
     () => buildResolvedBenchmarkOptions({ benchmark, benchmarkOptions }),
     [benchmark, benchmarkOptions]
@@ -171,6 +183,20 @@ export default function PerformanceChartPanel({
       period: "EXPLICIT",
       reportStartDate: fromDate,
       reportEndDate: toDate,
+    });
+  }
+
+  function updateFromDate(value: string) {
+    setDateDraft({
+      ...activeDateDraft,
+      fromDate: value,
+    });
+  }
+
+  function updateToDate(value: string) {
+    setDateDraft({
+      ...activeDateDraft,
+      toDate: value,
     });
   }
 
@@ -243,9 +269,9 @@ export default function PerformanceChartPanel({
           isUpdating={isUpdating}
           onRequestChange={updateSelection}
           onApplyExplicitDates={applyExplicitDates}
-          onFromDateChange={setFromDate}
-          onToDateChange={setToDate}
-          onChartViewModeChange={setChartViewMode}
+          onFromDateChange={updateFromDate}
+          onToDateChange={updateToDate}
+          onChartViewModeChange={setPreferredChartViewMode}
         />
       }
       loadingState={

--- a/src/apps/performance/components/performance-chart-panel.tsx
+++ b/src/apps/performance/components/performance-chart-panel.tsx
@@ -50,28 +50,7 @@ type ExplicitDateDraft = {
   toDate: string;
 };
 
-export default function PerformanceChartPanel({
-  title,
-  points,
-  summary,
-  portfolioId,
-  period,
-  detailBasis,
-  contributionDimension,
-  attributionDimension,
-  chartFrequency,
-  benchmark,
-  benchmarkOptions = [],
-  moneyWeightedReturn,
-  reportingCurrency,
-  reportStartDate,
-  reportEndDate,
-  capabilities,
-  onRequestChange,
-  isUpdating = false,
-  isDetailsPending = false,
-  id,
-}: {
+type PerformanceChartPanelProps = {
   title: string;
   points: PerformanceChartPoint[];
   summary: ComparativeSummary;
@@ -92,11 +71,48 @@ export default function PerformanceChartPanel({
   isUpdating?: boolean;
   isDetailsPending?: boolean;
   id?: string;
-}) {
+};
+
+type ResolvedReportDates = ReturnType<typeof resolveReportDates>;
+
+export default function PerformanceChartPanel(props: PerformanceChartPanelProps) {
   const resolvedReportDates = useMemo(
-    () => resolveReportDates(points, reportStartDate, reportEndDate),
-    [points, reportEndDate, reportStartDate]
+    () => resolveReportDates(props.points, props.reportStartDate, props.reportEndDate),
+    [props.points, props.reportEndDate, props.reportStartDate]
   );
+
+  return (
+    <PerformanceChartPanelBody
+      key={`${resolvedReportDates.startDate}|${resolvedReportDates.endDate}`}
+      {...props}
+      resolvedReportDates={resolvedReportDates}
+    />
+  );
+}
+
+function PerformanceChartPanelBody({
+  title,
+  points,
+  summary,
+  portfolioId,
+  period,
+  detailBasis,
+  contributionDimension,
+  attributionDimension,
+  chartFrequency,
+  benchmark,
+  benchmarkOptions = [],
+  moneyWeightedReturn,
+  reportingCurrency,
+  reportStartDate,
+  reportEndDate,
+  capabilities,
+  onRequestChange,
+  isUpdating = false,
+  isDetailsPending = false,
+  id,
+  resolvedReportDates,
+}: PerformanceChartPanelProps & { resolvedReportDates: ResolvedReportDates }) {
   const [dateDraft, setDateDraft] = useState<ExplicitDateDraft>({
     sourceStartDate: resolvedReportDates.startDate,
     sourceEndDate: resolvedReportDates.endDate,

--- a/src/apps/performance/components/performance-multi-horizon-panel.tsx
+++ b/src/apps/performance/components/performance-multi-horizon-panel.tsx
@@ -95,6 +95,11 @@ export default function PerformanceMultiHorizonPanel({
     period,
     selectedPeriodRow,
   });
+  const hasRelativeVisual = (rows ?? []).some(
+    (row) => row.active_return_pct != null || row.cumulative_active_return_pct != null
+  );
+  const resolvedVisualMode =
+    visualMode === "relative" && !hasRelativeVisual ? "absolute" : visualMode;
   const tableModel = useMemo(() => {
     return buildPerformanceHorizonTableModel({
       rows: rows ?? [],
@@ -109,19 +114,10 @@ export default function PerformanceMultiHorizonPanel({
       buildPerformanceHorizonVisualModel({
         rows: rows ?? [],
         basisView,
-        visualMode,
+        visualMode: resolvedVisualMode,
       }),
-    [basisView, rows, visualMode]
+    [basisView, resolvedVisualMode, rows]
   );
-  const hasRelativeVisual = (rows ?? []).some(
-    (row) => row.active_return_pct != null || row.cumulative_active_return_pct != null
-  );
-
-  useEffect(() => {
-    if (visualMode === "relative" && !hasRelativeVisual) {
-      setVisualMode("absolute");
-    }
-  }, [hasRelativeVisual, visualMode]);
 
   return (
     <PerformanceSummaryDriverModule
@@ -156,7 +152,7 @@ export default function PerformanceMultiHorizonPanel({
             <PerformanceHorizonComparisonToolbar
               tableView={tableView}
               basisView={basisView}
-              visualMode={visualMode}
+              visualMode={resolvedVisualMode}
               hasRelativeVisual={hasRelativeVisual}
               onTableViewChange={setTableView}
               onBasisViewChange={setBasisView}
@@ -164,7 +160,7 @@ export default function PerformanceMultiHorizonPanel({
             />
           </div>
           <div className="performance-horizon-panel-body">
-            <PerformanceHorizonComparisonMatrix cards={visualCards} visualMode={visualMode} />
+            <PerformanceHorizonComparisonMatrix cards={visualCards} visualMode={resolvedVisualMode} />
             <PerformanceHorizonComparisonDisclosure tableModel={tableModel} />
           </div>
         </>

--- a/src/apps/performance/components/performance-risk-mode.tsx
+++ b/src/apps/performance/components/performance-risk-mode.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import {
   ScreenStatePanel,
@@ -25,6 +25,13 @@ import RiskSnapshotPanel from "./risk/risk-snapshot-panel";
 import RiskStatusBar from "./risk/risk-status-bar";
 import RiskSupportabilityPanel from "./risk/risk-supportability-panel";
 
+type RiskDrawerState = {
+  contextKey: string;
+  underwaterDrawerOpen: boolean;
+  rollingDrawerOpen: boolean;
+  selectedRollingWindowKey: string;
+};
+
 export default function PerformanceRiskMode({
   workspace,
   period,
@@ -38,9 +45,28 @@ export default function PerformanceRiskMode({
     detailBasis,
     benchmark: workspace.benchmark_code ?? undefined,
   });
-  const [underwaterDrawerOpen, setUnderwaterDrawerOpen] = useState(false);
-  const [rollingDrawerOpen, setRollingDrawerOpen] = useState(false);
-  const [selectedRollingWindowKey, setSelectedRollingWindowKey] = useState("");
+  const riskContextKey = [
+    workspace.portfolio.portfolio_id,
+    workspace.as_of_date,
+    workspace.benchmark_code ?? "",
+    period,
+    detailBasis,
+  ].join("|");
+  const [drawerState, setDrawerState] = useState<RiskDrawerState>({
+    contextKey: riskContextKey,
+    underwaterDrawerOpen: false,
+    rollingDrawerOpen: false,
+    selectedRollingWindowKey: "",
+  });
+  const activeDrawerState =
+    drawerState.contextKey === riskContextKey
+      ? drawerState
+      : {
+          contextKey: riskContextKey,
+          underwaterDrawerOpen: false,
+          rollingDrawerOpen: false,
+          selectedRollingWindowKey: "",
+        };
   const {
     riskSummary,
     riskConcentration,
@@ -62,12 +88,6 @@ export default function PerformanceRiskMode({
     detailBasis,
     isDetailsPending,
   });
-
-  useEffect(() => {
-    setUnderwaterDrawerOpen(false);
-    setRollingDrawerOpen(false);
-    setSelectedRollingWindowKey("");
-  }, [detailBasis, period, workspace.as_of_date, workspace.benchmark_code, workspace.portfolio.portfolio_id]);
 
   const viewModel = buildPerformanceRiskViewModel({
     workspace,
@@ -103,7 +123,7 @@ export default function PerformanceRiskMode({
     ) : null;
 
   const resolvedSelectedRollingWindowKey =
-    viewModel.rollingWindows.find((window) => window.key === selectedRollingWindowKey)?.key ??
+    viewModel.rollingWindows.find((window) => window.key === activeDrawerState.selectedRollingWindowKey)?.key ??
     viewModel.rollingWindows[0]?.key ??
     "";
   const selectedRollingWindow =
@@ -140,7 +160,10 @@ export default function PerformanceRiskMode({
               <RiskDrawdownPanel
                 viewModel={viewModel}
                 onViewUnderwater={() => {
-                  setUnderwaterDrawerOpen(true);
+                  setDrawerState({
+                    ...activeDrawerState,
+                    underwaterDrawerOpen: true,
+                  });
                   requestDrawdownDetail();
                 }}
               />
@@ -152,10 +175,18 @@ export default function PerformanceRiskMode({
               <RiskRollingPanel
                 viewModel={viewModel}
                 selectedWindowKey={resolvedSelectedRollingWindowKey}
-                onWindowChange={setSelectedRollingWindowKey}
+                onWindowChange={(windowKey) =>
+                  setDrawerState({
+                    ...activeDrawerState,
+                    selectedRollingWindowKey: windowKey,
+                  })
+                }
                 onViewSeries={(windowKey) => {
-                  setSelectedRollingWindowKey(windowKey);
-                  setRollingDrawerOpen(true);
+                  setDrawerState({
+                    ...activeDrawerState,
+                    selectedRollingWindowKey: windowKey,
+                    rollingDrawerOpen: true,
+                  });
                   requestRollingDetail();
                 }}
               />
@@ -171,15 +202,25 @@ export default function PerformanceRiskMode({
         </div>
       )}
       <RiskDrawdownDetailDrawer
-        open={underwaterDrawerOpen}
+        open={activeDrawerState.underwaterDrawerOpen}
         viewModel={viewModel}
-        onClose={() => setUnderwaterDrawerOpen(false)}
+        onClose={() =>
+          setDrawerState({
+            ...activeDrawerState,
+            underwaterDrawerOpen: false,
+          })
+        }
       />
       <RiskRollingDetailDrawer
-        open={rollingDrawerOpen}
+        open={activeDrawerState.rollingDrawerOpen}
         viewModel={viewModel}
         selectedWindow={selectedRollingWindow}
-        onClose={() => setRollingDrawerOpen(false)}
+        onClose={() =>
+          setDrawerState({
+            ...activeDrawerState,
+            rollingDrawerOpen: false,
+          })
+        }
       />
     </PerformanceWorkspaceStageSurface>
   );

--- a/src/apps/performance/components/performance-risk-mode.tsx
+++ b/src/apps/performance/components/performance-risk-mode.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 
 import {
   ScreenStatePanel,
@@ -26,11 +26,18 @@ import RiskStatusBar from "./risk/risk-status-bar";
 import RiskSupportabilityPanel from "./risk/risk-supportability-panel";
 
 type RiskDrawerState = {
-  contextKey: string;
   underwaterDrawerOpen: boolean;
   rollingDrawerOpen: boolean;
   selectedRollingWindowKey: string;
 };
+
+function buildClosedRiskDrawerState(): RiskDrawerState {
+  return {
+    underwaterDrawerOpen: false,
+    rollingDrawerOpen: false,
+    selectedRollingWindowKey: "",
+  };
+}
 
 export default function PerformanceRiskMode({
   workspace,
@@ -52,21 +59,6 @@ export default function PerformanceRiskMode({
     period,
     detailBasis,
   ].join("|");
-  const [drawerState, setDrawerState] = useState<RiskDrawerState>({
-    contextKey: riskContextKey,
-    underwaterDrawerOpen: false,
-    rollingDrawerOpen: false,
-    selectedRollingWindowKey: "",
-  });
-  const activeDrawerState =
-    drawerState.contextKey === riskContextKey
-      ? drawerState
-      : {
-          contextKey: riskContextKey,
-          underwaterDrawerOpen: false,
-          rollingDrawerOpen: false,
-          selectedRollingWindowKey: "",
-        };
   const {
     riskSummary,
     riskConcentration,
@@ -122,8 +114,42 @@ export default function PerformanceRiskMode({
       />
     ) : null;
 
+  return (
+    <PerformanceRiskInteractionState
+      key={riskContextKey}
+      contextItems={contextItems}
+      modeIntro={modeIntro}
+      requestAttribution={requestAttribution}
+      requestDrawdownDetail={requestDrawdownDetail}
+      requestRollingDetail={requestRollingDetail}
+      statePanel={statePanel}
+      viewModel={viewModel}
+    />
+  );
+}
+
+function PerformanceRiskInteractionState({
+  contextItems,
+  modeIntro,
+  requestAttribution,
+  requestDrawdownDetail,
+  requestRollingDetail,
+  statePanel,
+  viewModel,
+}: {
+  contextItems: ReturnType<typeof buildPerformanceWorkspaceContextItems>;
+  modeIntro: NonNullable<ReturnType<typeof getPerformanceWorkspaceModeDefinition>["intro"]>;
+  requestAttribution: (attributionType: string, groupingDimension: string) => void;
+  requestDrawdownDetail: () => void;
+  requestRollingDetail: () => void;
+  statePanel: ReactNode;
+  viewModel: ReturnType<typeof buildPerformanceRiskViewModel>;
+}) {
+  const [drawerState, setDrawerState] = useState<RiskDrawerState>(
+    buildClosedRiskDrawerState,
+  );
   const resolvedSelectedRollingWindowKey =
-    viewModel.rollingWindows.find((window) => window.key === activeDrawerState.selectedRollingWindowKey)?.key ??
+    viewModel.rollingWindows.find((window) => window.key === drawerState.selectedRollingWindowKey)?.key ??
     viewModel.rollingWindows[0]?.key ??
     "";
   const selectedRollingWindow =
@@ -161,7 +187,7 @@ export default function PerformanceRiskMode({
                 viewModel={viewModel}
                 onViewUnderwater={() => {
                   setDrawerState({
-                    ...activeDrawerState,
+                    ...drawerState,
                     underwaterDrawerOpen: true,
                   });
                   requestDrawdownDetail();
@@ -177,13 +203,13 @@ export default function PerformanceRiskMode({
                 selectedWindowKey={resolvedSelectedRollingWindowKey}
                 onWindowChange={(windowKey) =>
                   setDrawerState({
-                    ...activeDrawerState,
+                    ...drawerState,
                     selectedRollingWindowKey: windowKey,
                   })
                 }
                 onViewSeries={(windowKey) => {
                   setDrawerState({
-                    ...activeDrawerState,
+                    ...drawerState,
                     selectedRollingWindowKey: windowKey,
                     rollingDrawerOpen: true,
                   });
@@ -202,22 +228,22 @@ export default function PerformanceRiskMode({
         </div>
       )}
       <RiskDrawdownDetailDrawer
-        open={activeDrawerState.underwaterDrawerOpen}
+        open={drawerState.underwaterDrawerOpen}
         viewModel={viewModel}
         onClose={() =>
           setDrawerState({
-            ...activeDrawerState,
+            ...drawerState,
             underwaterDrawerOpen: false,
           })
         }
       />
       <RiskRollingDetailDrawer
-        open={activeDrawerState.rollingDrawerOpen}
+        open={drawerState.rollingDrawerOpen}
         viewModel={viewModel}
         selectedWindow={selectedRollingWindow}
         onClose={() =>
           setDrawerState({
-            ...activeDrawerState,
+            ...drawerState,
             rollingDrawerOpen: false,
           })
         }

--- a/src/apps/performance/use-performance-risk-contract.ts
+++ b/src/apps/performance/use-performance-risk-contract.ts
@@ -47,6 +47,12 @@ type PerformanceRiskContractState = {
   requestRollingDetail: () => void;
 };
 
+type AttributionSelectionState = {
+  scopeKey: string;
+  attributionType: string;
+  groupingDimension: string;
+};
+
 export function usePerformanceRiskContract({
   workspace,
   period,
@@ -98,14 +104,10 @@ export function usePerformanceRiskContract({
     useState<WorkbenchRiskRollingResponse | null>(null);
   const [riskRollingDetail, setRiskRollingDetail] =
     useState<WorkbenchRiskRollingResponse | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [isAttributionLoading, setIsAttributionLoading] = useState(false);
   const [isDrawdownDetailLoading, setIsDrawdownDetailLoading] = useState(false);
   const [isRollingDetailLoading, setIsRollingDetailLoading] = useState(false);
-  const [selectedAttributionType, setSelectedAttributionType] =
-    useState("TOTAL_RISK");
-  const [selectedGroupingDimension, setSelectedGroupingDimension] =
-    useState("SECTOR");
   const riskWindowParams = useMemo(
     () =>
       period === "EXPLICIT"
@@ -117,6 +119,41 @@ export function usePerformanceRiskContract({
     [period, workspace.report_end_date, workspace.report_start_date],
   );
   const riskAsOfDate = getRiskAsOfDate(workspace);
+  const attributionScopeKey = useMemo(
+    () =>
+      JSON.stringify({
+        portfolioId: workspace.portfolio.portfolio_id,
+        period,
+        detailBasis,
+        benchmark: workspace.benchmark_code ?? null,
+        ...riskWindowParams,
+        asOfDate: riskAsOfDate,
+        reportingCurrency: workspace.portfolio.base_currency,
+      }),
+    [
+      detailBasis,
+      period,
+      riskWindowParams,
+      riskAsOfDate,
+      workspace.benchmark_code,
+      workspace.portfolio.base_currency,
+      workspace.portfolio.portfolio_id,
+    ],
+  );
+  const [attributionSelection, setAttributionSelection] =
+    useState<AttributionSelectionState>({
+      scopeKey: attributionScopeKey,
+      attributionType: "TOTAL_RISK",
+      groupingDimension: "SECTOR",
+    });
+  const selectedAttributionType =
+    attributionSelection.scopeKey === attributionScopeKey
+      ? attributionSelection.attributionType
+      : "TOTAL_RISK";
+  const selectedGroupingDimension =
+    attributionSelection.scopeKey === attributionScopeKey
+      ? attributionSelection.groupingDimension
+      : "SECTOR";
 
   useEffect(() => {
     workspaceRef.current = workspace;
@@ -257,161 +294,181 @@ export function usePerformanceRiskContract({
   );
 
   useEffect(() => {
-    if (isDetailsPending) {
-      setRiskSummary(null);
-      setRiskConcentration(null);
-      setRiskAttribution(null);
-      setRiskDrawdown(null);
-      setRiskDrawdownDetail(null);
-      setRiskRolling(null);
-      setRiskRollingDetail(null);
-      setIsLoading(true);
-      setIsAttributionLoading(false);
-      setIsDrawdownDetailLoading(false);
-      setIsRollingDetailLoading(false);
-      return;
-    }
+    let cancelled = false;
 
-    const cachedSummary = summaryCacheRef.current.get(summaryKey) ?? null;
-    const cachedConcentration =
-      concentrationCacheRef.current.get(concentrationKey) ?? null;
-    const cachedDrawdown = drawdownCacheRef.current.get(drawdownKey) ?? null;
-    const cachedRolling = rollingCacheRef.current.get(rollingKey) ?? null;
-
-    setRiskSummary(cachedSummary);
-    setRiskConcentration(cachedConcentration);
-    setRiskDrawdown(cachedDrawdown);
-    setRiskDrawdownDetail(
-      drawdownDetailCacheRef.current.get(drawdownDetailKey) ?? null,
-    );
-    setRiskRolling(cachedRolling);
-    setRiskRollingDetail(
-      rollingDetailCacheRef.current.get(rollingDetailKey) ?? null,
-    );
-
-    const needsSummary = !cachedSummary;
-    const needsConcentration = !cachedConcentration;
-    const needsDrawdown = !cachedDrawdown;
-    const needsRolling = !cachedRolling;
-    if (
-      !needsSummary &&
-      !needsConcentration &&
-      !needsDrawdown &&
-      !needsRolling
-    ) {
-      setIsLoading(false);
-      return;
-    }
-
-    const requestId = requestSequenceRef.current + 1;
-    requestSequenceRef.current = requestId;
-    setIsLoading(true);
-
-    const summaryPromise = needsSummary
-      ? getWorkbenchRiskSummaryClient(workspace.portfolio.portfolio_id, {
-          period,
-          detailBasis,
-          benchmark: workspace.benchmark_code ?? undefined,
-          ...riskWindowParams,
-          asOfDate: riskAsOfDate,
-          reportingCurrency: workspace.portfolio.base_currency,
-        }).catch((error: unknown) =>
-          buildUnavailableRiskSummary({
-            workspace: workspaceRef.current,
-            period,
-            detailBasis,
-            detail: buildRiskFetchFailureDetail(error, "Risk summary"),
-            permissionBlocked: isWorkbenchPermissionBlockedError(error),
-          }),
-        )
-      : Promise.resolve(cachedSummary);
-
-    const concentrationPromise = needsConcentration
-      ? getWorkbenchRiskConcentrationClient(workspace.portfolio.portfolio_id, {
-          period,
-          benchmark: workspace.benchmark_code ?? undefined,
-          ...riskWindowParams,
-          asOfDate: riskAsOfDate,
-          reportingCurrency: workspace.portfolio.base_currency,
-        }).catch((error: unknown) =>
-          buildUnavailableRiskConcentration({
-            workspace: workspaceRef.current,
-            period,
-            detail: buildRiskFetchFailureDetail(error, "Risk concentration"),
-            permissionBlocked: isWorkbenchPermissionBlockedError(error),
-          }),
-        )
-      : Promise.resolve(cachedConcentration);
-
-    const drawdownPromise = needsDrawdown
-      ? getWorkbenchRiskDrawdownClient(workspace.portfolio.portfolio_id, {
-          period,
-          detailBasis,
-          benchmark: workspace.benchmark_code ?? undefined,
-          ...riskWindowParams,
-          asOfDate: riskAsOfDate,
-          reportingCurrency: workspace.portfolio.base_currency,
-          includeUnderwaterSeries: false,
-        }).catch((error: unknown) =>
-          buildUnavailableRiskDrawdown({
-            workspace: workspaceRef.current,
-            period,
-            detailBasis,
-            detail: buildRiskFetchFailureDetail(error, "Risk drawdown"),
-            includeUnderwaterSeries: false,
-            permissionBlocked: isWorkbenchPermissionBlockedError(error),
-          }),
-        )
-      : Promise.resolve(cachedDrawdown);
-
-    const rollingPromise = needsRolling
-      ? getWorkbenchRiskRollingClient(workspace.portfolio.portfolio_id, {
-          period,
-          detailBasis,
-          benchmark: workspace.benchmark_code ?? undefined,
-          ...riskWindowParams,
-          asOfDate: riskAsOfDate,
-          reportingCurrency: workspace.portfolio.base_currency,
-          includeTimeSeries: false,
-        }).catch((error: unknown) =>
-          buildUnavailableRiskRolling({
-            workspace: workspaceRef.current,
-            period,
-            detailBasis,
-            detail: buildRiskFetchFailureDetail(error, "Risk rolling"),
-            includeTimeSeries: false,
-            permissionBlocked: isWorkbenchPermissionBlockedError(error),
-          }),
-        )
-      : Promise.resolve(cachedRolling);
-
-    void Promise.all([
-      summaryPromise,
-      concentrationPromise,
-      drawdownPromise,
-      rollingPromise,
-    ]).then(([nextSummary, nextConcentration, nextDrawdown, nextRolling]) => {
-      if (requestSequenceRef.current !== requestId) {
+    void Promise.resolve().then(() => {
+      if (cancelled) {
         return;
       }
-      if (nextSummary) {
-        summaryCacheRef.current.set(summaryKey, nextSummary);
-        setRiskSummary(nextSummary);
+      if (isDetailsPending) {
+        setRiskSummary(null);
+        setRiskConcentration(null);
+        setRiskAttribution(null);
+        setRiskDrawdown(null);
+        setRiskDrawdownDetail(null);
+        setRiskRolling(null);
+        setRiskRollingDetail(null);
+        setIsLoading(true);
+        setIsAttributionLoading(false);
+        setIsDrawdownDetailLoading(false);
+        setIsRollingDetailLoading(false);
+        return;
       }
-      if (nextConcentration) {
-        concentrationCacheRef.current.set(concentrationKey, nextConcentration);
-        setRiskConcentration(nextConcentration);
+
+      const cachedSummary = summaryCacheRef.current.get(summaryKey) ?? null;
+      const cachedConcentration =
+        concentrationCacheRef.current.get(concentrationKey) ?? null;
+      const cachedDrawdown = drawdownCacheRef.current.get(drawdownKey) ?? null;
+      const cachedRolling = rollingCacheRef.current.get(rollingKey) ?? null;
+
+      setRiskSummary(cachedSummary);
+      setRiskConcentration(cachedConcentration);
+      setRiskDrawdown(cachedDrawdown);
+      setRiskDrawdownDetail(
+        drawdownDetailCacheRef.current.get(drawdownDetailKey) ?? null,
+      );
+      setRiskRolling(cachedRolling);
+      setRiskRollingDetail(
+        rollingDetailCacheRef.current.get(rollingDetailKey) ?? null,
+      );
+
+      const needsSummary = !cachedSummary;
+      const needsConcentration = !cachedConcentration;
+      const needsDrawdown = !cachedDrawdown;
+      const needsRolling = !cachedRolling;
+      if (
+        !needsSummary &&
+        !needsConcentration &&
+        !needsDrawdown &&
+        !needsRolling
+      ) {
+        setIsLoading(false);
+        return;
       }
-      if (nextDrawdown) {
-        drawdownCacheRef.current.set(drawdownKey, nextDrawdown);
-        setRiskDrawdown(nextDrawdown);
-      }
-      if (nextRolling) {
-        rollingCacheRef.current.set(rollingKey, nextRolling);
-        setRiskRolling(nextRolling);
-      }
-      setIsLoading(false);
+
+      const requestId = requestSequenceRef.current + 1;
+      requestSequenceRef.current = requestId;
+      setIsLoading(true);
+
+      const summaryPromise = needsSummary
+        ? getWorkbenchRiskSummaryClient(workspace.portfolio.portfolio_id, {
+            period,
+            detailBasis,
+            benchmark: workspace.benchmark_code ?? undefined,
+            ...riskWindowParams,
+            asOfDate: riskAsOfDate,
+            reportingCurrency: workspace.portfolio.base_currency,
+          }).catch((error: unknown) =>
+            buildUnavailableRiskSummary({
+              workspace: workspaceRef.current,
+              period,
+              detailBasis,
+              detail: buildRiskFetchFailureDetail(error, "Risk summary"),
+              permissionBlocked: isWorkbenchPermissionBlockedError(error),
+            }),
+          )
+        : Promise.resolve(cachedSummary);
+
+      const concentrationPromise = needsConcentration
+        ? getWorkbenchRiskConcentrationClient(
+            workspace.portfolio.portfolio_id,
+            {
+              period,
+              benchmark: workspace.benchmark_code ?? undefined,
+              ...riskWindowParams,
+              asOfDate: riskAsOfDate,
+              reportingCurrency: workspace.portfolio.base_currency,
+            },
+          ).catch((error: unknown) =>
+            buildUnavailableRiskConcentration({
+              workspace: workspaceRef.current,
+              period,
+              detail: buildRiskFetchFailureDetail(
+                error,
+                "Risk concentration",
+              ),
+              permissionBlocked: isWorkbenchPermissionBlockedError(error),
+            }),
+          )
+        : Promise.resolve(cachedConcentration);
+
+      const drawdownPromise = needsDrawdown
+        ? getWorkbenchRiskDrawdownClient(workspace.portfolio.portfolio_id, {
+            period,
+            detailBasis,
+            benchmark: workspace.benchmark_code ?? undefined,
+            ...riskWindowParams,
+            asOfDate: riskAsOfDate,
+            reportingCurrency: workspace.portfolio.base_currency,
+            includeUnderwaterSeries: false,
+          }).catch((error: unknown) =>
+            buildUnavailableRiskDrawdown({
+              workspace: workspaceRef.current,
+              period,
+              detailBasis,
+              detail: buildRiskFetchFailureDetail(error, "Risk drawdown"),
+              includeUnderwaterSeries: false,
+              permissionBlocked: isWorkbenchPermissionBlockedError(error),
+            }),
+          )
+        : Promise.resolve(cachedDrawdown);
+
+      const rollingPromise = needsRolling
+        ? getWorkbenchRiskRollingClient(workspace.portfolio.portfolio_id, {
+            period,
+            detailBasis,
+            benchmark: workspace.benchmark_code ?? undefined,
+            ...riskWindowParams,
+            asOfDate: riskAsOfDate,
+            reportingCurrency: workspace.portfolio.base_currency,
+            includeTimeSeries: false,
+          }).catch((error: unknown) =>
+            buildUnavailableRiskRolling({
+              workspace: workspaceRef.current,
+              period,
+              detailBasis,
+              detail: buildRiskFetchFailureDetail(error, "Risk rolling"),
+              includeTimeSeries: false,
+              permissionBlocked: isWorkbenchPermissionBlockedError(error),
+            }),
+          )
+        : Promise.resolve(cachedRolling);
+
+      void Promise.all([
+        summaryPromise,
+        concentrationPromise,
+        drawdownPromise,
+        rollingPromise,
+      ]).then(([nextSummary, nextConcentration, nextDrawdown, nextRolling]) => {
+        if (cancelled || requestSequenceRef.current !== requestId) {
+          return;
+        }
+        if (nextSummary) {
+          summaryCacheRef.current.set(summaryKey, nextSummary);
+          setRiskSummary(nextSummary);
+        }
+        if (nextConcentration) {
+          concentrationCacheRef.current.set(
+            concentrationKey,
+            nextConcentration,
+          );
+          setRiskConcentration(nextConcentration);
+        }
+        if (nextDrawdown) {
+          drawdownCacheRef.current.set(drawdownKey, nextDrawdown);
+          setRiskDrawdown(nextDrawdown);
+        }
+        if (nextRolling) {
+          rollingCacheRef.current.set(rollingKey, nextRolling);
+          setRiskRolling(nextRolling);
+        }
+        setIsLoading(false);
+      });
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     concentrationKey,
     detailBasis,
@@ -455,19 +512,6 @@ export function usePerformanceRiskContract({
     ],
   );
 
-  useEffect(() => {
-    setSelectedAttributionType("TOTAL_RISK");
-    setSelectedGroupingDimension("SECTOR");
-    setRiskAttribution(null);
-    setIsAttributionLoading(false);
-  }, [
-    detailBasis,
-    period,
-    riskAsOfDate,
-    workspace.benchmark_code,
-    workspace.portfolio.portfolio_id,
-  ]);
-
   const requestAttribution = (
     attributionType: string,
     groupingDimension: string,
@@ -475,8 +519,11 @@ export function usePerformanceRiskContract({
     if (isDetailsPending) {
       return;
     }
-    setSelectedAttributionType(attributionType);
-    setSelectedGroupingDimension(groupingDimension);
+    setAttributionSelection({
+      scopeKey: attributionScopeKey,
+      attributionType,
+      groupingDimension,
+    });
   };
 
   useEffect(() => {

--- a/src/apps/portfolio/components/portfolio-allocation-visuals.tsx
+++ b/src/apps/portfolio/components/portfolio-allocation-visuals.tsx
@@ -48,7 +48,33 @@ export function AllocationDonutChart({
   onHover: (bucket: string | null) => void;
   onSelect: (bucket: string) => void;
 }) {
-  let cumulativeAngle = -90;
+  const allocationArcs = buckets.reduce<
+    Array<{
+      bucket: PortfolioAllocationView["buckets"][number];
+      index: number;
+      startAngle: number;
+      endAngle: number;
+      path: string;
+    }>
+  >((arcs, bucket, index) => {
+    const previousArc = arcs[arcs.length - 1];
+    const startAngle = previousArc ? previousArc.endAngle : -90;
+    const portion =
+      totalWeight > 0
+        ? Math.max(bucket.weight_pct ?? 0, 0) / totalWeight
+        : 0;
+    const endAngle = startAngle + portion * 360;
+    return [
+      ...arcs,
+      {
+        bucket,
+        index,
+        startAngle,
+        endAngle,
+        path: describeAllocationArc(110, 110, 86, 58, startAngle, endAngle),
+      },
+    ];
+  }, []);
 
   return (
     <div
@@ -63,22 +89,7 @@ export function AllocationDonutChart({
           r="58"
           className="portfolio-allocation-chart-track"
         />
-        {buckets.map((bucket, index) => {
-          const portion =
-            totalWeight > 0
-              ? Math.max(bucket.weight_pct ?? 0, 0) / totalWeight
-              : 0;
-          const startAngle = cumulativeAngle;
-          const endAngle = startAngle + portion * 360;
-          cumulativeAngle = endAngle;
-          const path = describeAllocationArc(
-            110,
-            110,
-            86,
-            58,
-            startAngle,
-            endAngle,
-          );
+        {allocationArcs.map(({ bucket, index, path }) => {
           const isHovered = hoveredBucket === bucket.bucket;
           const isSelected = selectedBucket === bucket.bucket;
           return (

--- a/src/apps/portfolio/components/portfolio-transactions-grid.tsx
+++ b/src/apps/portfolio/components/portfolio-transactions-grid.tsx
@@ -56,6 +56,17 @@ type PortfolioTransactionsGridProps = {
   onRowSelect?: (row: TransactionRow) => void;
 };
 
+type TransactionDateDraft = {
+  defaultDateKey: string;
+  startDate: string;
+  endDate: string;
+};
+
+type TransactionPageDraft = {
+  pageScopeKey: string;
+  pageSkip: number;
+};
+
 export default function PortfolioTransactionsGrid({
   portfolioId,
   baseCurrency,
@@ -71,31 +82,40 @@ export default function PortfolioTransactionsGrid({
 }: PortfolioTransactionsGridProps) {
   const [transactionType, setTransactionType] = useState("ALL");
   const [componentType, setComponentType] = useState("ALL");
-  const [startDate, setStartDate] = useState(defaultStartDate);
-  const [endDate, setEndDate] = useState(defaultEndDate);
+  const defaultDateKey = `${defaultStartDate}|${defaultEndDate}`;
+  const [dateDraft, setDateDraft] = useState<TransactionDateDraft>({
+    defaultDateKey,
+    startDate: defaultStartDate,
+    endDate: defaultEndDate,
+  });
+  const activeDateDraft =
+    dateDraft.defaultDateKey === defaultDateKey
+      ? dateDraft
+      : {
+          defaultDateKey,
+          startDate: defaultStartDate,
+          endDate: defaultEndDate,
+        };
+  const startDate = activeDateDraft.startDate;
+  const endDate = activeDateDraft.endDate;
   const [transactions, setTransactions] = useState<PortfolioTransactionView[]>(initialTransactions);
   const [ledgerPage, setLedgerPage] = useState<PortfolioTransactionLedgerPage>(() => ({
     total: initialLedgerPage?.total ?? initialTransactions.length,
     skip: initialLedgerPage?.skip ?? 0,
     limit: initialLedgerPage?.limit ?? 200,
   }));
-  const [pageSkip, setPageSkip] = useState(initialLedgerPage?.skip ?? 0);
+  const pageScopeKey = `${portfolioId}|${defaultDateKey}|${JSON.stringify(externalFilter ?? null)}`;
+  const [pageDraft, setPageDraft] = useState<TransactionPageDraft>({
+    pageScopeKey,
+    pageSkip: initialLedgerPage?.skip ?? 0,
+  });
+  const pageSkip = pageDraft.pageScopeKey === pageScopeKey ? pageDraft.pageSkip : 0;
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState(false);
   const [showFilters, setShowFilters] = useState(true);
   const [showExpandedColumns, setShowExpandedColumns] = useState(false);
   const [quickSearch, setQuickSearch] = useState("");
   const gridDensity = showExpandedColumns ? "expanded" : "essential";
-
-  useEffect(() => {
-    setStartDate(defaultStartDate);
-    setEndDate(defaultEndDate);
-    setPageSkip(0);
-  }, [defaultEndDate, defaultStartDate]);
-
-  useEffect(() => {
-    setPageSkip(0);
-  }, [externalFilter, portfolioId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -404,7 +424,7 @@ export default function PortfolioTransactionsGrid({
                 inputProps={{ "aria-label": "Transaction type filter" }}
                 onChange={(event) => {
                   setTransactionType(event.target.value);
-                  setPageSkip(0);
+                  setPageDraft({ pageScopeKey, pageSkip: 0 });
                 }}
               >
                 {transactionTypeOptions.map((option) => (
@@ -423,7 +443,7 @@ export default function PortfolioTransactionsGrid({
                 inputProps={{ "aria-label": "Transaction component type filter" }}
                 onChange={(event) => {
                   setComponentType(event.target.value);
-                  setPageSkip(0);
+                  setPageDraft({ pageScopeKey, pageSkip: 0 });
                 }}
               >
                 {componentTypeOptions.map((option) => (
@@ -440,8 +460,11 @@ export default function PortfolioTransactionsGrid({
               value={startDate}
               inputProps={{ "aria-label": "Transaction start date" }}
               onChange={(event) => {
-                setStartDate(event.target.value);
-                setPageSkip(0);
+                setDateDraft({
+                  ...activeDateDraft,
+                  startDate: event.target.value,
+                });
+                setPageDraft({ pageScopeKey, pageSkip: 0 });
               }}
               InputLabelProps={{ shrink: true }}
             />
@@ -452,8 +475,11 @@ export default function PortfolioTransactionsGrid({
               value={endDate}
               inputProps={{ "aria-label": "Transaction end date" }}
               onChange={(event) => {
-                setEndDate(event.target.value);
-                setPageSkip(0);
+                setDateDraft({
+                  ...activeDateDraft,
+                  endDate: event.target.value,
+                });
+                setPageDraft({ pageScopeKey, pageSkip: 0 });
               }}
               InputLabelProps={{ shrink: true }}
             />
@@ -537,7 +563,12 @@ export default function PortfolioTransactionsGrid({
               size="small"
               variant="outlined"
               disabled={!hasPreviousPage || loading}
-              onClick={() => setPageSkip(Math.max(0, ledgerPage.skip - ledgerPage.limit))}
+              onClick={() =>
+                setPageDraft({
+                  pageScopeKey,
+                  pageSkip: Math.max(0, ledgerPage.skip - ledgerPage.limit),
+                })
+              }
             >
               Previous entries
             </Button>
@@ -545,7 +576,12 @@ export default function PortfolioTransactionsGrid({
               size="small"
               variant="outlined"
               disabled={!hasNextPage || loading}
-              onClick={() => setPageSkip(ledgerPage.skip + ledgerPage.limit)}
+              onClick={() =>
+                setPageDraft({
+                  pageScopeKey,
+                  pageSkip: ledgerPage.skip + ledgerPage.limit,
+                })
+              }
             >
               Next entries
             </Button>

--- a/src/apps/portfolio/components/portfolio-transactions-grid.tsx
+++ b/src/apps/portfolio/components/portfolio-transactions-grid.tsx
@@ -67,7 +67,18 @@ type TransactionPageDraft = {
   pageSkip: number;
 };
 
-export default function PortfolioTransactionsGrid({
+export default function PortfolioTransactionsGrid(props: PortfolioTransactionsGridProps) {
+  const defaultDateKey = `${props.defaultStartDate}|${props.defaultEndDate}`;
+
+  return (
+    <PortfolioTransactionsGridBody
+      key={`${props.portfolioId}|${defaultDateKey}|${JSON.stringify(props.externalFilter ?? null)}`}
+      {...props}
+    />
+  );
+}
+
+function PortfolioTransactionsGridBody({
   portfolioId,
   baseCurrency,
   asOfDate,

--- a/src/apps/portfolio/components/portfolio-workspace-client.tsx
+++ b/src/apps/portfolio/components/portfolio-workspace-client.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   WorkbenchToolbarPlaceholder,
 } from "@/design-system";
+import { useClientMounted } from "@/design-system/hooks/use-client-mounted";
 
 import {
   getPortfolioWorkspaceShell,
@@ -39,6 +40,11 @@ const shellInflightRequests = new Map<
   ReturnType<typeof getPortfolioWorkspaceShell>
 >();
 
+type WorkspaceStateDraft = {
+  sourceKey: string;
+  workspace: PortfolioWorkspace | null;
+};
+
 export default function PortfolioWorkspaceClient({
   portfolios,
   selectedPortfolioId,
@@ -51,22 +57,49 @@ export default function PortfolioWorkspaceClient({
   const [controls, setControls] = useState<PortfolioWorkspaceControls>(
     buildInitialPortfolioControls(initialWorkspace)
   );
-  const [workspaceState, setWorkspaceState] = useState<PortfolioWorkspace | null>(initialWorkspace);
-  const [interactiveReady, setInteractiveReady] = useState(false);
+  const initialWorkspaceSourceKey = [
+    selectedPortfolioId ?? "",
+    initialWorkspace?.portfolio.portfolio_id ?? "",
+    initialWorkspace?.as_of_date ?? "",
+    initialWorkspace?.portfolio.base_currency ?? "",
+    initialWorkspace?.positions.length ?? 0,
+    initialWorkspace?.recent_transactions.length ?? 0,
+  ].join("|");
+  const [workspaceDraft, setWorkspaceDraft] = useState<WorkspaceStateDraft>({
+    sourceKey: initialWorkspaceSourceKey,
+    workspace: initialWorkspace,
+  });
+  const workspaceState =
+    workspaceDraft.sourceKey === initialWorkspaceSourceKey
+      ? workspaceDraft.workspace
+      : initialWorkspace;
+  const setWorkspaceState = useCallback(
+    (
+      next:
+        | PortfolioWorkspace
+        | null
+        | ((current: PortfolioWorkspace | null) => PortfolioWorkspace | null),
+    ) => {
+      setWorkspaceDraft((current) => {
+        const currentWorkspace =
+          current.sourceKey === initialWorkspaceSourceKey
+            ? current.workspace
+            : initialWorkspace;
+        return {
+          sourceKey: initialWorkspaceSourceKey,
+          workspace:
+            typeof next === "function" ? next(currentWorkspace) : next,
+        };
+      });
+    },
+    [initialWorkspace, initialWorkspaceSourceKey],
+  );
+  const interactiveReady = useClientMounted();
   const summaryRequestRef = useRef<{ key: string; status: "loading" | "loaded" } | null>(null);
   const context = useMemo(
     () => buildPortfolioWorkspaceContext(workspaceState, controls),
     [controls, workspaceState]
   );
-
-  useEffect(() => {
-    setInteractiveReady(true);
-  }, []);
-
-  useEffect(() => {
-    setWorkspaceState(initialWorkspace);
-    summaryRequestRef.current = null;
-  }, [initialWorkspace, selectedPortfolioId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -98,7 +131,7 @@ export default function PortfolioWorkspaceClient({
     return () => {
       cancelled = true;
     };
-  }, [initialWorkspace, selectedPortfolioId, workspaceState]);
+  }, [initialWorkspace, selectedPortfolioId, setWorkspaceState, workspaceState]);
 
   useEffect(() => {
     let cancelled = false;
@@ -139,6 +172,7 @@ export default function PortfolioWorkspaceClient({
   }, [
     context,
     selectedPortfolioId,
+    setWorkspaceState,
     workspaceState,
   ]);
 

--- a/src/apps/portfolio/components/portfolio-workspace-client.tsx
+++ b/src/apps/portfolio/components/portfolio-workspace-client.tsx
@@ -57,14 +57,10 @@ export default function PortfolioWorkspaceClient({
   const [controls, setControls] = useState<PortfolioWorkspaceControls>(
     buildInitialPortfolioControls(initialWorkspace)
   );
-  const initialWorkspaceSourceKey = [
-    selectedPortfolioId ?? "",
-    initialWorkspace?.portfolio.portfolio_id ?? "",
-    initialWorkspace?.as_of_date ?? "",
-    initialWorkspace?.portfolio.base_currency ?? "",
-    initialWorkspace?.positions.length ?? 0,
-    initialWorkspace?.recent_transactions.length ?? 0,
-  ].join("|");
+  const initialWorkspaceSourceKey = useMemo(
+    () => buildPortfolioWorkspaceSourceKey(selectedPortfolioId, initialWorkspace),
+    [initialWorkspace, selectedPortfolioId]
+  );
   const [workspaceDraft, setWorkspaceDraft] = useState<WorkspaceStateDraft>({
     sourceKey: initialWorkspaceSourceKey,
     workspace: initialWorkspace,
@@ -142,13 +138,14 @@ export default function PortfolioWorkspaceClient({
       }
 
       const request = buildPortfolioSummaryDetailsRequest(selectedPortfolioId, context);
-      if (summaryRequestRef.current?.key === request.key) {
+      const scopedRequestKey = `${initialWorkspaceSourceKey}|${request.key}`;
+      if (summaryRequestRef.current?.key === scopedRequestKey) {
         return;
       }
 
-      summaryRequestRef.current = { key: request.key, status: "loading" };
+      summaryRequestRef.current = { key: scopedRequestKey, status: "loading" };
       const details = await getPortfolioWorkspaceSummaryDetailsOnce(
-        request.key,
+        scopedRequestKey,
         selectedPortfolioId,
         request.params
       );
@@ -161,7 +158,7 @@ export default function PortfolioWorkspaceClient({
           current ? mergePortfolioWorkspace(current, details) : current
         );
       }
-      summaryRequestRef.current = { key: request.key, status: "loaded" };
+      summaryRequestRef.current = { key: scopedRequestKey, status: "loaded" };
     }
 
     void loadSummaryDetails();
@@ -171,6 +168,7 @@ export default function PortfolioWorkspaceClient({
     };
   }, [
     context,
+    initialWorkspaceSourceKey,
     selectedPortfolioId,
     setWorkspaceState,
     workspaceState,
@@ -337,4 +335,14 @@ function getPortfolioWorkspaceShellOnce(portfolioId: string) {
   });
   shellInflightRequests.set(portfolioId, request);
   return request;
+}
+
+function buildPortfolioWorkspaceSourceKey(
+  selectedPortfolioId: string | null,
+  initialWorkspace: PortfolioWorkspace | null,
+): string {
+  return JSON.stringify({
+    selectedPortfolioId,
+    initialWorkspace,
+  });
 }

--- a/src/apps/portfolio/components/use-portfolio-allocation-panel-state.ts
+++ b/src/apps/portfolio/components/use-portfolio-allocation-panel-state.ts
@@ -25,6 +25,25 @@ export type PortfolioAllocationPanelState = ReturnType<
   typeof usePortfolioAllocationPanelState
 >;
 
+type AllocationResolutionState = {
+  sourceKey: string;
+  resolvedAllocationViews: PortfolioAllocationView[];
+  lookThroughRequestedMode: PortfolioLookThroughMode;
+  lookThroughEffectiveMode: PortfolioLookThroughMode;
+  lookThroughSupported: boolean;
+  lookThroughBusy: boolean;
+  lookThroughProbeComplete: boolean;
+  cachedLookThroughResponse: {
+    views: PortfolioAllocationView[];
+    lookThrough: PortfolioAllocationLookThrough | null;
+  } | null;
+};
+
+type ActiveDimensionState = {
+  availableDimensionKey: string;
+  dimension: AllocationDimension;
+};
+
 export function usePortfolioAllocationPanelState({
   portfolioId,
   allocationViews,
@@ -42,50 +61,51 @@ export function usePortfolioAllocationPanelState({
   onSelectionChange: (selection: PortfolioAllocationSelection | null) => void;
   onExposureModeChange?: (mode: AllocationExposureMode) => void;
 }) {
-  const [resolvedAllocationViews, setResolvedAllocationViews] =
-    useState<PortfolioAllocationView[]>(allocationViews);
-  const [lookThroughRequestedMode, setLookThroughRequestedMode] =
-    useState<PortfolioLookThroughMode>("direct_only");
-  const [lookThroughEffectiveMode, setLookThroughEffectiveMode] =
-    useState<PortfolioLookThroughMode>("direct_only");
-  const [lookThroughSupported, setLookThroughSupported] = useState(false);
-  const [lookThroughBusy, setLookThroughBusy] = useState(false);
-  const [lookThroughProbeComplete, setLookThroughProbeComplete] =
-    useState(false);
-  const [cachedLookThroughResponse, setCachedLookThroughResponse] = useState<{
-    views: PortfolioAllocationView[];
-    lookThrough: PortfolioAllocationLookThrough | null;
-  } | null>(null);
-  const [activeDimension, setActiveDimension] = useState<AllocationDimension>(
-    getFirstAvailableAllocationDimension(allocationViews),
+  const allocationSourceKey = useMemo(
+    () =>
+      JSON.stringify({
+        portfolioId,
+        asOfDate,
+        reportingCurrency,
+        allocationViews,
+      }),
+    [allocationViews, asOfDate, portfolioId, reportingCurrency],
   );
+  const [allocationState, setAllocationState] =
+    useState<AllocationResolutionState>(() =>
+      buildInitialAllocationResolutionState(allocationSourceKey, allocationViews),
+    );
+  const activeAllocationState =
+    allocationState.sourceKey === allocationSourceKey
+      ? allocationState
+      : buildInitialAllocationResolutionState(allocationSourceKey, allocationViews);
   const [chartType, setChartType] = useState<AllocationChartType>("donut");
   const [hoveredBucket, setHoveredBucket] = useState<string | null>(null);
 
   const viewsByDimension = useMemo(() => {
     return new Map(
-      resolvedAllocationViews.map((view) => [view.dimension, view]),
+      activeAllocationState.resolvedAllocationViews.map((view) => [view.dimension, view]),
     );
-  }, [resolvedAllocationViews]);
+  }, [activeAllocationState.resolvedAllocationViews]);
 
   const firstAvailableDimension =
     ALLOCATION_DIMENSIONS.find((dimension) =>
       viewsByDimension.has(dimension.key),
     )?.key ?? "asset_class";
-
-  useEffect(() => {
-    setActiveDimension(firstAvailableDimension);
-  }, [firstAvailableDimension]);
+  const availableDimensionKey = Array.from(viewsByDimension.keys()).sort().join("|");
+  const [activeDimensionState, setActiveDimensionState] =
+    useState<ActiveDimensionState>({
+      availableDimensionKey,
+      dimension: firstAvailableDimension,
+    });
+  const activeDimension =
+    activeDimensionState.availableDimensionKey === availableDimensionKey &&
+    viewsByDimension.has(activeDimensionState.dimension)
+      ? activeDimensionState.dimension
+      : firstAvailableDimension;
 
   useEffect(() => {
     let cancelled = false;
-    setResolvedAllocationViews(allocationViews);
-    setLookThroughRequestedMode("direct_only");
-    setLookThroughEffectiveMode("direct_only");
-    setLookThroughSupported(false);
-    setLookThroughBusy(true);
-    setLookThroughProbeComplete(false);
-    setCachedLookThroughResponse(null);
 
     void Promise.all([
       getPortfolioAllocationViews(portfolioId, {
@@ -104,44 +124,38 @@ export function usePortfolioAllocationPanelState({
           return;
         }
 
-        if (directResponse?.views?.length) {
-          setResolvedAllocationViews(directResponse.views);
-        }
-        setLookThroughEffectiveMode(
-          normalizeLookThroughMode(
-            directResponse?.look_through?.effective_mode,
-          ),
+        const nextResolvedAllocationViews = directResponse?.views?.length
+          ? directResponse.views
+          : allocationViews;
+        const nextLookThroughEffectiveMode = normalizeLookThroughMode(
+          directResponse?.look_through?.effective_mode,
         );
 
         const supportsExpandedLookThrough = isExpandedLookThroughSupported(
           lookThroughResponse?.look_through ?? null,
         );
-        setLookThroughSupported(supportsExpandedLookThrough);
-        if (supportsExpandedLookThrough && lookThroughResponse?.views?.length) {
-          setCachedLookThroughResponse({
-            views: lookThroughResponse.views,
-            lookThrough: lookThroughResponse.look_through ?? null,
-          });
-        }
-        setLookThroughProbeComplete(true);
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setLookThroughBusy(false);
-        }
+        setAllocationState({
+          sourceKey: allocationSourceKey,
+          resolvedAllocationViews: nextResolvedAllocationViews,
+          lookThroughRequestedMode: "direct_only",
+          lookThroughEffectiveMode: nextLookThroughEffectiveMode,
+          lookThroughSupported: supportsExpandedLookThrough,
+          lookThroughBusy: false,
+          lookThroughProbeComplete: true,
+          cachedLookThroughResponse:
+            supportsExpandedLookThrough && lookThroughResponse?.views?.length
+              ? {
+                  views: lookThroughResponse.views,
+                  lookThrough: lookThroughResponse.look_through ?? null,
+                }
+              : null,
+        });
       });
 
     return () => {
       cancelled = true;
     };
-  }, [allocationViews, asOfDate, portfolioId, reportingCurrency]);
-
-  useEffect(() => {
-    if (viewsByDimension.has(activeDimension)) {
-      return;
-    }
-    setActiveDimension(firstAvailableDimension);
-  }, [activeDimension, firstAvailableDimension, viewsByDimension]);
+  }, [allocationSourceKey, allocationViews, asOfDate, portfolioId, reportingCurrency]);
 
   const activeView = viewsByDimension.get(activeDimension) ?? null;
   const buckets = activeView?.buckets ?? [];
@@ -156,8 +170,8 @@ export function usePortfolioAllocationPanelState({
       ? selectedAllocation.bucket
       : null;
   const lookThroughLabel =
-    lookThroughRequestedMode === "prefer_look_through" &&
-    lookThroughEffectiveMode === "prefer_look_through"
+    activeAllocationState.lookThroughRequestedMode === "prefer_look_through" &&
+    activeAllocationState.lookThroughEffectiveMode === "prefer_look_through"
       ? "Expanded exposure"
       : "Direct holdings";
   const exposureMode: AllocationExposureMode =
@@ -168,7 +182,10 @@ export function usePortfolioAllocationPanelState({
   }, [exposureMode, onExposureModeChange]);
 
   function changeDimension(nextDimension: AllocationDimension) {
-    setActiveDimension(nextDimension);
+    setActiveDimensionState({
+      availableDimensionKey,
+      dimension: nextDimension,
+    });
     setHoveredBucket(null);
     onSelectionChange(null);
   }
@@ -189,14 +206,17 @@ export function usePortfolioAllocationPanelState({
     nextRequestedMode: PortfolioLookThroughMode,
     nextLookThrough: PortfolioAllocationLookThrough | null | undefined,
   ) => {
-    setResolvedAllocationViews(nextViews);
-    setLookThroughRequestedMode(nextRequestedMode);
-    setLookThroughEffectiveMode(
-      normalizeLookThroughMode(
+    setAllocationState({
+      ...activeAllocationState,
+      resolvedAllocationViews: nextViews,
+      lookThroughRequestedMode: nextRequestedMode,
+      lookThroughEffectiveMode: normalizeLookThroughMode(
         nextLookThrough?.effective_mode,
         nextRequestedMode,
       ),
-    );
+      lookThroughBusy: false,
+      lookThroughProbeComplete: true,
+    });
     setHoveredBucket(null);
 
     const nextExposureMode: AllocationExposureMode =
@@ -230,17 +250,20 @@ export function usePortfolioAllocationPanelState({
 
   async function toggleLookThrough() {
     const nextMode: PortfolioLookThroughMode =
-      lookThroughRequestedMode === "prefer_look_through"
+      activeAllocationState.lookThroughRequestedMode === "prefer_look_through"
         ? "direct_only"
         : "prefer_look_through";
-    setLookThroughBusy(true);
+    setAllocationState({
+      ...activeAllocationState,
+      lookThroughBusy: true,
+    });
 
     try {
       const response =
-        nextMode === "prefer_look_through" && cachedLookThroughResponse
+        nextMode === "prefer_look_through" && activeAllocationState.cachedLookThroughResponse
           ? {
-              views: cachedLookThroughResponse.views,
-              look_through: cachedLookThroughResponse.lookThrough,
+              views: activeAllocationState.cachedLookThroughResponse.views,
+              look_through: activeAllocationState.cachedLookThroughResponse.lookThrough,
             }
           : await getPortfolioAllocationViews(portfolioId, {
               asOfDate,
@@ -256,7 +279,14 @@ export function usePortfolioAllocationPanelState({
         );
       }
     } finally {
-      setLookThroughBusy(false);
+      setAllocationState((current) =>
+        current.sourceKey === allocationSourceKey
+          ? {
+              ...current,
+              lookThroughBusy: false,
+            }
+          : current,
+      );
     }
   }
 
@@ -271,11 +301,11 @@ export function usePortfolioAllocationPanelState({
     hoveredBucket,
     setHoveredBucket,
     selectedBucket,
-    lookThroughRequestedMode,
+    lookThroughRequestedMode: activeAllocationState.lookThroughRequestedMode,
     lookThroughLabel,
-    lookThroughSupported,
-    lookThroughBusy,
-    lookThroughProbeComplete,
+    lookThroughSupported: activeAllocationState.lookThroughSupported,
+    lookThroughBusy: activeAllocationState.lookThroughBusy,
+    lookThroughProbeComplete: activeAllocationState.lookThroughProbeComplete,
     holdingsDrilldownAvailable: exposureMode === "direct",
     changeDimension,
     selectBucket,
@@ -283,15 +313,18 @@ export function usePortfolioAllocationPanelState({
   };
 }
 
-function getFirstAvailableAllocationDimension(
+function buildInitialAllocationResolutionState(
+  sourceKey: string,
   allocationViews: PortfolioAllocationView[],
-): AllocationDimension {
-  const availableDimensions = new Set(
-    allocationViews.map((view) => view.dimension),
-  );
-  return (
-    ALLOCATION_DIMENSIONS.find((dimension) =>
-      availableDimensions.has(dimension.key),
-    )?.key ?? "asset_class"
-  );
+): AllocationResolutionState {
+  return {
+    sourceKey,
+    resolvedAllocationViews: allocationViews,
+    lookThroughRequestedMode: "direct_only",
+    lookThroughEffectiveMode: "direct_only",
+    lookThroughSupported: false,
+    lookThroughBusy: true,
+    lookThroughProbeComplete: false,
+    cachedLookThroughResponse: null,
+  };
 }

--- a/src/apps/portfolio/components/use-portfolio-projected-cashflow.ts
+++ b/src/apps/portfolio/components/use-portfolio-projected-cashflow.ts
@@ -140,6 +140,9 @@ export function usePortfolioProjectedCashflow({
       }
     },
     retry: () => {
+      setFailure((current) =>
+        current?.requestedHorizonDays === selectedHorizonDays ? null : current,
+      );
       setSnapshots((current) => {
         const snapshot = current[selectedHorizonKey];
         if (!snapshot?.response || snapshot.response.cashflow_outlook) {

--- a/src/apps/portfolio/components/use-portfolio-projected-cashflow.ts
+++ b/src/apps/portfolio/components/use-portfolio-projected-cashflow.ts
@@ -60,7 +60,9 @@ export function usePortfolioProjectedCashflow({
   const activeRequestFailure =
     failure?.requestedHorizonDays === selectedHorizonDays ? failure : null;
   const effectiveLoading = !selectedSnapshot && !activeRequestFailure;
-  const effectiveRefreshingEvidence = Boolean(selectedSnapshot && !selectedSnapshot.response);
+  const effectiveRefreshingEvidence = Boolean(
+    selectedSnapshot && !selectedSnapshot.response && !activeRequestFailure,
+  );
   const effectiveFailure = selectedSnapshot?.response
     ? selectedSnapshotFailure
     : activeRequestFailure;

--- a/src/apps/portfolio/components/use-portfolio-projected-cashflow.ts
+++ b/src/apps/portfolio/components/use-portfolio-projected-cashflow.ts
@@ -46,32 +46,31 @@ export function usePortfolioProjectedCashflow({
   const [snapshots, setSnapshots] = useState<
     Partial<Record<CashflowHorizonKey, CashflowProjectionSnapshot>>
   >(initialSnapshot ? { [initialHorizonKey]: initialSnapshot } : {});
-  const [loading, setLoading] = useState(!initialSnapshot);
-  const [refreshingEvidence, setRefreshingEvidence] = useState(false);
   const [failure, setFailure] = useState<CashflowRequestFailure | null>(null);
   const [retrySequence, setRetrySequence] = useState(0);
   const selectedSnapshot = snapshots[selectedHorizonKey] ?? null;
   const selectedHorizonDays = resolveCashflowHorizonDays(selectedHorizonKey);
+  const selectedSnapshotFailure =
+    selectedSnapshot?.response && !selectedSnapshot.response.cashflow_outlook
+      ? {
+          requestedHorizonDays: selectedHorizonDays,
+          response: selectedSnapshot.response,
+        }
+      : null;
+  const activeRequestFailure =
+    failure?.requestedHorizonDays === selectedHorizonDays ? failure : null;
+  const effectiveLoading = !selectedSnapshot && !activeRequestFailure;
+  const effectiveRefreshingEvidence = Boolean(selectedSnapshot && !selectedSnapshot.response);
+  const effectiveFailure = selectedSnapshot?.response
+    ? selectedSnapshotFailure
+    : activeRequestFailure;
 
   useEffect(() => {
     if (selectedSnapshot?.response) {
-      setLoading(false);
-      setRefreshingEvidence(false);
-      setFailure(
-        selectedSnapshot.response.cashflow_outlook
-          ? null
-          : {
-              requestedHorizonDays: selectedHorizonDays,
-              response: selectedSnapshot.response,
-            }
-      );
       return;
     }
 
     let cancelled = false;
-    setLoading(!selectedSnapshot);
-    setRefreshingEvidence(Boolean(selectedSnapshot));
-    setFailure(null);
 
     async function loadProjectedCashflow() {
       const response = await getPortfolioProjectedCashflow(portfolioId, {
@@ -110,8 +109,6 @@ export function usePortfolioProjectedCashflow({
       } else {
         setFailure({ requestedHorizonDays: selectedHorizonDays, response });
       }
-      setLoading(false);
-      setRefreshingEvidence(false);
     }
 
     void loadProjectedCashflow();
@@ -132,11 +129,11 @@ export function usePortfolioProjectedCashflow({
     selectedHorizonKey,
     selectedHorizonDays,
     selectedSnapshot,
-    loading,
-    refreshingEvidence,
-    failure,
+    loading: effectiveLoading,
+    refreshingEvidence: effectiveRefreshingEvidence,
+    failure: effectiveFailure,
     selectHorizon: (nextHorizon: CashflowHorizonKey) => {
-      if (!loading) {
+      if (!effectiveLoading) {
         setSelectedHorizonKey(nextHorizon);
       }
     },

--- a/src/design-system/components/deferred-workbench-mount.tsx
+++ b/src/design-system/components/deferred-workbench-mount.tsx
@@ -15,7 +15,6 @@ export default function DeferredWorkbenchMount({
 
   useEffect(() => {
     if (!when) {
-      setIsMounted(false);
       return;
     }
 
@@ -28,5 +27,5 @@ export default function DeferredWorkbenchMount({
     };
   }, [when]);
 
-  return isMounted ? <>{children}</> : <>{placeholder}</>;
+  return when && isMounted ? <>{children}</> : <>{placeholder}</>;
 }

--- a/src/design-system/components/detail-drawer.tsx
+++ b/src/design-system/components/detail-drawer.tsx
@@ -46,12 +46,19 @@ export default function DetailDrawer({
     tabSelection.drawerIdentity === drawerIdentity ? tabSelection.activeTab : 0;
 
   const selectedTab = resolvedTabs[activeTab] ?? resolvedTabs[0];
+  const handleClose = () => {
+    setTabSelection({
+      drawerIdentity: `closed:${kicker}:${title}`,
+      activeTab: 0,
+    });
+    onClose();
+  };
 
   return (
     <Drawer
       anchor="right"
       open={open}
-      onClose={onClose}
+      onClose={handleClose}
       PaperProps={{ className: "portfolio-detail-drawer", "aria-label": `${title || "Detail"} drawer` }}
     >
       <div className="portfolio-detail-drawer-shell">
@@ -94,7 +101,7 @@ export default function DetailDrawer({
         </Box>
 
         <div className="portfolio-detail-drawer-footer">
-          <Button variant="outlined" onClick={onClose}>
+          <Button variant="outlined" onClick={handleClose}>
             Close
           </Button>
           <Button component="a" href={fullPageHref} variant="contained">

--- a/src/design-system/components/detail-drawer.tsx
+++ b/src/design-system/components/detail-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -36,12 +36,14 @@ export default function DetailDrawer({
   fullPageLabel: string;
   onClose: () => void;
 }) {
-  const [activeTab, setActiveTab] = useState(0);
+  const drawerIdentity = `${open ? "open" : "closed"}:${kicker}:${title}`;
+  const [tabSelection, setTabSelection] = useState({
+    drawerIdentity,
+    activeTab: 0,
+  });
   const resolvedTabs = useMemo(() => tabs.filter((tab) => Boolean(tab.content)), [tabs]);
-
-  useEffect(() => {
-    setActiveTab(0);
-  }, [kicker, title, open]);
+  const activeTab =
+    tabSelection.drawerIdentity === drawerIdentity ? tabSelection.activeTab : 0;
 
   const selectedTab = resolvedTabs[activeTab] ?? resolvedTabs[0];
 
@@ -71,7 +73,12 @@ export default function DetailDrawer({
         <div className="portfolio-detail-drawer-tabs">
           <Tabs
             value={Math.min(activeTab, Math.max(resolvedTabs.length - 1, 0))}
-            onChange={(_, value) => setActiveTab(value)}
+            onChange={(_, value) =>
+              setTabSelection({
+                drawerIdentity,
+                activeTab: value,
+              })
+            }
             variant="scrollable"
             scrollButtons={false}
             aria-label={`${title || "Detail"} tabs`}

--- a/src/design-system/hooks/use-client-mounted.ts
+++ b/src/design-system/hooks/use-client-mounted.ts
@@ -1,0 +1,11 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const subscribe = () => () => undefined;
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export function useClientMounted(): boolean {
+  return useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+}

--- a/src/features/advisor-book/components/advisor-book-workspace.tsx
+++ b/src/features/advisor-book/components/advisor-book-workspace.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, useMemo, useState } from "react";
 
 import {
   ActionButton,
@@ -33,12 +33,14 @@ export default function AdvisorBookWorkspace() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const query = useMemo(() => queryFromSearchParams(searchParams), [searchParams]);
-  const [clientId, setClientId] = useState(query.clientId ?? "");
+  const queryClientId = query.clientId ?? "";
+  const [clientDraft, setClientDraft] = useState({
+    queryClientId,
+    clientId: queryClientId,
+  });
+  const clientId =
+    clientDraft.queryClientId === queryClientId ? clientDraft.clientId : queryClientId;
   const { response, loading, error, reload } = useAdvisorBook(query);
-
-  useEffect(() => {
-    setClientId(query.clientId ?? "");
-  }, [query.clientId]);
 
   function applyFilters(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -144,7 +146,12 @@ export default function AdvisorBookWorkspace() {
             <input
               id="advisor-book-client-reference"
               value={clientId}
-              onChange={(event) => setClientId(event.target.value)}
+              onChange={(event) =>
+                setClientDraft({
+                  queryClientId,
+                  clientId: event.target.value,
+                })
+              }
               placeholder="Exact client reference"
               aria-label="Client reference"
             />

--- a/src/features/advisor-book/components/advisor-book-workspace.tsx
+++ b/src/features/advisor-book/components/advisor-book-workspace.tsx
@@ -29,17 +29,26 @@ import styles from "../advisor-book-workspace.module.css";
 const PAGE_SIZE = 25;
 
 export default function AdvisorBookWorkspace() {
+  const searchParams = useSearchParams();
+
+  return (
+    <AdvisorBookWorkspaceContent
+      key={searchParams.toString()}
+      searchParams={searchParams}
+    />
+  );
+}
+
+function AdvisorBookWorkspaceContent({
+  searchParams,
+}: {
+  searchParams: ReturnType<typeof useSearchParams>;
+}) {
   const pathname = usePathname();
   const router = useRouter();
-  const searchParams = useSearchParams();
   const query = useMemo(() => queryFromSearchParams(searchParams), [searchParams]);
   const queryClientId = query.clientId ?? "";
-  const [clientDraft, setClientDraft] = useState({
-    queryClientId,
-    clientId: queryClientId,
-  });
-  const clientId =
-    clientDraft.queryClientId === queryClientId ? clientDraft.clientId : queryClientId;
+  const [clientId, setClientId] = useState(queryClientId);
   const { response, loading, error, reload } = useAdvisorBook(query);
 
   function applyFilters(event: FormEvent<HTMLFormElement>) {
@@ -146,12 +155,7 @@ export default function AdvisorBookWorkspace() {
             <input
               id="advisor-book-client-reference"
               value={clientId}
-              onChange={(event) =>
-                setClientDraft({
-                  queryClientId,
-                  clientId: event.target.value,
-                })
-              }
+              onChange={(event) => setClientId(event.target.value)}
               placeholder="Exact client reference"
               aria-label="Client reference"
             />

--- a/src/features/advisor-book/use-advisor-book.ts
+++ b/src/features/advisor-book/use-advisor-book.ts
@@ -5,6 +5,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { getAdvisorBook, type AdvisorBookQuery } from "./api";
 import type { AdvisorBookResponse } from "./contracts";
 
+type AdvisorBookLoadState = {
+  requestKey: string;
+  status: "loading" | "ready" | "error";
+  response: AdvisorBookResponse | null;
+  error: unknown;
+};
+
 export function useAdvisorBook(query: AdvisorBookQuery) {
   const {
     asOfDate,
@@ -15,15 +22,35 @@ export function useAdvisorBook(query: AdvisorBookQuery) {
     offset,
     limit,
   } = query;
-  const [response, setResponse] = useState<AdvisorBookResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<unknown>(null);
+  const requestKey = JSON.stringify({
+    asOfDate,
+    clientId,
+    mandateType,
+    sortBy,
+    sortOrder,
+    offset,
+    limit,
+  });
+  const [loadState, setLoadState] = useState<AdvisorBookLoadState>({
+    requestKey,
+    status: "loading",
+    response: null,
+    error: null,
+  });
+  const activeLoadState =
+    loadState.requestKey === requestKey
+      ? loadState
+      : {
+          requestKey,
+          status: "loading" as const,
+          response: null,
+          error: null,
+        };
+  const loading = activeLoadState.status === "loading";
   const requestSequence = useRef(0);
 
   const load = useCallback(async () => {
     const requestId = ++requestSequence.current;
-    setLoading(true);
-    setError(null);
     try {
       const nextResponse = await getAdvisorBook({
         asOfDate,
@@ -35,26 +62,39 @@ export function useAdvisorBook(query: AdvisorBookQuery) {
         limit,
       });
       if (requestId === requestSequence.current) {
-        setResponse(nextResponse);
+        setLoadState({
+          requestKey,
+          status: "ready",
+          response: nextResponse,
+          error: null,
+        });
       }
     } catch (nextError) {
       if (requestId === requestSequence.current) {
-        setResponse(null);
-        setError(nextError);
-      }
-    } finally {
-      if (requestId === requestSequence.current) {
-        setLoading(false);
+        setLoadState({
+          requestKey,
+          status: "error",
+          response: null,
+          error: nextError,
+        });
       }
     }
-  }, [asOfDate, clientId, limit, mandateType, offset, sortBy, sortOrder]);
+  }, [asOfDate, clientId, limit, mandateType, offset, requestKey, sortBy, sortOrder]);
 
   useEffect(() => {
-    void load();
+    const timer = window.setTimeout(() => {
+      void load();
+    }, 0);
     return () => {
+      window.clearTimeout(timer);
       requestSequence.current += 1;
     };
   }, [load]);
 
-  return { response, loading, error, reload: load };
+  return {
+    response: activeLoadState.response,
+    loading,
+    error: activeLoadState.error,
+    reload: load,
+  };
 }

--- a/src/features/advisor-book/use-advisor-book.ts
+++ b/src/features/advisor-book/use-advisor-book.ts
@@ -51,6 +51,12 @@ export function useAdvisorBook(query: AdvisorBookQuery) {
 
   const load = useCallback(async () => {
     const requestId = ++requestSequence.current;
+    setLoadState((current) => ({
+      requestKey,
+      status: "loading",
+      response: current.requestKey === requestKey ? current.response : null,
+      error: null,
+    }));
     try {
       const nextResponse = await getAdvisorBook({
         asOfDate,

--- a/src/features/platform-capabilities/use-platform-capabilities.ts
+++ b/src/features/platform-capabilities/use-platform-capabilities.ts
@@ -187,15 +187,9 @@ export function resetPlatformCapabilitiesHookCache(options?: { clearPersistedSna
 }
 
 export function usePlatformCapabilities(): UsePlatformCapabilitiesResult {
-  const [state, setState] = useState<UsePlatformCapabilitiesResult>(() => {
-    const cached = getCachedSnapshot();
-    return cached
-      ? {
-          loading: false,
-          ...cached,
-        }
-      : getInitialResult();
-  });
+  const [state, setState] = useState<UsePlatformCapabilitiesResult>(
+    getInitialResult,
+  );
 
   useEffect(() => {
     let active = true;

--- a/src/features/platform-capabilities/use-platform-capabilities.ts
+++ b/src/features/platform-capabilities/use-platform-capabilities.ts
@@ -187,21 +187,18 @@ export function resetPlatformCapabilitiesHookCache(options?: { clearPersistedSna
 }
 
 export function usePlatformCapabilities(): UsePlatformCapabilitiesResult {
-  const [state, setState] = useState<UsePlatformCapabilitiesResult>(() => getInitialResult());
+  const [state, setState] = useState<UsePlatformCapabilitiesResult>(() => {
+    const cached = getCachedSnapshot();
+    return cached
+      ? {
+          loading: false,
+          ...cached,
+        }
+      : getInitialResult();
+  });
 
   useEffect(() => {
     let active = true;
-
-    const cached = getCachedSnapshot();
-    if (cached) {
-      setState({
-        loading: false,
-        ...cached,
-      });
-      return () => {
-        active = false;
-      };
-    }
 
     void loadPlatformCapabilitiesSnapshot().then((snapshot) => {
       if (!active) {

--- a/src/features/proposals/components/proposal-simulate-form.tsx
+++ b/src/features/proposals/components/proposal-simulate-form.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
 import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -62,6 +62,13 @@ type FormInput = z.infer<typeof schema>;
 const DEFAULT_ADVISORY_AS_OF_DATE = "2026-04-10";
 const DEFAULT_CANONICAL_PORTFOLIO_ID = "PB_SG_GLOBAL_BAL_001";
 
+function createUiIdempotencyKey(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `ui-${crypto.randomUUID()}`;
+  }
+  return `ui-${Date.now()}`;
+}
+
 function simulationHighlights(result: ProposalSimulateResponse): Array<{ label: string; value: string }> {
   const highlights: Array<{ label: string; value: string }> = [];
   Object.entries(result.data).forEach(([key, value]) => {
@@ -97,12 +104,7 @@ export default function ProposalSimulateForm({
 }: {
   initialPortfolioId?: string;
 }) {
-  const defaultIdempotencyKey = useMemo(() => {
-    if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
-      return `ui-${crypto.randomUUID()}`;
-    }
-    return `ui-${Date.now()}`;
-  }, []);
+  const [defaultIdempotencyKey] = useState(createUiIdempotencyKey);
 
   const form = useForm<FormInput>({
     resolver: zodResolver(schema),
@@ -134,10 +136,10 @@ export default function ProposalSimulateForm({
   const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(null);
   const [savedProposalId, setSavedProposalId] = useState<string | null>(null);
 
-  const portfolioId = form.watch("portfolioId");
-  const asOfDate = form.watch("asOfDate");
-  const baseCurrency = form.watch("baseCurrency");
-  const cashAmount = form.watch("cashAmount");
+  const portfolioId = useWatch({ control: form.control, name: "portfolioId" });
+  const asOfDate = useWatch({ control: form.control, name: "asOfDate" });
+  const baseCurrency = useWatch({ control: form.control, name: "baseCurrency" });
+  const cashAmount = useWatch({ control: form.control, name: "cashAmount" });
   const { data: portfolioBook, isLoading: positionsLoading } = useQuery({
     queryKey: ["proposal-position-builder-book", portfolioId, baseCurrency],
     queryFn: async () =>

--- a/src/features/report-ordering/components/report-readiness-rail.tsx
+++ b/src/features/report-ordering/components/report-readiness-rail.tsx
@@ -30,6 +30,9 @@ export function ReportReadinessRail({
   const selectedOutput = model?.outputChoices.find(
     (output) => output.id === model.configuration.outputFormat,
   );
+  const validationIssues = screenState.showValidationSummary
+    ? model?.readiness.issues ?? []
+    : [];
 
   return (
     <div className={styles.readinessStack}>
@@ -56,11 +59,11 @@ export function ReportReadinessRail({
           <p>{screenState.detail}</p>
         </div>
 
-        {model?.readiness.issues.length ? (
+        {validationIssues.length ? (
           <div className={styles.validationSummary} role="alert">
             <strong>Complete before review</strong>
             <ul>
-              {model.readiness.issues.map((issue) => (
+              {validationIssues.map((issue) => (
                 <li key={issue}>{issue}</li>
               ))}
             </ul>

--- a/src/features/report-ordering/report-ordering-screen-state.ts
+++ b/src/features/report-ordering/report-ordering-screen-state.ts
@@ -41,6 +41,7 @@ export type ReportOrderingReadinessState = {
   busy: boolean;
   showRequestSummary: boolean;
   showActions: boolean;
+  showValidationSummary: boolean;
 };
 
 export type ReportOrderingScreenState = {
@@ -133,6 +134,7 @@ function terminalReadinessState(
     busy: workspace.kind === "loading",
     showRequestSummary: false,
     showActions: false,
+    showValidationSummary: false,
   };
   if (workspace.kind === "loading") {
     return {
@@ -199,6 +201,7 @@ function configuredReadinessState({
     busy: submissionState === "submitting",
     showRequestSummary: true,
     showActions: submissionState !== "accepted",
+    showValidationSummary: false,
   };
   if (submissionState === "submitting") {
     return {
@@ -240,6 +243,7 @@ function configuredReadinessState({
       tone: "warn",
       title: model.readiness.title,
       detail: model.readiness.detail,
+      showValidationSummary: true,
     };
   }
   if (preflightReviewed) {

--- a/src/features/report-ordering/use-report-ordering-workflow.ts
+++ b/src/features/report-ordering/use-report-ordering-workflow.ts
@@ -238,6 +238,7 @@ export function useReportOrderingWorkflow({
     setReviewedIntent((current) => {
       const fingerprint = configurationFingerprint(configuration);
       if (
+        current?.portfolioId === portfolioId &&
         current?.configurationFingerprint === fingerprint &&
         current.sourceFingerprint === sourceFingerprintRef.current
       ) {

--- a/src/features/report-ordering/use-report-ordering-workflow.ts
+++ b/src/features/report-ordering/use-report-ordering-workflow.ts
@@ -35,11 +35,6 @@ type ReviewedIntent = {
   idempotencyKey: string;
 };
 
-type SubmittedHandleState = {
-  portfolioId: string;
-  handle: ReportJobHandle;
-};
-
 type SubmissionProgressState = {
   portfolioId: string;
   state: ReportOrderingSubmissionState;
@@ -73,8 +68,9 @@ export function useReportOrderingWorkflow({
       state: "idle",
       error: null,
     });
-  const [submittedHandleState, setSubmittedHandleState] =
-    useState<SubmittedHandleState | null>(null);
+  const [submittedHandlesByPortfolio, setSubmittedHandlesByPortfolio] = useState<
+    Record<string, ReportJobHandle>
+  >({});
   const sourceFingerprintRef = useRef<string>("");
   const activePortfolioIdRef = useRef(portfolioId);
 
@@ -173,10 +169,7 @@ export function useReportOrderingWorkflow({
       activeReviewedIntent.configurationFingerprint === currentConfigurationFingerprint &&
       activeReviewedIntent.sourceFingerprint === currentSourceFingerprint,
   );
-  const submittedHandle =
-    submittedHandleState?.portfolioId === portfolioId
-      ? submittedHandleState.handle
-      : null;
+  const submittedHandle = submittedHandlesByPortfolio[portfolioId] ?? null;
   const activeSubmissionProgress =
     submissionProgress.portfolioId === portfolioId
       ? submissionProgress
@@ -300,7 +293,10 @@ export function useReportOrderingWorkflow({
       if (activePortfolioIdRef.current !== portfolioId) {
         return false;
       }
-      setSubmittedHandleState({ portfolioId, handle });
+      setSubmittedHandlesByPortfolio((current) => ({
+        ...current,
+        [portfolioId]: handle,
+      }));
       setSubmissionProgress({ portfolioId, state: "accepted", error: null });
       await loadHistory();
       return true;

--- a/src/features/report-ordering/use-report-ordering-workflow.ts
+++ b/src/features/report-ordering/use-report-ordering-workflow.ts
@@ -181,8 +181,8 @@ export function useReportOrderingWorkflow({
     submissionProgress.portfolioId === portfolioId
       ? submissionProgress
       : { portfolioId, state: "idle" as const, error: null };
-  const submissionState = activeSubmissionProgress.state;
-  const submissionError = activeSubmissionProgress.error;
+  const submissionState = submittedHandle ? "accepted" : activeSubmissionProgress.state;
+  const submissionError = submittedHandle ? null : activeSubmissionProgress.error;
   const screenState = useMemo(
     () =>
       buildReportOrderingScreenState({

--- a/src/features/report-ordering/use-report-ordering-workflow.ts
+++ b/src/features/report-ordering/use-report-ordering-workflow.ts
@@ -40,6 +40,12 @@ type SubmittedHandleState = {
   handle: ReportJobHandle;
 };
 
+type SubmissionProgressState = {
+  portfolioId: string;
+  state: ReportOrderingSubmissionState;
+  error: string | null;
+};
+
 type HistoryLoadState = "loading" | "ready" | "permission_blocked" | "error";
 
 export function useReportOrderingWorkflow({
@@ -61,9 +67,12 @@ export function useReportOrderingWorkflow({
   const [historyState, setHistoryState] = useState<HistoryLoadState>("loading");
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [reviewedIntent, setReviewedIntent] = useState<ReviewedIntent | null>(null);
-  const [submissionState, setSubmissionState] =
-    useState<ReportOrderingSubmissionState>("idle");
-  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [submissionProgress, setSubmissionProgress] =
+    useState<SubmissionProgressState>({
+      portfolioId,
+      state: "idle",
+      error: null,
+    });
   const [submittedHandleState, setSubmittedHandleState] =
     useState<SubmittedHandleState | null>(null);
   const sourceFingerprintRef = useRef<string>("");
@@ -168,6 +177,12 @@ export function useReportOrderingWorkflow({
     submittedHandleState?.portfolioId === portfolioId
       ? submittedHandleState.handle
       : null;
+  const activeSubmissionProgress =
+    submissionProgress.portfolioId === portfolioId
+      ? submissionProgress
+      : { portfolioId, state: "idle" as const, error: null };
+  const submissionState = activeSubmissionProgress.state;
+  const submissionError = activeSubmissionProgress.error;
   const screenState = useMemo(
     () =>
       buildReportOrderingScreenState({
@@ -200,10 +215,13 @@ export function useReportOrderingWorkflow({
         return { ...current, ...patch };
       });
       setReviewedIntent(null);
-      setSubmissionError(null);
-      setSubmissionState((current) => (current === "submitting" ? current : "idle"));
+      setSubmissionProgress((current) =>
+        current.portfolioId === portfolioId && current.state === "submitting"
+          ? current
+          : { portfolioId, state: "idle", error: null },
+      );
     },
-    [catalogue],
+    [catalogue, portfolioId],
   );
 
   const toggleSection = useCallback(
@@ -239,7 +257,11 @@ export function useReportOrderingWorkflow({
         idempotencyKey: createReportOrderIntentKey(),
       };
     });
-    setSubmissionError(null);
+    setSubmissionProgress((current) =>
+      current.portfolioId === portfolioId
+        ? { ...current, error: null }
+        : { portfolioId, state: "idle", error: null },
+    );
     return true;
   }, [configuration, model?.canSubmit, portfolioId]);
 
@@ -254,8 +276,7 @@ export function useReportOrderingWorkflow({
       return false;
     }
 
-    setSubmissionState("submitting");
-    setSubmissionError(null);
+    setSubmissionProgress({ portfolioId, state: "submitting", error: null });
     try {
       const handle = await submitPortfolioReviewOrder({
         portfolioId,
@@ -276,13 +297,22 @@ export function useReportOrderingWorkflow({
         sections: configuration.selectedSections,
         idempotencyKey: activeReviewedIntent.idempotencyKey,
       });
+      if (activePortfolioIdRef.current !== portfolioId) {
+        return false;
+      }
       setSubmittedHandleState({ portfolioId, handle });
-      setSubmissionState("accepted");
+      setSubmissionProgress({ portfolioId, state: "accepted", error: null });
       await loadHistory();
       return true;
     } catch (error) {
-      setSubmissionState("error");
-      setSubmissionError(submissionErrorCopy(error));
+      if (activePortfolioIdRef.current !== portfolioId) {
+        return false;
+      }
+      setSubmissionProgress({
+        portfolioId,
+        state: "error",
+        error: submissionErrorCopy(error),
+      });
       return false;
     }
   }, [

--- a/src/features/report-ordering/use-report-ordering-workflow.ts
+++ b/src/features/report-ordering/use-report-ordering-workflow.ts
@@ -29,9 +29,15 @@ import {
 } from "./view-model";
 
 type ReviewedIntent = {
+  portfolioId: string;
   configurationFingerprint: string;
   sourceFingerprint: string;
   idempotencyKey: string;
+};
+
+type SubmittedHandleState = {
+  portfolioId: string;
+  handle: ReportJobHandle;
 };
 
 type HistoryLoadState = "loading" | "ready" | "permission_blocked" | "error";
@@ -58,7 +64,8 @@ export function useReportOrderingWorkflow({
   const [submissionState, setSubmissionState] =
     useState<ReportOrderingSubmissionState>("idle");
   const [submissionError, setSubmissionError] = useState<string | null>(null);
-  const [submittedHandle, setSubmittedHandle] = useState<ReportJobHandle | null>(null);
+  const [submittedHandleState, setSubmittedHandleState] =
+    useState<SubmittedHandleState | null>(null);
   const sourceFingerprintRef = useRef<string>("");
   const activePortfolioIdRef = useRef(portfolioId);
 
@@ -125,15 +132,13 @@ export function useReportOrderingWorkflow({
   useEffect(() => {
     activePortfolioIdRef.current = portfolioId;
     sourceFingerprintRef.current = "";
-    setCatalogue(null);
-    setConfiguration(null);
-    setHistory(null);
-    setReviewedIntent(null);
-    setSubmittedHandle(null);
-    setSubmissionState("idle");
-    setSubmissionError(null);
-    void loadCatalogue(true);
-    void loadHistory();
+    const timer = window.setTimeout(() => {
+      void loadCatalogue(true);
+      void loadHistory();
+    }, 0);
+    return () => {
+      window.clearTimeout(timer);
+    };
   }, [loadCatalogue, loadHistory, portfolioId]);
 
   const model = useMemo(
@@ -151,11 +156,18 @@ export function useReportOrderingWorkflow({
   const currentConfigurationFingerprint = configuration
     ? configurationFingerprint(configuration)
     : "";
+  const currentSourceFingerprint = catalogue ? JSON.stringify(catalogue) : "";
+  const activeReviewedIntent =
+    reviewedIntent?.portfolioId === portfolioId ? reviewedIntent : null;
   const preflightReviewed = Boolean(
-    reviewedIntent &&
-      reviewedIntent.configurationFingerprint === currentConfigurationFingerprint &&
-      reviewedIntent.sourceFingerprint === sourceFingerprintRef.current,
+    activeReviewedIntent &&
+      activeReviewedIntent.configurationFingerprint === currentConfigurationFingerprint &&
+      activeReviewedIntent.sourceFingerprint === currentSourceFingerprint,
   );
+  const submittedHandle =
+    submittedHandleState?.portfolioId === portfolioId
+      ? submittedHandleState.handle
+      : null;
   const screenState = useMemo(
     () =>
       buildReportOrderingScreenState({
@@ -221,6 +233,7 @@ export function useReportOrderingWorkflow({
         return current;
       }
       return {
+        portfolioId,
         configurationFingerprint: fingerprint,
         sourceFingerprint: sourceFingerprintRef.current,
         idempotencyKey: createReportOrderIntentKey(),
@@ -228,15 +241,15 @@ export function useReportOrderingWorkflow({
     });
     setSubmissionError(null);
     return true;
-  }, [configuration, model?.canSubmit]);
+  }, [configuration, model?.canSubmit, portfolioId]);
 
   const submitRequest = useCallback(async () => {
     if (
       !configuration ||
       !model?.canSubmit ||
-      !reviewedIntent ||
-      reviewedIntent.configurationFingerprint !== configurationFingerprint(configuration) ||
-      reviewedIntent.sourceFingerprint !== sourceFingerprintRef.current
+      !activeReviewedIntent ||
+      activeReviewedIntent.configurationFingerprint !== configurationFingerprint(configuration) ||
+      activeReviewedIntent.sourceFingerprint !== sourceFingerprintRef.current
     ) {
       return false;
     }
@@ -261,9 +274,9 @@ export function useReportOrderingWorkflow({
           ? { allocationDimensions: configuration.allocationDimensions }
           : {}),
         sections: configuration.selectedSections,
-        idempotencyKey: reviewedIntent.idempotencyKey,
+        idempotencyKey: activeReviewedIntent.idempotencyKey,
       });
-      setSubmittedHandle(handle);
+      setSubmittedHandleState({ portfolioId, handle });
       setSubmissionState("accepted");
       await loadHistory();
       return true;
@@ -278,7 +291,7 @@ export function useReportOrderingWorkflow({
     model?.canSubmit,
     portfolioId,
     publishedConfigurationFieldIds,
-    reviewedIntent,
+    activeReviewedIntent,
   ]);
 
   return {

--- a/src/features/workbench/components/sandbox-controls.tsx
+++ b/src/features/workbench/components/sandbox-controls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Alert, Box, MenuItem, Stack, TextField } from "@mui/material";
 
@@ -8,6 +8,12 @@ import { ActionButton, MetricRow, SectionBlock, SemanticBadge, Text } from "@/de
 
 import { applySandboxChanges, createSandboxSession } from "../workbench-core-api";
 import { WorkbenchPolicyFeedback } from "../types";
+
+type RuntimeSandboxFeedback = {
+  sessionId: string;
+  warnings: string[];
+  partialFailures: Array<{ source_service: string; error_code: string; detail: string }>;
+};
 
 export default function SandboxControls({
   portfolioId,
@@ -27,14 +33,13 @@ export default function SandboxControls({
   const [evaluatePolicy, setEvaluatePolicy] = useState(true);
   const [sessionVersion, setSessionVersion] = useState<number | null>(null);
   const [policyFeedback, setPolicyFeedback] = useState<WorkbenchPolicyFeedback | null>(null);
-  const [runtimeWarnings, setRuntimeWarnings] = useState<string[]>(warnings);
-  const [runtimePartialFailures, setRuntimePartialFailures] = useState<
-    Array<{ source_service: string; error_code: string; detail: string }>
-  >([]);
-
-  useEffect(() => {
-    setRuntimeWarnings(warnings);
-  }, [warnings]);
+  const [runtimeFeedback, setRuntimeFeedback] = useState<RuntimeSandboxFeedback | null>(null);
+  const effectiveRuntimeFeedback =
+    runtimeFeedback && (runtimeFeedback.sessionId === sessionId || sessionId === null)
+      ? runtimeFeedback
+      : null;
+  const runtimeWarnings = effectiveRuntimeFeedback?.warnings ?? warnings;
+  const runtimePartialFailures = effectiveRuntimeFeedback?.partialFailures ?? [];
 
   async function onCreateSession() {
     setError(null);
@@ -46,8 +51,11 @@ export default function SandboxControls({
       });
       setSessionVersion(response.session_version);
       setPolicyFeedback(response.policy_feedback ?? null);
-      setRuntimeWarnings(response.warnings);
-      setRuntimePartialFailures(response.partial_failures);
+      setRuntimeFeedback({
+        sessionId: response.session_id,
+        warnings: response.warnings,
+        partialFailures: response.partial_failures,
+      });
       router.push(`/workbench/${encodeURIComponent(portfolioId)}?sessionId=${encodeURIComponent(response.session_id)}`);
       router.refresh();
     } catch (err) {
@@ -81,8 +89,11 @@ export default function SandboxControls({
       });
       setSessionVersion(response.session_version);
       setPolicyFeedback(response.policy_feedback);
-      setRuntimeWarnings(response.warnings);
-      setRuntimePartialFailures(response.partial_failures);
+      setRuntimeFeedback({
+        sessionId,
+        warnings: response.warnings,
+        partialFailures: response.partial_failures,
+      });
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to apply changes");

--- a/src/features/workbench/use-construction-alternatives-actions.ts
+++ b/src/features/workbench/use-construction-alternatives-actions.ts
@@ -39,6 +39,13 @@ type UseConstructionAlternativesActionsResult = {
   selectAlternative: (alternativeId: string) => Promise<void>;
 };
 
+type ExecutionAcknowledgementState = {
+  portfolioKey: string;
+  status: "loading" | "ready" | "error";
+  response: ExternalOrderExecutionAcknowledgementResponse | null;
+  error: string | null;
+};
+
 export function useConstructionAlternativesActions({
   portfolio,
 }: UseConstructionAlternativesActionsInput): UseConstructionAlternativesActionsResult {
@@ -48,14 +55,25 @@ export function useConstructionAlternativesActions({
   const [selectionPendingId, setSelectionPendingId] = useState<string | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
-  const [executionAcknowledgementResponse, setExecutionAcknowledgementResponse] =
-    useState<ExternalOrderExecutionAcknowledgementResponse | null>(null);
-  const [executionAcknowledgementLoading, setExecutionAcknowledgementLoading] =
-    useState(false);
-  const [executionAcknowledgementError, setExecutionAcknowledgementError] =
-    useState<string | null>(null);
   const model = buildConstructionPanelModel(response);
   const portfolioId = portfolio.portfolio.portfolio_id;
+  const portfolioKey = `${portfolioId}|${portfolio.as_of_date}|${portfolio.contract_version}`;
+  const [executionAcknowledgementState, setExecutionAcknowledgementState] =
+    useState<ExecutionAcknowledgementState>({
+      portfolioKey,
+      status: "loading",
+      response: null,
+      error: null,
+    });
+  const activeExecutionAcknowledgementState =
+    executionAcknowledgementState.portfolioKey === portfolioKey
+      ? executionAcknowledgementState
+      : {
+          portfolioKey,
+          status: "loading" as const,
+          response: null,
+          error: null,
+        };
   const canSelectSelectedAlternative = canSelectConstructionAlternative({
     selectedAlternative: model.selectedAlternative,
     alternativeSetId: model.alternativeSetId,
@@ -66,33 +84,34 @@ export function useConstructionAlternativesActions({
 
   useEffect(() => {
     let cancelled = false;
-    setExecutionAcknowledgementLoading(true);
-    setExecutionAcknowledgementError(null);
     void getExternalOrderExecutionAcknowledgement({ portfolio })
       .then((nextResponse) => {
         if (!cancelled) {
-          setExecutionAcknowledgementResponse(nextResponse);
+          setExecutionAcknowledgementState({
+            portfolioKey,
+            status: "ready",
+            response: nextResponse,
+            error: null,
+          });
         }
       })
       .catch((error: unknown) => {
         if (!cancelled) {
-          setExecutionAcknowledgementResponse(null);
-          setExecutionAcknowledgementError(
-            error instanceof Error
-              ? error.message
-              : "External OMS acknowledgement supportability could not be loaded."
-          );
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setExecutionAcknowledgementLoading(false);
+          setExecutionAcknowledgementState({
+            portfolioKey,
+            status: "error",
+            response: null,
+            error:
+              error instanceof Error
+                ? error.message
+                : "External OMS acknowledgement supportability could not be loaded.",
+          });
         }
       });
     return () => {
       cancelled = true;
     };
-  }, [portfolio]);
+  }, [portfolio, portfolioKey]);
 
   async function generateAlternatives() {
     if (generatePending) {
@@ -157,9 +176,9 @@ export function useConstructionAlternativesActions({
     selectionPendingId,
     actionMessage,
     actionError,
-    executionAcknowledgementResponse,
-    executionAcknowledgementLoading,
-    executionAcknowledgementError,
+    executionAcknowledgementResponse: activeExecutionAcknowledgementState.response,
+    executionAcknowledgementLoading: activeExecutionAcknowledgementState.status === "loading",
+    executionAcknowledgementError: activeExecutionAcknowledgementState.error,
     canSelectSelectedAlternative,
     generateAlternatives,
     selectAlternative,

--- a/src/features/workbench/use-dpm-wave-command-center-actions.ts
+++ b/src/features/workbench/use-dpm-wave-command-center-actions.ts
@@ -228,6 +228,11 @@ export function useDpmWaveCommandCenterActions({
     useState<DpmCampaignWorkflowCommandEvidence | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const autoLoadedWaveIdRef = useRef<string | null>(null);
+  const autoLoadFailureCountsRef = useRef<Record<string, number>>({});
+  const [autoLoadRetryToken, setAutoLoadRetryToken] = useState<{
+    waveId: string;
+    attempt: number;
+  } | null>(null);
   const [selectedCampaignState, setSelectedCampaignState] =
     useState<SelectedCampaignState>({
       campaignRowKey: "",
@@ -280,11 +285,29 @@ export function useDpmWaveCommandCenterActions({
     }
     autoLoadedWaveIdRef.current = selectedWaveId;
     getDpmWaveItems(selectedWaveId)
-      .then(setItemsResponse)
+      .then((response) => {
+        setItemsResponse(response);
+        autoLoadFailureCountsRef.current = {
+          ...autoLoadFailureCountsRef.current,
+          [selectedWaveId]: 0,
+        };
+      })
       .catch(() => {
         autoLoadedWaveIdRef.current = null;
+        const nextFailureCount =
+          (autoLoadFailureCountsRef.current[selectedWaveId] ?? 0) + 1;
+        autoLoadFailureCountsRef.current = {
+          ...autoLoadFailureCountsRef.current,
+          [selectedWaveId]: nextFailureCount,
+        };
+        if (nextFailureCount === 1) {
+          setAutoLoadRetryToken({
+            waveId: selectedWaveId,
+            attempt: nextFailureCount,
+          });
+        }
       });
-  }, [itemsResponse, pendingAction, selectedWaveId]);
+  }, [autoLoadRetryToken, itemsResponse, pendingAction, selectedWaveId]);
 
   async function runAction(label: string, action: () => Promise<DpmWaveGatewayResponse>) {
     if (pendingAction) {

--- a/src/features/workbench/use-dpm-wave-command-center-actions.ts
+++ b/src/features/workbench/use-dpm-wave-command-center-actions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   approveDpmWave,
   createDpmCampaignApprovalDecision,
@@ -153,6 +153,11 @@ type UseDpmWaveCommandCenterActionsResult = {
   ) => Promise<void>;
 };
 
+type SelectedCampaignState = {
+  campaignRowKey: string;
+  selectedCampaignKey: string | null;
+};
+
 export function useDpmWaveCommandCenterActions({
   portfolioId,
   waveList,
@@ -222,8 +227,12 @@ export function useDpmWaveCommandCenterActions({
   const [campaignWorkflowCommandEvidence, setCampaignWorkflowCommandEvidence] =
     useState<DpmCampaignWorkflowCommandEvidence | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
-  const [autoLoadedWaveId, setAutoLoadedWaveId] = useState<string | null>(null);
-  const [selectedCampaignKey, setSelectedCampaignKey] = useState<string | null>(null);
+  const autoLoadedWaveIdRef = useRef<string | null>(null);
+  const [selectedCampaignState, setSelectedCampaignState] =
+    useState<SelectedCampaignState>({
+      campaignRowKey: "",
+      selectedCampaignKey: null,
+    });
 
   const model = buildDpmWaveCommandCenterModel({
     waveList,
@@ -249,28 +258,33 @@ export function useDpmWaveCommandCenterActions({
       campaignMakerCheckerControlsResponse ?? campaignMakerCheckerControls,
   });
   const selectedWaveId = model.selectedWaveId;
+  const campaignRowKey = model.campaignRows.map((row) => row.key).join("|");
+  const selectedCampaignKey =
+    selectedCampaignState.campaignRowKey === campaignRowKey &&
+    model.campaignRows.some((row) => row.key === selectedCampaignState.selectedCampaignKey)
+      ? selectedCampaignState.selectedCampaignKey
+      : model.campaignRows[0]?.key ?? null;
   const selectedCampaign =
     model.campaignRows.find((row) => row.key === selectedCampaignKey) ??
     model.campaignRows[0] ??
     null;
 
   useEffect(() => {
-    if (!selectedWaveId || autoLoadedWaveId === selectedWaveId || itemsResponse || pendingAction) {
+    if (
+      !selectedWaveId ||
+      autoLoadedWaveIdRef.current === selectedWaveId ||
+      itemsResponse ||
+      pendingAction
+    ) {
       return;
     }
-    setAutoLoadedWaveId(selectedWaveId);
+    autoLoadedWaveIdRef.current = selectedWaveId;
     getDpmWaveItems(selectedWaveId)
       .then(setItemsResponse)
       .catch(() => {
-        setAutoLoadedWaveId(null);
+        autoLoadedWaveIdRef.current = null;
       });
-  }, [autoLoadedWaveId, itemsResponse, pendingAction, selectedWaveId]);
-
-  useEffect(() => {
-    if (!selectedCampaignKey && model.campaignRows[0]) {
-      setSelectedCampaignKey(model.campaignRows[0].key);
-    }
-  }, [model.campaignRows, selectedCampaignKey]);
+  }, [itemsResponse, pendingAction, selectedWaveId]);
 
   async function runAction(label: string, action: () => Promise<DpmWaveGatewayResponse>) {
     if (pendingAction) {
@@ -359,7 +373,10 @@ export function useDpmWaveCommandCenterActions({
     if (pendingCampaignLifecycleKey) {
       return;
     }
-    setSelectedCampaignKey(row.key);
+    setSelectedCampaignState({
+      campaignRowKey,
+      selectedCampaignKey: row.key,
+    });
     setPendingCampaignLifecycleKey(row.key);
     setCampaignLifecycleError(null);
     setCampaignLifecycleResponse(null);
@@ -382,7 +399,10 @@ export function useDpmWaveCommandCenterActions({
     if (pendingCampaignLaunchHistoryKey) {
       return;
     }
-    setSelectedCampaignKey(row.key);
+    setSelectedCampaignState({
+      campaignRowKey,
+      selectedCampaignKey: row.key,
+    });
     setPendingCampaignLaunchHistoryKey(row.key);
     setCampaignLaunchHistoryError(null);
     setCampaignLaunchHistoryResponse(null);
@@ -411,7 +431,10 @@ export function useDpmWaveCommandCenterActions({
     ) {
       return;
     }
-    setSelectedCampaignKey(row.key);
+    setSelectedCampaignState({
+      campaignRowKey,
+      selectedCampaignKey: row.key,
+    });
     setPendingCampaignPreviewReadinessKey(row.key);
     setPendingCampaignLaunchPackageKey(row.key);
     setCampaignPreviewReadinessError(null);
@@ -460,7 +483,10 @@ export function useDpmWaveCommandCenterActions({
     if (pendingCampaignLaunchKey || !model.campaignLaunchPosture.canLaunch) {
       return;
     }
-    setSelectedCampaignKey(row.key);
+    setSelectedCampaignState({
+      campaignRowKey,
+      selectedCampaignKey: row.key,
+    });
     setPendingCampaignLaunchKey(row.key);
     setCampaignLaunchError(null);
     try {

--- a/tests/integration/advisor-book-workspace.test.tsx
+++ b/tests/integration/advisor-book-workspace.test.tsx
@@ -130,6 +130,37 @@ describe("AdvisorBookWorkspace", () => {
     );
   });
 
+  it("adopts the URL client filter when returning to an earlier query", async () => {
+    getAdvisorBookMock.mockResolvedValue(readyResponse);
+    const { rerender } = render(<AdvisorBookWorkspace />);
+    await screen.findByText("Book available");
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Client reference" }), {
+      target: { value: "CIF_SG_002" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply client" }));
+
+    useSearchParamsMock.mockReturnValue(
+      new URLSearchParams("asOfDate=2026-04-10&clientId=CIF_SG_002&offset=0"),
+    );
+    rerender(<AdvisorBookWorkspace />);
+    expect(await screen.findByRole("textbox", { name: "Client reference" })).toHaveValue(
+      "CIF_SG_002",
+    );
+
+    useSearchParamsMock.mockReturnValue(new URLSearchParams("asOfDate=2026-04-10"));
+    rerender(<AdvisorBookWorkspace />);
+
+    expect(await screen.findByRole("textbox", { name: "Client reference" })).toHaveValue("");
+    await waitFor(() => {
+      const lastQuery = getAdvisorBookMock.mock.calls.at(-1)?.[0];
+      expect(lastQuery).toMatchObject({
+        asOfDate: "2026-04-10",
+        clientId: undefined,
+      });
+    });
+  });
+
   it("shows a permission-specific boundary without substituting the global catalogue", async () => {
     getAdvisorBookMock.mockRejectedValue(new WorkbenchApiError("advisor book", 403));
     render(<AdvisorBookWorkspace />);

--- a/tests/integration/report-ordering-workspace.test.tsx
+++ b/tests/integration/report-ordering-workspace.test.tsx
@@ -148,6 +148,7 @@ describe("ReportOrderingWorkspace", () => {
     const status = screen.getByRole("status");
     expect(within(status).getByRole("heading", { name: "Report ordering restricted" })).toBeInTheDocument();
     expect(within(status).getByLabelText("Status Restricted")).toBeInTheDocument();
+    expect(screen.queryByText("Complete before review")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Review Request" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Submit Report Request" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Approved report" })).not.toBeInTheDocument();
@@ -162,6 +163,7 @@ describe("ReportOrderingWorkspace", () => {
     const status = screen.getByRole("status");
     expect(within(status).getByRole("heading", { name: "Report ordering unavailable" })).toBeInTheDocument();
     expect(within(status).getByLabelText("Status Unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("Complete before review")).not.toBeInTheDocument();
     const retryButton = screen.getByRole("button", { name: "Try Again" });
     expect(retryButton).toBeEnabled();
     expect(screen.queryByText("Loading report readiness")).not.toBeInTheDocument();
@@ -181,6 +183,10 @@ describe("ReportOrderingWorkspace", () => {
     expect(emptyPanels).toHaveLength(2);
     const status = screen.getByRole("status");
     expect(within(status).getByLabelText("Status No approved reports")).toBeInTheDocument();
+    expect(screen.queryByText("Complete before review")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("No report is available for the selected portfolio and business role."),
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Approved report" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Review Request" })).not.toBeInTheDocument();
   });
@@ -195,6 +201,7 @@ describe("ReportOrderingWorkspace", () => {
     expect(await screen.findByRole("heading", { name: "Approved report" })).toBeInTheDocument();
     const status = screen.getByRole("status");
     expect(within(status).getByLabelText("Status Setup required")).toBeInTheDocument();
+    expect(screen.getByText("Complete before review")).toBeInTheDocument();
     expect(screen.getByText("Select a valid report date.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Review Request" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Submit Report Request" })).toBeDisabled();

--- a/tests/unit/design-system-components.test.tsx
+++ b/tests/unit/design-system-components.test.tsx
@@ -15,6 +15,7 @@ import {
   DefinitionList,
   DeferredModulePlaceholder,
   DetailCard,
+  DetailDrawer,
   DisclosureToggleButton,
   DegradedStatePanel,
   EmptyStatePanel,
@@ -99,6 +100,68 @@ describe("design-system components", () => {
     expect(screen.getByRole("link", { name: "Portfolio" })).toHaveAttribute("href", "/portfolio");
     expect(screen.getByRole("link", { name: "Performance" })).toHaveAttribute("aria-current", "page");
     expect(screen.getByText("Proposal")).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("resets detail drawer tab selection when reopening the same item", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <DetailDrawer
+        open
+        kicker="Position"
+        title="UST 10Y"
+        summaryItems={[{ label: "Weight", value: "4.2%" }]}
+        tabs={[
+          { key: "summary", label: "Summary", content: <div>Summary content</div> },
+          { key: "evidence", label: "Evidence", content: <div>Evidence content</div> },
+        ]}
+        fullPageHref="/portfolio?position=ust"
+        fullPageLabel="Open full record"
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Evidence" }));
+    expect(screen.getByRole("tabpanel", { name: "Evidence" })).toHaveTextContent(
+      "Evidence content",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <DetailDrawer
+        open={false}
+        kicker="Position"
+        title="UST 10Y"
+        summaryItems={[{ label: "Weight", value: "4.2%" }]}
+        tabs={[
+          { key: "summary", label: "Summary", content: <div>Summary content</div> },
+          { key: "evidence", label: "Evidence", content: <div>Evidence content</div> },
+        ]}
+        fullPageHref="/portfolio?position=ust"
+        fullPageLabel="Open full record"
+        onClose={onClose}
+      />,
+    );
+    rerender(
+      <DetailDrawer
+        open
+        kicker="Position"
+        title="UST 10Y"
+        summaryItems={[{ label: "Weight", value: "4.2%" }]}
+        tabs={[
+          { key: "summary", label: "Summary", content: <div>Summary content</div> },
+          { key: "evidence", label: "Evidence", content: <div>Evidence content</div> },
+        ]}
+        fullPageHref="/portfolio?position=ust"
+        fullPageLabel="Open full record"
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByRole("tabpanel", { name: "Summary" })).toHaveTextContent(
+      "Summary content",
+    );
   });
 
   it("renders core panel and row primitives with shared classes", () => {

--- a/tests/unit/performance-chart-panel.test.tsx
+++ b/tests/unit/performance-chart-panel.test.tsx
@@ -396,6 +396,41 @@ describe("PerformanceChartPanel", () => {
     ).toContain("Observation");
   });
 
+  it("clears explicit date drafts when the source report-date context changes", () => {
+    const props = buildChartProps({
+      reportStartDate: "2026-01-01",
+      reportEndDate: "2026-02-28",
+    });
+    const { rerender } = render(<PerformanceChartPanel {...props} />);
+
+    fireEvent.change(screen.getByLabelText("From"), {
+      target: { value: "2026-01-15" },
+    });
+    expect(screen.getByLabelText("From")).toHaveValue("2026-01-15");
+
+    rerender(
+      <PerformanceChartPanel
+        {...props}
+        reportStartDate="2026-03-01"
+        reportEndDate="2026-03-31"
+      />,
+    );
+
+    expect(screen.getByLabelText("From")).toHaveValue("2026-03-01");
+    expect(screen.getByLabelText("To")).toHaveValue("2026-03-31");
+
+    rerender(
+      <PerformanceChartPanel
+        {...props}
+        reportStartDate="2026-01-01"
+        reportEndDate="2026-02-28"
+      />,
+    );
+
+    expect(screen.getByLabelText("From")).toHaveValue("2026-01-01");
+    expect(screen.getByLabelText("To")).toHaveValue("2026-02-28");
+  });
+
   it("uses benchmark options from the workspace contract for selector labels", () => {
     render(
       <PerformanceChartPanel

--- a/tests/unit/performance-risk-mode.test.tsx
+++ b/tests/unit/performance-risk-mode.test.tsx
@@ -47,7 +47,18 @@ function renderRiskMode(
     isDetailsPending?: boolean;
   } = {},
 ) {
-  return render(
+  return render(buildRiskModeElement(scenario, options));
+}
+
+function buildRiskModeElement(
+  scenario = buildSupportedPerformanceScenario(),
+  options: {
+    detailBasis?: "NET" | "GROSS";
+    period?: string;
+    isDetailsPending?: boolean;
+  } = {},
+) {
+  return (
     <PerformanceRiskMode
       workspace={scenario.workspace}
       capabilities={scenario.capabilities}
@@ -58,7 +69,7 @@ function renderRiskMode(
       chartFrequency="monthly"
       isUpdating={false}
       isDetailsPending={options.isDetailsPending ?? false}
-    />,
+    />
   );
 }
 
@@ -740,6 +751,94 @@ describe("PerformanceRiskMode", () => {
     });
     expect(within(detailDialog).getByText("Review window")).toBeInTheDocument();
     expect(within(detailDialog).getByText("63D")).toBeInTheDocument();
+  });
+
+  it("does not revive a previously opened rolling drawer after returning to an old risk context", async () => {
+    const scenario = buildSupportedPerformanceScenario();
+    vi.mocked(getWorkbenchRiskSummaryClient).mockImplementation(
+      (_portfolioId, params) =>
+        Promise.resolve(
+          buildFixtureRiskSummary(
+            scenario.workspace,
+            params.period ?? "YTD",
+            params.detailBasis ?? "NET",
+          ),
+        ),
+    );
+    vi.mocked(getWorkbenchRiskConcentrationClient).mockImplementation(
+      (_portfolioId, params) =>
+        Promise.resolve(
+          buildFixtureRiskConcentration(
+            scenario.workspace,
+            params.period ?? "YTD",
+          ),
+        ),
+    );
+    vi.mocked(getWorkbenchRiskAttributionClient).mockImplementation(
+      (_portfolioId, params) =>
+        Promise.resolve(
+          buildFixtureRiskAttribution(
+            scenario.workspace,
+            params.period ?? "YTD",
+            params.detailBasis ?? "NET",
+          ),
+        ),
+    );
+    vi.mocked(getWorkbenchRiskDrawdownClient).mockImplementation(
+      (_portfolioId, params) =>
+        Promise.resolve(
+          buildFixtureRiskDrawdown(
+            scenario.workspace,
+            params.period ?? "YTD",
+            params.detailBasis ?? "NET",
+            { includeUnderwaterSeries: Boolean(params.includeUnderwaterSeries) },
+          ),
+        ),
+    );
+    vi.mocked(getWorkbenchRiskRollingClient).mockImplementation(
+      (_portfolioId, params) =>
+        Promise.resolve(
+          buildFixtureRiskRolling(
+            scenario.workspace,
+            params.period ?? "YTD",
+            params.detailBasis ?? "NET",
+            { includeTimeSeries: Boolean(params.includeTimeSeries) },
+          ),
+        ),
+    );
+
+    const { rerender } = renderRiskMode(scenario, { period: "YTD" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "63D" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "63D" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "View rolling series" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Rolling series detail" }),
+      ).toBeInTheDocument();
+    });
+
+    rerender(buildRiskModeElement(scenario, { period: "1Y" }));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Rolling series detail" }),
+      ).not.toBeInTheDocument();
+    });
+
+    rerender(buildRiskModeElement(scenario, { period: "YTD" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "63D" })).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Rolling series detail" }),
+    ).not.toBeInTheDocument();
   });
 
   it("requests supported active-risk attribution directly and does not expose issuer as interactive", async () => {

--- a/tests/unit/portfolio-data-grids.test.tsx
+++ b/tests/unit/portfolio-data-grids.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 type MockGridRow = Record<string, unknown> & {
@@ -284,6 +284,70 @@ describe("portfolio data grids", () => {
     expect(createObjectUrl).toHaveBeenCalledTimes(1);
     expect(anchorClick).toHaveBeenCalledTimes(1);
     expect(revokeObjectUrl).toHaveBeenCalledWith("blob:portfolio-transactions");
+  });
+
+  it("clears transaction date drafts when the default ledger range changes", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ total: 0, skip: 0, limit: 200, transactions: [] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { rerender } = render(
+      <PortfolioTransactionsGrid
+        portfolioId="MANUAL_PB_USD_DRAFT"
+        baseCurrency="USD"
+        asOfDate="2026-03-28"
+        defaultStartDate="2026-03-01"
+        defaultEndDate="2026-03-28"
+        initialTransactions={[]}
+      />,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Transaction start date"), {
+        target: { value: "2026-03-10" },
+      });
+    });
+    expect(screen.getByLabelText("Transaction start date")).toHaveValue("2026-03-10");
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      rerender(
+        <PortfolioTransactionsGrid
+          portfolioId="MANUAL_PB_USD_DRAFT"
+          baseCurrency="USD"
+          asOfDate="2026-04-30"
+          defaultStartDate="2026-04-01"
+          defaultEndDate="2026-04-30"
+          initialTransactions={[]}
+        />,
+      );
+    });
+
+    expect(screen.getByLabelText("Transaction start date")).toHaveValue("2026-04-01");
+    expect(screen.getByLabelText("Transaction end date")).toHaveValue("2026-04-30");
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
+    await act(async () => {
+      rerender(
+        <PortfolioTransactionsGrid
+          portfolioId="MANUAL_PB_USD_DRAFT"
+          baseCurrency="USD"
+          asOfDate="2026-03-28"
+          defaultStartDate="2026-03-01"
+          defaultEndDate="2026-03-28"
+          initialTransactions={[]}
+        />,
+      );
+    });
+
+    expect(screen.getByLabelText("Transaction start date")).toHaveValue("2026-03-01");
+    expect(screen.getByLabelText("Transaction end date")).toHaveValue("2026-03-28");
+    expect(fetchMock).toHaveBeenCalled();
   });
 
   it("serializes portfolio grid exports as auditable CSV without spreadsheet runtime dependencies", () => {
@@ -890,7 +954,9 @@ describe("portfolio data grids", () => {
   it("shows an actionable error state when transactions cannot be loaded", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => new Response("{}", { status: 500 }))
+      vi.fn(async () => {
+        throw new Error("Gateway unavailable");
+      })
     );
 
     const { container } = render(

--- a/tests/unit/portfolio-projected-cashflow-module.test.tsx
+++ b/tests/unit/portfolio-projected-cashflow-module.test.tsx
@@ -241,6 +241,33 @@ describe("PortfolioProjectedCashflowModule", () => {
     });
   });
 
+  it("clears failure posture while an unavailable projection retry is pending", async () => {
+    getPortfolioProjectedCashflow
+      .mockResolvedValueOnce(
+        buildResponse(null, {
+          warnings: ["PORTFOLIO_CASHFLOW_UNAVAILABLE"],
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise<PortfolioProjectedCashflowResponse | null>(() => {})
+      );
+
+    renderModule({ initialCashflowOutlook: null });
+
+    expect(await screen.findByText("10-day projection unavailable")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry projection" }));
+
+    expect(await screen.findByText("Loading 10-day projection")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry projection" })).not.toBeInTheDocument();
+    expect(getPortfolioProjectedCashflow).toHaveBeenLastCalledWith("MANUAL_PB_USD_001", {
+      asOfDate: "2026-03-28",
+      horizonDays: 10,
+      includeProjected: true,
+      forceRefresh: true,
+    });
+  });
+
   it("treats a source-backed flat horizon as no movement rather than partial liquidity", () => {
     renderModule({
       initialCashflowOutlook: buildOutlook({

--- a/tests/unit/portfolio-projected-cashflow-module.test.tsx
+++ b/tests/unit/portfolio-projected-cashflow-module.test.tsx
@@ -201,6 +201,7 @@ describe("PortfolioProjectedCashflowModule", () => {
 
     expect(screen.getByLabelText("Projected cashflow summary")).toBeInTheDocument();
     expect(await screen.findByText("Projection evidence refresh unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("Refreshing projection evidence")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Export" })).toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: "Retry evidence refresh" }));

--- a/tests/unit/portfolio-workspace-client.test.tsx
+++ b/tests/unit/portfolio-workspace-client.test.tsx
@@ -45,6 +45,7 @@ vi.mock("../../src/apps/portfolio/components/portfolio-workspace", () => ({
     <div>
       {toolbar}
       <div data-testid="portfolio-id">{workspace?.portfolio?.portfolio_id ?? "none"}</div>
+      <div data-testid="market-value">{workspace?.summary?.market_value_base ?? "none"}</div>
       <div data-testid="insight-key">{workspace?.insights?.[0]?.key ?? "none"}</div>
       <div data-testid="exception-key">{workspace?.exception_summaries?.[0]?.key ?? "none"}</div>
       <div data-testid="workflow-action">{workspace?.workflow_actions?.[0]?.title ?? "none"}</div>
@@ -163,6 +164,99 @@ describe("PortfolioWorkspaceClient", () => {
     });
 
     expect(getSummaryDetailsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("adopts a changed server-rendered workspace snapshot even when summary request parameters are unchanged", async () => {
+    const firstDetailsRequest: {
+      resolve: ((value: Partial<PortfolioWorkspace>) => void) | null;
+    } = { resolve: null };
+    getShellWorkspaceMock.mockResolvedValue(buildWorkspace());
+    getSummaryDetailsMock
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          firstDetailsRequest.resolve = resolve;
+        })
+      )
+      .mockResolvedValueOnce({
+        positions: [],
+        top_positions: [],
+        allocations: [],
+        allocation_views: [],
+        income_summary: null,
+        activity_summary: null,
+      });
+
+    const initialWorkspace = buildWorkspace();
+    const refreshedWorkspace = {
+      ...buildWorkspace(),
+      summary: {
+        ...initialWorkspace.summary,
+        market_value_base: 2000000.25,
+      },
+      readiness: {
+        ...initialWorkspace.readiness,
+        reporting: {
+          status: "READY",
+          generated_at_utc: "2026-03-28T12:30:00Z",
+          row_count: 4,
+        },
+      },
+      warnings: ["valuation_source_refreshed"],
+    } satisfies PortfolioWorkspace;
+
+    const { rerender } = render(
+      <PortfolioWorkspaceClient
+        portfolios={[
+          {
+            portfolio_id: "MANUAL_PB_USD_001",
+            display_name: "MANUAL_PB_USD_001",
+            base_currency: "USD",
+            client_id: "MANUAL_CIF_001",
+            booking_center_code: "Singapore",
+          },
+        ]}
+        selectedPortfolioId="MANUAL_PB_USD_001"
+        initialWorkspace={initialWorkspace}
+      />
+    );
+
+    await waitFor(() => {
+      expect(getSummaryDetailsMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <PortfolioWorkspaceClient
+        portfolios={[
+          {
+            portfolio_id: "MANUAL_PB_USD_001",
+            display_name: "MANUAL_PB_USD_001",
+            base_currency: "USD",
+            client_id: "MANUAL_CIF_001",
+            booking_center_code: "Singapore",
+          },
+        ]}
+        selectedPortfolioId="MANUAL_PB_USD_001"
+        initialWorkspace={refreshedWorkspace}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("market-value")).toHaveTextContent("2000000.25");
+    });
+    await waitFor(() => {
+      expect(getSummaryDetailsMock).toHaveBeenCalledTimes(2);
+    });
+
+    firstDetailsRequest.resolve?.({
+      summary: {
+        ...initialWorkspace.summary,
+        market_value_base: 1001550.05,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("market-value")).toHaveTextContent("2000000.25");
+    });
   });
 
   it("recovers by fetching the portfolio shell when the server-rendered shell is unavailable", async () => {

--- a/tests/unit/report-ordering-screen-state.test.ts
+++ b/tests/unit/report-ordering-screen-state.test.ts
@@ -43,6 +43,7 @@ describe("report ordering screen state", () => {
           badgeLabel,
           showRequestSummary: false,
           showActions: false,
+          showValidationSummary: false,
         }),
       );
     },
@@ -72,6 +73,7 @@ describe("report ordering screen state", () => {
     expect(state.workspace.kind).toBe("empty");
     expect(state.readiness.kind).toBe("empty");
     expect(state.readiness.showActions).toBe(false);
+    expect(state.readiness.showValidationSummary).toBe(false);
   });
 
   it.each([
@@ -98,4 +100,24 @@ describe("report ordering screen state", () => {
       );
     },
   );
+
+  it("shows validation guidance only for actionable setup-required states", () => {
+    const setupRequiredModel = readyModel();
+    setupRequiredModel.readiness.state = "blocked";
+    setupRequiredModel.readiness.issues = ["Select a valid report date."];
+
+    const state = buildReportOrderingScreenState({
+      catalogueState: "ready",
+      catalogueError: null,
+      model: setupRequiredModel,
+      preflightReviewed: false,
+      submissionState: "idle",
+      submissionError: null,
+    });
+
+    expect(state.workspace.kind).toBe("configuration");
+    expect(state.readiness.kind).toBe("setup_required");
+    expect(state.readiness.showActions).toBe(true);
+    expect(state.readiness.showValidationSummary).toBe(true);
+  });
 });

--- a/tests/unit/use-advisor-book.test.tsx
+++ b/tests/unit/use-advisor-book.test.tsx
@@ -34,14 +34,27 @@ describe("useAdvisorBook", () => {
   });
 
   it("supports an explicit retry after an unavailable response", async () => {
+    let resolveRetry: ((value: { correlation_id: string }) => void) | null = null;
     getAdvisorBookMock
       .mockRejectedValueOnce(new Error("unavailable"))
-      .mockResolvedValueOnce({ correlation_id: "recovered" });
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveRetry = resolve;
+        }),
+      );
     const { result } = renderHook(() => useAdvisorBook({ asOfDate: "2026-04-10" }));
 
     await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    let retry: Promise<void> | null = null;
+    act(() => {
+      retry = result.current.reload();
+    });
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
+
     await act(async () => {
-      await result.current.reload();
+      resolveRetry?.({ correlation_id: "recovered" });
+      await retry;
     });
     expect(result.current.response).toEqual({ correlation_id: "recovered" });
     expect(result.current.error).toBeNull();

--- a/tests/unit/use-dpm-wave-command-center-actions.test.ts
+++ b/tests/unit/use-dpm-wave-command-center-actions.test.ts
@@ -372,6 +372,19 @@ describe("useDpmWaveCommandCenterActions", () => {
     await waitFor(() => expect(result.current.model.itemRows[0]?.security).toBe("AAPL US"));
   });
 
+  it("retries the selected wave proposed-change auto-load after a transient Gateway failure", async () => {
+    vi.mocked(getDpmWaveItems)
+      .mockRejectedValueOnce(new Error("Gateway timeout"))
+      .mockResolvedValueOnce(itemResponse);
+
+    const { result } = renderActions();
+
+    await waitFor(() => expect(getDpmWaveItems).toHaveBeenCalledTimes(2));
+    expect(getDpmWaveItems).toHaveBeenNthCalledWith(1, "dwv_001");
+    expect(getDpmWaveItems).toHaveBeenNthCalledWith(2, "dwv_001");
+    await waitFor(() => expect(result.current.model.itemRows[0]?.security).toBe("AAPL US"));
+  });
+
   it("routes bounded rebalance actions through Gateway helpers", async () => {
     vi.mocked(previewDpmWave).mockResolvedValue(waveResponse);
     vi.mocked(createDpmWave).mockResolvedValue(waveResponse);

--- a/tests/unit/use-platform-capabilities.test.tsx
+++ b/tests/unit/use-platform-capabilities.test.tsx
@@ -142,7 +142,11 @@ describe("usePlatformCapabilities", () => {
 
     const second = renderHook(() => usePlatformCapabilities());
 
-    expect(second.result.current.loading).toBe(false);
+    expect(second.result.current.loading).toBe(true);
+    expect(second.result.current.shellBootstrapSource).toBe("loading");
+    await waitFor(() => {
+      expect(second.result.current.loading).toBe(false);
+    });
     expect(getPlatformCapabilitiesMock).toHaveBeenCalledTimes(1);
   });
 
@@ -167,7 +171,11 @@ describe("usePlatformCapabilities", () => {
 
     const second = renderHook(() => usePlatformCapabilities());
 
-    expect(second.result.current.loading).toBe(false);
+    expect(second.result.current.loading).toBe(true);
+    expect(second.result.current.shellBootstrapSource).toBe("loading");
+    await waitFor(() => {
+      expect(second.result.current.loading).toBe(false);
+    });
     expect(getPlatformCapabilitiesMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/use-report-ordering-workflow.test.tsx
+++ b/tests/unit/use-report-ordering-workflow.test.tsx
@@ -309,6 +309,71 @@ describe("useReportOrderingWorkflow", () => {
     expect(result.current.canSubmitReviewedRequest).toBe(false);
   });
 
+  it("tracks accepted submission handles independently for multiple portfolios", async () => {
+    optionsMock.mockImplementation((portfolioId) => {
+      const payload = buildReportOrderingResponse();
+      payload.scopeSelection.scopeId = portfolioId;
+      return Promise.resolve(parseReportOrderingResponse(payload));
+    });
+    submitMock
+      .mockResolvedValueOnce({
+        report_request_id: "rrq_a",
+        report_job_id: "rjob_a",
+        status: "accepted",
+        status_url: "/api/v1/report-jobs/rjob_a",
+        idempotency_key: "intent_a",
+      })
+      .mockResolvedValueOnce({
+        report_request_id: "rrq_b",
+        report_job_id: "rjob_b",
+        status: "accepted",
+        status_url: "/api/v1/report-jobs/rjob_b",
+        idempotency_key: "intent_b",
+      });
+
+    const { result, rerender } = renderHook(
+      ({ portfolioId }) =>
+        useReportOrderingWorkflow({
+          portfolioId,
+          asOfDate: "2026-04-22",
+          reportingCurrency: "SGD",
+        }),
+      { initialProps: { portfolioId: "PB_SG_GLOBAL_BAL_001" } },
+    );
+
+    await waitFor(() => expect(result.current.model?.canSubmit).toBe(true));
+    act(() => {
+      expect(result.current.reviewRequest()).toBe(true);
+    });
+    await waitFor(() => expect(result.current.preflightReviewed).toBe(true));
+    await act(async () => {
+      expect(await result.current.submitRequest()).toBe(true);
+    });
+    expect(result.current.submittedHandle?.report_job_id).toBe("rjob_a");
+
+    rerender({ portfolioId: "PB_SG_OTHER_002" });
+
+    await waitFor(() =>
+      expect(result.current.catalogue?.scopeSelection?.scopeId).toBe("PB_SG_OTHER_002"),
+    );
+    act(() => {
+      expect(result.current.reviewRequest()).toBe(true);
+    });
+    await waitFor(() => expect(result.current.preflightReviewed).toBe(true));
+    await act(async () => {
+      expect(await result.current.submitRequest()).toBe(true);
+    });
+    expect(result.current.submittedHandle?.report_job_id).toBe("rjob_b");
+
+    rerender({ portfolioId: "PB_SG_GLOBAL_BAL_001" });
+
+    await waitFor(() =>
+      expect(result.current.submittedHandle?.report_job_id).toBe("rjob_a"),
+    );
+    expect(result.current.submissionState).toBe("accepted");
+    expect(result.current.canSubmitReviewedRequest).toBe(false);
+  });
+
   it("ignores a late catalogue response from the previously selected portfolio", async () => {
     let resolveFirst: ((value: ReturnType<typeof parseReportOrderingResponse>) => void) | null = null;
     const firstResponse = new Promise<ReturnType<typeof parseReportOrderingResponse>>(

--- a/tests/unit/use-report-ordering-workflow.test.tsx
+++ b/tests/unit/use-report-ordering-workflow.test.tsx
@@ -216,6 +216,47 @@ describe("useReportOrderingWorkflow", () => {
     expect(result.current.submittedHandle).toBeNull();
   });
 
+  it("creates a fresh reviewed intent when switching portfolios with the same catalogue", async () => {
+    const { result, rerender } = renderHook(
+      ({ portfolioId }) =>
+        useReportOrderingWorkflow({
+          portfolioId,
+          asOfDate: "2026-04-22",
+          reportingCurrency: "SGD",
+        }),
+      { initialProps: { portfolioId: "PB_SG_GLOBAL_BAL_001" } },
+    );
+
+    await waitFor(() => expect(result.current.model?.canSubmit).toBe(true));
+    act(() => {
+      expect(result.current.reviewRequest()).toBe(true);
+    });
+    await waitFor(() => expect(result.current.preflightReviewed).toBe(true));
+
+    rerender({ portfolioId: "PB_SG_OTHER_002" });
+
+    await waitFor(() => expect(optionsMock).toHaveBeenCalledWith("PB_SG_OTHER_002"));
+    await waitFor(() => expect(result.current.model?.canSubmit).toBe(true));
+    expect(result.current.preflightReviewed).toBe(false);
+
+    act(() => {
+      expect(result.current.reviewRequest()).toBe(true);
+    });
+
+    await waitFor(() => expect(result.current.preflightReviewed).toBe(true));
+    expect(result.current.canSubmitReviewedRequest).toBe(true);
+
+    await act(async () => {
+      expect(await result.current.submitRequest()).toBe(true);
+    });
+
+    expect(submitMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        portfolioId: "PB_SG_OTHER_002",
+      }),
+    );
+  });
+
   it("keeps late submission completion scoped to the originating portfolio", async () => {
     let resolveSubmit:
       | ((value: Awaited<ReturnType<typeof submitPortfolioReviewOrder>>) => void)

--- a/tests/unit/use-report-ordering-workflow.test.tsx
+++ b/tests/unit/use-report-ordering-workflow.test.tsx
@@ -271,6 +271,44 @@ describe("useReportOrderingWorkflow", () => {
     expect(result.current.submittedHandle).toBeNull();
   });
 
+  it("restores accepted submission posture when returning to the originating portfolio", async () => {
+    const { result, rerender } = renderHook(
+      ({ portfolioId }) =>
+        useReportOrderingWorkflow({
+          portfolioId,
+          asOfDate: "2026-04-22",
+          reportingCurrency: "SGD",
+        }),
+      { initialProps: { portfolioId: "PB_SG_GLOBAL_BAL_001" } },
+    );
+
+    await waitFor(() => expect(result.current.model?.canSubmit).toBe(true));
+    act(() => {
+      expect(result.current.reviewRequest()).toBe(true);
+    });
+    await act(async () => {
+      expect(await result.current.submitRequest()).toBe(true);
+    });
+    expect(result.current.submissionState).toBe("accepted");
+    expect(result.current.submittedHandle?.report_job_id).toBe("rjob_2");
+
+    rerender({ portfolioId: "PB_SG_OTHER_002" });
+    await waitFor(() => expect(optionsMock).toHaveBeenCalledWith("PB_SG_OTHER_002"));
+    act(() => {
+      result.current.updateConfiguration({ asOfDate: "2026-04-23" });
+    });
+    expect(result.current.submissionState).toBe("idle");
+    expect(result.current.submittedHandle).toBeNull();
+
+    rerender({ portfolioId: "PB_SG_GLOBAL_BAL_001" });
+
+    await waitFor(() =>
+      expect(result.current.submittedHandle?.report_job_id).toBe("rjob_2"),
+    );
+    expect(result.current.submissionState).toBe("accepted");
+    expect(result.current.canSubmitReviewedRequest).toBe(false);
+  });
+
   it("ignores a late catalogue response from the previously selected portfolio", async () => {
     let resolveFirst: ((value: ReturnType<typeof parseReportOrderingResponse>) => void) | null = null;
     const firstResponse = new Promise<ReturnType<typeof parseReportOrderingResponse>>(

--- a/tests/unit/use-report-ordering-workflow.test.tsx
+++ b/tests/unit/use-report-ordering-workflow.test.tsx
@@ -216,6 +216,61 @@ describe("useReportOrderingWorkflow", () => {
     expect(result.current.submittedHandle).toBeNull();
   });
 
+  it("keeps late submission completion scoped to the originating portfolio", async () => {
+    let resolveSubmit:
+      | ((value: Awaited<ReturnType<typeof submitPortfolioReviewOrder>>) => void)
+      | null = null;
+    submitMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSubmit = resolve;
+      }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ portfolioId }) =>
+        useReportOrderingWorkflow({
+          portfolioId,
+          asOfDate: "2026-04-22",
+          reportingCurrency: "SGD",
+        }),
+      { initialProps: { portfolioId: "PB_SG_GLOBAL_BAL_001" } },
+    );
+
+    await waitFor(() => expect(result.current.model?.canSubmit).toBe(true));
+    act(() => {
+      expect(result.current.reviewRequest()).toBe(true);
+    });
+    await waitFor(() => expect(result.current.preflightReviewed).toBe(true));
+
+    let submitOutcome: Promise<boolean> | null = null;
+    act(() => {
+      submitOutcome = result.current.submitRequest();
+    });
+    await waitFor(() => expect(result.current.submissionState).toBe("submitting"));
+
+    rerender({ portfolioId: "PB_SG_OTHER_002" });
+
+    await waitFor(() => expect(optionsMock).toHaveBeenCalledWith("PB_SG_OTHER_002"));
+    expect(result.current.submissionState).toBe("idle");
+    expect(result.current.submissionError).toBeNull();
+    expect(result.current.submittedHandle).toBeNull();
+
+    await act(async () => {
+      resolveSubmit?.({
+        report_request_id: "rrq_old",
+        report_job_id: "rjob_old",
+        status: "accepted",
+        status_url: "/api/v1/report-jobs/rjob_old",
+        idempotency_key: "intent_old",
+      });
+      await expect(submitOutcome).resolves.toBe(false);
+    });
+
+    expect(result.current.submissionState).toBe("idle");
+    expect(result.current.submissionError).toBeNull();
+    expect(result.current.submittedHandle).toBeNull();
+  });
+
   it("ignores a late catalogue response from the previously selected portfolio", async () => {
     let resolveFirst: ((value: ReturnType<typeof parseReportOrderingResponse>) => void) | null = null;
     const firstResponse = new Promise<ReturnType<typeof parseReportOrderingResponse>>(


### PR DESCRIPTION
## Summary

This PR resolves three Workbench hardening groups:

1. React Compiler cleanup for #506, #507, and #508.
   - Replaces render/effect state-mirroring patterns with source-keyed draft state, derived state, cancellable request state, and a small shared client-mounted hook.
   - Preserves Gateway-backed Workbench behavior while removing React Compiler findings across performance, portfolio, report ordering, proposal simulation, advisor book, platform capability, sandbox, and DPM/construction surfaces.

2. Report Centre terminal-state messaging fix for #495.
   - Makes validation-summary visibility part of the exhaustive Report Centre readiness projection.
   - Suppresses non-actionable `Complete before review` setup alerts in terminal empty/restricted/unavailable states.
   - Keeps actionable setup guidance visible only when the projected state is genuinely `setup_required`.

3. PR review fix-forward for state scoping and hydration correctness.
   - Keys report-order submission progress and accepted handles to portfolio state so A→B→A portfolio switches cannot expose actions alongside an accepted handle.
   - Keys Portfolio workspace draft/detail refreshes to the exact server-rendered workspace snapshot instead of weak row-count identity.
   - Stops failed projected-cashflow evidence hydration from showing indefinite refresh state and clears retry failure posture before forced refreshes.
   - Keeps platform-capabilities hook hydration-safe by adopting cache/sessionStorage snapshots after mount instead of inside the state initializer.
   - Transitions advisor-book retries back to loading and clears the stale error while retrying the same own-book request key.
   - Remounts only Performance Risk drawer-interaction state by risk context so old drawer selections cannot revive when returning to a prior portfolio/period/basis/benchmark context.`n   - Requires reviewed report-order intents to match the active portfolio before reuse, preserving A→B portfolio review/submit enablement when catalogue fingerprints match.`n   - Keys source-date and ledger-date draft state to source transitions and retries DPM proposed-change auto-load once after a transient Gateway failure.

## Issue links

- Addresses #495
- Addresses #506
- Addresses #507
- Addresses #508

## Validation

React Compiler lane:
- `npm run lint:react-compiler`
- `npm run lint`
- `npm run typecheck`
- `npm run test -- tests/unit/portfolio-projected-cashflow-module.test.tsx tests/unit/sandbox-controls.test.tsx tests/unit/use-platform-capabilities.test.tsx tests/unit/performance-risk-mode.test.tsx tests/integration/performance-analytics-page.test.tsx` — 76 passed
- `npm run test` — 311 test files / 1460 tests passed

Report Centre lane:
- `npm run test -- tests/unit/report-ordering-screen-state.test.ts tests/integration/report-ordering-workspace.test.tsx` — 21 passed
- `npm run lint`
- `npm run typecheck`
- `npm run test:e2e:reports:states` — 4 passed

Review fix-forward lane at `f82ac567e7e3947a479e075394040be31c4f63f2`:
- `npm run test -- tests/unit/use-report-ordering-workflow.test.tsx tests/unit/portfolio-workspace-client.test.tsx tests/unit/portfolio-projected-cashflow-module.test.tsx tests/unit/use-platform-capabilities.test.tsx` — 4 files / 27 tests passed
- `npm run lint:react-compiler`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 311 test files / 1463 tests passed

Second review fix-forward lane at `0903f87d9dac0bdaf58317ea8f8b079b4e629e19`:
- `npm run test -- tests/unit/use-report-ordering-workflow.test.tsx tests/unit/use-advisor-book.test.tsx tests/integration/advisor-book-workspace.test.tsx tests/integration/report-ordering-workspace.test.tsx` — 4 files / 26 tests passed
- `npm run lint:react-compiler`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 311 test files / 1464 tests passed

Third review fix-forward lane at `4888e3239e19fc085e96e6ddf950b07ce252520c`:
- `npm run test -- tests/unit/performance-risk-mode.test.tsx` — 1 file / 15 tests passed
- `npm run lint:react-compiler`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 311 test files / 1465 tests passed

Fourth review fix-forward lane at `a590fce2ede2c4d98ec21efd5623727af8a8167a`:
- `npm run test -- tests/unit/use-report-ordering-workflow.test.tsx tests/unit/portfolio-projected-cashflow-module.test.tsx` — 2 files / 22 tests passed
- `npm run lint:react-compiler`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 311 test files / 1467 tests passed

Fifth review fix-forward lane at `fab648ef78189660c0f27e81e9e64d5f1b62f7a6`:
- `npm run test -- tests/unit/design-system-components.test.tsx tests/integration/advisor-book-workspace.test.tsx` — 2 files / 42 tests passed
- `npm run lint:react-compiler`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 311 test files / 1469 tests passed

Sixth review fix-forward lane at `7f6159452adc3755d8674e7465809dfb1d7b7a27`:
- `npm run test -- tests/unit/use-report-ordering-workflow.test.tsx` — 1 file / 11 tests passed
- `npm run lint:react-compiler`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 311 test files / 1470 tests passed

Seventh review fix-forward lane at `91bab750b8d117b39b3035cb628bb75973100a24`:
- `npm run test -- tests/unit/performance-chart-panel.test.tsx tests/unit/portfolio-data-grids.test.tsx tests/unit/use-dpm-wave-command-center-actions.test.ts` — 3 files / 46 tests passed
- `npm run lint:react-compiler`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 311 test files / 1473 tests passed
## Notes

- No backend contract or supported-feature promotion change.
- No repo-authored wiki change required for these frontend/compiler and terminal-state bug fixes.
- Platform end-to-end screenshot proof was not required because this fix-forward changes state and hydration correctness, not governed layout or canonical visual behavior.
