### PR TITLE
Refactor CSS global governance to parser-backed imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
         "eslint": "10.8.0",
         "eslint-plugin-react-hooks": "7.1.1",
         "jsdom": "26.1.0",
+        "postcss": "8.5.23",
+        "postcss-value-parser": "4.2.0",
         "typescript": "5.9.3",
         "typescript-eslint": "8.65.0",
         "vitest": "3.2.7"
@@ -5069,6 +5071,13 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "eslint": "10.8.0",
     "eslint-plugin-react-hooks": "7.1.1",
     "jsdom": "26.1.0",
+    "postcss": "8.5.23",
+    "postcss-value-parser": "4.2.0",
     "typescript": "5.9.3",
     "typescript-eslint": "8.65.0",
     "vitest": "3.2.7"

--- a/scripts/quality/check-css-global-governance.mjs
+++ b/scripts/quality/check-css-global-governance.mjs
@@ -2,6 +2,9 @@ import { readFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import postcss from "postcss";
+import valueParser from "postcss-value-parser";
+
 function resolveDefaultRepoRoot() {
   return resolve(fileURLToPath(new URL("../..", import.meta.url)));
 }
@@ -37,206 +40,78 @@ function isExternalImportRef(importRef) {
   return /^[a-z][a-z0-9+.-]*:/i.test(importRef) || importRef.startsWith("//");
 }
 
-function isIdentifierCharacter(character) {
-  return /[a-z0-9_-]/i.test(character);
+function parseCssRoot(text, cssPath) {
+  try {
+    return postcss.parse(text, { from: cssPath });
+  } catch (error) {
+    const reason = error?.reason ?? error?.message ?? String(error);
+    throw new Error(`${cssPath} contains invalid CSS: ${reason}`);
+  }
 }
 
-function isEscapedCharacter(text, characterIndex) {
-  let slashCount = 0;
+function isImportAtRule(node) {
+  return node.type === "atrule" && /^import$/i.test(node.name);
+}
 
-  for (let index = characterIndex - 1; index >= 0 && text[index] === "\\"; index -= 1) {
-    slashCount += 1;
+function describeCssNode(node) {
+  if (node.type === "atrule") {
+    return `@${node.name}`;
   }
 
-  return slashCount % 2 === 1;
-}
-
-function replaceCssBlockCommentsOutsideStrings(text, replacement = " ") {
-  let result = "";
-  let activeQuote = null;
-
-  for (let index = 0; index < text.length; index += 1) {
-    const character = text[index];
-    const nextCharacter = index + 1 < text.length ? text[index + 1] : "";
-
-    if (activeQuote) {
-      result += character;
-      if (character === activeQuote && !isEscapedCharacter(text, index)) {
-        activeQuote = null;
-      }
-      continue;
-    }
-
-    if (character === '"' || character === "'") {
-      activeQuote = character;
-      result += character;
-      continue;
-    }
-
-    if (character === "/" && nextCharacter === "*") {
-      result += replacement;
-      index += 2;
-      while (index < text.length && !(text[index] === "*" && text[index + 1] === "/")) {
-        index += 1;
-      }
-      index += 1;
-      continue;
-    }
-
-    result += character;
+  if (node.type === "rule") {
+    return node.selector;
   }
 
-  return result;
-}
-
-function containsCssImportAtRule(text) {
-  let activeQuote = null;
-  let insideBlockComment = false;
-
-  for (let index = 0; index < text.length; index += 1) {
-    const character = text[index];
-    const nextCharacter = index + 1 < text.length ? text[index + 1] : "";
-
-    if (insideBlockComment) {
-      if (character === "*" && nextCharacter === "/") {
-        insideBlockComment = false;
-        index += 1;
-      }
-      continue;
-    }
-
-    if (activeQuote) {
-      if (character === activeQuote && !isEscapedCharacter(text, index)) {
-        activeQuote = null;
-      }
-      continue;
-    }
-
-    if (character === "/" && nextCharacter === "*") {
-      insideBlockComment = true;
-      index += 1;
-      continue;
-    }
-
-    if (character === '"' || character === "'") {
-      activeQuote = character;
-      continue;
-    }
-
-    if (character !== "@") {
-      continue;
-    }
-
-    const atRuleName = text.slice(index + 1, index + 7);
-    const nextAfterAtRuleName = index + 7 < text.length ? text[index + 7] : "";
-    if (/^import$/i.test(atRuleName) && !isIdentifierCharacter(nextAfterAtRuleName)) {
-      return true;
-    }
+  if (node.type === "decl") {
+    return node.prop;
   }
 
-  return false;
+  return node.type;
 }
 
-function parseImportTarget(statement) {
-  const importStatement = statement.trim();
-  const prefixMatch = importStatement.match(/^@import(?:\s+|(?=["']))/i);
-  if (!prefixMatch) {
+function significantValueNodes(nodes) {
+  return nodes.filter((node) => node.type !== "space" && node.type !== "comment");
+}
+
+function parseImportRef(params) {
+  const [targetNode] = significantValueNodes(valueParser(params).nodes);
+
+  if (!targetNode) {
     return null;
   }
 
-  const importBody = importStatement.slice(prefixMatch[0].length);
-  let activeQuote = null;
-  let insideBlockComment = false;
-  let parenthesisDepth = 0;
+  if (targetNode.type === "string") {
+    return targetNode.value;
+  }
 
-  for (let index = 0; index < importBody.length; index += 1) {
-    const character = importBody[index];
-    const nextCharacter = index + 1 < importBody.length ? importBody[index + 1] : "";
-
-    if (insideBlockComment) {
-      if (character === "*" && nextCharacter === "/") {
-        insideBlockComment = false;
-        index += 1;
-      }
-      continue;
-    }
-
-    if (activeQuote) {
-      if (character === activeQuote && !isEscapedCharacter(importBody, index)) {
-        activeQuote = null;
-      }
-      continue;
-    }
-
-    if (character === "/" && nextCharacter === "*") {
-      insideBlockComment = true;
-      index += 1;
-      continue;
-    }
-
-    if (character === '"' || character === "'") {
-      activeQuote = character;
-      continue;
-    }
-
-    if (character === "(") {
-      parenthesisDepth += 1;
-      continue;
-    }
-
-    if (character === ")" && parenthesisDepth > 0) {
-      parenthesisDepth -= 1;
-      continue;
-    }
-
-    if (character !== ";" || parenthesisDepth > 0) {
-      continue;
-    }
-
-    const trailingText = importBody.slice(index + 1).trim();
-    if (!/^(?:\/\*[\s\S]*?\*\/\s*)*$/.test(trailingText)) {
+  if (targetNode.type === "function" && targetNode.value.toLowerCase() === "url") {
+    const [urlValueNode] = significantValueNodes(targetNode.nodes);
+    if (!urlValueNode) {
       return null;
     }
 
-    const importTarget = importBody.slice(0, index).trim();
-    return importTarget.length > 0 ? importTarget : null;
+    if (urlValueNode.type === "string" || urlValueNode.type === "word") {
+      return urlValueNode.value;
+    }
   }
 
   return null;
 }
 
-function parseLocalImportPath(repoRoot, entrypointPath, statement) {
-  const importTarget = parseImportTarget(statement);
-  if (!importTarget) {
+function hasImportStatementTerminator(statement) {
+  return /;\s*(?:\/\*[\s\S]*?\*\/\s*)*$/.test(statement);
+}
+
+function parseLocalImportPath(repoRoot, entrypointPath, importNode) {
+  const importRef = parseImportRef(importNode.params);
+
+  if (!importRef || isExternalImportRef(importRef)) {
     return null;
   }
 
-  const normalizedImportTarget = replaceCssBlockCommentsOutsideStrings(importTarget);
-  const urlMatch = importTarget.match(
-    /^url\(\s*(?:"([^"]+)"|'([^']+)'|([^"')\s]+))\s*\)(?:\s+.*)?$/i
-  );
-  const normalizedUrlMatch = normalizedImportTarget.match(
-    /^url\(\s*(?:"([^"]+)"|'([^']+)'|([^"')\s]+))\s*\)(?:\s+.*)?$/i
-  );
-  const quotedMatch = normalizedImportTarget.match(/^(?:"([^"]+)"|'([^']+)')(?:\s+.*)?$/);
-  const importRef = [...(urlMatch?.slice(1) ?? []), ...(quotedMatch?.slice(1) ?? [])].find(Boolean);
-  const normalizedImportRef = [
-    ...(normalizedUrlMatch?.slice(1) ?? []),
-    ...(quotedMatch?.slice(1) ?? []),
-  ].find(Boolean);
-  const effectiveImportRef = importRef ?? normalizedImportRef;
-
-  if (!effectiveImportRef) {
-    return null;
-  }
-
-  if (isExternalImportRef(effectiveImportRef)) {
-    return null;
-  }
-
-  const importAbsolutePath = effectiveImportRef.startsWith("/")
-    ? resolve(repoRoot, effectiveImportRef.slice(1))
-    : resolve(repoRoot, dirname(entrypointPath), effectiveImportRef);
+  const importAbsolutePath = importRef.startsWith("/")
+    ? resolve(repoRoot, importRef.slice(1))
+    : resolve(repoRoot, dirname(entrypointPath), importRef);
   return repoRelativePath(repoRoot, importAbsolutePath);
 }
 
@@ -298,7 +173,16 @@ function assertWithinBudget(repoRoot, budget, kind = "module") {
 }
 
 function assertNoModuleImports(repoRoot, moduleBudget) {
-  if (containsCssImportAtRule(fileText(repoRoot, moduleBudget.path))) {
+  const text = fileText(repoRoot, moduleBudget.path);
+  const root = parseCssRoot(text, moduleBudget.path);
+  let nestedImport = null;
+  root.walkAtRules((node) => {
+    if (isImportAtRule(node)) {
+      nestedImport = node;
+    }
+  });
+
+  if (nestedImport) {
     throw new Error(
       `${moduleBudget.path} must not contain CSS @import statements. ` +
         "Keep global CSS composition in src/app/globals.css and add each imported layer to scripts/quality/css-global-governance-baseline.json."
@@ -334,6 +218,7 @@ function assertLocalImportBudgetCoverage(entrypointPath, localImportPaths, modul
 function assertEntrypoint(repoRoot, baseline) {
   const { path, imports } = baseline.entrypoint;
   const text = fileText(repoRoot, path);
+  const root = parseCssRoot(text, path);
   const statements = text
     .split(/\r?\n/)
     .map((line) => line.trim())
@@ -341,11 +226,22 @@ function assertEntrypoint(repoRoot, baseline) {
 
   assertWithinBudget(repoRoot, baseline.entrypoint, "entrypoint");
 
-  const invalidImports = statements.filter((line) => !parseImportTarget(line));
-  if (invalidImports.length > 0) {
+  const entrypointNodes = root.nodes ?? [];
+  const invalidNodes = entrypointNodes.filter((node) => node.type !== "comment" && !isImportAtRule(node));
+  const importNodes = entrypointNodes.filter(isImportAtRule);
+  const unterminatedImportStatements = statements.filter((statement) => !hasImportStatementTerminator(statement));
+  const invalidImportNodes = importNodes.filter((node) => !parseImportRef(node.params));
+
+  if (invalidNodes.length > 0 || unterminatedImportStatements.length > 0 || invalidImportNodes.length > 0) {
+    const invalidNodeSummary = invalidNodes.map(describeCssNode);
+    const invalidImportSummary = [
+      ...unterminatedImportStatements,
+      ...invalidImportNodes.map((node) => `@import ${node.params}`),
+      ...invalidNodeSummary,
+    ];
     throw new Error(
       `${path} must remain a composition entrypoint with only valid import statements and optional trailing comments. ` +
-        `Found invalid import statements: ${invalidImports.join(", ")}`
+        `Found invalid import statements: ${invalidImportSummary.join(", ")}`
     );
   }
 
@@ -356,8 +252,8 @@ function assertEntrypoint(repoRoot, baseline) {
     );
   }
 
-  const localImportPaths = statements
-    .map((statement) => parseLocalImportPath(repoRoot, path, statement))
+  const localImportPaths = importNodes
+    .map((importNode) => parseLocalImportPath(repoRoot, path, importNode))
     .filter(Boolean);
   assertLocalImportBudgetCoverage(path, localImportPaths, baseline.modules);
 }

--- a/scripts/quality/check-css-global-governance.mjs
+++ b/scripts/quality/check-css-global-governance.mjs
@@ -74,9 +74,17 @@ function significantValueNodes(nodes) {
 }
 
 function parseImportRef(params) {
-  const [targetNode] = significantValueNodes(valueParser(params).nodes);
+  const [targetNode, ...conditionNodes] = significantValueNodes(valueParser(params).nodes);
 
   if (!targetNode) {
+    return null;
+  }
+
+  if (
+    conditionNodes.some(
+      (node) => node.type === "string" || (node.type === "div" && node.value === ",")
+    )
+  ) {
     return null;
   }
 

--- a/scripts/quality/check-css-global-governance.mjs
+++ b/scripts/quality/check-css-global-governance.mjs
@@ -87,6 +87,27 @@ function normalizeUrlWordImportRef(value) {
   return normalizedValue.includes("'") || normalizedValue.includes('"') ? null : normalizedValue;
 }
 
+function hasEmptyConditionalMediaEntry(conditionNodes) {
+  let hasConditionTokenSinceComma = false;
+
+  for (const node of conditionNodes) {
+    if (node.type === "div" && node.value === ",") {
+      if (!hasConditionTokenSinceComma) {
+        return true;
+      }
+      hasConditionTokenSinceComma = false;
+      continue;
+    }
+
+    hasConditionTokenSinceComma = true;
+  }
+
+  return (
+    conditionNodes.some((node) => node.type === "div" && node.value === ",") &&
+    !hasConditionTokenSinceComma
+  );
+}
+
 function parseImportRef(params) {
   const [targetNode, ...conditionNodes] = significantValueNodes(valueParser(params).nodes);
 
@@ -98,7 +119,8 @@ function parseImportRef(params) {
     conditionNodes.some(
       (node) =>
         node.type === "string" || (node.type === "function" && node.value.toLowerCase() === "url")
-    )
+    ) ||
+    hasEmptyConditionalMediaEntry(conditionNodes)
   ) {
     return null;
   }

--- a/scripts/quality/check-css-global-governance.mjs
+++ b/scripts/quality/check-css-global-governance.mjs
@@ -82,7 +82,8 @@ function parseImportRef(params) {
 
   if (
     conditionNodes.some(
-      (node) => node.type === "string" || (node.type === "div" && node.value === ",")
+      (node) =>
+        node.type === "string" || (node.type === "function" && node.value.toLowerCase() === "url")
     )
   ) {
     return null;

--- a/scripts/quality/check-css-global-governance.mjs
+++ b/scripts/quality/check-css-global-governance.mjs
@@ -73,6 +73,20 @@ function significantValueNodes(nodes) {
   return nodes.filter((node) => node.type !== "space" && node.type !== "comment");
 }
 
+function normalizeUrlWordImportRef(value) {
+  const normalizedValue = value.replace(/\/\*[\s\S]*?\*\//g, "").trim();
+  if (!normalizedValue) {
+    return null;
+  }
+
+  const quote = normalizedValue[0];
+  if (quote === "'" || quote === '"') {
+    return normalizedValue.endsWith(quote) ? normalizedValue.slice(1, -1) : null;
+  }
+
+  return normalizedValue.includes("'") || normalizedValue.includes('"') ? null : normalizedValue;
+}
+
 function parseImportRef(params) {
   const [targetNode, ...conditionNodes] = significantValueNodes(valueParser(params).nodes);
 
@@ -100,8 +114,12 @@ function parseImportRef(params) {
     }
 
     const [urlValueNode] = urlValueNodes;
-    if (urlValueNode.type === "string" || urlValueNode.type === "word") {
+    if (urlValueNode.type === "string") {
       return urlValueNode.value;
+    }
+
+    if (urlValueNode.type === "word") {
+      return normalizeUrlWordImportRef(urlValueNode.value);
     }
   }
 

--- a/scripts/quality/check-css-global-governance.mjs
+++ b/scripts/quality/check-css-global-governance.mjs
@@ -85,11 +85,12 @@ function parseImportRef(params) {
   }
 
   if (targetNode.type === "function" && targetNode.value.toLowerCase() === "url") {
-    const [urlValueNode] = significantValueNodes(targetNode.nodes);
-    if (!urlValueNode) {
+    const urlValueNodes = significantValueNodes(targetNode.nodes);
+    if (urlValueNodes.length !== 1) {
       return null;
     }
 
+    const [urlValueNode] = urlValueNodes;
     if (urlValueNode.type === "string" || urlValueNode.type === "word") {
       return urlValueNode.value;
     }

--- a/tests/unit/css-global-governance.test.ts
+++ b/tests/unit/css-global-governance.test.ts
@@ -142,6 +142,37 @@ describe("CSS global governance gate", () => {
     }
   });
 
+  it("normalizes CSS comments inside URL imports before resolving module budgets", async () => {
+    const { repoRoot, baseline } = createFixture();
+    const { validateCssGlobalGovernance } = await governanceModulePromise;
+
+    try {
+      const globalsText =
+        '@import url(/**/"../styles/global/tokens.css");\n@import url(../styles/global/base.css/**/);\n';
+      const entrypointBudget = writeFixtureFile(repoRoot, "src/app/globals.css", globalsText);
+      const baselineWithCommentedUrlImports: CssBaseline = {
+        ...baseline,
+        entrypoint: {
+          ...baseline.entrypoint,
+          ...entrypointBudget,
+          imports: [
+            '@import url(/**/"../styles/global/tokens.css");',
+            "@import url(../styles/global/base.css/**/);",
+          ],
+        },
+      };
+
+      expect(() =>
+        validateCssGlobalGovernance({
+          repoRoot,
+          baseline: baselineWithCommentedUrlImports,
+        }),
+      ).not.toThrow();
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
   it("parses local imports with whitespace before the semicolon before checking budgets", async () => {
     const { repoRoot, baseline } = createFixture();
     const { validateCssGlobalGovernance } = await governanceModulePromise;

--- a/tests/unit/css-global-governance.test.ts
+++ b/tests/unit/css-global-governance.test.ts
@@ -401,6 +401,40 @@ describe("CSS global governance gate", () => {
     }
   });
 
+  it("parses local URL imports with comma-separated media queries before checking module budgets", async () => {
+    const { repoRoot, baseline } = createFixture();
+    const { validateCssGlobalGovernance } = await governanceModulePromise;
+
+    try {
+      const globalsText =
+        '@import url("../styles/global/tokens.css") screen, print;\n@import "../styles/global/base.css";\n';
+      const entrypointBudget = writeFixtureFile(repoRoot, "src/app/globals.css", globalsText);
+      const baselineWithMediaQueryList: CssBaseline = {
+        ...baseline,
+        entrypoint: {
+          ...baseline.entrypoint,
+          ...entrypointBudget,
+          imports: [
+            '@import url("../styles/global/tokens.css") screen, print;',
+            '@import "../styles/global/base.css";',
+          ],
+        },
+        modules: baseline.modules.filter(
+          (moduleBudget) => !moduleBudget.path.endsWith("tokens.css"),
+        ),
+      };
+
+      expect(() =>
+        validateCssGlobalGovernance({
+          repoRoot,
+          baseline: baselineWithMediaQueryList,
+        }),
+      ).toThrow(/imports local global CSS files without module budgets/);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
   it("parses local URL imports with layer, supports, and media conditions before checking module budgets", async () => {
     const { repoRoot, baseline } = createFixture();
     const { validateCssGlobalGovernance } = await governanceModulePromise;

--- a/tests/unit/css-global-governance.test.ts
+++ b/tests/unit/css-global-governance.test.ts
@@ -466,6 +466,37 @@ describe("CSS global governance gate", () => {
     }
   });
 
+  it("rejects URL imports with empty conditional media entries", async () => {
+    const { repoRoot, baseline } = createFixture();
+    const { validateCssGlobalGovernance } = await governanceModulePromise;
+
+    try {
+      const globalsText =
+        '@import/**/url("../styles/global/tokens.css"),;\n@import "../styles/global/base.css";\n';
+      const entrypointBudget = writeFixtureFile(repoRoot, "src/app/globals.css", globalsText);
+      const baselineWithTrailingMediaComma: CssBaseline = {
+        ...baseline,
+        entrypoint: {
+          ...baseline.entrypoint,
+          ...entrypointBudget,
+          imports: [
+            '@import/**/url("../styles/global/tokens.css"),;',
+            '@import "../styles/global/base.css";',
+          ],
+        },
+      };
+
+      expect(() =>
+        validateCssGlobalGovernance({
+          repoRoot,
+          baseline: baselineWithTrailingMediaComma,
+        }),
+      ).toThrow(/only valid import statements/);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
   it("parses local URL imports with layer, supports, and media conditions before checking module budgets", async () => {
     const { repoRoot, baseline } = createFixture();
     const { validateCssGlobalGovernance } = await governanceModulePromise;

--- a/tests/unit/css-global-governance.test.ts
+++ b/tests/unit/css-global-governance.test.ts
@@ -339,6 +339,38 @@ describe("CSS global governance gate", () => {
     }
   });
 
+  it("parses local URL imports with layer, supports, and media conditions before checking module budgets", async () => {
+    const { repoRoot, baseline } = createFixture();
+    const { validateCssGlobalGovernance } = await governanceModulePromise;
+
+    try {
+      const globalsText =
+        '@import url("../styles/global/tokens.css") layer(tokens) supports(display: grid) screen;\n@import "../styles/global/base.css";\n';
+      const entrypointBudget = writeFixtureFile(repoRoot, "src/app/globals.css", globalsText);
+      const baselineWithConditionalImport: CssBaseline = {
+        ...baseline,
+        entrypoint: {
+          ...baseline.entrypoint,
+          ...entrypointBudget,
+          imports: [
+            '@import url("../styles/global/tokens.css") layer(tokens) supports(display: grid) screen;',
+            '@import "../styles/global/base.css";',
+          ],
+        },
+        modules: baseline.modules.filter((moduleBudget) => !moduleBudget.path.endsWith("tokens.css")),
+      };
+
+      expect(() =>
+        validateCssGlobalGovernance({
+          repoRoot,
+          baseline: baselineWithConditionalImport,
+        }),
+      ).toThrow(/imports local global CSS files without module budgets/);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
   it("rejects same-line declarations after import statements in the entrypoint", async () => {
     const { repoRoot, baseline } = createFixture();
     const { validateCssGlobalGovernance } = await governanceModulePromise;
@@ -395,6 +427,36 @@ describe("CSS global governance gate", () => {
           baseline: baselineWithNestedModuleImport,
         }),
       ).toThrow(/must not contain CSS @import statements/);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts CSS module strings and comments that mention import text without real at-rules", async () => {
+    const { repoRoot, baseline } = createFixture();
+    const { validateCssGlobalGovernance } = await governanceModulePromise;
+
+    try {
+      const baseWithImportTextOnly =
+        '.before { content: "@import \\"./not-a-real-import.css\\""; }\n/* @import "./also-not-real.css"; */\nbody {\n  margin: 0;\n}\n';
+      const updatedBaseBudget = writeFixtureFile(
+        repoRoot,
+        "src/styles/global/base.css",
+        baseWithImportTextOnly,
+      );
+      const baselineWithImportTextOnly: CssBaseline = {
+        ...baseline,
+        modules: baseline.modules.map((moduleBudget) =>
+          moduleBudget.path.endsWith("base.css") ? updatedBaseBudget : moduleBudget,
+        ),
+      };
+
+      expect(() =>
+        validateCssGlobalGovernance({
+          repoRoot,
+          baseline: baselineWithImportTextOnly,
+        }),
+      ).not.toThrow();
     } finally {
       rmSync(repoRoot, { recursive: true, force: true });
     }

--- a/tests/unit/css-global-governance.test.ts
+++ b/tests/unit/css-global-governance.test.ts
@@ -307,6 +307,37 @@ describe("CSS global governance gate", () => {
     }
   });
 
+  it("rejects malformed URL imports with multiple target values", async () => {
+    const { repoRoot, baseline } = createFixture();
+    const { validateCssGlobalGovernance } = await governanceModulePromise;
+
+    try {
+      const globalsText =
+        '@import url("../styles/global/tokens.css", "../styles/global/other.css");\n@import "../styles/global/base.css";\n';
+      const entrypointBudget = writeFixtureFile(repoRoot, "src/app/globals.css", globalsText);
+      const baselineWithMalformedUrlImport: CssBaseline = {
+        ...baseline,
+        entrypoint: {
+          ...baseline.entrypoint,
+          ...entrypointBudget,
+          imports: [
+            '@import url("../styles/global/tokens.css", "../styles/global/other.css");',
+            '@import "../styles/global/base.css";',
+          ],
+        },
+      };
+
+      expect(() =>
+        validateCssGlobalGovernance({
+          repoRoot,
+          baseline: baselineWithMalformedUrlImport,
+        }),
+      ).toThrow(/only valid import statements/);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
   it("parses local URL imports with comment-separated conditions before checking module budgets", async () => {
     const { repoRoot, baseline } = createFixture();
     const { validateCssGlobalGovernance } = await governanceModulePromise;

--- a/tests/unit/css-global-governance.test.ts
+++ b/tests/unit/css-global-governance.test.ts
@@ -338,6 +338,37 @@ describe("CSS global governance gate", () => {
     }
   });
 
+  it("rejects malformed quoted imports with extra target values", async () => {
+    const { repoRoot, baseline } = createFixture();
+    const { validateCssGlobalGovernance } = await governanceModulePromise;
+
+    try {
+      const globalsText =
+        '@import "../styles/global/tokens.css", "../styles/global/other.css";\n@import "../styles/global/base.css";\n';
+      const entrypointBudget = writeFixtureFile(repoRoot, "src/app/globals.css", globalsText);
+      const baselineWithMalformedQuotedImport: CssBaseline = {
+        ...baseline,
+        entrypoint: {
+          ...baseline.entrypoint,
+          ...entrypointBudget,
+          imports: [
+            '@import "../styles/global/tokens.css", "../styles/global/other.css";',
+            '@import "../styles/global/base.css";',
+          ],
+        },
+      };
+
+      expect(() =>
+        validateCssGlobalGovernance({
+          repoRoot,
+          baseline: baselineWithMalformedQuotedImport,
+        }),
+      ).toThrow(/only valid import statements/);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
   it("parses local URL imports with comment-separated conditions before checking module budgets", async () => {
     const { repoRoot, baseline } = createFixture();
     const { validateCssGlobalGovernance } = await governanceModulePromise;


### PR DESCRIPTION
## Scope

Refs #513. Keep #513 open until merged-main validation and QA closure evidence are posted.

This PR replaces the CSS global governance gate's hand-rolled import scanner with parser-backed extraction:

- pins direct governed dev dependencies on `postcss@8.5.23` and `postcss-value-parser@4.2.0`;
- parses CSS source with PostCSS before evaluating entrypoint/module rules;
- parses CSS import values with `postcss-value-parser` for quoted, `url(...)`, case-insensitive URL, conditional import, and comment-separated syntax;
- preserves stricter Workbench governance: `src/app/globals.css` remains an import-only composition entrypoint, semicolon-terminated imports remain required, local global CSS imports must have module budgets, and governed CSS modules cannot contain real nested `@import` at-rules;
- adds regression coverage for modern conditional imports and for strings/comments that mention `@import` text without introducing a real at-rule.

## Local validation

- `npm run test -- tests/unit/css-global-governance.test.ts` -> 19 tests passed
- `npm run test -- tests/unit/css-global-governance.test.ts tests/unit/dependency-security-governance.test.ts tests/unit/design-system-token-contract.test.ts tests/unit/docker-ci-parity-governance.test.ts` -> 34 tests passed
- `npm run lint:css-global` -> passed
- `npm run security:audit` -> found 0 vulnerabilities for full and omit-dev audits
- `npm run lint` -> passed
- `npm run typecheck` -> passed
- `npm run build` -> passed
- `git diff --check` -> passed

## Dependency posture

- `postcss@8.5.23` is already the locked Next/Vite parser version; this PR makes the quality gate's parser usage direct instead of transitive.
- `postcss-value-parser@4.2.0` is a mature CSS value parser used only by the local governance script.
- No beta, experimental, or novelty-driven package adoption.
- `npm audit` reports 0 vulnerabilities.

## Governance and non-degradation

- Repository profile: UI Product / frontend governance tooling.
- Product runtime/UI behavior: no change.
- API/OpenAPI/migration impact: none.
- Wiki decision: no wiki source change required; this hardens an internal quality gate and does not change operator-facing Workbench runtime truth.
- Stranded truth: `git fetch origin --prune` and `git branch -r --no-merged origin/main` reported no unmerged remote branches before implementation.
- Branch hygiene: branch started from clean `main`; two signed commits; repo-local branch commit budget validator is not present.