### PR TITLE
Bind Idea capacity seed trusted caller context

### DIFF
--- a/docs/operations/canonical-front-office-local-runtime.md
+++ b/docs/operations/canonical-front-office-local-runtime.md
@@ -169,6 +169,14 @@ Capacity evidence uses the isolated `CAPACITY_SYNTHETIC_PORTFOLIO_001` namespace
 persist credentials in evidence. This is deterministic seed and integration-readiness proof only;
 it is not load or soak evidence, capacity certification, or supported-feature promotion.
 
+The capacity seed is still exercised through Lotus Idea's public API policy. Canonical startup
+creates one per-run local trusted-caller marker, passes it to the Idea runtime as
+`LOTUS_IDEA_TRUSTED_CALLER_CONTEXT_TOKEN`, and forwards the same marker to the seed process as
+`LOTUS_IDEA_CAPACITY_TRUSTED_CALLER_CONTEXT`. The Idea seed process must also send complete
+synthetic tenant, book, portfolio, client, role, and capability scope headers for each governed
+mutation. This is local/dev proof wiring only; it is not a production identity provider,
+session/token-claims authority, or endpoint-policy bypass.
+
 For active RFC or UI development, pass `-LocalApps` with a comma-separated app list. Local apps use
 the same canonical hostnames and public ports as Docker-backed apps, so live evidence remains
 comparable:

--- a/scripts/live/Start-LotusFrontOfficeCanonical.ps1
+++ b/scripts/live/Start-LotusFrontOfficeCanonical.ps1
@@ -703,15 +703,19 @@ function Invoke-CanonicalIdeaCapacitySeed {
   Wait-HttpReady -Url "http://127.0.0.1:8000/health/ready" -Description "lotus-advise"
 
   Write-Host "Seeding isolated Lotus Idea downstream-capacity evidence ..."
-  & (Join-Path $workbenchRepo "scripts\\live\\Invoke-IdeaCapacitySeed.ps1") `
-    -ProjectsRoot $ProjectsRoot `
-    -IdeaBaseUrl "http://127.0.0.1:8330" `
-    -AsOfDate $datePolicy.AsOfDate `
-    -SeededAtUtc $datePolicy.GeneratedAtUtc `
-    -RunId $ideaCanonicalRunId `
-    -ExpectedCommitSha $ideaSourceIdentity.CommitSha `
-    -ExpectedBranch $ideaSourceIdentity.Branch `
-    -EvidenceDirectory $ideaCapacityEvidenceRoot
+  Invoke-WithProcessEnvironment `
+    -Environment @{ LOTUS_IDEA_CAPACITY_TRUSTED_CALLER_CONTEXT = $ideaCapacityTrustedCallerContext } `
+    -ScriptBlock {
+      & (Join-Path $workbenchRepo "scripts\\live\\Invoke-IdeaCapacitySeed.ps1") `
+        -ProjectsRoot $ProjectsRoot `
+        -IdeaBaseUrl "http://127.0.0.1:8330" `
+        -AsOfDate $datePolicy.AsOfDate `
+        -SeededAtUtc $datePolicy.GeneratedAtUtc `
+        -RunId $ideaCanonicalRunId `
+        -ExpectedCommitSha $ideaSourceIdentity.CommitSha `
+        -ExpectedBranch $ideaSourceIdentity.Branch `
+        -EvidenceDirectory $ideaCapacityEvidenceRoot
+    }
   if ($LASTEXITCODE -ne 0) {
     throw "Canonical Lotus Idea capacity seed failed with exit code $LASTEXITCODE."
   }
@@ -763,6 +767,7 @@ if ($CoreManageOnly) {
 $ideaSourceIdentity = Get-GitRepositoryIdentity -RepoPath $ideaRepo
 $ideaDatePolicy = Get-CanonicalFrontOfficeDatePolicy
 $ideaCanonicalRunId = "canonical-front-office-$($ideaDatePolicy.AsOfDate)-$([guid]::NewGuid().ToString('N'))"
+$ideaCapacityTrustedCallerContext = "canonical-local-idea-capacity-seed-$([guid]::NewGuid().ToString('N'))"
 $ideaBuildTimestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 $ideaBuildEnvironment = @{
   LOTUS_IDEA_BUILD_GIT_COMMIT_SHA = $ideaSourceIdentity.CommitSha
@@ -772,6 +777,7 @@ $ideaBuildEnvironment = @{
   LOTUS_IDEA_BUILD_RUN_ID = $ideaCanonicalRunId
   LOTUS_IDEA_BUILD_IMAGE_ID = "$($ideaSourceIdentity.CommitSha).$ideaCanonicalRunId"
   LOTUS_IDEA_BUILD_SERVICE_VERSION = "0.1.0"
+  LOTUS_IDEA_TRUSTED_CALLER_CONTEXT_TOKEN = $ideaCapacityTrustedCallerContext
 }
 $resolvedLotusAiEnvFile = Resolve-LotusAiEnvFile -EnvFile $LotusAiEnvFile
 Write-Host "Using lotus-ai env file for canonical proof: $resolvedLotusAiEnvFile"

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -474,6 +474,17 @@ describe("canonical live validation script", () => {
     expect(script).not.toContain("client-001");
     expect(script).not.toContain("LOTUS_IDEA_CAPACITY_AUTHORIZATION");
     expect(script).not.toContain("LOTUS_IDEA_CAPACITY_TRUSTED_CALLER_CONTEXT");
+
+    const startScript = readFileSync(
+      join(process.cwd(), "scripts", "live", "Start-LotusFrontOfficeCanonical.ps1"),
+      "utf8",
+    );
+    expect(startScript).toContain(
+      '$ideaCapacityTrustedCallerContext = "canonical-local-idea-capacity-seed-$([guid]::NewGuid().ToString(\'N\'))"',
+    );
+    expect(startScript).toContain("LOTUS_IDEA_TRUSTED_CALLER_CONTEXT_TOKEN");
+    expect(startScript).toContain("LOTUS_IDEA_CAPACITY_TRUSTED_CALLER_CONTEXT");
+    expect(startScript).toContain("Invoke-WithProcessEnvironment");
   });
 
   it("asserts canonical performance and risk calculation sanity", () => {

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -174,7 +174,11 @@ concurrency group.
   requires the isolated `CAPACITY_SYNTHETIC_PORTFOLIO_001` namespace, and accepts exactly one
   report-only downstream-submission probe. Workbench evidence retains artifact paths, SHA-256
   digests, and provenance but excludes conversion-intent identifiers, downstream paths, and
-  credentials. This proof does not certify load, soak, production capacity, or feature support.
+  credentials. Canonical startup binds one per-run local trusted-caller marker to the Idea runtime
+  and capacity seed process, while Idea must still send complete synthetic entitlement scope through
+  its public API policy for every governed mutation. This is local/dev proof wiring only; it is not
+  a production identity provider, session/token-claims authority, endpoint-policy bypass, load,
+  soak, production capacity, or feature-support certification.
 - RFC-0028 bank-demo proof validation must read the Gateway-backed scenario contract and
   supported-claim register, verify the governed scenario id, proof marker, and claim postures, and
   render `/recommendations?mode=proof` as `advisory.bank_demo_proof`. The screenshot is accepted


### PR DESCRIPTION
## Scope

Keep sgajbi/lotus-idea#814 open.

This PR implements the Workbench canonical orchestration side of the RFC-0002 #814 local/dev authorization wiring:

- creates one per-run local Idea capacity trusted-caller marker
- passes the marker to the Idea runtime as `LOTUS_IDEA_TRUSTED_CALLER_CONTEXT_TOKEN`
- forwards the same marker to the capacity seed process as `LOTUS_IDEA_CAPACITY_TRUSTED_CALLER_CONTEXT`
- keeps the child capacity-seed script free of hard-coded portfolio/client identities or environment binding
- updates canonical runtime docs and wiki source with the bounded local/dev identity boundary

## Validation

- PowerShell parser check for `scripts/live/Start-LotusFrontOfficeCanonical.ps1`
- `npm run test -- --runTestsByPath tests/unit/live-canonical-validation-script.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-workbench -AllowUnpublishedSourceChanges`
- `audit_wiki_quality.py --wiki-dir C:/Users/Sandeep/projects/lotus-workbench/wiki --changed-page Validation-and-CI.md`

## Remaining before #814 closure

Keep sgajbi/lotus-idea#814 open until the paired Idea PR is merged, fresh Idea image provenance and capacity seed proof pass, and the full `Start-LotusFrontOfficeCanonical.ps1 -BuildImages -RunValidation` path completes on main. This PR does not implement production authentication, production IdP/session/token-claims authority, supported-feature promotion, capacity certification, or client-publication proof.