### PR TITLE
Align Idea capacity workload evidence validation

### DIFF
--- a/scripts/live/validation/idea-capacity-seed-evidence.mjs
+++ b/scripts/live/validation/idea-capacity-seed-evidence.mjs
@@ -107,9 +107,12 @@ export function validateIdeaCapacityWorkload(payload, { commitSha, branch, runId
     }
   }
   const scenarios = Array.isArray(payload.scenarios) ? payload.scenarios : [];
-  const downstream = scenarios[0];
+  const downstreamScenarios = scenarios.filter(
+    (scenario) => scenario?.scenario === "downstream_submission",
+  );
+  const downstream = downstreamScenarios[0];
   if (
-    scenarios.length !== 1 ||
+    downstreamScenarios.length !== 1 ||
     !downstream ||
     downstream.scenario !== "downstream_submission" ||
     downstream.sampleCount !== 1 ||

--- a/tests/unit/idea-capacity-seed-evidence.test.ts
+++ b/tests/unit/idea-capacity-seed-evidence.test.ts
@@ -90,6 +90,31 @@ describe("Idea capacity seed evidence", () => {
       validateIdeaCapacityWorkload(
         {
           ...workload,
+          scenarios: [
+            {
+              scenario: "api",
+              sampleCount: 0,
+              acceptedCount: 0,
+              errorCount: 0,
+              conflictCount: 0,
+            },
+            workload.scenarios[0],
+            {
+              scenario: "source_ingestion",
+              sampleCount: 0,
+              acceptedCount: 0,
+              errorCount: 0,
+              conflictCount: 0,
+            },
+          ],
+        },
+        expected,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      validateIdeaCapacityWorkload(
+        {
+          ...workload,
           scenarios: [{ ...workload.scenarios[0], acceptedCount: 0, errorCount: 1 }],
         },
         expected,


### PR DESCRIPTION
## Summary
- Aligns Workbench's Idea capacity-seed evidence validator with the current Idea service-capacity baseline contract.
- Accepts exactly one successful `downstream_submission` scenario inside the normal multi-scenario workload evidence shape.
- Preserves the non-certifying posture: this remains source-safe seed proof, not production capacity certification or supported-feature promotion.

## Linked issue
- sgajbi/lotus-idea#814
- Keep #814 open: this PR fixes the validator drift found during canonical mainline validation, but the full `Start-LotusFrontOfficeCanonical.ps1 -BuildImages -RunValidation` proof still needs to rerun after merge.

## Validation
- `npm test -- --run tests/unit/idea-capacity-seed-evidence.test.ts`
- `npm run lint`
- `npm run typecheck`

## Non-degradation
- Authorization is unchanged; Workbench still consumes Idea-owned artifacts and does not construct the synthetic resource itself.
- Evidence remains source-safe: no conversion intent id, downstream path, authorization header, or canonical portfolio identity is copied into the final Workbench evidence.
- No docs/wiki change: this corrects validator compatibility with the already-documented runtime contract.