### PR TITLE
fix(workbench): derive advisory copilot caller authority

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -176,6 +176,13 @@ Current repository posture:
     `lotus-advise` directly. `/recommendations?mode=copilot` renders Gateway-backed RFC-0027
     advisor-use copilot actions over Advise-owned proposal-version source projection, action runs,
     human review posture, unsupported-evidence posture, and blocked client-publication boundaries.
+    Its BFF authority adapter strips browser-supplied reviewer, proposal, portfolio, tenant,
+    legal-entity, role, capability, principal-status, authorization, cookie, proxy-authorization,
+    session, and upstream-auth identity claims; resolves the action run through Gateway before
+    review submission; applies only server-derived reviewer context; verifies the source-owned
+    portfolio against the configured development entitlement; and forwards the source-owned
+    proposal and portfolio identifiers needed by Gateway review authority. Unresolved or
+    cross-entitlement run scope fails closed before the review mutation is proxied.
     It must not construct evidence sections, prompts, guardrails, AI/model lineage, review state,
     policy semantics, client-ready release, client communication, order, fill, settlement, or OMS
     posture locally. The proposal builder sources positions and cash through

--- a/scripts/live/validation/advisor-cockpit-proof.mjs
+++ b/scripts/live/validation/advisor-cockpit-proof.mjs
@@ -1,4 +1,4 @@
-import { fetchJson, sendJson, sendJsonExpectingStatus } from "./probes.mjs";
+import { sendJson, sendJsonExpectingStatus } from "./probes.mjs";
 import {
   buildPayloadScopedIdempotencyKey,
   extractGatewayEnvelopeData,
@@ -7,18 +7,22 @@ import {
 
 const DEFAULT_ADVISOR_ID = "advisor_sg_001";
 const DEFAULT_ROLE = "ADVISOR";
+const DEFAULT_CALLER_APPLICATION = "lotus-workbench";
+const DEFAULT_TENANT_ID = "tenant-sg";
+const DEFAULT_REGION = "APAC";
+const DEFAULT_BOOKING_CENTER_CODE = "SG";
+const DEFAULT_LEGAL_ENTITY_CODE = "SGPB";
+const DEFAULT_PRINCIPAL_STATUS = "ACTIVE";
+const READ_CAPABILITY = "advisory.advisor_cockpit.read";
+const ACKNOWLEDGE_CAPABILITY = "advisory.advisor_cockpit.acknowledge";
 
 function advisorCockpitQuery({
   portfolioId,
-  advisorId = DEFAULT_ADVISOR_ID,
-  role = DEFAULT_ROLE,
   limit,
   cursor,
 }) {
   const query = new URLSearchParams({
     portfolio_id: portfolioId,
-    advisor_id: advisorId,
-    role,
   });
   if (limit) {
     query.set("limit", String(limit));
@@ -27,6 +31,27 @@ function advisorCockpitQuery({
     query.set("cursor", String(cursor));
   }
   return query.toString();
+}
+
+function advisorCockpitHeaders({
+  portfolioId,
+  advisorId = DEFAULT_ADVISOR_ID,
+  role = DEFAULT_ROLE,
+  capability = READ_CAPABILITY,
+}) {
+  return {
+    "X-Actor-Id": advisorId,
+    "X-Caller-Application": DEFAULT_CALLER_APPLICATION,
+    "X-Tenant-Id": DEFAULT_TENANT_ID,
+    "X-Region": DEFAULT_REGION,
+    "X-Booking-Center-Code": DEFAULT_BOOKING_CENTER_CODE,
+    "X-Legal-Entity-Code": DEFAULT_LEGAL_ENTITY_CODE,
+    "X-Role": role,
+    "X-Caller-Capabilities": capability,
+    "X-Principal-Status": DEFAULT_PRINCIPAL_STATUS,
+    "X-Authorized-Advisor-Id": advisorId,
+    "X-Authorized-Portfolio-Id": portfolioId,
+  };
 }
 
 function assertPortfolioScopedActions(items, portfolioId) {
@@ -221,18 +246,20 @@ async function validateActionDetail({
   summary,
   gatewayBaseUrl,
   query,
+  headers,
   policyAction,
   portfolioId,
   timeoutMs,
 }) {
   const actionItemId = readString(policyAction?.action_item_id);
-  const detail = await fetchJson(
+  const detail = await sendJson(
     summary,
     `${gatewayBaseUrl}/api/v1/advisor-cockpit/actions/${encodeURIComponent(
       actionItemId,
     )}?${query}`,
     "Advisor cockpit canonical action detail",
     timeoutMs,
+    { headers },
   );
   const detailData = extractGatewayEnvelopeData(detail);
   if (readString(detailData?.action_item_id) !== actionItemId) {
@@ -263,15 +290,15 @@ async function validateActionPagination({
   }
   const pagedQuery = advisorCockpitQuery({
     portfolioId,
-    advisorId,
-    role,
     limit: 1,
   });
-  const firstPaged = await fetchJson(
+  const headers = advisorCockpitHeaders({ portfolioId, advisorId, role });
+  const firstPaged = await sendJson(
     summary,
     `${gatewayBaseUrl}/api/v1/advisor-cockpit/actions?${pagedQuery}`,
     "Advisor cockpit canonical pagination first page",
     timeoutMs,
+    { headers },
   );
   const firstPagedData = extractGatewayEnvelopeData(firstPaged);
   const firstItems = Array.isArray(firstPagedData?.items)
@@ -283,17 +310,16 @@ async function validateActionPagination({
       "Advisor cockpit pagination did not return one item and a stable next_cursor.",
     );
   }
-  const secondPaged = await fetchJson(
+  const secondPaged = await sendJson(
     summary,
     `${gatewayBaseUrl}/api/v1/advisor-cockpit/actions?${advisorCockpitQuery({
       portfolioId,
-      advisorId,
-      role,
       limit: 1,
       cursor: nextCursor,
     })}`,
     "Advisor cockpit canonical pagination second page",
     timeoutMs,
+    { headers },
   );
   const secondPagedData = extractGatewayEnvelopeData(secondPaged);
   const secondItems = Array.isArray(secondPagedData?.items)
@@ -320,16 +346,21 @@ async function validateRoleProjection({
   timeoutMs,
   expectedActionFamilies: families,
 }) {
-  const compliance = await fetchJson(
+  const compliance = await sendJson(
     summary,
     `${gatewayBaseUrl}/api/v1/advisor-cockpit/actions?${advisorCockpitQuery({
       portfolioId,
-      advisorId,
-      role: "COMPLIANCE_REVIEWER",
       limit: 25,
     })}`,
     "Advisor cockpit canonical compliance projection",
     timeoutMs,
+    {
+      headers: advisorCockpitHeaders({
+        portfolioId,
+        advisorId,
+        role: "COMPLIANCE_REVIEWER",
+      }),
+    },
   );
   const compliancePage = extractGatewayEnvelopeData(compliance);
   const complianceItems = Array.isArray(compliancePage?.items)
@@ -351,16 +382,21 @@ async function validateRoleProjection({
   if (!families.includes("HOUSE_VIEW_IMPACT_REVIEW")) {
     return false;
   }
-  const dpm = await fetchJson(
+  const dpm = await sendJson(
     summary,
     `${gatewayBaseUrl}/api/v1/advisor-cockpit/actions?${advisorCockpitQuery({
       portfolioId,
-      advisorId,
-      role: "DPM_OWNER",
       limit: 25,
     })}`,
-    "Advisor cockpit canonical DPM house-view projection",
+    "Advisor cockpit canonical portfolio-manager house-view projection",
     timeoutMs,
+    {
+      headers: advisorCockpitHeaders({
+        portfolioId,
+        advisorId,
+        role: "PORTFOLIO_MANAGER",
+      }),
+    },
   );
   const dpmPage = extractGatewayEnvelopeData(dpm);
   const dpmItems = Array.isArray(dpmPage?.items) ? dpmPage.items : [];
@@ -390,15 +426,15 @@ export async function validateCanonicalAdvisorCockpit({
   });
   const query = advisorCockpitQuery({
     portfolioId,
-    advisorId,
-    role,
     limit: 25,
   });
-  const actions = await fetchJson(
+  const readHeaders = advisorCockpitHeaders({ portfolioId, advisorId, role });
+  const actions = await sendJson(
     summary,
     `${gatewayBaseUrl}/api/v1/advisor-cockpit/actions?${query}`,
     "Advisor cockpit canonical action list",
     timeoutMs,
+    { headers: readHeaders },
   );
   const actionPage = extractGatewayEnvelopeData(actions);
   const items = Array.isArray(actionPage?.items) ? actionPage.items : [];
@@ -439,6 +475,7 @@ export async function validateCanonicalAdvisorCockpit({
     summary,
     gatewayBaseUrl,
     query,
+    headers: readHeaders,
     policyAction,
     portfolioId,
     timeoutMs,
@@ -464,20 +501,20 @@ export async function validateCanonicalAdvisorCockpit({
     summary,
     `${gatewayBaseUrl}/api/v1/advisor-cockpit/actions?${advisorCockpitQuery({
       portfolioId,
-      advisorId,
-      role,
       cursor: "invalid-rfc0026-cursor",
     })}`,
     "Advisor cockpit canonical invalid cursor rejection",
     timeoutMs,
     422,
+    { headers: readHeaders },
   );
 
-  const snapshot = await fetchJson(
+  const snapshot = await sendJson(
     summary,
     `${gatewayBaseUrl}/api/v1/advisor-cockpit/snapshot?${query}`,
     "Advisor cockpit canonical operating snapshot",
     timeoutMs,
+    { headers: readHeaders },
   );
   const snapshotData = extractGatewayEnvelopeData(snapshot);
   if (!readString(snapshotData?.snapshot_id)) {
@@ -499,11 +536,12 @@ export async function validateCanonicalAdvisorCockpit({
       `Advisor cockpit snapshot returned ${preparationPackets.length} preparation packets, expected at least ${expectedMinPreparationPackets}.`,
     );
   }
-  const preparationPacketResponse = await fetchJson(
+  const preparationPacketResponse = await sendJson(
     summary,
     `${gatewayBaseUrl}/api/v1/advisor-cockpit/preparation-packets?${query}`,
     "Advisor cockpit canonical preparation packets",
     timeoutMs,
+    { headers: readHeaders },
   );
   const preparationPacketPage = extractGatewayEnvelopeData(
     preparationPacketResponse,
@@ -547,17 +585,16 @@ export async function validateCanonicalAdvisorCockpit({
     );
   }
 
-  const supportability = await fetchJson(
+  const supportability = await sendJson(
     summary,
     `${gatewayBaseUrl}/api/v1/advisor-cockpit/supportability?${advisorCockpitQuery(
       {
         portfolioId,
-        advisorId,
-        role,
       },
     )}`,
     "Advisor cockpit canonical supportability",
     timeoutMs,
+    { headers: readHeaders },
   );
   const supportabilityData = extractGatewayEnvelopeData(supportability);
   const supportabilityPosture = readString(supportabilityData?.posture);
@@ -581,14 +618,11 @@ export async function validateCanonicalAdvisorCockpit({
   if (!alreadyAcknowledged) {
     const acknowledgementBody = {
       action_item_version: actionItemVersion,
-      acknowledged_by: "workbench-canonical-validator",
       acknowledgement_note:
         "Canonical validation recorded advisor cockpit acknowledgement without clearing source-owned blockers.",
     };
     const acknowledgementIdempotencyMaterial = {
       portfolio_id: portfolioId,
-      advisor_id: advisorId,
-      role,
       action_item_id: actionItemId,
       ...acknowledgementBody,
     };
@@ -596,13 +630,19 @@ export async function validateCanonicalAdvisorCockpit({
       summary,
       `${gatewayBaseUrl}/api/v1/advisor-cockpit/actions/${encodeURIComponent(
         actionItemId,
-      )}/acknowledgements?${advisorCockpitQuery({ portfolioId, advisorId, role })}`,
+      )}/acknowledgements?${advisorCockpitQuery({ portfolioId })}`,
       "Advisor cockpit canonical acknowledgement",
       timeoutMs,
       {
         method: "POST",
         body: acknowledgementBody,
         headers: {
+          ...advisorCockpitHeaders({
+            portfolioId,
+            advisorId,
+            role,
+            capability: ACKNOWLEDGE_CAPABILITY,
+          }),
           "Idempotency-Key": buildPayloadScopedIdempotencyKey(
             "wb-advisor-cockpit-ack",
             acknowledgementIdempotencyMaterial,

--- a/scripts/live/validation/advisory-copilot-proof.mjs
+++ b/scripts/live/validation/advisory-copilot-proof.mjs
@@ -294,13 +294,14 @@ async function reviewCopilotRun({
   gatewayBaseUrl,
   run,
   action,
+  portfolioId,
+  proposalId,
   timeoutMs,
   proofExecutionId,
 }) {
   const requestBody = {
     body: {
       action: "APPROVE_FOR_INTERNAL_USE",
-      actor_id: "desk_head_sg_001",
       reason: {
         decision: "Reviewed against cited source evidence for internal advisor use.",
         scenario_id: scenario.scenarioId,
@@ -323,6 +324,14 @@ async function reviewCopilotRun({
           "wb-copilot-review",
           { run_id: run.run_id, ...requestBody },
         ),
+        "X-Actor-Id": "desk_head_sg_001",
+        "X-Tenant-Id": "tenant-sg-001",
+        "X-Legal-Entity-Code": "PB_SG",
+        "X-Role": "ADVISORY_SUPERVISOR",
+        "X-Caller-Capabilities": "advisory.copilot.review",
+        "X-Principal-Status": "ACTIVE",
+        "X-Authorized-Proposal-Id": proposalId,
+        "X-Authorized-Portfolio-Id": portfolioId,
       },
     },
   );
@@ -452,6 +461,8 @@ export async function validateCanonicalAdvisoryCopilot({
       gatewayBaseUrl,
       run,
       action,
+      portfolioId,
+      proposalId,
       timeoutMs,
       proofExecutionId,
     });

--- a/src/app/api/bff/[...path]/route.ts
+++ b/src/app/api/bff/[...path]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveGatewayBaseUrl } from "@/features/platform-runtime/service-addressing";
+import { applyAdvisoryCopilotCallerContextHeaders } from "@/features/advisory-copilot/caller-context";
 import { prepareAnalyticsUiProxyHeaders } from "@/features/analytics-observability/correlation";
 import { applyAdvisorBookCallerContextHeaders } from "@/features/advisor-book/caller-context";
 import { applyAdvisorCockpitCallerContextHeaders } from "@/features/advisor-cockpit/caller-context";
@@ -68,6 +69,18 @@ async function proxy(request: NextRequest, params: { path: string[] }) {
   });
   if (advisorCockpitAuthority.status === "rejected") {
     const rejection = advisorCockpitAuthorityRejection(advisorCockpitAuthority.reason);
+    return NextResponse.json(
+      { code: rejection.code, status: "rejected" },
+      { status: rejection.status, headers: { "cache-control": "no-store" } },
+    );
+  }
+  const advisoryCopilotAuthority = applyAdvisoryCopilotCallerContextHeaders(headers, {
+    method: request.method,
+    upstreamPath,
+    bodyText: requestBody,
+  });
+  if (advisoryCopilotAuthority.status === "rejected") {
+    const rejection = advisoryCopilotAuthorityRejection(advisoryCopilotAuthority.reason);
     return NextResponse.json(
       { code: rejection.code, status: "rejected" },
       { status: rejection.status, headers: { "cache-control": "no-store" } },
@@ -142,6 +155,24 @@ function advisorBookAuthorityRejection(
     case "invalid_authority_mode":
     case "invalid_advisor_book_configuration":
       return { code: "advisor_book_authority_configuration_rejected", status: 500 };
+  }
+}
+
+function advisoryCopilotAuthorityRejection(
+  reason: Exclude<
+    ReturnType<typeof applyAdvisoryCopilotCallerContextHeaders>,
+    { status: "not_applicable" } | { status: "applied" }
+  >["reason"],
+): { code: string; status: number } {
+  switch (reason) {
+    case "authenticated_principal_required":
+      return { code: "advisory_copilot_authenticated_principal_required", status: 401 };
+    case "invalid_advisory_copilot_request":
+      return { code: "advisory_copilot_invalid_request", status: 422 };
+    case "development_authority_not_allowed":
+    case "invalid_authority_mode":
+    case "invalid_advisory_copilot_configuration":
+      return { code: "advisory_copilot_authority_configuration_rejected", status: 500 };
   }
 }
 

--- a/src/app/api/bff/[...path]/route.ts
+++ b/src/app/api/bff/[...path]/route.ts
@@ -13,7 +13,8 @@ import {
 async function proxy(request: NextRequest, params: { path: string[] }) {
   const upstreamPath = params.path.join("/");
   const search = request.nextUrl.search;
-  const url = `${resolveGatewayBaseUrl()}/${upstreamPath}${search}`;
+  const gatewayBaseUrl = resolveGatewayBaseUrl();
+  const url = `${gatewayBaseUrl}/${upstreamPath}${search}`;
 
   const headers = new Headers();
   request.headers.forEach((value, key) => {
@@ -74,10 +75,11 @@ async function proxy(request: NextRequest, params: { path: string[] }) {
       { status: rejection.status, headers: { "cache-control": "no-store" } },
     );
   }
-  const advisoryCopilotAuthority = applyAdvisoryCopilotCallerContextHeaders(headers, {
+  const advisoryCopilotAuthority = await applyAdvisoryCopilotCallerContextHeaders(headers, {
     method: request.method,
     upstreamPath,
     bodyText: requestBody,
+    gatewayBaseUrl,
   });
   if (advisoryCopilotAuthority.status === "rejected") {
     const rejection = advisoryCopilotAuthorityRejection(advisoryCopilotAuthority.reason);
@@ -160,7 +162,7 @@ function advisorBookAuthorityRejection(
 
 function advisoryCopilotAuthorityRejection(
   reason: Exclude<
-    ReturnType<typeof applyAdvisoryCopilotCallerContextHeaders>,
+    Awaited<ReturnType<typeof applyAdvisoryCopilotCallerContextHeaders>>,
     { status: "not_applicable" } | { status: "applied" }
   >["reason"],
 ): { code: string; status: number } {
@@ -169,6 +171,10 @@ function advisoryCopilotAuthorityRejection(
       return { code: "advisory_copilot_authenticated_principal_required", status: 401 };
     case "invalid_advisory_copilot_request":
       return { code: "advisory_copilot_invalid_request", status: 422 };
+    case "advisory_copilot_scope_not_entitled":
+      return { code: "advisory_copilot_scope_not_entitled", status: 403 };
+    case "advisory_copilot_scope_not_resolved":
+      return { code: "advisory_copilot_scope_not_resolved", status: 502 };
     case "development_authority_not_allowed":
     case "invalid_authority_mode":
     case "invalid_advisory_copilot_configuration":

--- a/src/features/advisory-copilot/caller-context.ts
+++ b/src/features/advisory-copilot/caller-context.ts
@@ -5,6 +5,9 @@ import {
 } from "@/features/workbench/caller-context";
 
 const ADVISORY_COPILOT_AUTH_MODE_ENV = "WORKBENCH_ADVISORY_COPILOT_AUTH_MODE";
+const ADVISORY_COPILOT_PORTFOLIO_IDS_ENV =
+  "WORKBENCH_ADVISORY_COPILOT_PORTFOLIO_IDS";
+const READ_CAPABILITY = "advisory.copilot.read";
 const REVIEW_CAPABILITY = "advisory.copilot.review";
 const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 
@@ -14,6 +17,7 @@ const DEFAULT_DEVELOPMENT_REVIEW_AUTHORITY = {
   legalEntityCode: "PB_SG",
   role: "ADVISORY_SUPERVISOR",
   principalStatus: "ACTIVE",
+  portfolioIds: "PB_SG_GLOBAL_BAL_001",
 } as const;
 
 const AUTHORITY_BODY_FIELDS = new Set([
@@ -32,21 +36,24 @@ type AdvisoryCopilotAuthorityRejection =
   | "development_authority_not_allowed"
   | "invalid_authority_mode"
   | "invalid_advisory_copilot_configuration"
-  | "invalid_advisory_copilot_request";
+  | "invalid_advisory_copilot_request"
+  | "advisory_copilot_scope_not_entitled"
+  | "advisory_copilot_scope_not_resolved";
 
 export type AdvisoryCopilotAuthorityResolution =
   | { status: "not_applicable" }
   | { status: "applied"; mode: "development_configured" }
   | { status: "rejected"; reason: AdvisoryCopilotAuthorityRejection };
 
-export function applyAdvisoryCopilotCallerContextHeaders(
+export async function applyAdvisoryCopilotCallerContextHeaders(
   headers: Headers,
   request: {
     method: string;
     upstreamPath: string;
     bodyText?: string;
+    gatewayBaseUrl: string;
   },
-): AdvisoryCopilotAuthorityResolution {
+): Promise<AdvisoryCopilotAuthorityResolution> {
   if (!isAdvisoryCopilotReviewRoute(request.method, request.upstreamPath)) {
     return { status: "not_applicable" };
   }
@@ -71,15 +78,21 @@ export function applyAdvisoryCopilotCallerContextHeaders(
     };
   }
 
-  headers.set("X-Actor-Id", context.actorId);
-  headers.set("X-Caller-Application", context.callerApplication);
-  headers.set("X-Tenant-Id", context.tenantId);
-  headers.set("X-Region", context.region);
-  headers.set("X-Booking-Center-Code", context.bookingCenterCode);
-  headers.set("X-Legal-Entity-Code", context.legalEntityCode);
-  headers.set("X-Role", context.role);
-  headers.set("X-Caller-Capabilities", REVIEW_CAPABILITY);
-  headers.set("X-Principal-Status", context.principalStatus);
+  const scope = await resolveAdvisoryCopilotReviewScope({
+    context,
+    gatewayBaseUrl: request.gatewayBaseUrl,
+    upstreamPath: request.upstreamPath,
+  });
+  if (!scope) {
+    return { status: "rejected", reason: "advisory_copilot_scope_not_resolved" };
+  }
+  if (!context.portfolioIds.has(scope.portfolioId)) {
+    return { status: "rejected", reason: "advisory_copilot_scope_not_entitled" };
+  }
+
+  applyDevelopmentHeaders(headers, context, REVIEW_CAPABILITY);
+  headers.set("X-Authorized-Proposal-Id", scope.proposalId);
+  headers.set("X-Authorized-Portfolio-Id", scope.portfolioId);
 
   return { status: "applied", mode: authorityMode };
 }
@@ -114,6 +127,15 @@ function hasAuthorityField(value: unknown): boolean {
 
 function resolveAdvisoryCopilotDevelopmentContext() {
   const defaults = resolveDefaultCallerContext();
+  const portfolioIds = new Set(
+    (
+      process.env[ADVISORY_COPILOT_PORTFOLIO_IDS_ENV]?.trim() ||
+      DEFAULT_DEVELOPMENT_REVIEW_AUTHORITY.portfolioIds
+    )
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean),
+  );
   const context = {
     actorId:
       process.env.WORKBENCH_ADVISORY_COPILOT_ACTOR_ID?.trim() ||
@@ -133,11 +155,17 @@ function resolveAdvisoryCopilotDevelopmentContext() {
     principalStatus:
       process.env.WORKBENCH_ADVISORY_COPILOT_PRINCIPAL_STATUS?.trim().toUpperCase() ||
       DEFAULT_DEVELOPMENT_REVIEW_AUTHORITY.principalStatus,
+    portfolioIds,
   };
 
   if (
-    Object.values(context).some((value) => !IDENTIFIER_PATTERN.test(value)) ||
-    context.principalStatus !== "ACTIVE"
+    Object.entries(context).some(
+      ([key, value]) =>
+        key !== "portfolioIds" && !IDENTIFIER_PATTERN.test(String(value).trim()),
+    ) ||
+    context.principalStatus !== "ACTIVE" ||
+    portfolioIds.size === 0 ||
+    [...portfolioIds].some((portfolioId) => !IDENTIFIER_PATTERN.test(portfolioId))
   ) {
     return null;
   }
@@ -146,4 +174,104 @@ function resolveAdvisoryCopilotDevelopmentContext() {
     legalEntityCode: context.legalEntityCode.toUpperCase(),
     role: context.role.toUpperCase(),
   };
+}
+
+type AdvisoryCopilotDevelopmentContext = NonNullable<
+  ReturnType<typeof resolveAdvisoryCopilotDevelopmentContext>
+>;
+
+type AdvisoryCopilotReviewScope = {
+  proposalId: string;
+  portfolioId: string;
+};
+
+async function resolveAdvisoryCopilotReviewScope({
+  context,
+  gatewayBaseUrl,
+  upstreamPath,
+}: {
+  context: AdvisoryCopilotDevelopmentContext;
+  gatewayBaseUrl: string;
+  upstreamPath: string;
+}): Promise<AdvisoryCopilotReviewScope | null> {
+  const runId = extractReviewRunId(upstreamPath);
+  if (!runId) {
+    return null;
+  }
+
+  const headers = new Headers();
+  headers.set("Accept", "application/json");
+  applyDevelopmentHeaders(headers, context, READ_CAPABILITY);
+
+  try {
+    const response = await fetch(
+      `${gatewayBaseUrl}/api/v1/advisory-copilot/actions/${encodeURIComponent(runId)}`,
+      {
+        method: "GET",
+        headers,
+        cache: "no-store",
+      },
+    );
+    if (!response.ok) {
+      return null;
+    }
+    return extractReviewScopeFromPayload(await response.json());
+  } catch {
+    return null;
+  }
+}
+
+function applyDevelopmentHeaders(
+  headers: Headers,
+  context: AdvisoryCopilotDevelopmentContext,
+  capability: string,
+) {
+  headers.set("X-Actor-Id", context.actorId);
+  headers.set("X-Caller-Application", context.callerApplication);
+  headers.set("X-Tenant-Id", context.tenantId);
+  headers.set("X-Region", context.region);
+  headers.set("X-Booking-Center-Code", context.bookingCenterCode);
+  headers.set("X-Legal-Entity-Code", context.legalEntityCode);
+  headers.set("X-Role", context.role);
+  headers.set("X-Caller-Capabilities", capability);
+  headers.set("X-Principal-Status", context.principalStatus);
+}
+
+function extractReviewRunId(upstreamPath: string): string | null {
+  const match = /^api\/v1\/advisory-copilot\/actions\/([^/]+)\/reviews$/.exec(
+    upstreamPath,
+  );
+  if (!match) {
+    return null;
+  }
+  try {
+    const runId = decodeURIComponent(match[1]);
+    return IDENTIFIER_PATTERN.test(runId) ? runId : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractReviewScopeFromPayload(
+  payload: unknown,
+): AdvisoryCopilotReviewScope | null {
+  const data = objectValue(objectValue(payload)?.data) ?? objectValue(payload);
+  const run = objectValue(data?.run) ?? data;
+  const proposalId = readIdentifier(run?.proposal_id);
+  const portfolioId = readIdentifier(run?.portfolio_id);
+  return proposalId && portfolioId ? { proposalId, portfolioId } : null;
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readIdentifier(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return IDENTIFIER_PATTERN.test(trimmed) ? trimmed : null;
 }

--- a/src/features/advisory-copilot/caller-context.ts
+++ b/src/features/advisory-copilot/caller-context.ts
@@ -1,0 +1,149 @@
+import { resolveConfiguredAuthorityMode } from "@/features/workbench/authority-mode";
+import {
+  resolveDefaultCallerContext,
+  stripBrowserSuppliedAuthorityHeaders,
+} from "@/features/workbench/caller-context";
+
+const ADVISORY_COPILOT_AUTH_MODE_ENV = "WORKBENCH_ADVISORY_COPILOT_AUTH_MODE";
+const REVIEW_CAPABILITY = "advisory.copilot.review";
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+const DEFAULT_DEVELOPMENT_REVIEW_AUTHORITY = {
+  actorId: "desk_head_sg_001",
+  tenantId: "tenant-sg-001",
+  legalEntityCode: "PB_SG",
+  role: "ADVISORY_SUPERVISOR",
+  principalStatus: "ACTIVE",
+} as const;
+
+const AUTHORITY_BODY_FIELDS = new Set([
+  "actor_id",
+  "authorized_portfolio_id",
+  "authorized_proposal_id",
+  "capabilities",
+  "legal_entity_code",
+  "principal_status",
+  "role",
+  "tenant_id",
+]);
+
+type AdvisoryCopilotAuthorityRejection =
+  | "authenticated_principal_required"
+  | "development_authority_not_allowed"
+  | "invalid_authority_mode"
+  | "invalid_advisory_copilot_configuration"
+  | "invalid_advisory_copilot_request";
+
+export type AdvisoryCopilotAuthorityResolution =
+  | { status: "not_applicable" }
+  | { status: "applied"; mode: "development_configured" }
+  | { status: "rejected"; reason: AdvisoryCopilotAuthorityRejection };
+
+export function applyAdvisoryCopilotCallerContextHeaders(
+  headers: Headers,
+  request: {
+    method: string;
+    upstreamPath: string;
+    bodyText?: string;
+  },
+): AdvisoryCopilotAuthorityResolution {
+  if (!isAdvisoryCopilotReviewRoute(request.method, request.upstreamPath)) {
+    return { status: "not_applicable" };
+  }
+
+  stripBrowserSuppliedAuthorityHeaders(headers);
+  if (request.bodyText && containsAuthorityBodyField(request.bodyText)) {
+    return { status: "rejected", reason: "invalid_advisory_copilot_request" };
+  }
+
+  const authorityMode = resolveConfiguredAuthorityMode(ADVISORY_COPILOT_AUTH_MODE_ENV);
+  if (authorityMode !== "development_configured") {
+    return authorityMode === "authenticated_session"
+      ? { status: "rejected", reason: "authenticated_principal_required" }
+      : { status: "rejected", reason: authorityMode };
+  }
+
+  const context = resolveAdvisoryCopilotDevelopmentContext();
+  if (!context) {
+    return {
+      status: "rejected",
+      reason: "invalid_advisory_copilot_configuration",
+    };
+  }
+
+  headers.set("X-Actor-Id", context.actorId);
+  headers.set("X-Caller-Application", context.callerApplication);
+  headers.set("X-Tenant-Id", context.tenantId);
+  headers.set("X-Region", context.region);
+  headers.set("X-Booking-Center-Code", context.bookingCenterCode);
+  headers.set("X-Legal-Entity-Code", context.legalEntityCode);
+  headers.set("X-Role", context.role);
+  headers.set("X-Caller-Capabilities", REVIEW_CAPABILITY);
+  headers.set("X-Principal-Status", context.principalStatus);
+
+  return { status: "applied", mode: authorityMode };
+}
+
+function isAdvisoryCopilotReviewRoute(method: string, upstreamPath: string): boolean {
+  return (
+    method === "POST" &&
+    /^api\/v1\/advisory-copilot\/actions\/[^/]+\/reviews$/.test(upstreamPath)
+  );
+}
+
+function containsAuthorityBodyField(bodyText: string): boolean {
+  try {
+    return hasAuthorityField(JSON.parse(bodyText));
+  } catch {
+    return true;
+  }
+}
+
+function hasAuthorityField(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some(hasAuthorityField);
+  }
+  return Object.entries(value).some(
+    ([key, nestedValue]) =>
+      AUTHORITY_BODY_FIELDS.has(key.toLowerCase()) || hasAuthorityField(nestedValue),
+  );
+}
+
+function resolveAdvisoryCopilotDevelopmentContext() {
+  const defaults = resolveDefaultCallerContext();
+  const context = {
+    actorId:
+      process.env.WORKBENCH_ADVISORY_COPILOT_ACTOR_ID?.trim() ||
+      DEFAULT_DEVELOPMENT_REVIEW_AUTHORITY.actorId,
+    callerApplication: defaults.callerApplication,
+    tenantId:
+      process.env.WORKBENCH_ADVISORY_COPILOT_TENANT_ID?.trim() ||
+      DEFAULT_DEVELOPMENT_REVIEW_AUTHORITY.tenantId,
+    region: defaults.region,
+    bookingCenterCode: defaults.bookingCenterCode,
+    legalEntityCode:
+      process.env.WORKBENCH_ADVISORY_COPILOT_LEGAL_ENTITY_CODE?.trim() ||
+      DEFAULT_DEVELOPMENT_REVIEW_AUTHORITY.legalEntityCode,
+    role:
+      process.env.WORKBENCH_ADVISORY_COPILOT_ROLE?.trim() ||
+      DEFAULT_DEVELOPMENT_REVIEW_AUTHORITY.role,
+    principalStatus:
+      process.env.WORKBENCH_ADVISORY_COPILOT_PRINCIPAL_STATUS?.trim().toUpperCase() ||
+      DEFAULT_DEVELOPMENT_REVIEW_AUTHORITY.principalStatus,
+  };
+
+  if (
+    Object.values(context).some((value) => !IDENTIFIER_PATTERN.test(value)) ||
+    context.principalStatus !== "ACTIVE"
+  ) {
+    return null;
+  }
+  return {
+    ...context,
+    legalEntityCode: context.legalEntityCode.toUpperCase(),
+    role: context.role.toUpperCase(),
+  };
+}

--- a/src/features/proposals/components/advisory-copilot-workspace.tsx
+++ b/src/features/proposals/components/advisory-copilot-workspace.tsx
@@ -32,7 +32,6 @@ import type {
 import styles from "./advisory-copilot-workspace.module.css";
 
 const ADVISOR_ID = "advisor_sg_001";
-const REVIEWER_ID = "desk_head_sg_001";
 
 export default function AdvisoryCopilotWorkspace({
   portfolioId,
@@ -118,7 +117,6 @@ export default function AdvisoryCopilotWorkspace({
         runId,
         {
           action: "APPROVE_FOR_INTERNAL_USE",
-          actor_id: REVIEWER_ID,
           reason: {
             decision: "Reviewed against source evidence for internal advisor use.",
           },

--- a/src/features/proposals/types.ts
+++ b/src/features/proposals/types.ts
@@ -412,7 +412,7 @@ export type AdvisoryCopilotReviewRequest = {
     | "REQUEST_CHANGES"
     | "SUPERSEDE"
     | "EXPIRE";
-  actor_id: string;
+  actor_id?: string;
   reason?: Record<string, unknown>;
 };
 

--- a/src/features/workbench/caller-context.ts
+++ b/src/features/workbench/caller-context.ts
@@ -58,8 +58,11 @@ export const SERVER_DERIVED_CALLER_AUTHORITY_HEADERS = [
   "X-Caller-Portfolio-Ids",
   "X-Caller-Client-Ids",
   "X-Caller-Book-Ids",
+  "X-Capabilities",
+  "X-Service-Identity",
   "X-Principal-Status",
   "X-Authorized-Advisor-Id",
+  "X-Authorized-Proposal-Id",
   "X-Authorized-Portfolio-Id",
 ] as const;
 

--- a/tests/integration/advisory-copilot-workspace.test.tsx
+++ b/tests/integration/advisory-copilot-workspace.test.tsx
@@ -268,7 +268,6 @@ describe("AdvisoryCopilotWorkspace", () => {
         "copilot_run_1",
         {
           action: "APPROVE_FOR_INTERNAL_USE",
-          actor_id: "desk_head_sg_001",
           reason: {
             decision: "Reviewed against source evidence for internal advisor use.",
           },

--- a/tests/unit/advisor-cockpit-proof.test.ts
+++ b/tests/unit/advisor-cockpit-proof.test.ts
@@ -56,6 +56,27 @@ type ValidateCanonicalAdvisorCockpit = (args: {
 
 let validateCanonicalAdvisorCockpit: ValidateCanonicalAdvisorCockpit;
 
+function fetchCallUrl(fetchMock: ReturnType<typeof vi.fn>, index: number): string {
+  return fetchMock.mock.calls[index][0].toString();
+}
+
+function fetchCallHeaders(
+  fetchMock: ReturnType<typeof vi.fn>,
+  index: number,
+): Record<string, string> {
+  return fetchMock.mock.calls[index][1]?.headers as Record<string, string>;
+}
+
+function expectNoLegacyAuthorityQuery(fetchMock: ReturnType<typeof vi.fn>): void {
+  for (const [url] of fetchMock.mock.calls) {
+    const value = url.toString();
+    if (value.includes("/api/v1/advisor-cockpit/")) {
+      expect(value).not.toContain("advisor_id=");
+      expect(value).not.toContain("role=");
+    }
+  }
+}
+
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
     status,
@@ -288,27 +309,40 @@ describe("advisor cockpit live proof", () => {
       paginationCursor: null,
       roleProjectionValidated: false,
     });
-    expect(fetchMock.mock.calls[0][0].toString()).toContain(
+    expect(fetchCallUrl(fetchMock, 0)).toContain(
       `/api/v1/advisor-cockpit/actions?portfolio_id=${PORTFOLIO_ID}`,
     );
-    expect(fetchMock.mock.calls[6][0].toString()).toContain(
+    expect(fetchCallHeaders(fetchMock, 0)).toMatchObject({
+      "X-Actor-Id": "advisor_sg_001",
+      "X-Authorized-Advisor-Id": "advisor_sg_001",
+      "X-Authorized-Portfolio-Id": PORTFOLIO_ID,
+      "X-Caller-Application": "lotus-workbench",
+      "X-Caller-Capabilities": "advisory.advisor_cockpit.read",
+      "X-Role": "ADVISOR",
+    });
+    expect(fetchCallUrl(fetchMock, 6)).toContain(
       "/api/v1/advisor-cockpit/supportability",
     );
-    expect(fetchMock.mock.calls[5][0].toString()).toContain(
+    expect(fetchCallUrl(fetchMock, 5)).toContain(
       "/api/v1/advisor-cockpit/preparation-packets",
     );
-    expect(fetchMock.mock.calls[7][0].toString()).toContain(
+    expect(fetchCallUrl(fetchMock, 7)).toContain(
       "/api/v1/advisor-cockpit/actions/aci_policy_review_001/acknowledgements",
     );
-    expect(fetchMock.mock.calls[7][1].headers["Idempotency-Key"]).toMatch(
+    expect(fetchCallHeaders(fetchMock, 7)["Idempotency-Key"]).toMatch(
       /^wb-advisor-cockpit-ack-/,
     );
-    expect(JSON.parse(fetchMock.mock.calls[7][1].body as string)).toMatchObject(
-      {
-        action_item_version: 7,
-        acknowledged_by: "workbench-canonical-validator",
-      },
-    );
+    expect(fetchCallHeaders(fetchMock, 7)).toMatchObject({
+      "X-Caller-Capabilities": "advisory.advisor_cockpit.acknowledge",
+      "X-Role": "ADVISOR",
+      "X-Authorized-Advisor-Id": "advisor_sg_001",
+      "X-Authorized-Portfolio-Id": PORTFOLIO_ID,
+    });
+    expect(JSON.parse(fetchMock.mock.calls[7][1].body as string)).toEqual({
+      action_item_version: 7,
+      acknowledgement_note:
+        "Canonical validation recorded advisor cockpit acknowledgement without clearing source-owned blockers.",
+    });
     expect(summary.workflowPackChecks[0]).toMatchObject({
       actionType: "ADVISOR_COCKPIT_ACTION_ACKNOWLEDGED",
       portfolioId: PORTFOLIO_ID,
@@ -321,15 +355,19 @@ describe("advisor cockpit live proof", () => {
         "ADVISE_GATEWAY_WORKBENCH_CANONICAL_PROOF_SUPPORTED",
       replayed: true,
     });
-    expect(fetchMock.mock.calls[1][0].toString()).toContain(
+    expect(fetchCallUrl(fetchMock, 1)).toContain(
       "/api/v1/advisor-cockpit/actions/aci_policy_review_001",
     );
-    expect(fetchMock.mock.calls[2][0].toString()).toContain(
-      "role=COMPLIANCE_REVIEWER",
+    expect(fetchCallHeaders(fetchMock, 2)["X-Role"]).toBe(
+      "COMPLIANCE_REVIEWER",
     );
-    expect(fetchMock.mock.calls[3][0].toString()).toContain(
+    expect(fetchCallHeaders(fetchMock, 2)["X-Caller-Capabilities"]).toBe(
+      "advisory.advisor_cockpit.read",
+    );
+    expect(fetchCallUrl(fetchMock, 3)).toContain(
       "cursor=invalid-rfc0026-cursor",
     );
+    expectNoLegacyAuthorityQuery(fetchMock);
   });
 
   it("seeds house-view cohort evidence and requires cockpit action projection", async () => {
@@ -385,7 +423,7 @@ describe("advisor cockpit live proof", () => {
       timeoutMs: 1000,
     });
 
-    expect(fetchMock.mock.calls[0][0].toString()).toContain(
+    expect(fetchCallUrl(fetchMock, 0)).toContain(
       "/api/v1/advisor-cockpit/house-view-cohorts/evaluate",
     );
     expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toMatchObject(
@@ -406,6 +444,13 @@ describe("advisor cockpit live proof", () => {
       paginationCursor: "aci_policy_review_001",
       roleProjectionValidated: true,
     });
+    expect(fetchCallHeaders(fetchMock, 5)["X-Role"]).toBe(
+      "COMPLIANCE_REVIEWER",
+    );
+    expect(fetchCallHeaders(fetchMock, 6)["X-Role"]).toBe(
+      "PORTFOLIO_MANAGER",
+    );
+    expectNoLegacyAuthorityQuery(fetchMock);
   });
 
   it("rejects missing expected cockpit action families", async () => {
@@ -552,15 +597,16 @@ describe("advisor cockpit live proof", () => {
       summary: { apiChecks: [], workflowPackChecks: [] },
     });
 
-    expect(fetchMock.mock.calls[7][1].headers["Idempotency-Key"]).toMatch(
+    expect(fetchCallHeaders(fetchMock, 7)["Idempotency-Key"]).toMatch(
       /^wb-advisor-cockpit-ack-/,
     );
-    expect(fetchMock.mock.calls[15][1].headers["Idempotency-Key"]).toMatch(
+    expect(fetchCallHeaders(fetchMock, 15)["Idempotency-Key"]).toMatch(
       /^wb-advisor-cockpit-ack-/,
     );
-    expect(fetchMock.mock.calls[7][1].headers["Idempotency-Key"]).not.toBe(
-      fetchMock.mock.calls[15][1].headers["Idempotency-Key"],
+    expect(fetchCallHeaders(fetchMock, 7)["Idempotency-Key"]).not.toBe(
+      fetchCallHeaders(fetchMock, 15)["Idempotency-Key"],
     );
+    expectNoLegacyAuthorityQuery(fetchMock);
   });
 
   it("treats already acknowledged source state as repeatable canonical proof", async () => {

--- a/tests/unit/bff-route.test.ts
+++ b/tests/unit/bff-route.test.ts
@@ -43,6 +43,7 @@ describe("BFF proxy route", () => {
     "WORKBENCH_ADVISORY_COPILOT_LEGAL_ENTITY_CODE",
     "WORKBENCH_ADVISORY_COPILOT_ROLE",
     "WORKBENCH_ADVISORY_COPILOT_PRINCIPAL_STATUS",
+    "WORKBENCH_ADVISORY_COPILOT_PORTFOLIO_IDS",
     "LOTUS_ENVIRONMENT",
   ] as const;
   const originalCallerContextEnv = Object.fromEntries(
@@ -778,7 +779,22 @@ describe("BFF proxy route", () => {
 
   it("derives Advisory Copilot review authority at the BFF instead of trusting browser headers", async () => {
     const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValue(new Response('{"data":{}}', { status: 200 }));
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              run: {
+                run_id: "copilot_run_1",
+                proposal_id: "proposal_sg_structured_note_001",
+                portfolio_id: "PB_SG_GLOBAL_BAL_001",
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response('{"data":{}}', { status: 200 }));
     const body = JSON.stringify({
       body: {
         action: "APPROVE_FOR_INTERNAL_USE",
@@ -825,7 +841,24 @@ describe("BFF proxy route", () => {
     });
 
     expect(response.status).toBe(200);
-    const [upstreamUrl, upstreamInit] = fetchMock.mock.calls[0];
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [scopeLookupUrl, scopeLookupInit] = fetchMock.mock.calls[0];
+    expect(String(scopeLookupUrl)).toBe(
+      "http://gateway.dev.lotus/api/v1/advisory-copilot/actions/copilot_run_1",
+    );
+    expect(scopeLookupInit).toMatchObject({
+      method: "GET",
+      cache: "no-store",
+    });
+    const scopeLookupHeaders = scopeLookupInit?.headers as Headers;
+    expect(scopeLookupHeaders.get("X-Actor-Id")).toBe("desk_head_sg_001");
+    expect(scopeLookupHeaders.get("X-Caller-Capabilities")).toBe(
+      "advisory.copilot.read",
+    );
+    expect(scopeLookupHeaders.get("X-Authorized-Proposal-Id")).toBeNull();
+    expect(scopeLookupHeaders.get("X-Authorized-Portfolio-Id")).toBeNull();
+
+    const [upstreamUrl, upstreamInit] = fetchMock.mock.calls[1];
     expect(String(upstreamUrl)).toBe(
       "http://gateway.dev.lotus/api/v1/advisory-copilot/actions/copilot_run_1/reviews",
     );
@@ -842,12 +875,122 @@ describe("BFF proxy route", () => {
       "advisory.copilot.review",
     );
     expect(upstreamHeaders.get("X-Principal-Status")).toBe("ACTIVE");
-    expect(upstreamHeaders.get("X-Authorized-Proposal-Id")).toBeNull();
-    expect(upstreamHeaders.get("X-Authorized-Portfolio-Id")).toBeNull();
+    expect(upstreamHeaders.get("X-Authorized-Proposal-Id")).toBe(
+      "proposal_sg_structured_note_001",
+    );
+    expect(upstreamHeaders.get("X-Authorized-Portfolio-Id")).toBe(
+      "PB_SG_GLOBAL_BAL_001",
+    );
     expect(upstreamHeaders.get("X-Capabilities")).toBeNull();
     expect(upstreamHeaders.get("X-Service-Identity")).toBeNull();
     expect(upstreamHeaders.get("Authorization")).toBeNull();
     expect(upstreamHeaders.get("Cookie")).toBeNull();
+  });
+
+  it("rejects Advisory Copilot review when Gateway run scope is outside server entitlement", async () => {
+    process.env.WORKBENCH_ADVISORY_COPILOT_PORTFOLIO_IDS = "PB_SG_GLOBAL_BAL_001";
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            run: {
+              run_id: "copilot_run_1",
+              proposal_id: "proposal_sg_structured_note_001",
+              portfolio_id: "UNENTITLED_PORTFOLIO",
+            },
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/bff/api/v1/advisory-copilot/actions/copilot_run_1/reviews",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          body: {
+            action: "APPROVE_FOR_INTERNAL_USE",
+            reason: { decision: "Reviewed against source evidence." },
+          },
+        }),
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({
+        path: [
+          "api",
+          "v1",
+          "advisory-copilot",
+          "actions",
+          "copilot_run_1",
+          "reviews",
+        ],
+      }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(403);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      code: "advisory_copilot_scope_not_entitled",
+      status: "rejected",
+    });
+  });
+
+  it("rejects Advisory Copilot review when Gateway run scope cannot prove proposal and portfolio", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            run: {
+              run_id: "copilot_run_1",
+              proposal_id: "proposal_sg_structured_note_001",
+            },
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/bff/api/v1/advisory-copilot/actions/copilot_run_1/reviews",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          body: {
+            action: "APPROVE_FOR_INTERNAL_USE",
+            reason: { decision: "Reviewed against source evidence." },
+          },
+        }),
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({
+        path: [
+          "api",
+          "v1",
+          "advisory-copilot",
+          "actions",
+          "copilot_run_1",
+          "reviews",
+        ],
+      }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(502);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      code: "advisory_copilot_scope_not_resolved",
+      status: "rejected",
+    });
   });
 
   it("rejects browser-selected Advisory Copilot reviewer identity before proxying", async () => {

--- a/tests/unit/bff-route.test.ts
+++ b/tests/unit/bff-route.test.ts
@@ -37,6 +37,12 @@ describe("BFF proxy route", () => {
     "WORKBENCH_ADVISOR_COCKPIT_LEGAL_ENTITY_CODE",
     "WORKBENCH_ADVISOR_COCKPIT_PRINCIPAL_STATUS",
     "WORKBENCH_ADVISOR_COCKPIT_PORTFOLIO_IDS",
+    "WORKBENCH_ADVISORY_COPILOT_AUTH_MODE",
+    "WORKBENCH_ADVISORY_COPILOT_ACTOR_ID",
+    "WORKBENCH_ADVISORY_COPILOT_TENANT_ID",
+    "WORKBENCH_ADVISORY_COPILOT_LEGAL_ENTITY_CODE",
+    "WORKBENCH_ADVISORY_COPILOT_ROLE",
+    "WORKBENCH_ADVISORY_COPILOT_PRINCIPAL_STATUS",
     "LOTUS_ENVIRONMENT",
   ] as const;
   const originalCallerContextEnv = Object.fromEntries(
@@ -83,6 +89,9 @@ describe("BFF proxy route", () => {
       expect.arrayContaining([
         "X-Actor-Id",
         "X-Caller-Capabilities",
+        "X-Capabilities",
+        "X-Service-Identity",
+        "X-Authorized-Proposal-Id",
         "Authorization",
         "Cookie",
         "Proxy-Authorization",
@@ -763,6 +772,120 @@ describe("BFF proxy route", () => {
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toEqual({
       code: "advisor_cockpit_authenticated_principal_required",
+      status: "rejected",
+    });
+  });
+
+  it("derives Advisory Copilot review authority at the BFF instead of trusting browser headers", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response('{"data":{}}', { status: 200 }));
+    const body = JSON.stringify({
+      body: {
+        action: "APPROVE_FOR_INTERNAL_USE",
+        reason: {
+          decision: "Reviewed against source evidence for internal advisor use.",
+        },
+      },
+    });
+    const request = new NextRequest(
+      "http://localhost:3000/api/bff/api/v1/advisory-copilot/actions/copilot_run_1/reviews",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "idem-copilot-review-1",
+          "X-Actor-Id": "spoofed-actor",
+          "X-Tenant-Id": "spoofed-tenant",
+          "X-Legal-Entity-Code": "spoofed-entity",
+          "X-Role": "ADVISOR",
+          "X-Caller-Capabilities": "advisory.copilot.admin",
+          "X-Capabilities": "advisory.copilot.admin",
+          "X-Service-Identity": "browser-spoofed-service",
+          "X-Principal-Status": "SUSPENDED",
+          "X-Authorized-Proposal-Id": "spoofed-proposal",
+          "X-Authorized-Portfolio-Id": "UNENTITLED_PORTFOLIO",
+          Authorization: "Bearer browser-asserted-authority",
+          Cookie: "lotus_session=browser-asserted-cookie",
+        },
+        body,
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({
+        path: [
+          "api",
+          "v1",
+          "advisory-copilot",
+          "actions",
+          "copilot_run_1",
+          "reviews",
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const [upstreamUrl, upstreamInit] = fetchMock.mock.calls[0];
+    expect(String(upstreamUrl)).toBe(
+      "http://gateway.dev.lotus/api/v1/advisory-copilot/actions/copilot_run_1/reviews",
+    );
+    expect(upstreamInit?.body).toBe(body);
+    const upstreamHeaders = upstreamInit?.headers as Headers;
+    expect(upstreamHeaders.get("X-Actor-Id")).toBe("desk_head_sg_001");
+    expect(upstreamHeaders.get("X-Caller-Application")).toBe("lotus-workbench");
+    expect(upstreamHeaders.get("X-Tenant-Id")).toBe("tenant-sg-001");
+    expect(upstreamHeaders.get("X-Region")).toBe("APAC");
+    expect(upstreamHeaders.get("X-Booking-Center-Code")).toBe("SG");
+    expect(upstreamHeaders.get("X-Legal-Entity-Code")).toBe("PB_SG");
+    expect(upstreamHeaders.get("X-Role")).toBe("ADVISORY_SUPERVISOR");
+    expect(upstreamHeaders.get("X-Caller-Capabilities")).toBe(
+      "advisory.copilot.review",
+    );
+    expect(upstreamHeaders.get("X-Principal-Status")).toBe("ACTIVE");
+    expect(upstreamHeaders.get("X-Authorized-Proposal-Id")).toBeNull();
+    expect(upstreamHeaders.get("X-Authorized-Portfolio-Id")).toBeNull();
+    expect(upstreamHeaders.get("X-Capabilities")).toBeNull();
+    expect(upstreamHeaders.get("X-Service-Identity")).toBeNull();
+    expect(upstreamHeaders.get("Authorization")).toBeNull();
+    expect(upstreamHeaders.get("Cookie")).toBeNull();
+  });
+
+  it("rejects browser-selected Advisory Copilot reviewer identity before proxying", async () => {
+    const fetchMock = vi.mocked(fetch);
+    const request = new NextRequest(
+      "http://localhost:3000/api/bff/api/v1/advisory-copilot/actions/copilot_run_1/reviews",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "Idempotency-Key": "idem-copilot-review-1",
+        },
+        body: JSON.stringify({
+          body: {
+            action: "APPROVE_FOR_INTERNAL_USE",
+            actor_id: "browser_selected_reviewer",
+          },
+        }),
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({
+        path: [
+          "api",
+          "v1",
+          "advisory-copilot",
+          "actions",
+          "copilot_run_1",
+          "reviews",
+        ],
+      }),
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({
+      code: "advisory_copilot_invalid_request",
       status: "rejected",
     });
   });

--- a/tests/unit/live-canonical-validation-script.test.ts
+++ b/tests/unit/live-canonical-validation-script.test.ts
@@ -647,6 +647,10 @@ describe("canonical live validation script", () => {
     );
     expect(advisoryCopilotProof).toContain("wb-copilot-run");
     expect(advisoryCopilotProof).toContain("wb-copilot-review");
+    expect(advisoryCopilotProof).toContain('"X-Caller-Capabilities": "advisory.copilot.review"');
+    expect(advisoryCopilotProof).toContain('"X-Authorized-Proposal-Id": proposalId');
+    expect(advisoryCopilotProof).toContain('"X-Authorized-Portfolio-Id": portfolioId');
+    expect(advisoryCopilotProof).not.toContain('actor_id: "desk_head_sg_001"');
     expect(advisoryCopilotProof).toContain(
       "/api/v1/advisory-copilot/evidence-packets/from-proposal-version",
     );

--- a/tests/unit/proposals-api.test.ts
+++ b/tests/unit/proposals-api.test.ts
@@ -921,7 +921,6 @@ describe("proposal api", () => {
       "copilot_run_1",
       {
         action: "APPROVE_FOR_INTERNAL_USE",
-        actor_id: "desk_head_sg_001",
         reason: { decision: "Reviewed for internal advisor use." },
       },
       "idem-copilot-review",
@@ -961,6 +960,12 @@ describe("proposal api", () => {
         headers: expect.objectContaining({
           "Idempotency-Key": "idem-copilot-review",
         }),
+        body: JSON.stringify({
+          body: {
+            action: "APPROVE_FOR_INTERNAL_USE",
+            reason: { decision: "Reviewed for internal advisor use." },
+          },
+        }),
       }),
     );
     expect(fetchMock).toHaveBeenCalledWith(
@@ -969,6 +974,7 @@ describe("proposal api", () => {
     expect(JSON.stringify(fetchMock.mock.calls)).not.toContain(
       "source_sections",
     );
+    expect(JSON.stringify(fetchMock.mock.calls)).not.toContain("actor_id");
   });
 
   it("calls proposal version endpoints", async () => {

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -119,6 +119,26 @@ query parameters, or the acknowledgement body is rejected. The fixture is reject
 `dev`, `development`, `local`, or `test`; UAT and production require Workbench #436 and the
 platform authenticated-principal contract in #563.
 
+### Advisory Copilot local review authority fixture
+
+Advisor-use copilot review submissions use a separate BFF-owned development fixture:
+
+```txt
+WORKBENCH_ADVISORY_COPILOT_AUTH_MODE=development_configured
+WORKBENCH_ADVISORY_COPILOT_ACTOR_ID=desk_head_sg_001
+WORKBENCH_ADVISORY_COPILOT_TENANT_ID=tenant-sg-001
+WORKBENCH_ADVISORY_COPILOT_LEGAL_ENTITY_CODE=PB_SG
+WORKBENCH_ADVISORY_COPILOT_ROLE=ADVISORY_SUPERVISOR
+WORKBENCH_ADVISORY_COPILOT_PRINCIPAL_STATUS=ACTIVE
+WORKBENCH_ADVISORY_COPILOT_PORTFOLIO_IDS=PB_SG_GLOBAL_BAL_001
+```
+
+The browser submits only the review action and business reason. Workbench strips browser-supplied
+reviewer and authority headers, reads the source-owned Gateway copilot run, verifies the run
+portfolio against the configured entitlement list, and forwards the run's proposal and portfolio
+scope with `advisory.copilot.review`. Missing run scope or cross-entitlement scope fails closed
+before the review mutation reaches Gateway.
+
 ## First checks
 
 ```txt

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -48,6 +48,25 @@ Advisor Cockpit browser requests carry business scope, not caller authority. The
 This is a local and test fixture, not production authentication. UAT and production remain closed
 until Workbench #436 and platform #563 supply the governed authenticated-session principal.
 
+## Advisory Copilot review authority boundary
+
+Advisory Copilot browser review submissions carry only business review intent, not reviewer,
+proposal, portfolio, or upstream authority. The Workbench BFF:
+
+1. discards browser-supplied caller identity, tenant, legal entity, role, capability, principal
+   status, proposal scope, portfolio scope, browser `Authorization`, browser `Cookie`, proxy
+   authorization, session id, and common upstream-auth identity aliases,
+2. rejects reviewer or authority claims in the review request body,
+3. resolves the source-owned Gateway copilot action run before forwarding the review mutation,
+4. verifies the run portfolio against the server-configured development entitlement list,
+5. forwards only the server-derived reviewer context, `advisory.copilot.review`, and the
+   source-owned proposal and portfolio identifiers needed by Gateway review authorization,
+6. rejects malformed, unresolved, or cross-entitlement source scope before Gateway receives the
+   review mutation.
+
+This is a local and test fixture, not production authentication. UAT and production remain closed
+until Workbench #436 and platform #563 supply the governed authenticated-session principal.
+
 Workbench now consumes the `lotus-platform.bff-principal-session.v1` source-contract identifiers
 for the governed BFF principal boundary and keeps the certification posture explicit:
 `not_certified`, `productionIdentityCertified=false`, `supportedFeaturePromoted=false`, and


### PR DESCRIPTION
## Summary
- derive Advisory Copilot review caller authority in the Workbench BFF for local/dev runtime
- reject caller-supplied browser/body authority for the touched advisory copilot review path
- clean canonical proof scripts so authority is server-derived instead of query/body supplied
- preserve production fail-closed posture pending authenticated principal work

## Related issues
- Keep #517 open until merge-to-main, exact-main validation, and QA closure evidence are recorded.
- Production authenticated-principal support remains blocked by #436 and sgajbi/lotus-platform#563.

## Local validation
- `npm run test -- tests/unit/bff-route.test.ts tests/unit/live-canonical-validation-script.test.ts tests/unit/proposals-api.test.ts tests/unit/advisor-cockpit-proof.test.ts tests/integration/advisory-copilot-workspace.test.tsx` — 5 files passed, 84 tests passed
- `npm run typecheck` — passed
- `npm run lint` — passed, including CSS global governance and ESLint
- `git diff --check` — passed

## Evidence posture
- Tiering: local focused UI/BFF proof complete; PR checks are required before merge.
- Non-degradation: Workbench remains Gateway/BFF-first and does not implement production authentication in this PR.
- Stranded truth: no docs/wiki/context/contract files changed in this PR.