### PR TITLE
fix(ci): bound critical Workbench proof jobs

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -57,6 +57,7 @@ jobs:
     name: Main Releasability / Playwright Smoke
     needs: [quality-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -83,6 +84,7 @@ jobs:
     name: Main Releasability / Docker Build And Security
     needs: [quality-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
       - name: Build image
@@ -121,6 +123,7 @@ jobs:
     name: Main Releasability / CI Local Docker Parity
     needs: [quality-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - name: Dockerized Local CI Parity

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -56,6 +56,7 @@ jobs:
     name: PR Merge Gate / Playwright Smoke
     needs: [quality-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -82,6 +83,7 @@ jobs:
     name: PR Merge Gate / Docker Build And Security
     needs: [quality-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
       - name: Build image
@@ -120,6 +122,7 @@ jobs:
     name: PR Merge Gate / CI Local Docker Parity
     needs: [quality-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - name: Dockerized Local CI Parity

--- a/tests/unit/dependency-security-governance.test.ts
+++ b/tests/unit/dependency-security-governance.test.ts
@@ -14,6 +14,14 @@ function hasExactLine(source: string, expectedLine: string): boolean {
   return source.split(/\r?\n/).includes(expectedLine);
 }
 
+function workflowJobBlock(source: string, jobId: string): string {
+  const match = source.match(
+    new RegExp(`\\n  ${jobId}:\\n(?<block>[\\s\\S]*?)(?=\\n  [a-z0-9-]+:\\n|\\n*$)`),
+  );
+
+  return match?.groups?.block ?? "";
+}
+
 function collectLocalNodeScripts(
   scripts: Record<string, string>,
   entrypoint: string,
@@ -279,6 +287,48 @@ describe("dependency security governance", () => {
       expect(workflow).toContain("workbench-image.cdx.json");
       expect(workflow).not.toContain("aquasecurity/trivy-action@master");
       expect(workflow).not.toContain("version: latest");
+    }
+  });
+
+  it("bounds critical Docker and browser proof jobs in protected lanes", () => {
+    const governedTimeoutsByJob = new Map([
+      [
+        "e2e-smoke",
+        {
+          nameSuffix: "Playwright Smoke",
+          timeout: 30,
+        },
+      ],
+      [
+        "docker-build",
+        {
+          nameSuffix: "Docker Build And Security",
+          timeout: 45,
+        },
+      ],
+      [
+        "ci-local-docker",
+        {
+          nameSuffix: "CI Local Docker Parity",
+          timeout: 60,
+        },
+      ],
+    ]);
+
+    for (const [workflowName, jobNamePrefix] of [
+      ["pr-merge-gate.yml", "PR Merge Gate"],
+      ["main-releasability.yml", "Main Releasability"],
+    ] as const) {
+      const workflow = readRepositoryFile(".github", "workflows", workflowName);
+
+      for (const [jobId, expectation] of governedTimeoutsByJob) {
+        const jobBlock = workflowJobBlock(workflow, jobId);
+
+        expect(jobBlock).toContain(
+          `name: ${jobNamePrefix} / ${expectation.nameSuffix}`,
+        );
+        expect(jobBlock).toContain(`timeout-minutes: ${expectation.timeout}`);
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

- Adds explicit job-level timeouts to the protected Workbench PR Merge Gate proof jobs:
  - Playwright smoke: 30 minutes
  - Docker build/security/SBOM: 45 minutes
  - CI-local Docker parity: 60 minutes
- Applies the same bounded timeouts to the equivalent Main Releasability jobs.
- Extends dependency/security governance coverage so the critical browser and Docker proof jobs cannot drop their timeouts silently.

## Issue

Issue: #558

## Validation

- `npm test -- --run tests/unit/dependency-security-governance.test.ts` => 15 passed
- `npm run lint` => passed
- `git diff --check` => passed

## Boundary

This does not weaken required checks, remove Docker/Playwright coverage, bypass PR #555 validation, or change vulnerability/SBOM expectations.