### PR TITLE
fix(data-products): keep cached catalogue source truth

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1053,8 +1053,10 @@ Most relevant current governance:
 11. Shared interactive primitives own their base, priority, focus, hover, disabled, reduced-motion,
     and accessibility presentation beside the component. `ActionButton` keeps stable compatibility
     class names only for existing feature-level sizing and placement; global CSS must not regain its
-    base or state contract. Disabled actions remain native `disabled`, visually unambiguous, and
-    protected from hover overrides across primary, secondary, and quiet priorities. When migrating
+    base or state contract. Permanently unavailable actions remain native `disabled`. A mounted
+    async control may use focus-preserving `aria-disabled` only through `ActionButton`, which
+    centrally suppresses activation and applies the same unambiguous disabled and hover treatment
+    across primary, secondary, and quiet priorities. When migrating
     a shared primitive out of legacy global CSS, remove duplicate selectors and ratchet the governed
     global line and normalized-byte budgets in the same issue-backed change.
 12. Dead presentation cleanup requires an exact production, test, and selector consumer map. Delete

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1065,10 +1065,13 @@ Most relevant current governance:
     production consumer.
 13. Data Product Catalogue treats its catalogue as the required discovery source and live
     assurance plus dependency impact as independently recoverable evidence sources. Use separate
-    strict query keys, retain confirmed catalogue facts during optional-source failure, label any
-    retained earlier evidence, keep recovery controls mounted for focus stability, and never
-    convert failure into a successful empty certification or graph. The browser consumes these
-    contracts through Gateway only and does not read platform artifacts directly.
+    strict query keys. Cached required-catalogue `data` is not current confirmation while a stale
+    refresh is checking or after it fails: withhold discovery, keep the catalogue recovery control
+    mounted, and recertify only after Gateway success. Retain confirmed catalogue facts during
+    optional-source failure, label any retained earlier evidence, keep every recovery control
+    mounted for focus stability, and never convert failure into a successful empty certification or
+    graph. The browser consumes these contracts through Gateway only and does not read platform
+    artifacts directly.
 
 ## Context Maintenance Rule
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1066,8 +1066,9 @@ Most relevant current governance:
 13. Data Product Catalogue treats its catalogue as the required discovery source and live
     assurance plus dependency impact as independently recoverable evidence sources. Use separate
     strict query keys. Cached required-catalogue `data` is not current confirmation while a stale
-    refresh is checking or after it fails: withhold discovery, keep the catalogue recovery control
-    mounted, and recertify only after Gateway success. Retain confirmed catalogue facts during
+    refresh is fetching, paused offline, or has failed: withhold discovery, keep the catalogue
+    recovery control mounted, distinguish initial unavailability from refresh failure, and
+    recertify only after Gateway success. Retain confirmed catalogue facts during
     optional-source failure, label any retained earlier evidence, keep every recovery control
     mounted for focus stability, and never convert failure into a successful empty certification or
     graph. The browser consumes these contracts through Gateway only and does not read platform

--- a/docs/product/WORKBENCH-EXPERIENCE-RESEARCH-LEDGER.md
+++ b/docs/product/WORKBENCH-EXPERIENCE-RESEARCH-LEDGER.md
@@ -4325,7 +4325,9 @@ Research was reviewed on 2026-08-14 from primary enterprise catalogue sources:
    retain **Source confirmed** language. Keep initial unavailability distinct from a failed refresh.
 4. Keep catalogue, assurance, and dependency refresh controls mounted, suppress duplicate refresh
    activation with `aria-disabled`, and announce checking, failure, and confirmation in stable live
-   regions so keyboard focus does not fall back to the document after recovery.
+   regions so keyboard focus does not fall back to the document after recovery. The shared
+   `ActionButton` primitive owns `aria-disabled` activation suppression plus disabled/hover styling;
+   feature handlers retain only their synchronous duplicate-request fence.
 5. Preserve earlier source-confirmed optional evidence after refresh failure only when it is
    explicitly labelled earlier evidence. A response that reports trust unavailable remains
    distinct from transport failure and never becomes a zero-certified success.

--- a/docs/product/WORKBENCH-EXPERIENCE-RESEARCH-LEDGER.md
+++ b/docs/product/WORKBENCH-EXPERIENCE-RESEARCH-LEDGER.md
@@ -4321,7 +4321,8 @@ Research was reviewed on 2026-08-14 from primary enterprise catalogue sources:
    evidence and never fabricates certification or graph totals.
 3. Treat required-catalogue first load, background checking, refetch failure, and confirmation as
    explicit states. Withhold cached catalogue content while its required refresh is checking or has
-   failed; cached `data` alone cannot retain **Source confirmed** language.
+   failed; `fetchStatus: paused` is still an outstanding check, and cached `data` alone cannot
+   retain **Source confirmed** language. Keep initial unavailability distinct from a failed refresh.
 4. Keep catalogue, assurance, and dependency refresh controls mounted, suppress duplicate refresh
    activation with `aria-disabled`, and announce checking, failure, and confirmation in stable live
    regions so keyboard focus does not fall back to the document after recovery.

--- a/docs/product/WORKBENCH-EXPERIENCE-RESEARCH-LEDGER.md
+++ b/docs/product/WORKBENCH-EXPERIENCE-RESEARCH-LEDGER.md
@@ -4303,6 +4303,13 @@ Research was reviewed on 2026-08-14 from primary enterprise catalogue sources:
 3. [IBM data-product guidance](https://www.ibm.com/docs/en/watsonx/wdi/saas?topic=data-products)
    describes a catalogue organized around trustworthy, reusable products for a business need,
    with ownership and availability evidence supporting consumption decisions.
+4. [TanStack Query `useQuery` reference](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery)
+   distinguishes first-load failure from `isRefetchError` and retains the last successful `data`
+   after a refetch failure. Cached data presence is therefore not proof that a required refresh
+   succeeded.
+5. [WCAG 2.2 status-message guidance](https://www.w3.org/WAI/WCAG22/Techniques/failures/F103.html)
+   requires dynamic progress, failure, and recovery messages to be programmatically determinable
+   without taking focus merely to announce the outcome.
 
 ### Adopted decisions
 
@@ -4312,13 +4319,16 @@ Research was reviewed on 2026-08-14 from primary enterprise catalogue sources:
 2. Read catalogue, trust certification, and dependency graph through three independent TanStack
    Query sources. The catalogue is required; optional source failure retains confirmed catalogue
    evidence and never fabricates certification or graph totals.
-3. Keep assurance and dependency refresh controls mounted, suppress duplicate refresh activation
-   with `aria-disabled`, and announce checking, failure, and confirmation in stable live regions so
-   keyboard focus does not fall back to the document after recovery.
-4. Preserve earlier source-confirmed optional evidence after refresh failure only when it is
+3. Treat required-catalogue first load, background checking, refetch failure, and confirmation as
+   explicit states. Withhold cached catalogue content while its required refresh is checking or has
+   failed; cached `data` alone cannot retain **Source confirmed** language.
+4. Keep catalogue, assurance, and dependency refresh controls mounted, suppress duplicate refresh
+   activation with `aria-disabled`, and announce checking, failure, and confirmation in stable live
+   regions so keyboard focus does not fall back to the document after recovery.
+5. Preserve earlier source-confirmed optional evidence after refresh failure only when it is
    explicitly labelled earlier evidence. A response that reports trust unavailable remains
    distinct from transport failure and never becomes a zero-certified success.
-5. Move every screen selector from legacy global CSS into a feature-owned module, lower the global
+6. Move every screen selector from legacy global CSS into a feature-owned module, lower the global
    CSS ratchet, and forbid the removed `domain-products-` selector prefix from returning.
 
 ### Rejected decisions
@@ -4343,3 +4353,12 @@ optimized-browser proof covers desktop, tablet, narrow-screen, overflow, deliber
 recovery, console, and keyboard posture without disturbing the shared stack. The screen registry,
 complete business guide, catalogue, API notes, mesh boundary, wiki navigation, and CSS governance
 change with the implementation. Gateway contracts and platform-generated artifacts are unchanged.
+
+Workbench #695 owns the late required-cache correction. The always-mounted catalogue source
+context now blocks discovery during required refresh and after refetch failure, exposes one real
+duplicate-fenced Gateway retry, preserves focus across checking and recovery, and recertifies the
+screen only after source success. Focused component proof covers initial failure, cached refetch
+failure, repeat activation, recovery, safe copy, and focus. Isolated optimized-browser proof covers
+the same path at narrow width with exact expected source-error evidence and no page overflow. The
+guide and repository context change because required-source state truth changed; Gateway/API,
+OpenAPI, authentication, platform artifacts, and the mature dependency stack do not.

--- a/src/design-system/components/action-button.module.css
+++ b/src/design-system/components/action-button.module.css
@@ -19,7 +19,7 @@
     transform 120ms ease;
 }
 
-.base:hover:not(:disabled) {
+.base:hover:not(:disabled):not([aria-disabled="true"]) {
   border-color: rgba(87, 121, 157, 0.24);
   background: rgba(247, 249, 251, 0.98);
 }
@@ -36,7 +36,7 @@
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
-.primary:hover:not(:disabled) {
+.primary:hover:not(:disabled):not([aria-disabled="true"]) {
   border-color: rgba(24, 43, 61, 0.95);
   background: linear-gradient(180deg, #1d3143, #152433);
 }
@@ -48,13 +48,13 @@
   padding-inline: 0.2rem;
 }
 
-.quiet:hover:not(:disabled) {
+.quiet:hover:not(:disabled):not([aria-disabled="true"]) {
   border-color: transparent;
   background: transparent;
   color: var(--brand-strong);
 }
 
-.base:disabled {
+.base:is(:disabled, [aria-disabled="true"]) {
   border-color: #cbd4dc;
   background: #eef2f5;
   color: #596671;
@@ -63,7 +63,7 @@
   opacity: 1;
 }
 
-.quiet:disabled {
+.quiet:is(:disabled, [aria-disabled="true"]) {
   border-color: transparent;
   background: transparent;
   color: #6a7680;

--- a/src/design-system/components/action-button.tsx
+++ b/src/design-system/components/action-button.tsx
@@ -18,14 +18,26 @@ const ActionButton = forwardRef<HTMLButtonElement, ActionButtonProps>(function A
     priority = "secondary",
     className,
     type = "button",
+    onClick,
+    "aria-disabled": ariaDisabled,
     ...buttonProps
   },
   ref,
 ) {
+  const isAriaDisabled = ariaDisabled === true || ariaDisabled === "true";
+
   return (
     <button
       ref={ref}
       {...buttonProps}
+      aria-disabled={ariaDisabled}
+      onClick={(event) => {
+        if (isAriaDisabled) {
+          event.preventDefault();
+          return;
+        }
+        onClick?.(event);
+      }}
       type={type}
       className={cx(
         "action-button",

--- a/src/features/domain-products/domain-product-discovery-client.tsx
+++ b/src/features/domain-products/domain-product-discovery-client.tsx
@@ -52,9 +52,15 @@ export default function DomainProductDiscoveryClient() {
     queryFn: getDomainProductTrustCertification,
     ...workbenchStrictQueryDefaults,
   });
-  const catalogueChecking = catalogQuery.isFetching;
-  const catalogueFailed =
-    !catalogueChecking && (catalogQuery.isLoadingError || catalogQuery.isRefetchError);
+  const catalogueChecking = catalogQuery.isFetching || catalogQuery.fetchStatus === "paused";
+  const catalogueFailure = !catalogueChecking
+    ? catalogQuery.isLoadingError
+      ? "initial"
+      : catalogQuery.isRefetchError
+        ? "refresh"
+        : null
+    : null;
+  const catalogueFailed = catalogueFailure !== null;
   const catalogueConfirmed = Boolean(catalogQuery.data) && !catalogueChecking && !catalogueFailed;
   const trustHeader = getTrustHeaderPresentation({
     data: trustCertificationQuery.data,
@@ -78,7 +84,7 @@ export default function DomainProductDiscoveryClient() {
     >
       <CatalogueSourceContext
         catalog={catalogueConfirmed ? catalogQuery.data : undefined}
-        hasError={catalogueFailed}
+        failure={catalogueFailure}
         isChecking={catalogueChecking}
         onRefresh={() => catalogQuery.refetch()}
       />
@@ -117,16 +123,17 @@ export default function DomainProductDiscoveryClient() {
 
 function CatalogueSourceContext({
   catalog,
-  hasError,
+  failure,
   isChecking,
   onRefresh,
 }: {
   catalog: DomainProductCatalogData | undefined;
-  hasError: boolean;
+  failure: "initial" | "refresh" | null;
   isChecking: boolean;
   onRefresh: () => Promise<unknown>;
 }) {
   const refreshInFlight = useRef(false);
+  const hasError = failure !== null;
   const state = isChecking ? "checking" : hasError ? "failed" : "confirmed";
   const actionLabel = isChecking
     ? "Checking catalogue"
@@ -157,9 +164,11 @@ function CatalogueSourceContext({
         <strong>
           {isChecking
             ? "Checking required source"
-            : hasError
+            : failure === "refresh"
               ? "Catalogue refresh failed"
-              : "Source confirmed"}
+              : failure === "initial"
+                ? "Catalogue unavailable"
+                : "Source confirmed"}
         </strong>
       </div>
       <div>

--- a/src/features/domain-products/domain-product-discovery-client.tsx
+++ b/src/features/domain-products/domain-product-discovery-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import {
@@ -32,9 +32,8 @@ import {
 } from "./domain-product-source-sections";
 import {
   formatDateTime,
-  formatStateLabel,
   getTrustAvailability,
-  getTrustTone,
+  getTrustHeaderPresentation,
 } from "./presentation";
 
 export default function DomainProductDiscoveryClient() {
@@ -53,54 +52,137 @@ export default function DomainProductDiscoveryClient() {
     queryFn: getDomainProductTrustCertification,
     ...workbenchStrictQueryDefaults,
   });
+  const catalogueChecking = catalogQuery.isFetching;
+  const catalogueFailed =
+    !catalogueChecking && (catalogQuery.isLoadingError || catalogQuery.isRefetchError);
+  const catalogueConfirmed = Boolean(catalogQuery.data) && !catalogueChecking && !catalogueFailed;
+  const trustHeader = getTrustHeaderPresentation({
+    data: trustCertificationQuery.data,
+    hasError: trustCertificationQuery.isError,
+  });
 
-  if (catalogQuery.isLoading && !catalogQuery.data) {
-    return (
-      <DiscoveryFrame trustBadge={<SemanticBadge>Checking assurance</SemanticBadge>}>
+  return (
+    <DiscoveryFrame
+      trustBadge={
+        <SemanticBadge
+          tone={catalogueConfirmed ? trustHeader.tone : catalogueFailed ? "danger" : "default"}
+          emphasis="strong"
+        >
+          {catalogueConfirmed
+            ? trustHeader.label
+            : catalogueFailed
+              ? "Catalogue unavailable"
+              : "Checking catalogue"}
+        </SemanticBadge>
+      }
+    >
+      <CatalogueSourceContext
+        catalog={catalogueConfirmed ? catalogQuery.data : undefined}
+        hasError={catalogueFailed}
+        isChecking={catalogueChecking}
+        onRefresh={() => catalogQuery.refetch()}
+      />
+      {catalogueChecking ? (
         <ScreenStatePanel
           kind="loading"
-          title="Loading the data product catalogue"
-          body="Confirming the governed products available to the Workbench."
+          title={catalogQuery.data ? "Checking the latest data product catalogue" : "Loading the data product catalogue"}
+          body="Confirming the required governed product source before discovery is made available."
           rows={5}
         />
-      </DiscoveryFrame>
-    );
-  }
-
-  if (catalogQuery.error && !catalogQuery.data) {
-    return (
-      <DiscoveryFrame trustBadge={<SemanticBadge tone="danger">Catalogue unavailable</SemanticBadge>}>
+      ) : catalogueFailed || !catalogQuery.data ? (
         <ScreenStatePanel
           kind="error"
           title="The data product catalogue is temporarily unavailable"
-          body="Product ownership and approved-use evidence cannot be confirmed. No substitute catalogue has been shown."
-          hint="Retry when the governed catalogue service is available."
-          action={
-            <ActionButton onClick={() => void catalogQuery.refetch()}>
-              Retry catalogue
-            </ActionButton>
-          }
+          body="Product ownership and approved-use evidence cannot be confirmed. Cached or substitute catalogue entries have not been shown."
+          hint="Choose Retry catalogue in the source context when the governed catalogue service is available."
         />
-      </DiscoveryFrame>
-    );
+      ) : (
+        <ReadyDiscovery
+          catalog={catalogQuery.data}
+          dependencyGraph={dependencyGraphQuery.data}
+          dependencyGraphError={dependencyGraphQuery.isError}
+          dependencyGraphLoading={dependencyGraphQuery.isLoading}
+          dependencyGraphRefreshing={dependencyGraphQuery.isFetching}
+          onRefreshDependencyGraph={() => dependencyGraphQuery.refetch()}
+          trustCertification={trustCertificationQuery.data}
+          trustCertificationError={trustCertificationQuery.isError}
+          trustCertificationLoading={trustCertificationQuery.isLoading}
+          trustCertificationRefreshing={trustCertificationQuery.isFetching}
+          onRefreshTrustCertification={() => trustCertificationQuery.refetch()}
+        />
+      )}
+    </DiscoveryFrame>
+  );
+}
+
+function CatalogueSourceContext({
+  catalog,
+  hasError,
+  isChecking,
+  onRefresh,
+}: {
+  catalog: DomainProductCatalogData | undefined;
+  hasError: boolean;
+  isChecking: boolean;
+  onRefresh: () => Promise<unknown>;
+}) {
+  const refreshInFlight = useRef(false);
+  const state = isChecking ? "checking" : hasError ? "failed" : "confirmed";
+  const actionLabel = isChecking
+    ? "Checking catalogue"
+    : hasError
+      ? "Retry catalogue"
+      : "Refresh catalogue";
+
+  async function refreshOnce() {
+    if (refreshInFlight.current || isChecking) return;
+    refreshInFlight.current = true;
+    try {
+      await onRefresh();
+    } finally {
+      refreshInFlight.current = false;
+    }
   }
 
-  if (!catalogQuery.data) return null;
-
   return (
-    <ReadyDiscovery
-      catalog={catalogQuery.data}
-      dependencyGraph={dependencyGraphQuery.data}
-      dependencyGraphError={Boolean(dependencyGraphQuery.error)}
-      dependencyGraphLoading={dependencyGraphQuery.isLoading}
-      dependencyGraphRefreshing={dependencyGraphQuery.isFetching}
-      onRefreshDependencyGraph={() => dependencyGraphQuery.refetch()}
-      trustCertification={trustCertificationQuery.data}
-      trustCertificationError={Boolean(trustCertificationQuery.error)}
-      trustCertificationLoading={trustCertificationQuery.isLoading}
-      trustCertificationRefreshing={trustCertificationQuery.isFetching}
-      onRefreshTrustCertification={() => trustCertificationQuery.refetch()}
-    />
+    <div
+      className={styles.sourceContext}
+      role={hasError ? "alert" : "status"}
+      aria-live={hasError ? "assertive" : "polite"}
+      aria-atomic="true"
+      data-state={state}
+    >
+      <div>
+        <span>Catalogue status</span>
+        <strong>
+          {isChecking
+            ? "Checking required source"
+            : hasError
+              ? "Catalogue refresh failed"
+              : "Source confirmed"}
+        </strong>
+      </div>
+      <div>
+        <span>Published</span>
+        <strong>{catalog ? formatDateTime(catalog.generatedAtUtc) : "Not confirmed"}</strong>
+      </div>
+      <div>
+        <span>Contract</span>
+        <strong>{catalog?.contractVersion ?? "Not confirmed"}</strong>
+      </div>
+      <span className={styles.sourceReference}>
+        {catalog ? `Gateway · ${catalog.correlationId}` : "Gateway confirmation required"}
+      </span>
+      <ActionButton
+        priority="quiet"
+        className={styles.sourceAction}
+        aria-disabled={isChecking}
+        onClick={() => void refreshOnce()}
+        aria-label={actionLabel}
+      >
+        {actionLabel}
+      </ActionButton>
+    </div>
   );
 }
 
@@ -145,48 +227,12 @@ function ReadyDiscovery({
     hasError: trustCertificationError,
   });
   const hasRetainedTrust = Boolean(trustCertification && trustCertificationError);
-  const trustTone = hasRetainedTrust
-    ? "warn"
-    : trustCertification
-      ? getTrustTone(trustCertification.trustPosture)
-      : trustCertificationError
-        ? "warn"
-        : "default";
-  const trustLabel = hasRetainedTrust
-    ? "Assurance refresh failed"
-    : trustCertification
-      ? formatStateLabel(trustCertification.trustPosture)
-      : trustCertificationError
-        ? "Assurance unavailable"
-        : "Checking assurance";
   const certifiedCount = trustCertification?.trustAvailable
     ? (trustCertification.summary?.certifiedSnapshotCount ?? 0)
     : undefined;
 
   return (
-    <DiscoveryFrame
-      trustBadge={
-        <SemanticBadge tone={trustTone} emphasis="strong">
-          {trustLabel}
-        </SemanticBadge>
-      }
-    >
-      <div className={styles.sourceContext} aria-label="Catalogue source context">
-        <div>
-          <span>Catalogue status</span>
-          <strong>Source confirmed</strong>
-        </div>
-        <div>
-          <span>Published</span>
-          <strong>{formatDateTime(catalog.generatedAtUtc)}</strong>
-        </div>
-        <div>
-          <span>Contract</span>
-          <strong>{catalog.contractVersion}</strong>
-        </div>
-        <span className={styles.sourceReference}>Gateway · {catalog.correlationId}</span>
-      </div>
-
+    <>
       <WorkbenchSummaryMetricStrip
         ariaLabel="Data product catalogue summary"
         items={[
@@ -242,7 +288,7 @@ function ReadyDiscovery({
         isRefreshing={dependencyGraphRefreshing}
         onRefresh={onRefreshDependencyGraph}
       />
-    </DiscoveryFrame>
+    </>
   );
 }
 

--- a/src/features/domain-products/domain-product-discovery.module.css
+++ b/src/features/domain-products/domain-product-discovery.module.css
@@ -36,6 +36,10 @@
   overflow-wrap: anywhere;
 }
 
+.sourceAction {
+  flex: 0 0 auto;
+}
+
 .productGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/features/domain-products/presentation.ts
+++ b/src/features/domain-products/presentation.ts
@@ -6,6 +6,19 @@ import type {
 export type TrustTone = "success" | "warn" | "danger" | "default";
 export type SourceAvailability = "checking" | "ready" | "retained" | "unavailable";
 
+export function getTrustHeaderPresentation({
+  data,
+  hasError,
+}: {
+  data: DomainProductTrustCertificationData | undefined;
+  hasError: boolean;
+}): { label: string; tone: TrustTone } {
+  if (hasError && data) return { label: "Assurance refresh failed", tone: "warn" };
+  if (data) return { label: formatStateLabel(data.trustPosture), tone: getTrustTone(data.trustPosture) };
+  if (hasError) return { label: "Assurance unavailable", tone: "warn" };
+  return { label: "Checking assurance", tone: "default" };
+}
+
 export function getTrustAvailability({
   data,
   loading,

--- a/tests/e2e/data-product-catalogue.spec.ts
+++ b/tests/e2e/data-product-catalogue.spec.ts
@@ -188,10 +188,57 @@ test("keeps catalogue evidence visible while optional sources fail and recover",
   );
 });
 
+test("blocks cached catalogue evidence until its required source recovers", async ({ page }) => {
+  const runtime = observeBrowserRuntimeFailures(page);
+  await mockDomainProductSources(page, { failCatalogRefreshOnce: true });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/data-products", { waitUntil: "domcontentloaded" });
+
+  await expect(page.getByRole("heading", { name: "Portfolio State Snapshot" })).toBeVisible();
+
+  const refresh = page.getByRole("button", { name: "Refresh catalogue" });
+  await refresh.focus();
+  await refresh.click();
+
+  await expect(
+    page.getByText("The data product catalogue is temporarily unavailable")
+  ).toBeVisible();
+  await expect(page.getByText("Catalogue refresh failed")).toBeVisible();
+  await expect(page.getByText("Source confirmed")).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "Portfolio State Snapshot" })).toHaveCount(0);
+
+  const retry = page.getByRole("button", { name: "Retry catalogue" });
+  await expect(retry).toBeFocused();
+  await retry.click();
+
+  await expect(page.getByText("Source confirmed")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Portfolio State Snapshot" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Refresh catalogue" })).toBeFocused();
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth
+    )
+  ).toBe(true);
+
+  const expectedSourceFailures = runtime.snapshot();
+  expect(expectedSourceFailures).toHaveLength(1);
+  expect(expectedSourceFailures[0]).toEqual(
+    expect.objectContaining({
+      source: "console",
+      url: expect.stringContaining("/domain-products/catalog"),
+    })
+  );
+});
+
 async function mockDomainProductSources(
   page: Page,
-  options: { failTrustOnce?: boolean; failGraphOnce?: boolean } = {}
+  options: {
+    failCatalogRefreshOnce?: boolean;
+    failTrustOnce?: boolean;
+    failGraphOnce?: boolean;
+  } = {}
 ) {
+  let catalogRequests = 0;
   let trustRequests = 0;
   let graphRequests = 0;
 
@@ -199,6 +246,11 @@ async function mockDomainProductSources(
     await route.fulfill({ json: buildPlatformCapabilitiesFixture() });
   });
   await page.route("**/api/bff/api/v1/domain-products/catalog?**", async (route) => {
+    catalogRequests += 1;
+    if (options.failCatalogRefreshOnce && catalogRequests === 2) {
+      await route.fulfill({ status: 503, body: "catalogue path unavailable" });
+      return;
+    }
     await route.fulfill({ json: { data: catalog } });
   });
   await page.route("**/api/bff/api/v1/domain-products/dependency-graph?**", async (route) => {

--- a/tests/e2e/data-product-catalogue.spec.ts
+++ b/tests/e2e/data-product-catalogue.spec.ts
@@ -188,7 +188,10 @@ test("keeps catalogue evidence visible while optional sources fail and recover",
   );
 });
 
-test("blocks cached catalogue evidence until its required source recovers", async ({ page }) => {
+test("blocks cached catalogue evidence until its required source recovers", async ({
+  page,
+  context,
+}) => {
   const runtime = observeBrowserRuntimeFailures(page);
   await mockDomainProductSources(page, { failCatalogRefreshOnce: true });
   await page.setViewportSize({ width: 390, height: 844 });
@@ -211,6 +214,22 @@ test("blocks cached catalogue evidence until its required source recovers", asyn
   await expect(retry).toBeFocused();
   await retry.click();
 
+  await expect(page.getByText("Source confirmed")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Portfolio State Snapshot" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Refresh catalogue" })).toBeFocused();
+
+  await context.setOffline(true);
+  await page.getByRole("button", { name: "Refresh catalogue" }).click();
+  await expect(page.getByText("Checking required source")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Checking catalogue" })).toBeFocused();
+  await expect(page.getByRole("button", { name: "Checking catalogue" })).toHaveAttribute(
+    "aria-disabled",
+    "true"
+  );
+  await expect(page.getByText("Source confirmed")).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "Portfolio State Snapshot" })).toHaveCount(0);
+
+  await context.setOffline(false);
   await expect(page.getByText("Source confirmed")).toBeVisible();
   await expect(page.getByRole("heading", { name: "Portfolio State Snapshot" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Refresh catalogue" })).toBeFocused();

--- a/tests/unit/design-system-components.test.tsx
+++ b/tests/unit/design-system-components.test.tsx
@@ -338,6 +338,9 @@ describe("design-system components", () => {
         <ActionButton priority="quiet" disabled onClick={onDisabledClick}>
           Clear Selection
         </ActionButton>
+        <ActionButton aria-disabled="true" onClick={onDisabledClick}>
+          Checking Catalogue
+        </ActionButton>
         <ModeTabs
           idBase="workspace-modes"
           value="advisor"
@@ -367,6 +370,13 @@ describe("design-system components", () => {
     expect(screen.getByRole("button", { name: "Clear Selection" })).toHaveClass(
       "action-button-quiet"
     );
+    const ariaDisabledAction = screen.getByRole("button", { name: "Checking Catalogue" });
+    expect(ariaDisabledAction).toHaveAttribute("aria-disabled", "true");
+    expect(ariaDisabledAction).not.toBeDisabled();
+    ariaDisabledAction.focus();
+    fireEvent.click(ariaDisabledAction);
+    expect(ariaDisabledAction).toHaveFocus();
+    expect(onDisabledClick).not.toHaveBeenCalled();
     expect(screen.getByRole("tablist", { name: "Workspace modes" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Advisor Brief" })).toHaveAttribute(
       "data-state",

--- a/tests/unit/domain-product-discovery-client.test.tsx
+++ b/tests/unit/domain-product-discovery-client.test.tsx
@@ -201,14 +201,71 @@ describe("DomainProductDiscoveryClient", () => {
     expect(screen.queryByText(/internal path missing/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Portfolio State Snapshot")).not.toBeInTheDocument();
   });
+
+  it("blocks cached catalogue evidence when its required-source refresh fails", async () => {
+    const discovery = buildDiscovery();
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(["domain-product-catalog"], discovery.catalog, {
+      updatedAt: Date.now() - 31_000,
+    });
+    getDomainProductCatalogMock.mockRejectedValueOnce(new Error("catalogue refresh failed"));
+
+    renderDiscovery(queryClient);
+
+    expect(
+      await screen.findByText("The data product catalogue is temporarily unavailable")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Catalogue refresh failed")).toBeInTheDocument();
+    expect(screen.getByText("Gateway confirmation required")).toBeInTheDocument();
+    expect(screen.queryByText("Source confirmed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Portfolio State Snapshot")).not.toBeInTheDocument();
+    expect(screen.queryByText("catalogue refresh failed", { selector: "p" })).not.toBeInTheDocument();
+  });
+
+  it("recovers cached catalogue failure in place, preserves focus, and fences repeat retry", async () => {
+    const discovery = buildDiscovery();
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(["domain-product-catalog"], discovery.catalog, {
+      updatedAt: Date.now() - 31_000,
+    });
+    let resolveCatalog!: (value: DomainProductCatalogData) => void;
+    const pendingCatalog = new Promise<DomainProductCatalogData>((resolve) => {
+      resolveCatalog = resolve;
+    });
+    getDomainProductCatalogMock
+      .mockRejectedValueOnce(new Error("catalogue refresh failed"))
+      .mockImplementationOnce(() => pendingCatalog);
+
+    renderDiscovery(queryClient);
+
+    const retry = await screen.findByRole("button", { name: "Retry catalogue" });
+    retry.focus();
+    fireEvent.click(retry);
+
+    const pendingControl = await screen.findByRole("button", { name: "Checking catalogue" });
+    expect(pendingControl).toHaveFocus();
+    expect(pendingControl).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(pendingControl);
+    expect(getDomainProductCatalogMock).toHaveBeenCalledTimes(2);
+
+    resolveCatalog(discovery.catalog);
+
+    expect(await screen.findByText("Portfolio State Snapshot")).toBeInTheDocument();
+    expect(screen.getByText("Source confirmed")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Refresh catalogue" })).toHaveFocus();
+    expect(getDomainProductCatalogMock).toHaveBeenCalledTimes(2);
+  });
 });
 
-function renderDiscovery() {
-  const queryClient = new QueryClient({
+function createQueryClient() {
+  return new QueryClient({
     defaultOptions: {
       queries: { retry: false },
     },
   });
+}
+
+function renderDiscovery(queryClient = createQueryClient()) {
   return render(
     <QueryClientProvider client={queryClient}>
       <DomainProductDiscoveryClient />

--- a/tests/unit/domain-product-discovery-client.test.tsx
+++ b/tests/unit/domain-product-discovery-client.test.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { onlineManager, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -25,6 +25,7 @@ vi.mock("../../src/features/domain-products/api", async () => {
 
 describe("DomainProductDiscoveryClient", () => {
   beforeEach(() => {
+    onlineManager.setOnline(true);
     getDomainProductCatalogMock.mockReset();
     getDomainProductDependencyGraphMock.mockReset();
     getDomainProductTrustCertificationMock.mockReset();
@@ -198,6 +199,8 @@ describe("DomainProductDiscoveryClient", () => {
       await screen.findByText("The data product catalogue is temporarily unavailable")
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Retry catalogue" })).toBeInTheDocument();
+    expect(screen.getAllByText("Catalogue unavailable")).toHaveLength(2);
+    expect(screen.queryByText("Catalogue refresh failed")).not.toBeInTheDocument();
     expect(screen.queryByText(/internal path missing/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Portfolio State Snapshot")).not.toBeInTheDocument();
   });
@@ -254,6 +257,33 @@ describe("DomainProductDiscoveryClient", () => {
     expect(screen.getByText("Source confirmed")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Refresh catalogue" })).toHaveFocus();
     expect(getDomainProductCatalogMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("withholds cached catalogue evidence while an offline refresh is paused", async () => {
+    const discovery = buildDiscovery();
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(["domain-product-catalog"], discovery.catalog, {
+      updatedAt: Date.now() - 31_000,
+    });
+    onlineManager.setOnline(false);
+
+    renderDiscovery(queryClient);
+
+    expect(
+      await screen.findByText("Checking the latest data product catalogue")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Checking catalogue" })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    );
+    expect(screen.queryByText("Source confirmed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Portfolio State Snapshot")).not.toBeInTheDocument();
+    expect(getDomainProductCatalogMock).not.toHaveBeenCalled();
+
+    onlineManager.setOnline(true);
+
+    expect(await screen.findByText("Portfolio State Snapshot")).toBeInTheDocument();
+    expect(screen.getByText("Source confirmed")).toBeInTheDocument();
   });
 });
 

--- a/wiki/Data-Product-Catalogue-Screen-Guide.md
+++ b/wiki/Data-Product-Catalogue-Screen-Guide.md
@@ -108,7 +108,7 @@ and never reads platform files or domain services directly. Shared contract deta
 | Catalogue ready | Source context, business summary, products, approved use, assurance, and dependency impact | Confirm the publication time and intended use |
 | Empty catalogue | An explicit source-confirmed absence of products | Do not infer that products exist; follow the first support step if entries are expected |
 | Catalogue unavailable | A blocking business-safe error with no raw Gateway response and no product cards | Choose **Retry catalogue**; the full discovery surface remains unavailable until the catalogue succeeds |
-| Catalogue refresh checking | The source context remains visible, but cached product cards are withheld while the required catalogue is reconfirmed | Wait; **Source confirmed** returns only after Gateway success |
+| Catalogue refresh checking or paused | The source context remains visible, but cached product cards are withheld while the required catalogue is reconfirmed, including an offline-paused request | Wait or restore connectivity; **Source confirmed** returns only after Gateway success |
 | Catalogue refresh failure | A blocking error and the same focused **Retry catalogue** control; cached product cards and prior publication metadata are not presented as current | Retry the required source; no optional evidence can recertify the catalogue |
 | Assurance checking | Product cards remain visible with assurance fields marked **Checking** | Wait or keep reviewing catalogue facts that do not depend on assurance |
 | Assurance unavailable | Product cards and approved use remain visible; assurance fields show **Not available** and no certified total is invented | Choose **Retry assurance** or **Refresh assurance** |
@@ -152,8 +152,8 @@ superiority.
   bounded observability labels.
 - `tests/unit/domain-product-discovery-client.test.tsx` proves success, empty catalogue, blocking
   catalogue failure, cached required-source refresh failure, duplicate-fenced retry, source-owned
-  unavailable assurance, optional-source failure, retained earlier evidence, recovery, safe copy,
-  no fabricated certification, and stable focus.
+  unavailable assurance, optional-source failure, retained earlier evidence, offline-paused
+  refresh, recovery, safe copy, no fabricated certification, and stable focus.
 - `tests/e2e/data-product-catalogue.spec.ts` runs against an optimized Workbench build and proves
   desktop, tablet, narrow-screen, horizontal-overflow, console, required and optional source
   failure, recovery, cached-evidence blocking, and keyboard-focus posture.

--- a/wiki/Data-Product-Catalogue-Screen-Guide.md
+++ b/wiki/Data-Product-Catalogue-Screen-Guide.md
@@ -108,6 +108,8 @@ and never reads platform files or domain services directly. Shared contract deta
 | Catalogue ready | Source context, business summary, products, approved use, assurance, and dependency impact | Confirm the publication time and intended use |
 | Empty catalogue | An explicit source-confirmed absence of products | Do not infer that products exist; follow the first support step if entries are expected |
 | Catalogue unavailable | A blocking business-safe error with no raw Gateway response and no product cards | Choose **Retry catalogue**; the full discovery surface remains unavailable until the catalogue succeeds |
+| Catalogue refresh checking | The source context remains visible, but cached product cards are withheld while the required catalogue is reconfirmed | Wait; **Source confirmed** returns only after Gateway success |
+| Catalogue refresh failure | A blocking error and the same focused **Retry catalogue** control; cached product cards and prior publication metadata are not presented as current | Retry the required source; no optional evidence can recertify the catalogue |
 | Assurance checking | Product cards remain visible with assurance fields marked **Checking** | Wait or keep reviewing catalogue facts that do not depend on assurance |
 | Assurance unavailable | Product cards and approved use remain visible; assurance fields show **Not available** and no certified total is invented | Choose **Retry assurance** or **Refresh assurance** |
 | Source-reported assurance unavailable | The source-owned reason and unavailable posture are shown | Do not interpret catalogue presence as certification |
@@ -149,11 +151,12 @@ superiority.
 - `tests/unit/domain-products-api.test.ts` proves the three independent BFF contract reads and
   bounded observability labels.
 - `tests/unit/domain-product-discovery-client.test.tsx` proves success, empty catalogue, blocking
-  catalogue failure, source-owned unavailable assurance, optional-source failure, retained earlier
-  evidence, recovery, safe copy, no fabricated certification, and stable focus.
+  catalogue failure, cached required-source refresh failure, duplicate-fenced retry, source-owned
+  unavailable assurance, optional-source failure, retained earlier evidence, recovery, safe copy,
+  no fabricated certification, and stable focus.
 - `tests/e2e/data-product-catalogue.spec.ts` runs against an optimized Workbench build and proves
-  desktop, tablet, narrow-screen, horizontal-overflow, console, partial-source failure, recovery,
-  and keyboard-focus posture.
+  desktop, tablet, narrow-screen, horizontal-overflow, console, required and optional source
+  failure, recovery, cached-evidence blocking, and keyboard-focus posture.
 - The focused production-browser command uses an isolated port and does not require or mutate the
   shared canonical stack.
 - Use [Validation and CI](Validation-and-CI) and [Operations Runbook](Operations-Runbook) for the


### PR DESCRIPTION
## Outcome  Data Product Catalogue no longer presents a cached required catalogue as current after its background refresh fails. Discovery is withheld until Gateway reconfirms the catalogue, while one mounted source control provides truthful checking, failure, retry, and recovery evidence without losing keyboard focus.  Closes #695.  ## Implementation  - distinguishes TanStack Query initial-load and refetch failures from successful source confirmation - blocks cached product cards and prior publication metadata during required-source checking/failure - keeps one catalogue source context and refresh/retry control mounted across every state - fences repeat activation with a synchronous request guard and `aria-disabled` - announces checking/recovery politely and failure assertively without moving focus - restores **Source confirmed** only after a successful Gateway response - leaves optional assurance/dependency degradation behavior and all Gateway contracts unchanged - adds no dependency, fallback catalogue, browser-authored freshness, or authentication work  ## Proof  - 12 focused component tests pass, including initial failure, cached refetch failure, offline-paused refresh, no stale current label, repeat-activation fencing, exact recovery, and focus continuity - isolated optimized-production `data-product-catalogue.spec.ts` passes desktop/tablet/narrow, required and optional failure/recovery, exact expected source-error evidence, keyboard focus, and horizontal overflow - security audit: 0 vulnerabilities - runtime/dependency/CSS/risk/screen-doc/React-Compiler/ESLint governance passes - TypeScript passes - optimized 25-route build and portfolio record bundle budgets pass; `/data-products` remains 4.79 kB route JS / 963 kB first load - wiki pre-publication check passes with one intentional source difference; publish after merge  ## Known aggregate-gate evidence  `make check` ran the complete 362-file / 2,521-test coverage suite. 2,519 tests passed; two unrelated tests exceeded the shared 5-second timeout only under full parallel coverage. Both pass immediately in isolated reruns (1.53s and 1.64s) and are durably tracked under #585. No timeout was inflated and no unrelated DPM/Proposal code was mixed into this PR. Protected CI remains the merge authority.  ## Documentation  The research ledger now records official TanStack Query cached-refetch semantics and WCAG status-message guidance. Repository context and the Data Product Catalogue screen guide explicitly govern required-source checking, cache failure, recovery, and validation evidence.